### PR TITLE
Update example URLs after nginx is the only implementation in repo

### DIFF
--- a/examples/daemonset/README.md
+++ b/examples/daemonset/README.md
@@ -7,7 +7,7 @@ In some cases, the Ingress controller will be required to be run at all the node
 The default backend is a service of handling all url paths and hosts the nginx controller doesn't understand. Deploy the default-http-backend as follow:
 
 ```console
-$ kubectl apply -f ../../deployment/nginx/default-backend.yaml 
+$ kubectl apply -f ../../deployment/default-backend.yaml
 deployment "default-http-backend" configured
 service "default-http-backend" configured
 

--- a/examples/deployment/kubeadm/README.md
+++ b/examples/deployment/kubeadm/README.md
@@ -17,7 +17,7 @@ The Nginx Ingress Controller uses nginx (surprisingly!) to loadbalance requests 
 ports 80 and 443 to Services in the cluster.
 
 ```console
-$ kubectl apply -f https://rawgit.com/kubernetes/ingress/master/examples/deployment/nginx/kubeadm/nginx-ingress-controller.yaml
+$ kubectl apply -f https://rawgit.com/kubernetes/ingress/master/examples/deployment/kubeadm/nginx-ingress-controller.yaml
 deployment "default-http-backend" created
 service "default-http-backend" created
 deployment "nginx-ingress-controller" created

--- a/examples/rbac/README.md
+++ b/examples/rbac/README.md
@@ -89,12 +89,12 @@ change as well.
 `ClusterRoleBinding`, and `RoleBinding`.
 
 ```sh
-kubectl create -f https://raw.githubusercontent.com/kubernetes/ingress/master/examples/rbac/nginx/nginx-ingress-controller-rbac.yml
+kubectl create -f https://raw.githubusercontent.com/kubernetes/ingress/master/examples/rbac/nginx-ingress-controller-rbac.yml
 ```
 
 2. Create default backend
 ```sh
-kubectl create -f https://raw.githubusercontent.com/kubernetes/ingress/master/examples/rbac/nginx/default-backend.yml
+kubectl create -f https://raw.githubusercontent.com/kubernetes/ingress/master/examples/rbac/default-backend.yml
 ```
 
 3. Create the nginx-ingress-controller
@@ -102,7 +102,7 @@ kubectl create -f https://raw.githubusercontent.com/kubernetes/ingress/master/ex
 For this example to work, the Service must be in the nginx-ingress namespace:
 
 ```sh
-kubectl create -f https://raw.githubusercontent.com/kubernetes/ingress/master/examples/rbac/nginx/nginx-ingress-controller.yml
+kubectl create -f https://raw.githubusercontent.com/kubernetes/ingress/master/examples/rbac/nginx-ingress-controller.yml
 ```
 
 The serviceAccountName associated with the containers in the deployment must
@@ -112,5 +112,5 @@ should be in the nginx-ingress namespace.
 
 4. Create ingress service
 ```sh
-kubectl create -f https://raw.githubusercontent.com/kubernetes/ingress/master/examples/rbac/nginx/nginx-ingress-controller-service.yml
+kubectl create -f https://raw.githubusercontent.com/kubernetes/ingress/master/examples/rbac/nginx-ingress-controller-service.yml
 ```

--- a/examples/scaling-deployment/README.md
+++ b/examples/scaling-deployment/README.md
@@ -7,7 +7,7 @@ This example aims to demonstrate the Deployment of multi nginx ingress controlle
 The default backend is a service of handling all url paths and hosts the nginx controller doesn't understand. Deploy the default-http-backend as follow:
 
 ```console
-$ kubectl apply -f ../../deployment/nginx/default-backend.yaml 
+$ kubectl apply -f ../../deployment/default-backend.yaml
 deployment "default-http-backend" configured
 service "default-http-backend" configured
 


### PR DESCRIPTION
I have been going through some examples and found out that some URLs are not working properly, I guess these ale leftovers from #1494 and #1497.

(My CLA is probably not signed yet, ended up in `There are no servers available for serving this page. We are currently aware of the problem and are working to fix it. We apologize for the inconvenience.`)