### PR TITLE
Add brotli support

### DIFF
--- a/docs/user-guide/configmap.md
+++ b/docs/user-guide/configmap.md
@@ -114,6 +114,18 @@ Setting at least one code also enables [proxy_intercept_errors](http://nginx.org
 
 Example usage: `custom-http-errors: 404,415`
 
+### Other Directives
+
+#### brotli-level
+Sets the Brotli Compression Level that will be used.
+*Defaults to* 4
+
+
+#### brotli-types
+Sets the MIME Types that will be compressed on-the-fly by brotli.
+*Defaults to* `application/xml+rss application/atom+xml application/javascript application/x-javascript application/json application/rss+xml application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/svg+xml image/x-icon text/css text/plain text/x-component`
+
+
 #### enable-modsecurity
 
 Enables the modsecurity module for NGINX
@@ -313,6 +325,15 @@ Sets the number of unsuccessful attempts to communicate with the [server](http:/
 #### upstream-fail-timeout
 
 Sets the time during which the specified number of unsuccessful attempts to communicate with the [server](http://nginx.org/en/docs/http/ngx_http_upstream_module.html#upstream) should happen to consider the server unavailable.
+
+#### use-brotli
+
+Enables or disables compression of HTTP responses using the ["brotli" module](https://github.com/google/ngx_brotli).
+
+The default mime type list to compress is: `application/xml+rss application/atom+xml application/javascript application/x-javascript application/json application/rss+xml application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/svg+xml image/x-icon text/css text/plain text/x-component`.
+
+This is *enabled* by default
+
 
 #### use-gzip
 

--- a/images/nginx-slim/build.sh
+++ b/images/nginx-slim/build.sh
@@ -147,6 +147,11 @@ make install
 
 cd "$BUILD_PATH"
 
+# Get Brotli source and deps
+git clone https://github.com/google/ngx_brotli.git
+cd ngx_brotli && git submodule update --init
+
+
 if [[ ${ARCH} == "x86_64" ]]; then
   # build modsecurity library
   git clone https://github.com/SpiderLabs/ModSecurity
@@ -204,6 +209,7 @@ WITH_MODULES="--add-module=$BUILD_PATH/ngx_devel_kit-$NDK_VERSION \
   --add-module=$BUILD_PATH/nginx-goodies-nginx-sticky-module-ng-$STICKY_SESSIONS_VERSION \
   --add-module=$BUILD_PATH/nginx-http-auth-digest-$NGINX_DIGEST_AUTH \
   --add-module=$BUILD_PATH/ngx_http_substitutions_filter_module-$NGINX_SUBSTITUTIONS \
+  --add-module=$BUILD_PATH/ngx_brotli \
   --add-dynamic-module=$BUILD_PATH/nginx-opentracing-$NGINX_OPENTRACING_VERSION/opentracing \
   --add-dynamic-module=$BUILD_PATH/nginx-opentracing-$NGINX_OPENTRACING_VERSION/zipkin"
 

--- a/pkg/nginx/config/config.go
+++ b/pkg/nginx/config/config.go
@@ -47,6 +47,8 @@ const (
 
 	gzipTypes = "application/atom+xml application/javascript application/x-javascript application/json application/rss+xml application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/svg+xml image/x-icon text/css text/plain text/x-component"
 
+	brotliTypes = "application/xml+rss application/atom+xml application/javascript application/x-javascript application/json application/rss+xml application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/svg+xml image/x-icon text/css text/plain text/x-component"
+
 	logFormatUpstream = `%v - [$the_real_ip] - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" $request_length $request_time [$proxy_upstream_name] $upstream_addr $upstream_response_length $upstream_response_time $upstream_status`
 
 	logFormatStream = `[$time_local] $protocol $status $bytes_sent $bytes_received $session_time`
@@ -331,6 +333,16 @@ type Configuration struct {
 	// http://nginx.org/en/docs/http/ngx_http_gzip_module.html
 	UseGzip bool `json:"use-gzip,omitempty"`
 
+	// Enables or disables the use of the NGINX Brotli Module for compression
+	// https://github.com/google/ngx_brotli
+	UseBrotli bool `json:"use-brotli,omitempty"`
+
+	// Brotli Compression Level that will be used
+	BrotliLevel int `json:"brotli-level,omitempty"`
+
+	// MIME Types that will be compressed on-the-fly using Brotli module
+	BrotliTypes string `json:"brotli-types,omitempty"`
+
 	// Enables or disables the HTTP/2 support in secure connections
 	// http://nginx.org/en/docs/http/ngx_http_v2_module.html
 	// Default: true
@@ -424,6 +436,8 @@ func NewDefault() Configuration {
 		AllowBackendServerHeader:   false,
 		AccessLogPath:              "/var/log/nginx/access.log",
 		ErrorLogPath:               "/var/log/nginx/error.log",
+		BrotliLevel:                4,
+		BrotliTypes:                brotliTypes,
 		ClientHeaderBufferSize:     "1k",
 		ClientHeaderTimeout:        60,
 		ClientBodyBufferSize:       "8k",
@@ -462,6 +476,7 @@ func NewDefault() Configuration {
 		SSLSessionCacheSize:        sslSessionCacheSize,
 		SSLSessionTickets:          true,
 		SSLSessionTimeout:          sslSessionTimeout,
+		UseBrotli:                  true,
 		UseGzip:                    true,
 		WorkerProcesses:            strconv.Itoa(runtime.NumCPU()),
 		WorkerShutdownTimeout:      "10s",

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -112,6 +112,13 @@ http {
 
     include /etc/nginx/mime.types;
     default_type text/html;
+    
+    {{ if $cfg.UseBrotli }}
+    brotli on;
+    brotli_comp_level {{ $cfg.BrotliLevel }};
+    brotli_types {{ $cfg.BrotliTypes }};
+    {{ end }}
+
     {{ if $cfg.UseGzip }}
     gzip on;
     gzip_comp_level 5;


### PR DESCRIPTION
**What this PR does / why we need it**: This PR adds support for Brotli compression.

Brotli is an algorithm designed by Google that have up to 25% of efficience when compared to gzip.

There's more info [here](https://github.com/google/ngx_brotli) and [here](https://certsimple.com/blog/nginx-brotli)

The following tasks need to be executed:
* [x] Add Brotli module to NGINX
* [x] Add ConfigMap annotation to enable brotli, and also the selected mime types that are going to be supported

**Special notes for your reviewer**:
