### PR TITLE
Return 503 by default when no endpoint is available

### DIFF
--- a/pkg/ingress/controller/controller.go
+++ b/pkg/ingress/controller/controller.go
@@ -603,8 +603,8 @@ func (ic *GenericController) getBackendServers(ingresses []*extensions.Ingress) 
 			for _, location := range server.Locations {
 				if upstream.Name == location.Backend {
 					if len(upstream.Endpoints) == 0 {
-						glog.V(3).Infof("upstream %v does not have any active endpoints. Using default backend", upstream.Name)
-						location.Backend = "upstream-default-backend"
+						glog.V(3).Infof("upstream %v does not have any active endpoints.", upstream.Name)
+						location.Backend = ""
 
 						// check if the location contains endpoints and a custom default backend
 						if location.DefaultBackend != nil {

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -592,7 +592,7 @@ stream {
         ssl_certificate                         {{ $server.SSLCertificate }};
         ssl_certificate_key                     {{ $server.SSLCertificate }};
         {{ if not (empty $server.SSLFullChainCertificate)}}
-        ssl_trusted_certificate                 {{ $server.SSLFullChainCertificate }};        
+        ssl_trusted_certificate                 {{ $server.SSLFullChainCertificate }};
         ssl_stapling                            on;
         ssl_stapling_verify                     on;
         {{ end }}
@@ -616,7 +616,7 @@ stream {
         {{ if not (empty $server.ServerSnippet) }}
         {{ $server.ServerSnippet }}
         {{ end }}
-        
+
         {{ range $location := $server.Locations }}
         {{ $path := buildLocation $location }}
         {{ $authPath := buildAuthLocation $location }}
@@ -808,7 +808,13 @@ stream {
             proxy_set_header       X-Service-Name     $service_name;
             {{ end }}
 
+
+            {{ if not (empty $location.Backend) }}
             {{ buildProxyPass $server.Hostname $all.Backends $location }}
+            {{ else }}
+            # No endpoints available for the request
+            return 503;
+            {{ end }}
             {{ else }}
             # Location denied. Reason: {{ $location.Denied }}
             return 503;


### PR DESCRIPTION
```release-note
Return 503 by default when no endpoint is available
```

**What this PR does / why we need it**:
This PRs changes the backend of a location to be empty per default instead of "upstream-default-backend". During template rendering, if the backend of a location is empty, a `503` is returned to the client.

**Which issue this PR fixes**
Currently, if no endpoint is available for an upstream, the backends of locations using that upstream will be set to the default-backend. 

This means that a client might get a `404`under heavy load when no end-points are available. This sound wrong has clients interpret `404` as a valid response meaning the resource doesn't exist. I think that instead of a `404`, the answer should be a `503 Service Unavailable` (*The server is currently unable to handle the request*).

The definition of the default backend from the documentation says it's **a service [for] handling all url paths and hosts the nginx controller doesn't understand.**

I think that perfectly fine and would like not to use it anymore for upstreams without endpoints, which the Nginx Controller knows about but are simply temporarily unavailable.

**Special notes for your reviewer**
I didn't tested the behavior when using a `custom-default-backend`, but I expect it to be unchanged by this PR.
