### PR TITLE
Teach L4Backend.Equal about more attributes

### DIFF
--- a/core/pkg/ingress/types_equals.go
+++ b/core/pkg/ingress/types_equals.go
@@ -476,6 +476,11 @@ func (l4b1 *L4Backend) Equal(l4b2 *L4Backend) bool {
 	if l4b1.Protocol != l4b2.Protocol {
 		return false
 	}
-
+	if l4b1.ServerName != l4b2.ServerName {
+                return false
+        }
+        if l4b1.UseProxyProtocol != l4b2.UseProxyProtocol {
+                return false
+        }
 	return true
 }


### PR DESCRIPTION
We were missing the ServerName and UseProxyProtocol attributes which was causing updates to not trigger in my environment.