### PR TITLE
SNI routing using the nginx map preread module

### DIFF
--- a/controllers/nginx/Makefile
+++ b/controllers/nginx/Makefile
@@ -26,7 +26,7 @@ ARCH ?= $(shell go env GOARCH)
 GOARCH = ${ARCH}
 DUMB_ARCH = ${ARCH}
 
-ALL_ARCH = amd64 arm arm64 ppc64le
+ALL_ARCH ?= amd64 arm arm64 ppc64le
 
 QEMUVERSION=v2.9.1
 

--- a/controllers/nginx/pkg/cmd/controller/nginx.go
+++ b/controllers/nginx/pkg/cmd/controller/nginx.go
@@ -649,6 +649,7 @@ func (n *NGINXController) OnUpdate(ingressCfg ingress.Configuration) error {
 		PassthroughBackends:     ingressCfg.PassthroughBackends,
 		Servers:                 ingressCfg.Servers,
 		TCPBackends:             ingressCfg.TCPEndpoints,
+		SNIBackends:             ingressCfg.SNIEndpoints,
 		UDPBackends:             ingressCfg.UDPEndpoints,
 		HealthzURI:              ngxHealthPath,
 		CustomErrors:            len(cfg.CustomHTTPErrors) > 0,

--- a/controllers/nginx/pkg/config/config.go
+++ b/controllers/nginx/pkg/config/config.go
@@ -478,6 +478,7 @@ type TemplateConfig struct {
 	PassthroughBackends     []*ingress.SSLPassthroughBackend
 	Servers                 []*ingress.Server
 	TCPBackends             []ingress.L4Service
+	SNIBackends             []ingress.L4Service
 	UDPBackends             []ingress.L4Service
 	HealthzURI              string
 	CustomErrors            bool

--- a/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
+++ b/controllers/nginx/rootfs/etc/nginx/template/nginx.tmpl
@@ -405,13 +405,11 @@ http {
 }
 
 stream {
-    log_format log_stream {{ $cfg.LogFormatStream }};
-
-    {{ if $cfg.DisableAccessLog }}
-    access_log off;
-    {{ else }}
-    access_log {{ $cfg.AccessLogPath }} log_stream;
-    {{ end }}
+    log_format proxy '$msec $remote_addr:$remote_port $ssl_preread_server_name '
+                     '$protocol st:$status bs:$bytes_sent br:$bytes_received '
+                     'sesstime:$session_time pod:"$upstream_addr" '
+                     'ubs:"$upstream_bytes_sent" ubr:"$upstream_bytes_received" uct:"$upstream_connect_time"';
+    access_log /var/log/nginx/access.log proxy if=$bytes_received;
 
     error_log  {{ $cfg.ErrorLogPath }};
 
@@ -440,6 +438,32 @@ stream {
     }
 
     {{ end }}
+
+    # SNI services
+    map $ssl_preread_server_name $name {
+    {{ range $i, $sniServer := .SNIBackends }}
+        {{ $sniServer.Backend.ServerName }} sni-{{ $sniServer.Port }}-{{ $sniServer.Backend.Namespace }}-{{ $sniServer.Backend.Name }}-{{ $sniServer.Backend.Port }};
+    {{ end }}
+    }
+
+    {{ range $i, $sniServer := .SNIBackends }}
+    upstream sni-{{ $sniServer.Port }}-{{ $sniServer.Backend.Namespace }}-{{ $sniServer.Backend.Name }}-{{ $sniServer.Backend.Port }} {
+    {{ range $j, $endpoint := $sniServer.Endpoints }}
+        server                  {{ $endpoint.Address }}:{{ $endpoint.Port }};
+    {{ end }}
+    }
+    {{ end }}
+
+    proxy_protocol on;
+    proxy_timeout 305;
+
+    server {
+        listen 8443 reuseport;
+        ssl_preread on;
+        proxy_pass $name;
+        proxy_timeout 305;
+    }
+
 
     # UDP services
     {{ range $i, $udpServer := .UDPBackends }}

--- a/core/pkg/ingress/controller/launch.go
+++ b/core/pkg/ingress/controller/launch.go
@@ -60,6 +60,15 @@ func NewIngressController(backend ingress.Controller) *GenericController {
 		number of the name of the port.
 		The ports 80 and 443 are not allowed as external ports. This ports are reserved for the backend`)
 
+		sniConfigMapName = flags.String("sni-services-configmap", "",
+			`Name of the ConfigMap that contains the definition of the SNI services to expose.
+		The key in the map indicates the SNI name to look for in a TLS client
+		hello and the external port to be used. The value is the name of the
+		service with the format namespace/serviceName and the port of the
+		service could be a number of the name of the port. The ports 80 and 443
+		are not allowed as external ports. This ports are reserved for the
+		backend`)
+
 		udpConfigMapName = flags.String("udp-services-configmap", "",
 			`Name of the ConfigMap that contains the definition of the UDP services to expose.
 		The key in the map indicates the external port to be used. The value is the name of the
@@ -180,6 +189,7 @@ func NewIngressController(backend ingress.Controller) *GenericController {
 		Namespace:               *watchNamespace,
 		ConfigMapName:           *configMap,
 		TCPConfigMapName:        *tcpConfigMapName,
+		SNIConfigMapName:        *sniConfigMapName,
 		UDPConfigMapName:        *udpConfigMapName,
 		DefaultSSLCertificate:   *defSSLCertificate,
 		DefaultHealthzURL:       *defHealthzURL,

--- a/core/pkg/ingress/types.go
+++ b/core/pkg/ingress/types.go
@@ -140,6 +140,9 @@ type Configuration struct {
 	// TCPEndpoints contain endpoints for tcp streams handled by this backend
 	// +optional
 	TCPEndpoints []L4Service `json:"tcpEndpoints,omitempty"`
+	// SNIEndpoints contain endpoints for SNI streams handled by this backend
+	// +optional
+	SNIEndpoints []L4Service `json:"sniEndpoints,omitempty"`
 	// UDPEndpoints contain endpoints for udp streams handled by this backend
 	// +optional
 	UDPEndpoints []L4Service `json:"udpEndpoints,omitempty"`
@@ -349,7 +352,7 @@ type L4Service struct {
 	// Backend of the service
 	Backend L4Backend `json:"backend"`
 	// Endpoints active endpoints of the service
-	Endpoints []Endpoint `json:"endpoins,omitEmpty"`
+	Endpoints []Endpoint `json:"endpoints,omitEmpty"`
 }
 
 // L4Backend describes the kubernetes service behind L4 Ingress service
@@ -360,4 +363,6 @@ type L4Backend struct {
 	Protocol  api.Protocol       `json:"protocol"`
 	// +optional
 	UseProxyProtocol bool `json:"useProxyProtocol"`
+	// +optional This is the name we'll route SNI requests on when proto is SNI
+	ServerName string `json:"servername"`
 }

--- a/core/pkg/ingress/types_equals.go
+++ b/core/pkg/ingress/types_equals.go
@@ -505,6 +505,12 @@ func (l4b1 *L4Backend) Equal(l4b2 *L4Backend) bool {
 	if l4b1.Protocol != l4b2.Protocol {
 		return false
 	}
+	if l4b1.ServerName != l4b2.ServerName {
+		return false
+	}
+	if l4b1.UseProxyProtocol != l4b2.UseProxyProtocol {
+		return false
+	}
 
 	return true
 }

--- a/core/pkg/ingress/types_equals.go
+++ b/core/pkg/ingress/types_equals.go
@@ -100,6 +100,23 @@ func (c1 *Configuration) Equal(c2 *Configuration) bool {
 		}
 	}
 
+	if len(c1.SNIEndpoints) != len(c2.SNIEndpoints) {
+		return false
+	}
+
+	for _, sni1 := range c1.SNIEndpoints {
+		found := false
+		for _, sni2 := range c2.SNIEndpoints {
+			if (&sni1).Equal(&sni2) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+
 	if len(c1.UDPEndpoints) != len(c2.UDPEndpoints) {
 		return false
 	}

--- a/vendor/k8s.io/api/core/v1/types.go
+++ b/vendor/k8s.io/api/core/v1/types.go
@@ -847,6 +847,8 @@ type Protocol string
 const (
 	// ProtocolTCP is the TCP protocol.
 	ProtocolTCP Protocol = "TCP"
+	// ProtocolSNI is the TCP protocol where we will inspect the TLS client hello for name information.
+	ProtocolSNI Protocol = "SNI"
 	// ProtocolUDP is the UDP protocol.
 	ProtocolUDP Protocol = "UDP"
 )


### PR DESCRIPTION
I want to preface this by saying that this is a disgusting pile of a diff here. The purpose of me sharing this commit is to share how I'm using the project and possibly spawn conversation.

I was a little surprised to learn that the current SNI routing system implemented by this project is not actually leveraging nginx at all, but is entirely done in golang. I simply was unwilling to connect the current ingress sni routing feature to the Internet. nginx, however, is tried and true and supports SNI routing.

I modeled this change after the TCP l4 stuff that already exists, there's a fair bit of copy-pasta in here.

I also really wanted to leverage the serviceUpstream change that is reasonably recent to the project. My deployment of Kubernetes relies on having persistent connections last as long as possible because TLS handshakes are expensive. During deployments every time the "pod topology" changed (i.e. anytime a pod changed status) nginx would reload it's configuration and recycle, ultimately nuking all open connections. Using serviceUpstream we are ~never reloading our nginx config and therefore aren't artificially terminating connections.

Again, I don't expect this code to ever get merged, at least not as-is. I just wanted the maintainers to be able to see how we're using the project.

Since you might be wondering why I would deploy code that I don't want merged upstream: we're expecting to migrate away from SNI routing ~soon. This is a stopgap (prior to this we were SNI routing with haproxy and code that looks like an ingress controller but that predates ingress controllers).

