### PR TITLE
change buildDS param

### DIFF
--- a/controllers/nginx/pkg/metric/collector/nginx.go
+++ b/controllers/nginx/pkg/metric/collector/nginx.go
@@ -18,6 +18,7 @@ package collector
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/golang/glog"
 	"github.com/prometheus/client_golang/prometheus"
@@ -42,12 +43,15 @@ type (
 	}
 )
 
-func buildNS(namespace, class string) string {
+func buildNS(system, namespace, class string) string {
 	if namespace == "" {
 		namespace = "all"
 	}
 	if class == "" {
 		class = "all"
+	}
+	if strings.Compare(system, namespace) == 1 {
+		namespace = ""
 	}
 
 	return fmt.Sprintf("%v_%v", namespace, class)
@@ -61,7 +65,7 @@ func NewNginxStatus(namespace, class string, ngxHealthPort int, ngxVtsPath strin
 		ngxVtsPath:    ngxVtsPath,
 	}
 
-	ns := buildNS(namespace, class)
+	ns := buildNS(system, namespace, class)
 
 	p.data = &nginxStatusData{
 		active: prometheus.NewDesc(

--- a/controllers/nginx/pkg/metric/collector/nginx.go
+++ b/controllers/nginx/pkg/metric/collector/nginx.go
@@ -43,13 +43,15 @@ type (
 	}
 )
 
-func buildNS(system, namespace, class string) string {
+func buildNS(namespace, class string) string {
 	if namespace == "" {
 		namespace = "all"
 	}
+
 	if class == "" {
 		class = "all"
 	}
+
 	if strings.Compare(system, namespace) == 1 {
 		namespace = ""
 	}
@@ -65,7 +67,7 @@ func NewNginxStatus(namespace, class string, ngxHealthPort int, ngxVtsPath strin
 		ngxVtsPath:    ngxVtsPath,
 	}
 
-	ns := buildNS(system, namespace, class)
+	ns := buildNS(namespace, class)
 
 	p.data = &nginxStatusData{
 		active: prometheus.NewDesc(

--- a/controllers/nginx/pkg/metric/collector/vts.go
+++ b/controllers/nginx/pkg/metric/collector/vts.go
@@ -62,7 +62,7 @@ func NewNGINXVTSCollector(namespace, class string, ngxHealthPort int, ngxVtsPath
 		ngxVtsPath:    ngxVtsPath,
 	}
 
-	ns := buildNS(system, namespace, class)
+	ns := buildNS(namespace, class)
 
 	p.data = &vtsData{
 		bytes: prometheus.NewDesc(

--- a/controllers/nginx/pkg/metric/collector/vts.go
+++ b/controllers/nginx/pkg/metric/collector/vts.go
@@ -62,7 +62,7 @@ func NewNGINXVTSCollector(namespace, class string, ngxHealthPort int, ngxVtsPath
 		ngxVtsPath:    ngxVtsPath,
 	}
 
-	ns := buildNS(namespace, class)
+	ns := buildNS(system, namespace, class)
 
 	p.data = &vtsData{
 		bytes: prometheus.NewDesc(


### PR DESCRIPTION
vts metrics result snippet：
```
# HELP nginx_nginx_all_bytes_total Nginx bytes count
# TYPE nginx_nginx_all_bytes_total counter
nginx_nginx_all_bytes_total{direction="in",server_zone="*"} 158448
nginx_nginx_all_bytes_total{direction="in",server_zone="_"} 158448
nginx_nginx_all_bytes_total{direction="out",server_zone="*"} 227061
nginx_nginx_all_bytes_total{direction="out",server_zone="_"} 227061
```
`nginx_nginx`will make somebody  uncomfortable and confuse, which generated by buildDS function.
@aledbf 