### PR TITLE
Fix full XFF with PROXY

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -214,8 +214,13 @@ http {
     # We can't use $proxy_add_x_forwarded_for because the realip module
     # replaces the remote_addr too soon
     map $http_x_forwarded_for $full_x_forwarded_for {
+        {{ if $all.Cfg.UseProxyProtocol }}
+        default          "$http_x_forwarded_for, $proxy_protocol_addr";
+        ''               "$proxy_protocol_addr";
+        {{ else }}
         default          "$http_x_forwarded_for, $realip_remote_addr";
         ''               "$realip_remote_addr";
+        {{ end}}
     }
     {{ end }}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The PR #1489 added a new ConfigMap option (`compute-full-forwarded-for`) that allows us to compute a full `X-Forwarded-For` header as described in https://tools.ietf.org/html/rfc7239, section 5.2. With this option enabled, the Nginx Ingress adds the remote IP to the list of IPs (empty or not) of the `X-Forwarded-For` header (header name configurable). This is fine for requests proxied using the HTTP protocol.

When using the PROXY protocol to forward the request to the Nginx Ingress (with `use-proxy-protocol=true` in the Ingress Controller ConfigMap), with the current implementation the remote IP is added to the list, which is the L4 proxy IP. As discussed in #1489, this is not the expected behavior as:
* we loose the address of the client that connected to the L4 proxy
* L4 proxies act on the TCP level and are supposed to be transparent, meaning they don't appear in the `X-Forwarded-For` header

This PR will change the behavior of the Ingress when `compute-full-forwarded-for` and `use-proxy-protocol` are set to true, and adds the client IP as sent in the PROXY protocol to the `X-Forwarded-For` header.
 
 **Example with `compute-full-forwarded-for` enabled**
With `use-proxy-protocol=false`, for a client (ip 1.2.3.4) that makes a request to a L7 load-balancer (ip 10.0.0.1) in front of the Ingress, the `X-Forwarded-For` received by the back-end is `1.2.3.4, 10.0.0.1` (unchanged)

With `use-proxy-protocol=true`, for a client (ip 1.2.3.4) that makes a request to a L4 load-balancer (ip 10.0.0.1) in front of the Ingress, the `X-Forwarded-For` received by the back-end would be `1.2.3.4` with this PR. It would have been `10.0.0.1` without.




**Special notes for your reviewer**:
I used HAProxy in front of the Ingress to test the behavior with the PROXY protocol. I can post the configuration and yaml file if needed.