### PR TITLE
Split travis jobs to avoid timeouts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 sudo: required
 
 services:
@@ -6,7 +8,9 @@ services:
 language: go
 
 notifications:
-  email: true
+  email:
+    on_failure: always
+    on_success: never
 
 go:
   - 1.9.2
@@ -43,6 +47,20 @@ jobs:
     - test/e2e/up.sh
     script:
     - make e2e-test
-  - stage: publish
+  # split builds to avoid job timeouts
+  - stage: publish amd64
+    if: type = api AND branch = master AND repo = kubernetes/ingress-nginx
     script:
-    - .travis/publish.sh
+    - ARCH=amd64 .travis/publish.sh
+  - stage: publish arm
+    if: type = api AND branch = master AND repo = kubernetes/ingress-nginx
+    script:
+    - ARCH=arm .travis/publish.sh
+  - stage: publish arm64
+    if: type = api AND branch = master AND repo = kubernetes/ingress-nginx
+    script:
+    - ARCH=arm64 .travis/publish.sh
+  - stage: publish ppc64le
+    if: type = api AND branch = master AND repo = kubernetes/ingress-nginx
+    script:
+    - ARCH=ppc64le .travis/publish.sh

--- a/.travis/common.sh
+++ b/.travis/common.sh
@@ -18,7 +18,13 @@ if ! [ -z $DEBUG ]; then
   set -x
 fi
 
+if [ -z $ARCH ]; then
+  echo "Environment variable ARCH is not defined. Aborting.";
+  exit 0;
+fi
+
 echo "COMPONENT:                  $COMPONENT"
+echo "PLATFORM:                   $ARCH"
 echo "TRAVIS_REPO_SLUG:           $TRAVIS_REPO_SLUG"
 echo "TRAVIS_PULL_REQUEST:        $TRAVIS_PULL_REQUEST"
 echo "TRAVIS_EVENT_TYPE:          $TRAVIS_EVENT_TYPE"
@@ -75,7 +81,7 @@ fi
 
 function docker_tag_exists() {
     TAG=${2//\"/}
-    IMAGES=$(curl -s -H "Authorization: Bearer ${QUAY_PASSWORD}" https://quay.io/api/v1/repository/$1/image/ | jq '.images | sort_by(.sort_index) | .[] .tags | select(.[] !=null) | .[0]' | sed s/\"//g)
+    IMAGES=$(curl -s -H "Authorization: Bearer ${QUAY_PASSWORD}" https://quay.io/api/v1/repository/$1-$3/image/ | jq '.images | sort_by(.sort_index) | .[] .tags | select(.[] !=null) | .[0]' | sed s/\"//g)
     if echo "$IMAGES" | grep -q "$TAG" ; then
         return 0
     fi

--- a/.travis/ingress-controller.sh
+++ b/.travis/ingress-controller.sh
@@ -20,10 +20,11 @@ source $DIR/common.sh
 
 IMAGE=$(make -s -C $DIR/../ image-info)
 
-if docker_tag_exists "kubernetes-ingress-controller/nginx-ingress-controller" $(echo $IMAGE | jq .tag); then
+if docker_tag_exists "kubernetes-ingress-controller/nginx-ingress-controller" $(echo $IMAGE | jq .tag) "$ARCH"; then
     echo "Image already published"
     exit 0
 fi
 
-echo "building kubernetes-ingress-controller/nginx-ingress-controller image..."
-make -C $DIR/../ release
+echo "building nginx-ingress-controller-$ARCH image..."
+make -C $DIR/../ sub-container-$ARCH
+make -C $DIR/../ sub-push-$ARCH

--- a/.travis/nginx-slim.sh
+++ b/.travis/nginx-slim.sh
@@ -20,10 +20,11 @@ source $DIR/common.sh
 
 IMAGE=$(make -s -C $DIR/../images/nginx-slim image-info)
 
-if docker_tag_exists "kubernetes-ingress-controller/nginx-slim" $(echo $IMAGE | jq .tag); then
+if docker_tag_exists "kubernetes-ingress-controller/nginx-slim" $(echo $IMAGE | jq .tag) "$ARCH"; then
     echo "Image already published"
     exit 0
 fi
 
-echo "building nginx-slim image..."
-make -C $DIR/../images/nginx-slim release
+echo "building nginx-slim-$ARCH image..."
+make -C $DIR/../images/nginx-slim sub-container-$ARCH
+make -C $DIR/../images/nginx-slim sub-push-$ARCH

--- a/.travis/ubuntu-slim.sh
+++ b/.travis/ubuntu-slim.sh
@@ -20,10 +20,11 @@ source $DIR/common.sh
 
 IMAGE=$(make -s -C $DIR/../images/ubuntu-slim image-info)
 
-if docker_tag_exists "kubernetes-ingress-controller/ubuntu-slim" $(echo $IMAGE | jq .tag); then
+if docker_tag_exists "kubernetes-ingress-controller/ubuntu-slim" $(echo $IMAGE | jq .tag) "$ARCH"; then
     echo "Image already published"
     exit 0
 fi
 
-echo "building ubuntu-slim image..."
-make -C $DIR/../images/ubuntu-slim release
+echo "building ubuntu-slim-$ARCH image..."
+make -C $DIR/../images/ubuntu-slim sub-container-$ARCH
+make -C $DIR/../images/ubuntu-slim sub-push-$ARCH


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR splits the travis jobs to avoid timeouts building the docker images (nginx-slim in particular)