### PR TITLE
Allow usage of non_idempotent option in proxy_next_upstream

### DIFF
--- a/docs/user-guide/annotations.md
+++ b/docs/user-guide/annotations.md
@@ -28,6 +28,7 @@ The following annotations are supported:
 |[ingress.kubernetes.io/proxy-connect-timeout](#custom-timeouts)|number|
 |[ingress.kubernetes.io/proxy-send-timeout](#custom-timeouts)|number|
 |[ingress.kubernetes.io/proxy-read-timeout](#custom-timeouts)|number|
+|[ingress.kubernetes.io/proxy-next-upstream](#custom-timeouts)|string|
 |[ingress.kubernetes.io/proxy-request-buffering](#custom-timeouts)|string|
 |[ingress.kubernetes.io/rewrite-target](#rewrite)|URI|
 |[ingress.kubernetes.io/secure-backends](#secure-backends)|true or false|
@@ -313,6 +314,7 @@ In some scenarios is required to have different values. To allow this we provide
 - `ingress.kubernetes.io/proxy-connect-timeout`
 - `ingress.kubernetes.io/proxy-send-timeout`
 - `ingress.kubernetes.io/proxy-read-timeout`
+- `ingress.kubernetes.io/proxy-next-upstream`
 - `ingress.kubernetes.io/proxy-request-buffering`
 
 ### Custom max body size

--- a/pkg/nginx/template/template_test.go
+++ b/pkg/nginx/template/template_test.go
@@ -311,13 +311,40 @@ func TestBuildResolvers(t *testing.T) {
 }
 
 func TestBuildNextUpstream(t *testing.T) {
-	nextUpstream := "timeout http_500 http_502 non_idempotent"
-	validNextUpstream := "timeout http_500 http_502"
+	cases := map[string]struct {
+		NextUpstream  string
+		NonIdempotent bool
+		Output        string
+	}{
+		"default": {
+			"timeout http_500 http_502",
+			false,
+			"timeout http_500 http_502",
+		},
+		"global": {
+			"timeout http_500 http_502",
+			true,
+			"timeout http_500 http_502 non_idempotent",
+		},
+		"local": {
+			"timeout http_500 http_502 non_idempotent",
+			false,
+			"timeout http_500 http_502 non_idempotent",
+		},
+	}
 
-	buildNextUpstream := buildNextUpstream(nextUpstream)
-
-	if buildNextUpstream != validNextUpstream {
-		t.Errorf("Expected '%v' but returned '%v'", validNextUpstream, buildNextUpstream)
+	for k, tc := range cases {
+		nextUpstream := buildNextUpstream(tc.NextUpstream, tc.NonIdempotent)
+		if nextUpstream != tc.Output {
+			t.Errorf(
+				"%s: called buildNextUpstream('%s', %v); expected '%v' but returned '%v'",
+				k,
+				tc.NextUpstream,
+				tc.NonIdempotent,
+				tc.Output,
+				nextUpstream,
+			)
+		}
 	}
 }
 

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -788,7 +788,7 @@ stream {
             proxy_cookie_path                       {{ $location.Proxy.CookiePath }};
 
             # In case of errors try the next upstream server before returning an error
-            proxy_next_upstream                     {{ buildNextUpstream $location.Proxy.NextUpstream }}{{ if $all.Cfg.RetryNonIdempotent }} non_idempotent{{ end }};
+            proxy_next_upstream                     {{ buildNextUpstream $location.Proxy.NextUpstream $all.Cfg.RetryNonIdempotent }};
 
             {{/* rewrite only works if the content is not compressed */}}
             {{ if $location.Rewrite.AddBaseURL }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows usage of `non_idempotent` option in `ingress.kubernetes.io/proxy-next-upstream` annotation, with fallback to global `retry-non-idempotent` option.

**Which issue this PR fixes**: fixes #1512 

**Special notes for your reviewer**:
I've also added `ingress.kubernetes.io/proxy-next-upstream` annotation to annotations table in configuration.md