### PR TITLE
Release nginx ingress controller 0.9-beta.16

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,100 @@
 # Changelog
 
+### 0.9-beta.16
+
+**Image:**  `quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.9.0-beta.16`
+
+*New Features:*
+
+- Images are published to [quay.io](https://quay.io/repository/kubernetes-ingress-controller)
+- NGINX 1.13.6
+- OpenTracing Jaeger support inNGINX
+- [ModSecurity support](https://github.com/SpiderLabs/ModSecurity-nginx)
+- Support for [brotli compression in NGINX](https://certsimple.com/blog/nginx-brotli)
+- Return 503 error instead of 404 when no endpoint is available
+
+*Breaking changes:*
+
+- The default SSL configuration was updated to use `TLSv1.2` and the default cipher list is `ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256`
+
+*Known issues:*
+
+- When ModSecurity is enabled a segfault could occur - [ModSecurity#1590](https://github.com/SpiderLabs/ModSecurity/issues/1590)
+
+*Changes:*
+
+- [X] [#1489](https://github.com/kubernetes/ingress-nginx/pull/1489) Compute a real `X-Forwarded-For` header
+- [X] [#1490](https://github.com/kubernetes/ingress-nginx/pull/1490) Introduce an upstream-hash-by annotation to support consistent hashing by nginx variable or text
+- [X] [#1498](https://github.com/kubernetes/ingress-nginx/pull/1498) Add modsecurity module
+- [X] [#1500](https://github.com/kubernetes/ingress-nginx/pull/1500) Enable modsecurity feature
+- [X] [#1501](https://github.com/kubernetes/ingress-nginx/pull/1501) Request ingress controller version in issue template
+- [X] [#1502](https://github.com/kubernetes/ingress-nginx/pull/1502) Force reload on template change
+- [X] [#1503](https://github.com/kubernetes/ingress-nginx/pull/1503) Add falg to report node internal IP address in ingress status
+- [X] [#1505](https://github.com/kubernetes/ingress-nginx/pull/1505) Increase size of variable hash bucket
+- [X] [#1506](https://github.com/kubernetes/ingress-nginx/pull/1506) Update nginx ssl configuration
+- [X] [#1507](https://github.com/kubernetes/ingress-nginx/pull/1507) Add tls session ticket key setting
+- [X] [#1511](https://github.com/kubernetes/ingress-nginx/pull/1511) fix deprecated ssl_client_cert. add ssl_client_verify header
+- [X] [#1513](https://github.com/kubernetes/ingress-nginx/pull/1513) Return 503 by default when no endpoint is available
+- [X] [#1520](https://github.com/kubernetes/ingress-nginx/pull/1520) Change alias behaviour not to create new server section needlessly
+- [X] [#1523](https://github.com/kubernetes/ingress-nginx/pull/1523) Include the serversnippet from the config map in server blocks
+- [X] [#1533](https://github.com/kubernetes/ingress-nginx/pull/1533) Remove authentication send body annotation
+- [X] [#1535](https://github.com/kubernetes/ingress-nginx/pull/1535) Remove auth-send-body [ci skip]
+- [X] [#1538](https://github.com/kubernetes/ingress-nginx/pull/1538) Rename service-nodeport.yml to service-nodeport.yaml
+- [X] [#1543](https://github.com/kubernetes/ingress-nginx/pull/1543) Fix glog initialization error
+- [X] [#1544](https://github.com/kubernetes/ingress-nginx/pull/1544) Fix `make container` for OSX.
+- [X] [#1547](https://github.com/kubernetes/ingress-nginx/pull/1547) fix broken GCE-GKE service descriptor
+- [X] [#1550](https://github.com/kubernetes/ingress-nginx/pull/1550) Add e2e tests - default backend
+- [X] [#1553](https://github.com/kubernetes/ingress-nginx/pull/1553) Cors features improvements
+- [X] [#1554](https://github.com/kubernetes/ingress-nginx/pull/1554) Add missing unit test for nextPowerOf2 function
+- [X] [#1556](https://github.com/kubernetes/ingress-nginx/pull/1556) fixed https port forwarding in Azure LB service
+- [X] [#1566](https://github.com/kubernetes/ingress-nginx/pull/1566) Release nginx-slim 0.27
+- [X] [#1568](https://github.com/kubernetes/ingress-nginx/pull/1568) update defaultbackend tag
+- [X] [#1569](https://github.com/kubernetes/ingress-nginx/pull/1569) Update 404 server image
+- [X] [#1570](https://github.com/kubernetes/ingress-nginx/pull/1570) Update nginx version
+- [X] [#1571](https://github.com/kubernetes/ingress-nginx/pull/1571) Fix cors tests
+- [X] [#1572](https://github.com/kubernetes/ingress-nginx/pull/1572) Certificate Auth Bugfix
+- [X] [#1577](https://github.com/kubernetes/ingress-nginx/pull/1577) Do not use relative urls for yaml files
+- [X] [#1580](https://github.com/kubernetes/ingress-nginx/pull/1580) Upgrade to use the latest version of nginx-opentracing.
+- [X] [#1581](https://github.com/kubernetes/ingress-nginx/pull/1581) Fix Makefile to work in OSX.
+- [X] [#1582](https://github.com/kubernetes/ingress-nginx/pull/1582) Add scripts to release from travis-ci
+- [X] [#1584](https://github.com/kubernetes/ingress-nginx/pull/1584) Add missing probes in deployments
+- [X] [#1585](https://github.com/kubernetes/ingress-nginx/pull/1585) Add version flag
+- [X] [#1587](https://github.com/kubernetes/ingress-nginx/pull/1587) Use pass access scheme in signin url
+- [X] [#1589](https://github.com/kubernetes/ingress-nginx/pull/1589) Fix upstream vhost Equal comparison
+- [X] [#1590](https://github.com/kubernetes/ingress-nginx/pull/1590) Fix Equals Comparison for CORS annotation
+- [X] [#1592](https://github.com/kubernetes/ingress-nginx/pull/1592) Update opentracing module and release image to  quay.io
+- [X] [#1593](https://github.com/kubernetes/ingress-nginx/pull/1593) Fix makefile default task
+- [X] [#1605](https://github.com/kubernetes/ingress-nginx/pull/1605) Fix ExternalName services
+- [X] [#1607](https://github.com/kubernetes/ingress-nginx/pull/1607) Add support for named ports with service-upstream. #1459
+- [X] [#1608](https://github.com/kubernetes/ingress-nginx/pull/1608) Fix issue with clusterIP detection on service upstream. #1534
+- [X] [#1610](https://github.com/kubernetes/ingress-nginx/pull/1610) Only set alias if not already set
+- [X] [#1618](https://github.com/kubernetes/ingress-nginx/pull/1618) Fix full XFF with PROXY
+- [X] [#1620](https://github.com/kubernetes/ingress-nginx/pull/1620) Add gzip_vary
+- [X] [#1621](https://github.com/kubernetes/ingress-nginx/pull/1621) Fix path to ELB listener image
+- [X] [#1627](https://github.com/kubernetes/ingress-nginx/pull/1627) Add brotli support
+- [X] [#1629](https://github.com/kubernetes/ingress-nginx/pull/1629) Add ssl-client-dn header
+- [X] [#1632](https://github.com/kubernetes/ingress-nginx/pull/1632) Rename OWNERS assignees: to approvers:
+- [X] [#1635](https://github.com/kubernetes/ingress-nginx/pull/1635) Install dumb-init using apt-get
+- [X] [#1636](https://github.com/kubernetes/ingress-nginx/pull/1636) Update go to 1.9.2
+- [X] [#1640](https://github.com/kubernetes/ingress-nginx/pull/1640) Update nginx to 0.28 and enable brotli
+
+*Documentation:*
+
+- [X] [#1491](https://github.com/kubernetes/ingress-nginx/pull/1491) Note that GCE has moved to a new repo
+- [X] [#1492](https://github.com/kubernetes/ingress-nginx/pull/1492) Cleanup readme.md
+- [X] [#1494](https://github.com/kubernetes/ingress-nginx/pull/1494) Cleanup
+- [X] [#1497](https://github.com/kubernetes/ingress-nginx/pull/1497) Cleanup examples directory
+- [X] [#1504](https://github.com/kubernetes/ingress-nginx/pull/1504) Clean readme
+- [X] [#1508](https://github.com/kubernetes/ingress-nginx/pull/1508) Fixed link in prometheus example
+- [X] [#1527](https://github.com/kubernetes/ingress-nginx/pull/1527) Split documentation
+- [X] [#1536](https://github.com/kubernetes/ingress-nginx/pull/1536) Update documentation and examples [ci skip]
+- [X] [#1541](https://github.com/kubernetes/ingress-nginx/pull/1541) fix(documentation): Fix some typos
+- [X] [#1548](https://github.com/kubernetes/ingress-nginx/pull/1548) link to prometheus docs
+- [X] [#1562](https://github.com/kubernetes/ingress-nginx/pull/1562) Fix development guide link
+- [X] [#1563](https://github.com/kubernetes/ingress-nginx/pull/1563) Add task to verify markdown links
+- [X] [#1583](https://github.com/kubernetes/ingress-nginx/pull/1583) Add note for certificate authentication in Cloudflare
+- [X] [#1617](https://github.com/kubernetes/ingress-nginx/pull/1617) fix typo in user-guide/annotations.md
+
 ### 0.9-beta.15
 
 **Image:**  `gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.15`

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ all: push
 BUILDTAGS=
 
 # Use the 0.0 tag for testing, it shouldn't clobber any release builds
-TAG?=0.9.0-beta.15
+TAG?=0.9.0-beta.16
 REGISTRY?=quay.io/kubernetes-ingress-controller
 GOOS?=linux
 DOCKER?=gcloud docker --

--- a/deploy/provider/patch-service-with-rbac.yaml
+++ b/deploy/provider/patch-service-with-rbac.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: nginx-ingress-serviceaccount   
       containers:
         - name: nginx-ingress-controller
-          image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.15
+          image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.9.0-beta.16
           args:
             - /nginx-ingress-controller
             - --default-backend-service=$(POD_NAMESPACE)/default-http-backend

--- a/deploy/provider/patch-service-without-rbac.yaml
+++ b/deploy/provider/patch-service-without-rbac.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: nginx-ingress-controller
-          image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.15
+          image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.9.0-beta.16
           args:
             - /nginx-ingress-controller
             - --default-backend-service=$(POD_NAMESPACE)/default-http-backend

--- a/deploy/with-rbac.yaml
+++ b/deploy/with-rbac.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: nginx-ingress-serviceaccount
       containers:
         - name: nginx-ingress-controller
-          image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.15
+          image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.9.0-beta.16
           args:
             - /nginx-ingress-controller
             - --default-backend-service=$(POD_NAMESPACE)/default-http-backend

--- a/deploy/without-rbac.yaml
+++ b/deploy/without-rbac.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: nginx-ingress-controller
-          image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.15
+          image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.9.0-beta.16
           args:
             - /nginx-ingress-controller
             - --default-backend-service=$(POD_NAMESPACE)/default-http-backend

--- a/docs/examples/customization/custom-errors/rc-custom-errors.yaml
+++ b/docs/examples/customization/custom-errors/rc-custom-errors.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 60
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.15
+      - image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.9.0-beta.16
         name: nginx-ingress-lb
         imagePullPolicy: Always
         readinessProbe:

--- a/docs/examples/static-ip/nginx-ingress-controller.yaml
+++ b/docs/examples/static-ip/nginx-ingress-controller.yaml
@@ -18,7 +18,7 @@ spec:
       # hostNetwork: true
       terminationGracePeriodSeconds: 60
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.15
+      - image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.9.0-beta.16
         name: nginx-ingress-controller
         readinessProbe:
           httpGet:


### PR DESCRIPTION
Temporal image:  `quay.io/aledbf/nginx-ingress-controller:0.270`