### PR TITLE
Fix merging of ingress-specific annotations.

### DIFF
--- a/pkg/ingress/controller/util.go
+++ b/pkg/ingress/controller/util.go
@@ -51,7 +51,7 @@ func mergeLocationAnnotations(loc *ingress.Location, anns map[string]interface{}
 		loc.Denied = anns[DeniedKeyName].(error)
 	}
 	delete(anns, DeniedKeyName)
-	err := mergo.Map(loc, anns)
+	err := mergo.MapWithOverwrite(loc, anns)
 	if err != nil {
 		glog.Errorf("unexpected error merging extracted annotations in location type: %v", err)
 	}

--- a/pkg/ingress/controller/util_test.go
+++ b/pkg/ingress/controller/util_test.go
@@ -82,6 +82,29 @@ func TestMergeLocationAnnotations(t *testing.T) {
 	}
 }
 
+func TestMergeLocationAnnotationsExisting(t *testing.T) {
+	loc := ingress.Location{
+		IsDefBackend: true,
+		Proxy: proxy.Configuration{ReadTimeout: 60},
+	}
+	annotations := map[string]interface{}{
+		"Proxy": proxy.Configuration{ReadTimeout: 999},
+	}
+
+	mergeLocationAnnotations(&loc, annotations)
+
+	// Existing value should be unmodified.
+	if got, want := loc.IsDefBackend, true; got != want {
+		t.Errorf("loc.IsDefBackend = %v, want %v", got, want)
+	}
+
+	// New value from annotation should be updated.
+	if got, want := loc.Proxy.ReadTimeout, annotations["Proxy"].(proxy.Configuration).ReadTimeout; got != want {
+		t.Errorf("loc.Proxy.ReadTimeout = %v, want %v", got, want)
+	}
+}
+
+
 func TestIntInSlice(t *testing.T) {
 	fooTests := []struct {
 		i    int


### PR DESCRIPTION
```release-note
Fixes application of ingress annotations which were not being applied correctly.
```

Annotations were not overriding the default values for their Location; this was
especially evident on the "/" Location for a host, which gains more defaults
than ancillary Locations.

Also adds a test to detect this case.

Fixes #1660.

As far as I can tell this was introduced by https://github.com/kubernetes/ingress-nginx/commit/601fb7dacfad8c897d5d2edb5c81642c96f60e90 which bumps the version of mergo and changes some of the Map merge logic, but I'm not entirely convinced.