### PR TITLE
Change alias behaviour not to create new server section needlessly

### DIFF
--- a/configuration.md
+++ b/configuration.md
@@ -201,7 +201,7 @@ For more information please check https://enable-cors.org/server_nginx.html
 ### Server Alias
 
 To add Server Aliases to an Ingress rule add the annotation `ingress.kubernetes.io/server-alias: "<alias>"`.
-This will create a server with the same configuration, but a different server_name as the provided host.
+This will create a server with two server_names (hostname and alias)
 
 *Note:* A server-alias name cannot conflict with the hostname of an existing server. If it does the server-alias
 annotation will be ignored. If a server-alias is created and later a new server with the same hostname is created

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -362,26 +362,12 @@ http {
     {{ range $index, $server := $servers }}
 
     server {
-        server_name {{ $server.Hostname }};
+        server_name {{ $server.Hostname }} {{ $server.Alias }};
         {{ template "SERVER" serverConfig $all $server }}
 
 
         {{ template "CUSTOM_ERRORS" $all }}
     }
-
-    {{ if $server.Alias }}
-    server {
-        server_name {{ $server.Alias }};
-        {{ template "SERVER" serverConfig $all $server }}
-
-        {{ if not (empty $cfg.ServerSnippet) }}
-        # Custom code snippet configured in the configuration configmap
-        {{ $cfg.ServerSnippet }}
-        {{ end }}
-
-        {{ template "CUSTOM_ERRORS" $all }}
-    }
-    {{ end }}
     {{ end }}
 
     # default server, used for NGINX healthcheck and access to nginx stats


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
It simplifies alias configuration in nginx template.

**Special notes for your reviewer**:
I was going through the template code and this section didn't make much sense to me. I would expect it to be defined like in my PR but there could be some reason behind it that I am missing. 
