### PR TITLE
Fix use merge of annotations

### DIFF
--- a/internal/ingress/annotations/annotations.go
+++ b/internal/ingress/annotations/annotations.go
@@ -153,7 +153,7 @@ func (e Extractor) Extract(ing *extensions.Ingress) *Ingress {
 		}
 	}
 
-	err := mergo.Map(pia, data)
+	err := mergo.MapWithOverwrite(pia, data)
 	if err != nil {
 		glog.Errorf("unexpected error merging extracted annotations: %v", err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

The library mergo do not overwrites value by default (breaking change introduced in latest version)