### PR TITLE
Add option to disable OCSP stapling

### DIFF
--- a/configuration.md
+++ b/configuration.md
@@ -502,6 +502,9 @@ https://www.openssl.org/docs/manmaster/apps/dhparam.html
 https://wiki.mozilla.org/Security/Server_Side_TLS#DHE_handshake_and_dhparam
 http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_dhparam
 
+**ssl-enable-ocsp:** Enable the stapling of OCSP responses. Ingress must have internet access when this option is enabled
+http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_stapling
+
 **ssl-protocols:** Sets the [SSL protocols](http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_protocols) to use.
 The default is: `TLSv1.2`.
 
@@ -615,6 +618,7 @@ The following table shows the options, the default value and a description.
 |ssl-buffer-size|4k|
 |ssl-ciphers||
 |ssl-dh-param|value from openssl|
+|ssl-enable-ocsp|"true"
 |ssl-protocols|TLSv1 TLSv1.1 TLSv1.2|
 |ssl-session-cache|"true"|
 |ssl-session-cache-size|10m|

--- a/pkg/nginx/config/config.go
+++ b/pkg/nginx/config/config.go
@@ -289,6 +289,11 @@ type Configuration struct {
 	// http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_dhparam
 	SSLDHParam string `json:"ssl-dh-param,omitempty"`
 
+	// Enables or disables the stapling of OCSP responses to verify Certificates
+	// If enabled, Ingress must have internet access
+	// http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_stapling
+	SSLEnableOCSP bool `json:"ssl-enable-ocsp"`
+
 	// SSL enabled protocols to use
 	// http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_protocols
 	SSLProtocols string `json:"ssl-protocols,omitempty"`
@@ -452,6 +457,7 @@ func NewDefault() Configuration {
 		SSLBufferSize:              sslBufferSize,
 		SSLCiphers:                 sslCiphers,
 		SSLECDHCurve:               "auto",
+		SSLEnableOCSP:              true,
 		SSLProtocols:               sslProtocols,
 		SSLSessionCache:            true,
 		SSLSessionCacheSize:        sslSessionCacheSize,

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -584,8 +584,10 @@ stream {
         ssl_certificate_key                     {{ $server.SSLCertificate }};
         {{ if not (empty $server.SSLFullChainCertificate)}}
         ssl_trusted_certificate                 {{ $server.SSLFullChainCertificate }};
+        {{ if $cfg.SSLEnableOCSP }}
         ssl_stapling                            on;
         ssl_stapling_verify                     on;
+        {{ end }}
         {{ end }}
         {{ end }}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
This PR adds option to disable OCSP stapling. While OCSP stapling is a desired behaviour in secure environments, some controllers doesn't have direct Internet Access and face some issues while starting, because NGINX tries to fetch the OCSP stapling from each SSL chain used.

The default behaviour here is to maintain OCSP enabled, so user must ensure ssl-enable-ocsp is 'false' when He/She doesn't want to enable this feature.

Thanks!


