### PR TITLE
Enable modsecurity feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ IMAGE = $(REGISTRY)/$(IMGNAME)
 MULTI_ARCH_IMG = $(IMAGE)-$(ARCH)
 
 # Set default base image dynamically for each arch
-BASEIMAGE?=gcr.io/google_containers/nginx-slim-$(ARCH):0.25
+BASEIMAGE?=gcr.io/google_containers/nginx-slim-$(ARCH):0.26
 
 ifeq ($(ARCH),arm)
     QEMUARCH=arm

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ An Ingress Controller is a daemon, deployed as a Kubernetes Pod, that watches th
 * [TCP Services](#exposing-tcp-services)
 * [UDP Services](#exposing-udp-services)
 * [Proxy Protocol](#proxy-protocol)
+* [ModSecurity Web Application Firewall](#modsecurity-web-application-firewall)
 * [Opentracing](#opentracing)
 * [NGINX customization](configuration.md)
 * [Custom errors](#custom-errors)
@@ -403,7 +404,20 @@ Amongst others [ELBs in AWS](http://docs.aws.amazon.com/ElasticLoadBalancing/lat
 
 Please check the [proxy-protocol](examples/proxy-protocol/) example
 
-### Opentracing
+## ModSecurity Web Application Firewall
+
+ModSecurity is an open source, cross platform web application firewall (WAF) engine for Apache, IIS and Nginx that is developed by Trustwave's SpiderLabs. It has a robust event-based programming language which provides protection from a range of attacks against web applications and allows for HTTP traffic monitoring, logging and real-time analys… https://www.modsecurity.org
+
+The [ModSecurity-nginx](https://github.com/SpiderLabs/ModSecurity-nginx) connector is the connection point between NGINX and libmodsecurity (ModSecurity v3).
+
+The default modsecurity configuration file is located in `/etc/nginx/modsecurity/modsecurity.conf`. This is the only file located in this directory and it contains the default recommended configuration. Using a volume we can replace this file with the desired configuration.
+To enable the modsecurity feature we need to specify `enable-modsecurity: "true"` in the configuration configmap.
+
+The OWASP ModSecurity Core Rule Set (CRS) is a set of generic attack detection rules for use with ModSecurity or compatible web application firewalls. The CRS aims to protect web applications from a wide range of attacks, including the OWASP Top Ten, with a minimum of false alerts.
+The directory `/etc/nginx/owasp-modsecurity-crs` contains the https://github.com/SpiderLabs/owasp-modsecurity-crs repository.
+Using `enable-owasp-modsecurity-crs: "true"` we enable the use of the this rules.
+
+## Opentracing
 
 Using the third party module [rnburn/nginx-opentracing](https://github.com/rnburn/nginx-opentracing) the NGINX ingress controller can configure NGINX to enable [OpenTracing](http://opentracing.io) instrumentation.
 By default this feature is disabled.

--- a/configuration.md
+++ b/configuration.md
@@ -384,6 +384,12 @@ Example usage: `custom-http-errors: 404,415`
 
 **error-log-path:** Error log path. Goes to '/var/log/nginx/error.log' by default. http://nginx.org/en/docs/ngx_core_module.html#error_log
 
+**enable-modsecurity:**  enables the modsecurity module for NGINX
+By default this is disabled
+
+**enable-owasp-modsecurity-crs:** enables the OWASP ModSecurity Core Rule Set (CRS)
+By default this is disabled
+
 **disable-ipv6:** Disable listening on IPV6. This is 'false' by default.
 
 **enable-dynamic-tls-records:** Enables dynamically sized TLS records to improve time-to-first-byte. Enabled by default. See [CloudFlare's blog](https://blog.cloudflare.com/optimizing-tls-over-tcp-to-reduce-latency) for more information.

--- a/pkg/nginx/config/config.go
+++ b/pkg/nginx/config/config.go
@@ -109,6 +109,14 @@ type Configuration struct {
 	// By default this is enabled
 	EnableDynamicTLSRecords bool `json:"enable-dynamic-tls-records"`
 
+	// EnableModsecurity enables the modsecurity module for NGINX
+	// By default this is disabled
+	EnableModsecurity bool `json:"enable-modsecurity"`
+
+	// EnableModsecurity enables the OWASP ModSecurity Core Rule Set (CRS)
+	// By default this is disabled
+	EnableOWASPCoreRules bool `json:"enable-owasp-modsecurity-crs"`
+
 	// ClientHeaderBufferSize allows to configure a custom buffer
 	// size for reading client request header
 	// http://nginx.org/en/docs/http/ngx_http_core_module.html#client_header_buffer_size

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -6,6 +6,11 @@
 {{ $backends := .Backends }}
 {{ $proxyHeaders := .ProxySetHeaders }}
 {{ $addHeaders := .AddHeaders }}
+
+{{ if $cfg.EnableModsecurity }}
+load_module /etc/nginx/modules/ngx_http_modsecurity_module.so;
+{{ end }}
+
 daemon off;
 
 worker_processes {{ $cfg.WorkerProcesses }};
@@ -655,10 +660,7 @@ stream {
             set $target {{ $location.ExternalAuth.URL }};
             proxy_pass $target;
         }
-
         {{ end }}
-
-
         location {{ $path }} {
             {{ if $all.Cfg.EnableVtsStatus }}{{ if $location.VtsFilterKey }} vhost_traffic_status_filter_by_set_key {{ $location.VtsFilterKey }};{{ end }}{{ end }}
 
@@ -675,6 +677,15 @@ stream {
             if ($pass_access_scheme = http) {
                 return 301 https://$best_http_host$request_uri;
             }
+            {{ end }}
+
+            {{ if $all.Cfg.EnableModsecurity }}
+            modsecurity on;
+
+            modsecurity_rules_file /etc/nginx/modsecurity/modsecurity.conf;
+            {{ if $all.Cfg.EnableOWASPCoreRules }}
+            modsecurity_rules_file /etc/nginx/owasp-modsecurity-crs/nginx-modsecurity.conf;
+            {{ end }}
             {{ end }}
 
             {{ if isLocationAllowed $location }}
@@ -821,6 +832,7 @@ stream {
             return 503;
             {{ end }}
         }
+        
         {{ end }}
 
         {{ if eq $server.Hostname "_" }}


### PR DESCRIPTION
Temporal image: `quay.io/aledbf/nginx-ingress-controller:0.262`

fixes #116

