### PR TITLE
Certificate Auth Bugfix

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -720,8 +720,11 @@ stream {
 
             # Pass the extracted client certificate to the backend
             {{ if not (empty $server.CertificateAuth.CAFileName) }}
-            proxy_set_header ssl-client-cert        $ssl_client_escaped_cert;
+            proxy_set_header ssl-client-cert        $ssl_client_raw_cert;
             proxy_set_header ssl-client-verify      $ssl_client_verify;
+            {{ else }}
+            proxy_set_header ssl-client-cert        "";
+            proxy_set_header ssl-client-verify      "";
             {{ end }}
 
             # Allow websocket connections


### PR DESCRIPTION
**What this PR does / why we need it**: Changes the behaviour of Environment Variables when not using Certificate Authentication 

**Special notes for your reviewer**:

@auhlig Can you please make any comments about this, and also about changing the ssl_client_escaped_cert to ssl_client_raw_cert?

Thanks!
