### PR TITLE
Add the original http request method to the auth request

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -646,6 +646,7 @@ stream {
 
             proxy_set_header            Host                    {{ $location.ExternalAuth.Host }};
             proxy_set_header            X-Original-URL          $scheme://$http_host$request_uri;
+            proxy_set_header            X-Original-Method       $request_method;
             proxy_set_header            X-Auth-Request-Redirect $request_uri;
             proxy_set_header            X-Sent-From             "nginx-ingress-controller";
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Added the original http request method to the auth request. This is for example useful for granting access depending on reads/writes.

```release-note
Access the original http request method in auth subrequests
```