### PR TITLE
Compute a real `X-Forwarded-For` header

### DIFF
--- a/docs/user-guide/configmap.md
+++ b/docs/user-guide/configmap.md
@@ -72,7 +72,7 @@ _References:_
 
 #### proxy-body-size
 
-Sets the maximum allowed size of the client request body. 
+Sets the maximum allowed size of the client request body.
 See NGINX [client_max_body_size](http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size).
 
 #### proxy-buffer-size
@@ -237,7 +237,7 @@ By default this is enabled.
 
 #### map-hash-bucket-size
 
-Sets the bucket size for the [map variables hash tables](http://nginx.org/en/docs/http/ngx_http_map_module.html#map_hash_bucket_size). 
+Sets the bucket size for the [map variables hash tables](http://nginx.org/en/docs/http/ngx_http_map_module.html#map_hash_bucket_size).
 The details of setting up hash tables are provided in a separate [document](http://nginx.org/en/docs/hash.html).
 
 #### ssl-buffer-size
@@ -248,7 +248,7 @@ https://www.igvita.com/2013/12/16/optimizing-nginx-tls-time-to-first-byte/
 
 #### ssl-ciphers
 
-Sets the [ciphers](http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_ciphers) list to enable. 
+Sets the [ciphers](http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_ciphers) list to enable.
 The ciphers are specified in the format understood by the OpenSSL library.
 
 The default cipher list is:
@@ -336,7 +336,7 @@ See [ngx_http_access_module](http://nginx.org/en/docs/http/ngx_http_access_modul
 
 #### worker-processes
 
-Sets the number of [worker processes](http://nginx.org/en/docs/ngx_core_module.html#worker_processes). 
+Sets the number of [worker processes](http://nginx.org/en/docs/ngx_core_module.html#worker_processes).
 The default of "auto" means number of available CPU cores.
 
 #### worker-shutdown-timeout
@@ -375,6 +375,10 @@ Default: ""
 
 Adds custom configuration to all the locations in the nginx configuration
 Default: ""
+
+#### compute-full-forwarded-for
+
+Append the remote address to the X-Forwarded-For header instead of replacing it. When this option is enabled, the upstream application is responsible for extracting the client IP based on its own list of trusted proxies.
 
 ### Opentracing
 

--- a/pkg/nginx/config/config.go
+++ b/pkg/nginx/config/config.go
@@ -386,6 +386,10 @@ type Configuration struct {
 	// Default is X-Forwarded-For
 	ForwardedForHeader string `json:"forwarded-for-header,omitempty"`
 
+	// Append the remote address to the X-Forwarded-For header instead of replacing it
+	// Default: false
+	ComputeFullForwardedFor bool `json:"compute-full-forwarded-for,omitempty"`
+
 	// EnableOpentracing enables the nginx Opentracing extension
 	// https://github.com/rnburn/nginx-opentracing
 	// By default this is disabled
@@ -428,6 +432,7 @@ func NewDefault() Configuration {
 		EnableUnderscoresInHeaders: false,
 		ErrorLogLevel:              errorLevel,
 		ForwardedForHeader:         "X-Forwarded-For",
+		ComputeFullForwardedFor:    false,
 		HTTP2MaxFieldSize:          "4k",
 		HTTP2MaxHeaderSize:         "16k",
 		HSTS:                       true,

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -210,6 +210,13 @@ http {
         ''               $host;
     }
 
+    # We can't use $proxy_add_x_forwarded_for because the realip module
+    # replaces the remote_addr to soon
+    map $http_x_forwarded_for $the_real_x_forwarded_for {
+        default          "$http_x_forwarded_for, $realip_remote_addr";
+        ''               "$realip_remote_addr";
+    }
+
     server_name_in_redirect off;
     port_in_redirect        off;
 
@@ -742,7 +749,7 @@ stream {
             proxy_set_header                        Connection        $connection_upgrade;
 
             proxy_set_header X-Real-IP              $the_real_ip;
-            proxy_set_header X-Forwarded-For        $the_real_ip;
+            proxy_set_header X-Forwarded-For        $the_real_x_forwarded_for;
             proxy_set_header X-Forwarded-Host       $best_http_host;
             proxy_set_header X-Forwarded-Port       $pass_port;
             proxy_set_header X-Forwarded-Proto      $pass_access_scheme;

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -210,12 +210,14 @@ http {
         ''               $host;
     }
 
+    {{ if $cfg.ComputeFullForwardedFor }}
     # We can't use $proxy_add_x_forwarded_for because the realip module
-    # replaces the remote_addr to soon
-    map $http_x_forwarded_for $the_real_x_forwarded_for {
+    # replaces the remote_addr too soon
+    map $http_x_forwarded_for $full_x_forwarded_for {
         default          "$http_x_forwarded_for, $realip_remote_addr";
         ''               "$realip_remote_addr";
     }
+    {{ end }}
 
     server_name_in_redirect off;
     port_in_redirect        off;
@@ -749,7 +751,11 @@ stream {
             proxy_set_header                        Connection        $connection_upgrade;
 
             proxy_set_header X-Real-IP              $the_real_ip;
-            proxy_set_header X-Forwarded-For        $the_real_x_forwarded_for;
+            {{ if $all.Cfg.ComputeFullForwardedFor }}
+            proxy_set_header X-Forwarded-For        $full_x_forwarded_for;
+            {{ else }}
+            proxy_set_header X-Forwarded-For        $the_real_ip;
+            {{ end }}
             proxy_set_header X-Forwarded-Host       $best_http_host;
             proxy_set_header X-Forwarded-Port       $pass_port;
             proxy_set_header X-Forwarded-Proto      $pass_access_scheme;


### PR DESCRIPTION
Hi !
It's great that the real-ip module has been built in the Ingress. It simplifies the work of a lot of applications by extracting the real client ip automatically for them, avoid the hassle of implementing this is a lot of different languages.

However, the `X-Forwarded-For` header is supposed to contain all the L7 LB or Reverse-proxies that have been crossed, from the client to the application. Of course this information could still be computed by appending `remote_addr` to the `X-Original-Forwarded-For` header on the server side, but it sounds a bit weird.

I would expect the Ingress to behave as any classic reverse-proxy installation, but maybe my "classic" picture is wrong. 

On the other hand, if you are only interested in having the real client IP and you extract it from the `x-forwarded-for` header, since you already trust the Ingress it should not be an issue to loose the addresses of other L7 reverse-proxy that have been traversed.