### PR TITLE
Disable brotli temporarily [ci skip]

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -114,9 +114,9 @@ http {
     default_type text/html;
     
     {{ if $cfg.UseBrotli }}
-    brotli on;
-    brotli_comp_level {{ $cfg.BrotliLevel }};
-    brotli_types {{ $cfg.BrotliTypes }};
+#    brotli on;
+#    brotli_comp_level {{ $cfg.BrotliLevel }};
+#    brotli_types {{ $cfg.BrotliTypes }};
     {{ end }}
 
     {{ if $cfg.UseGzip }}


### PR DESCRIPTION
We need to disable brotli until we release nginx-slim 0.28