### PR TITLE
adds a regexp location path option on configmap

### DIFF
--- a/controllers/nginx/configuration.md
+++ b/controllers/nginx/configuration.md
@@ -425,6 +425,9 @@ The default mime type list to compress is: `application/atom+xml application/jav
 **worker-processes:** Sets the number of [worker processes](http://nginx.org/en/docs/ngx_core_module.html#worker_processes). The default of "auto" means number of available CPU cores.
 
 
+**use-regexp-location-path:** Handles a path in Ingress pathes rules as a regexp location directive.
+The default is: `false`.
+
 ### Default configuration options
 
 The following table shows the options, the default value and a description.

--- a/controllers/nginx/pkg/config/config.go
+++ b/controllers/nginx/pkg/config/config.go
@@ -188,7 +188,7 @@ type Configuration struct {
 	MaxWorkerConnections int `json:"max-worker-connections,omitempty"`
 
 	// Sets the bucket size for the map variables hash tables.
-	// Default value depends on the processor’s cache line size.
+	// Default value depends on the processor?s cache line size.
 	// http://nginx.org/en/docs/http/ngx_http_map_module.html#map_hash_bucket_size
 	MapHashBucketSize int `json:"map-hash-bucket-size,omitempty"`
 
@@ -199,7 +199,7 @@ type Configuration struct {
 	// Sets the name of the configmap that contains the headers to pass to the backend
 	ProxySetHeaders string `json:"proxy-set-headers,omitempty"`
 
-	// Maximum size of the server names hash tables used in server names, map directive’s values,
+	// Maximum size of the server names hash tables used in server names, map directive?s values,
 	// MIME types, names of request header strings, etcd.
 	// http://nginx.org/en/docs/hash.html
 	// http://nginx.org/en/docs/http/ngx_http_core_module.html#server_names_hash_max_size
@@ -210,7 +210,7 @@ type Configuration struct {
 	// http://nginx.org/en/docs/http/ngx_http_core_module.html#server_names_hash_bucket_size
 	ServerNameHashBucketSize int `json:"server-name-hash-bucket-size,omitempty"`
 
-	// Enables or disables emitting nginx version in error messages and in the “Server” response header field.
+	// Enables or disables emitting nginx version in error messages and in the ?Server? response header field.
 	// http://nginx.org/en/docs/http/ngx_http_core_module.html#server_tokens
 	// Default: true
 	ShowServerTokens bool `json:"server-tokens"`
@@ -271,8 +271,8 @@ type Configuration struct {
 	// Default: true
 	UseHTTP2 bool `json:"use-http2,omitempty"`
 
-	// MIME types in addition to "text/html" to compress. The special value “*” matches any MIME type.
-	// Responses with the “text/html” type are always compressed if UseGzip is enabled
+	// MIME types in addition to "text/html" to compress. The special value ?*? matches any MIME type.
+	// Responses with the ?text/html? type are always compressed if UseGzip is enabled
 	GzipTypes string `json:"gzip-types,omitempty"`
 
 	// Defines the number of worker processes. By default auto means number of available CPU cores
@@ -289,6 +289,7 @@ type Configuration struct {
 	// Sets the maximum size of the variables hash table.
 	// http://nginx.org/en/docs/http/ngx_http_map_module.html#variables_hash_max_size
 	VariablesHashMaxSize int `json:"variables-hash-max-size,omitempty"`
+	UseRegexpLocationPath bool `json:"use-regexp-location-path,omitempty"`
 }
 
 // NewDefault returns the default nginx configuration
@@ -346,6 +347,7 @@ func NewDefault() Configuration {
 			WhitelistSourceRange: []string{},
 			SkipAccessLogURLs:    []string{},
 		},
+		UseRegexpLocationPath:        false,
 	}
 
 	if glog.V(5) {

--- a/controllers/nginx/pkg/template/configmap_test.go
+++ b/controllers/nginx/pkg/template/configmap_test.go
@@ -42,6 +42,7 @@ func TestMergeConfigMapToStruct(t *testing.T) {
 		"use-gzip":                   "true",
 		"enable-dynamic-tls-records": "false",
 		"gzip-types":                 "text/html",
+		"use-regexp-location-path":   "false",
 	}
 	def := config.NewDefault()
 	def.CustomHTTPErrors = []int{300, 400}
@@ -52,6 +53,7 @@ func TestMergeConfigMapToStruct(t *testing.T) {
 	def.EnableDynamicTLSRecords = false
 	def.UseProxyProtocol = true
 	def.GzipTypes = "text/html"
+	def.UseRegexpLocationPath = false
 
 	to := ReadConfig(conf)
 	if diff := pretty.Compare(to, def); diff != "" {

--- a/controllers/nginx/pkg/template/template.go
+++ b/controllers/nginx/pkg/template/template.go
@@ -131,6 +131,7 @@ var (
 		},
 		"buildLocation":            buildLocation,
 		"buildAuthLocation":        buildAuthLocation,
+		"withLocationPathType":     withLocationPathType,
 		"buildAuthResponseHeaders": buildAuthResponseHeaders,
 		"buildProxyPass":           buildProxyPass,
 		"buildRateLimitZones":      buildRateLimitZones,
@@ -192,6 +193,20 @@ func buildLocation(input interface{}) string {
 	}
 
 	return path
+}
+
+func withLocationPathType(input interface{}, cfgInput interface{}) string {
+	cfg, ok := cfgInput.(config.Configuration)
+	if !ok {
+		glog.Errorf("error an ingress.withLocationPathType type but %T was returned", cfgInput)
+	}
+	path := input.(string)
+
+	if cfg.UseRegexpLocationPath && strings.HasPrefix(path, "/") {
+		return fmt.Sprintf("~ ^%s", path)
+	} else {
+		return path
+	}
 }
 
 func buildAuthLocation(input interface{}) string {

--- a/controllers/nginx/pkg/template/template_test.go
+++ b/controllers/nginx/pkg/template/template_test.go
@@ -102,6 +102,26 @@ func TestBuildLocation(t *testing.T) {
 	}
 }
 
+func TestWithLocationPathType(t *testing.T) {
+	conf := config.NewDefault()
+
+	path0 := "/foo"
+	if "/foo" != withLocationPathType(path0, conf) {
+		t.Errorf("%s: expected not to be regexp path", path0)
+	}
+
+	conf.UseRegexpLocationPath = true
+	path1 := "/foo"
+	if "~ ^/foo" != withLocationPathType(path1, conf) {
+		t.Errorf("%s: expected to be regexp path", path1)
+	}
+
+	path2 := "~* /foo"
+	if "~* /foo" != withLocationPathType(path2, conf) {
+		t.Errorf("%s: expected to be regexp path", path2)
+	}
+}
+
 func TestBuildProxyPass(t *testing.T) {
 	for k, tc := range tmplFuncTestcases {
 		loc := &ingress.Location{

--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -287,7 +287,8 @@ http {
         {{ if $cfg.EnableVtsStatus }}vhost_traffic_status_filter_by_set_key $geoip_country_code country::$server_name;{{ end }}
 
         {{ range $location := $server.Locations }}
-        {{ $path := buildLocation $location }}
+        {{ $builtPath := buildLocation $location }}
+        {{ $path := withLocationPathType $builtPath $cfg }}
         {{ $authPath := buildAuthLocation $location }}
 
         {{ if not (empty $location.CertificateAuth.AuthSSLCert.CAFileName) }}


### PR DESCRIPTION
I would like to use regexp in Ingress path rules. like this:

```yaml
    http:
      paths:
      - path: "/$"
        backend:
          serviceName: www
          servicePort: 80
      - path: "/index.html"
        backend:
          serviceName: www
          servicePort: 80
      - path: "/static_html"
        backend:
          serviceName: www
          servicePort: 80
      - path: "/.+"
        backend:
          serviceName: api
          servicePort: 80
```

This PR achieves the case using regex path for nginx location directive.