### PR TITLE
Rename OWNERS assignees: to approvers:

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,4 +1,4 @@
-assignees:
+approvers:
 - aledbf
 - justinsb
 - bprashanth


### PR DESCRIPTION
They are effectively the same, assignees is deprecated

ref: kubernetes/test-infra#3851