### PR TITLE
Add labels.yaml file

### DIFF
--- a/labels.yaml
+++ b/labels.yaml
@@ -1,0 +1,34 @@
+repo: kubernetes/ingress
+labels:
+- name: area/api
+  color: ededed
+- name: area/docs
+  color: 1d76db
+- name: area/infra
+  color: bfdadc
+- name: backend/gce
+  color: "5319e7"
+- name: backend/generic
+  color: c2e0c6
+- name: backend/nginx
+  color: c5def5
+- name: bug
+  color: ee0701
+- name: 'cncf-cla: no'
+  color: ededed
+- name: 'cncf-cla: yes'
+  color: ededed
+- name: duplicate
+  color: cccccc
+- name: enhancement
+  color: 84b6eb
+- name: help wanted
+  color: 128A0C
+- name: invalid
+  color: e6e6e6
+- name: lgtm
+  color: 15dd18
+- name: question
+  color: cc317c
+- name: wontfix
+  color: ffffff


### PR DESCRIPTION
Added a `labels.yaml` file like the one in [kubernetes/kubernetes](https://github.com/kubernetes/kubernetes/blob/master/labels.yaml).

Scanned it using a [tool](https://github.com/tonglil/labeler) that can also manage renames/adds/deletes.

May be useful for the automation.