### PR TITLE
Fix Makefile to work in OSX.

### DIFF
--- a/images/nginx-slim/Makefile
+++ b/images/nginx-slim/Makefile
@@ -17,6 +17,12 @@ TAG ?= 0.27
 REGISTRY ?= gcr.io/google_containers
 ARCH ?= $(shell go env GOARCH)
 ALL_ARCH = amd64 arm arm64 ppc64le
+SED_I?=sed -i
+GOHOSTOS ?= $(shell go env GOHOSTOS)
+
+ifeq ($(GOHOSTOS),darwin)
+  SED_I=sed -i ''
+endif
 
 QEMUVERSION=v2.9.1
 
@@ -59,18 +65,18 @@ all-push: $(addprefix sub-push-,$(ALL_ARCH))
 container: .container-$(ARCH)
 .container-$(ARCH):
 	cp ./* $(TEMP_DIR)
-	cd $(TEMP_DIR) && sed -i 's|BASEIMAGE|$(BASEIMAGE)|g' Dockerfile
-	cd $(TEMP_DIR) && sed -i "s|ARCH|$(QEMUARCH)|g" Dockerfile
+	cd $(TEMP_DIR) && $(SED_I) 's|BASEIMAGE|$(BASEIMAGE)|g' Dockerfile
+	cd $(TEMP_DIR) && $(SED_I) "s|ARCH|$(QEMUARCH)|g" Dockerfile
 
 ifeq ($(ARCH),amd64)
 	# When building "normally" for amd64, remove the whole line, it has no part in the amd64 image
-	cd $(TEMP_DIR) && sed -i "/CROSS_BUILD_/d" Dockerfile
+	cd $(TEMP_DIR) && $(SED_I) "/CROSS_BUILD_/d" Dockerfile
 else
 	# When cross-building, only the placeholder "CROSS_BUILD_" should be removed
 	# Register /usr/bin/qemu-ARCH-static as the handler for ARM binaries in the kernel
 	docker run --rm --privileged multiarch/qemu-user-static:register --reset
 	curl -sSL https://github.com/multiarch/qemu-user-static/releases/download/$(QEMUVERSION)/x86_64_qemu-$(QEMUARCH)-static.tar.gz | tar -xz -C $(TEMP_DIR)
-	cd $(TEMP_DIR) && sed -i "s/CROSS_BUILD_//g" Dockerfile
+	cd $(TEMP_DIR) && $(SED_I) "s/CROSS_BUILD_//g" Dockerfile
 endif
 
 	docker build -t $(MULTI_ARCH_IMG):$(TAG) $(TEMP_DIR)


### PR DESCRIPTION
Updates `images/nginx-slim/Makefile` so that it can work on OS X. It follows the convention used [here](https://github.com/kubernetes/ingress-nginx/blob/master/Makefile) to make the `sed -i` command portable.