### PR TITLE
Only set alias if not already set

### DIFF
--- a/pkg/ingress/controller/controller.go
+++ b/pkg/ingress/controller/controller.go
@@ -998,10 +998,15 @@ func (ic *GenericController) createServers(data []*extensions.Ingress,
 			}
 
 			// setup server aliases
-			servers[host].Alias = aliasAnnotation
 			if aliasAnnotation != "" {
-				if _, ok := aliases[aliasAnnotation]; !ok {
-					aliases[aliasAnnotation] = host
+				if servers[host].Alias == "" {
+					servers[host].Alias = aliasAnnotation
+					if _, ok := aliases[aliasAnnotation]; !ok {
+						aliases[aliasAnnotation] = host
+					}
+				} else {
+					glog.Warningf("ingress %v/%v for host %v contains an Alias but one has already been configured.",
+						ing.Namespace, ing.Name, host)
 				}
 			}
 


### PR DESCRIPTION
If multiple ingress resources are created for the same host, with a server-alias annotation, the most recent ingress is the one that wins - even if this ingress does not have the annotation.

The real world use case that we have hit is using kube-lego. It creates an ingress to authenticate the domain, and this is usually after other ingress resources are deployed. This doesn't have the server-alias annotations that our other ingress resources do - meaning that the server-alias is dropped entirely.

This uses similar logic to the ServerSnippet annotation to resolve the issue, an alternative approach could be to somehow try and merge the alias annotations, but I'm not sure how best to approach that.

I've tested this on our cluster using `rowleyaj/nginx-ingress-controller:0.9.0-beta.15.server-alias`