### PR TITLE
Modify how locations are built

### DIFF
--- a/controllers/nginx/pkg/template/template_test.go
+++ b/controllers/nginx/pkg/template/template_test.go
@@ -42,7 +42,7 @@ var (
 		AddBaseURL bool
 	}{
 		"invalid redirect / to /": {"/", "/", "/", "proxy_pass http://upstream-name;", false},
-		"redirect / to /jenkins": {"/", "/jenkins", "~* /",
+		"redirect / to /jenkins": {"/", "/jenkins", "/",
 			`
 	rewrite /(.*) /jenkins/$1 break;
 	proxy_pass http://upstream-name;
@@ -60,7 +60,7 @@ var (
 	rewrite /something-complex/(.*) /not-root/$1 break;
 	proxy_pass http://upstream-name;
 	`, false},
-		"redirect / to /jenkins and rewrite": {"/", "/jenkins", "~* /", `
+		"redirect / to /jenkins and rewrite": {"/", "/jenkins", "/", `
 	rewrite /(.*) /jenkins/$1 break;
 	proxy_pass http://upstream-name;
 	subs_filter '<head(.*)>' '<head$1><base href="$scheme://$http_host/$baseuri">' r;


### PR DESCRIPTION
Opening this PR for discussion rather than a merge right away - it was just easier to write code to illustrate the points I need to discuss. There are a few issues that this relates to which I've tried to include inline.

This is an attempt to resolve #619 and bring the nginx ingress controller more inline with the HTTPIngressPath type as defined in https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/extensions/types.go#L704

> Path is an extended POSIX regex as defined by IEEE Std 1003.1, (i.e this follows the egrep/unix syntax, not the perl syntax) matched against the path of an incoming request. Currently it can contain characters disallowed from the conventional "path" part of a URL as defined by RFC 3986. Paths must begin with a '/'. If unspecified, the path defaults to a catch all sending traffic to the backend.

#646 raises a valid objection to this method of fixing the controller
>Also, if #619 would be fixed by unconditionally enabling regular expressions, even the currently working cases (without rewrite) will break.

Having looked at https://github.com/kubernetes/ingress/pull/565#issuecomment-293486981 I believe that the use case where rewrite-target is not used (the use case raised as a potential issue in #646), is being treated as an edge case. It is an edge case I'm hitting though - our apps are aware of their routes, which is why I'm looking to fix the controller so we can use regex routes without enabling the rewrite. 

I'm aware that although enabling this would bring the ingress controller closer to the documented spec, it will also be an unexpected change for existing users of the controller. I'm not sure how this should be handled, but perhaps this change could be wrapped in some kind of annotation to preserve the current behaviour for a limited time, and then the default swapped and the annotation deprecated.

This will also increase the range of location blocks affected by the ordering issues in #495. I'm not sure of a solution there but understand the problem raised.

Politely pinging @ankon @ohmystack @aledbf @himikof and @jurgenweber as interested parties from other PRs/issues related to this. I'd appreciate your feedback so that I can try and craft a solution that can be merged upstream rather than just suiting my own needs.

--

The HTTPIngressPath defines the path as an extended POSIX regex.
https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/extensions/types.go#L704

This treats any path passed from the ingress as a regex based location block.
The only exception to this is the / path, which is set as a prefix location
block, this should work as a catchall without affecting other locations defined
using regex location blocks.

It should be noted that there may be some incompatibilities between the spec
and the regex implementation within nginx.