### PR TITLE
Add better documentation for deploying for dev

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -15,7 +15,11 @@
 - [Verify installation](#verify-installation)
 - [Detect installed version](#detect-installed-version)
 
-## Mandatory commands
+## Generic Deployment 
+
+The following resources are required for a generic deployment.
+
+### Mandatory commands
 
 ```console
 curl https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/namespace.yaml \
@@ -34,14 +38,14 @@ curl https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/ud
     | kubectl apply -f -
 ```
 
-## Install without RBAC roles
+### Install without RBAC roles
 
 ```console
 curl https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/without-rbac.yaml \
     | kubectl apply -f -
 ```
 
-## Install with RBAC roles
+### Install with RBAC roles
 
 Please check the [RBAC](rbac.md) document.
 
@@ -53,14 +57,51 @@ curl https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/wi
     | kubectl apply -f -
 ```
 
-## Custom Service provider
+## Custom Service Provider Deployment
 
-There are cloud provider specific yaml files
+There are cloud provider specific yaml files.
 
 ### minikube
 
+For standard usage:
+
 ```console
 minikube addons enable ingress
+```
+
+For development:
+
+1. Disable the ingress addon:
+
+```console
+$ minikube addons disable ingress
+```
+
+2. Use the [docker daemon](https://github.com/kubernetes/minikube/blob/master/docs/reusing_the_docker_daemon.md)
+3. [Build the image](../docs/development.md)
+4. Perform [Mandatory commands](#mandatory-commands)
+5. Install the `nginx-ingress-controller` deployment [without RBAC roles](#install-without-rbac-roles) or [with RBAC roles](#install-with-rbac-roles)
+6. Edit the `nginx-ingress-controller` deployment to use your custom image. Local images can be seen by performing `docker images`.
+
+```console
+$ kubectl edit deployment nginx-ingress-controller -n ingress-nginx
+```
+
+edit the following section:
+
+```yaml
+image: <IMAGE-NAME>:<TAG>
+imagePullPolicy: IfNotPresent
+name: nginx-ingress-controller
+```
+
+7. Confirm the `nginx-ingress-controller` deployment exists:
+
+```console
+$ kubectl get pods -n ingress-nginx 
+NAME                                       READY     STATUS    RESTARTS   AGE
+default-http-backend-66b447d9cf-rrlf9      1/1       Running   0          12s
+nginx-ingress-controller-fdcdcd6dd-vvpgs   1/1       Running   0          11s
 ```
 
 ### AWS

--- a/docs/development.md
+++ b/docs/development.md
@@ -123,4 +123,3 @@ cherry-picked into a release branch.
 * If you're not confident about the stability of the code,
 [tag](https://help.github.com/articles/working-with-tags/) it as alpha or beta.
 Typically, a release branch should have stable code.
-


### PR DESCRIPTION
Adds more information on deploying an nginx-ingress controller for development. Adds info to the minikube section of deployments which is commonly used for local development.