### PR TITLE
Add tests to cover sticky cookie and rewrite-target annotations

### DIFF
--- a/internal/ingress/controller/template/template_test.go
+++ b/internal/ingress/controller/template/template_test.go
@@ -42,53 +42,58 @@ var (
 		ProxyPass     string
 		AddBaseURL    bool
 		BaseURLScheme string
+		Sticky        bool
 	}{
-		"invalid redirect / to /": {"/", "/", "/", "proxy_pass http://upstream-name;", false, ""},
+		"invalid redirect / to /": {"/", "/", "/", "proxy_pass http://upstream-name;", false, "", false},
 		"redirect / to /jenkins": {"/", "/jenkins", "~* /",
 			`
 	    rewrite /(.*) /jenkins/$1 break;
 	    proxy_pass http://upstream-name;
-	    `, false, ""},
+	    `, false, "", false},
 		"redirect /something to /": {"/something", "/", `~* ^/something\/?(?<baseuri>.*)`, `
 	    rewrite /something/(.*) /$1 break;
 	    rewrite /something / break;
 	    proxy_pass http://upstream-name;
-	    `, false, ""},
+	    `, false, "", false},
 		"redirect /end-with-slash/ to /not-root": {"/end-with-slash/", "/not-root", "~* ^/end-with-slash/(?<baseuri>.*)", `
 	    rewrite /end-with-slash/(.*) /not-root/$1 break;
 	    proxy_pass http://upstream-name;
-	    `, false, ""},
+	    `, false, "", false},
 		"redirect /something-complex to /not-root": {"/something-complex", "/not-root", `~* ^/something-complex\/?(?<baseuri>.*)`, `
 	    rewrite /something-complex/(.*) /not-root/$1 break;
 	    proxy_pass http://upstream-name;
-	    `, false, ""},
+	    `, false, "", false},
 		"redirect / to /jenkins and rewrite": {"/", "/jenkins", "~* /", `
 	    rewrite /(.*) /jenkins/$1 break;
 	    proxy_pass http://upstream-name;
 	    subs_filter '(<(?:H|h)(?:E|e)(?:A|a)(?:D|d)(?:[^">]|"[^"]*")*>)' '$1<base href="$scheme://$http_host/$baseuri">' ro;
-	    `, true, ""},
+	    `, true, "", false},
 		"redirect /something to / and rewrite": {"/something", "/", `~* ^/something\/?(?<baseuri>.*)`, `
 	    rewrite /something/(.*) /$1 break;
 	    rewrite /something / break;
 	    proxy_pass http://upstream-name;
 	    subs_filter '(<(?:H|h)(?:E|e)(?:A|a)(?:D|d)(?:[^">]|"[^"]*")*>)' '$1<base href="$scheme://$http_host/something/$baseuri">' ro;
-	    `, true, ""},
+	    `, true, "", false},
 		"redirect /end-with-slash/ to /not-root and rewrite": {"/end-with-slash/", "/not-root", `~* ^/end-with-slash/(?<baseuri>.*)`, `
 	    rewrite /end-with-slash/(.*) /not-root/$1 break;
 	    proxy_pass http://upstream-name;
 	    subs_filter '(<(?:H|h)(?:E|e)(?:A|a)(?:D|d)(?:[^">]|"[^"]*")*>)' '$1<base href="$scheme://$http_host/end-with-slash/$baseuri">' ro;
-	    `, true, ""},
+	    `, true, "", false},
 		"redirect /something-complex to /not-root and rewrite": {"/something-complex", "/not-root", `~* ^/something-complex\/?(?<baseuri>.*)`, `
 	    rewrite /something-complex/(.*) /not-root/$1 break;
 	    proxy_pass http://upstream-name;
 	    subs_filter '(<(?:H|h)(?:E|e)(?:A|a)(?:D|d)(?:[^">]|"[^"]*")*>)' '$1<base href="$scheme://$http_host/something-complex/$baseuri">' ro;
-	    `, true, ""},
+	    `, true, "", false},
 		"redirect /something to / and rewrite with specific scheme": {"/something", "/", `~* ^/something\/?(?<baseuri>.*)`, `
 	    rewrite /something/(.*) /$1 break;
 	    rewrite /something / break;
 	    proxy_pass http://upstream-name;
 	    subs_filter '(<(?:H|h)(?:E|e)(?:A|a)(?:D|d)(?:[^">]|"[^"]*")*>)' '$1<base href="http://$http_host/something/$baseuri">' ro;
-	    `, true, "http"},
+	    `, true, "http", false},
+		"redirect / to /something with sticky enabled": {"/", "/something", `~* /`, `
+	    rewrite /(.*) /something/$1 break;
+	    proxy_pass http://sticky-upstream-name;
+	    `, false, "http", true},
 	}
 )
 
@@ -126,14 +131,34 @@ func TestBuildLocation(t *testing.T) {
 }
 
 func TestBuildProxyPass(t *testing.T) {
+	defaultBackend := "upstream-name"
+	defaultHost := "example.com"
+
 	for k, tc := range tmplFuncTestcases {
 		loc := &ingress.Location{
 			Path:    tc.Path,
 			Rewrite: rewrite.Config{Target: tc.Target, AddBaseURL: tc.AddBaseURL, BaseURLScheme: tc.BaseURLScheme},
-			Backend: "upstream-name",
+			Backend: defaultBackend,
 		}
 
-		pp := buildProxyPass("", []*ingress.Backend{}, loc)
+		backends := []*ingress.Backend{}
+		if tc.Sticky {
+			backends = []*ingress.Backend{
+				{
+					Name: defaultBackend,
+					SessionAffinity: ingress.SessionAffinityConfig{
+						AffinityType: "cookie",
+						CookieSessionAffinity: ingress.CookieSessionAffinity{
+							Locations: map[string][]string{
+								defaultHost: {tc.Path},
+							},
+						},
+					},
+				},
+			}
+		}
+
+		pp := buildProxyPass(defaultHost, backends, loc)
 		if !strings.EqualFold(tc.ProxyPass, pp) {
 			t.Errorf("%s: expected \n'%v'\nbut returned \n'%v'", k, tc.ProxyPass, pp)
 		}

--- a/test/e2e/annotations/affinity.go
+++ b/test/e2e/annotations/affinity.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package annotations
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/parnurzeal/gorequest"
+
+	v1beta1 "k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"k8s.io/ingress-nginx/test/e2e/framework"
+)
+
+var _ = framework.IngressNginxDescribe("Annotations - Affinity", func() {
+	f := framework.NewDefaultFramework("affinity")
+
+	BeforeEach(func() {
+		err := f.NewEchoDeploymentWithReplicas(2)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+	})
+
+	It("should set sticky cookie SERVERID", func() {
+		host := "sticky.foo.com"
+
+		ing, err := f.EnsureIngress(&v1beta1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      host,
+				Namespace: f.Namespace.Name,
+				Annotations: map[string]string{
+					"nginx.ingress.kubernetes.io/affinity": "cookie",
+					"nginx.ingress.kubernetes.io/session-cookie-name": "SERVERID",
+				},
+			},
+			Spec: v1beta1.IngressSpec{
+				Rules: []v1beta1.IngressRule{
+					{
+						Host: host,
+						IngressRuleValue: v1beta1.IngressRuleValue{
+							HTTP: &v1beta1.HTTPIngressRuleValue{
+								Paths: []v1beta1.HTTPIngressPath{
+									{
+										Path: "/",
+										Backend: v1beta1.IngressBackend{
+											ServiceName: "http-svc",
+											ServicePort: intstr.FromInt(80),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ing).NotTo(BeNil())
+
+		err = f.WaitForNginxServer(host,
+			func(server string) bool {
+				return strings.Contains(server, "proxy_pass http://sticky-"+f.Namespace.Name+"-http-svc-80;")
+			})
+		Expect(err).NotTo(HaveOccurred())
+
+		resp, _, errs := gorequest.New().
+			Get(f.NginxHTTPURL).
+			Set("Host", host).
+			End()
+
+		Expect(len(errs)).Should(BeNumerically("==", 0))
+		Expect(resp.StatusCode).Should(Equal(http.StatusOK))
+		Expect(resp.Header.Get("Set-Cookie")).Should(ContainSubstring("SERVERID="))
+	})
+
+	It("should redirect to '/something' with enabled affinity", func() {
+		host := "example.com"
+
+		ing, err := f.EnsureIngress(&v1beta1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      host,
+				Namespace: f.Namespace.Name,
+				Annotations: map[string]string{
+					"nginx.ingress.kubernetes.io/affinity": "cookie",
+					"nginx.ingress.kubernetes.io/session-cookie-name": "SERVERID",
+					"nginx.ingress.kubernetes.io/rewrite-target": "/something",
+				},
+			},
+			Spec: v1beta1.IngressSpec{
+				Rules: []v1beta1.IngressRule{
+					{
+						Host: host,
+						IngressRuleValue: v1beta1.IngressRuleValue{
+							HTTP: &v1beta1.HTTPIngressRuleValue{
+								Paths: []v1beta1.HTTPIngressPath{
+									{
+										Path: "/",
+										Backend: v1beta1.IngressBackend{
+											ServiceName: "http-svc",
+											ServicePort: intstr.FromInt(80),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ing).NotTo(BeNil())
+
+		err = f.WaitForNginxServer(host,
+			func(server string) bool {
+				return strings.Contains(server, "proxy_pass http://sticky-"+f.Namespace.Name+"-http-svc-80;")
+			})
+		Expect(err).NotTo(HaveOccurred())
+
+		resp, body, errs := gorequest.New().
+			Get(f.NginxHTTPURL).
+			Set("Host", host).
+			End()
+
+		Expect(len(errs)).Should(BeNumerically("==", 0))
+		Expect(resp.StatusCode).Should(Equal(http.StatusOK))
+		Expect(body).Should(ContainSubstring(fmt.Sprintf("request_uri=http://%v:8080/something/", host)))
+		Expect(resp.Header.Get("Set-Cookie")).Should(ContainSubstring("SERVERID="))
+	})
+})

--- a/test/e2e/framework/echo.go
+++ b/test/e2e/framework/echo.go
@@ -29,15 +29,21 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-// NewEchoDeployment creates a new deployment of the echoserver image in a particular namespace
+// NewEchoDeployment creates a new single replica deployment of the echoserver image in a particular namespace
 func (f *Framework) NewEchoDeployment() error {
+	return f.NewEchoDeploymentWithReplicas(1)
+}
+
+// NewEchoDeploymentWithReplicas creates a new deployment of the echoserver image in a particular namespace. Number of
+// replicas is configurable
+func (f *Framework) NewEchoDeploymentWithReplicas(replicas int32) error {
 	deployment := &extensions.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "http-svc",
 			Namespace: f.Namespace.Name,
 		},
 		Spec: extensions.DeploymentSpec{
-			Replicas: NewInt32(1),
+			Replicas: NewInt32(replicas),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"app": "http-svc",
@@ -78,7 +84,7 @@ func (f *Framework) NewEchoDeployment() error {
 		return fmt.Errorf("unexpected error creating deployement for echoserver")
 	}
 
-	err = f.WaitForPodsReady(10*time.Second, 1, metav1.ListOptions{
+	err = f.WaitForPodsReady(10*time.Second, int(replicas), metav1.ListOptions{
 		LabelSelector: fields.SelectorFromSet(fields.Set(d.Spec.Template.ObjectMeta.Labels)).String(),
 	})
 	if err != nil {


### PR DESCRIPTION
When an ingress rule enables sticky cookie (`ingress.kubernetes.io/affinity: cookie` combining with the `ingress.kubernetes.io/rewrite-target`,  the sticky cookie feature does not work anymore.

Affect versions: from nginx-ingress-controller:0.9.0-beta.11

Reproduction:

- Deploy http-svc:
```
kubectl create -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/docs/examples/http-svc.yaml
```
- Scale http-svc to 2 pods:
```
kubectl scale deploy http-svc --replicas=2
```
- Create an ingress rule
```
echo "
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  annotations:
    ingress.kubernetes.io/affinity: cookie
    ingress.kubernetes.io/session-cookie-hash: sha1
    ingress.kubernetes.io/session-cookie-name: SERVERID
    ingress.kubernetes.io/rewrite-target: /foo
    kubernetes.io/ingress.class: "nginx"
  name: example.com
spec:
  rules:
  - host: example.com
    http:
      paths:
      - backend:
          serviceName: http-svc
          servicePort: 80
        path: /
" | kubectl create -f - 
```
- Create a request
```
curl -v http://<ingress-svc-address> -H 'Host: example.com'
```
Verify that the response header does not container a sticky cookie like
```
Set-Cookie: SERVERID=cbe88003c2aefcf43d9103dc5ce614ed733d0891; Path=/; HttpOnly
```
Remove ingress.kubernetes.io/rewrite-target annotation from the example.com ingress rule, the response header contains the sticky cookie.

Update: this bug has been fixed in NGINX: 0.9.0-beta.17.