### PR TITLE
doc change to allow for generic ca.crt file secret

### DIFF
--- a/examples/PREREQUISITES.md
+++ b/examples/PREREQUISITES.md
@@ -132,7 +132,7 @@ The final step is to create a secret with the content of this file. This secret 
 the TLS Auth directive:
 
 ```console
-$ kubectl create secret generic caingress --namespace=default --from-file=ca.crt
+$ kubectl create secret generic caingress --namespace=default --from-file=ca.crt="/path/to/your/cert"
 ```
 
 ## Test HTTP Service


### PR DESCRIPTION
This clarifies to the user that they can use a cert chain or cert with any file name yet will still resolve as ca.crt once in the container.