### PR TITLE
Fix `make container` for OSX.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ all-push: $(addprefix sub-push-,$(ALL_ARCH))
 
 container: .container-$(ARCH)
 .container-$(ARCH):
-	cp -r ./* $(TEMP_DIR)
+	cp -RP ./* $(TEMP_DIR)
 	$(SED_I) 's|BASEIMAGE|$(BASEIMAGE)|g' $(DOCKERFILE)
 	$(SED_I) "s|QEMUARCH|$(QEMUARCH)|g" $(DOCKERFILE)
 	$(SED_I) "s|DUMB_ARCH|$(DUMB_ARCH)|g" $(DOCKERFILE)


### PR DESCRIPTION
Running `make container` won't work on OSX because `cp -r` defaults to not copy symbol links. This changes the `cp` command to use [portable options](https://unix.stackexchange.com/a/18718) so that it will work regardless of platform.

