### PR TITLE
fix deprecated ssl_client_cert. add ssl_client_verify header

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -741,7 +741,8 @@ stream {
 
             # Pass the extracted client certificate to the backend
             {{ if not (empty $server.CertificateAuth.CAFileName) }}
-            proxy_set_header ssl-client-cert        $ssl_client_cert;
+            proxy_set_header ssl-client-cert        $ssl_client_escaped_cert;
+            proxy_set_header ssl-client-verify      $ssl_client_verify;
             {{ end }}
 
             # Allow websocket connections


### PR DESCRIPTION
(1) The `ssl_client_cert` header is deprecated. Use `ssl_client_escaped_cert` instead. [Reference](http://nginx.org/en/docs/http/ngx_http_ssl_module.html#var_ssl_client_cert)
(2) Setting the `ssl-client-verify` header allows client certificate verification. See [docs](http://nginx.org/en/docs/http/ngx_http_ssl_module.html#var_ssl_client_verify) 
