### PR TITLE
Add gzip_vary

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -119,6 +119,7 @@ http {
     gzip_min_length 256;
     gzip_types {{ $cfg.GzipTypes }};
     gzip_proxied any;
+    gzip_vary on;
     {{ end }}
 
     # Custom headers for response


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**: Add gzip_vary on;

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: If gzip_vary don't turn on, CDN will cached gzipped response and return gzipped version to request which don't have `Accept-Encoding: gzip` header

**Special notes for your reviewer**:
