### PR TITLE
Disable features not availables in some platforms

### DIFF
--- a/docs/user-guide/configmap.md
+++ b/docs/user-guide/configmap.md
@@ -123,14 +123,23 @@ Example usage: `custom-http-errors: 404,415`
 ### Other Directives
 
 #### brotli-level
+
 Sets the Brotli Compression Level that will be used.
 *Defaults to* 4
 
 
 #### brotli-types
+
 Sets the MIME Types that will be compressed on-the-fly by brotli.
 *Defaults to* `application/xml+rss application/atom+xml application/javascript application/x-javascript application/json application/rss+xml application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/svg+xml image/x-icon text/css text/plain text/x-component`
 
+#### enable-brotli
+
+Enables or disables compression of HTTP responses using the ["brotli" module](https://github.com/google/ngx_brotli).
+
+The default mime type list to compress is: `application/xml+rss application/atom+xml application/javascript application/x-javascript application/json application/rss+xml application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/svg+xml image/x-icon text/css text/plain text/x-component`.
+
+This is *enabled* by default
 
 #### enable-modsecurity
 
@@ -331,14 +340,6 @@ Sets the number of unsuccessful attempts to communicate with the [server](http:/
 #### upstream-fail-timeout
 
 Sets the time during which the specified number of unsuccessful attempts to communicate with the [server](http://nginx.org/en/docs/http/ngx_http_upstream_module.html#upstream) should happen to consider the server unavailable.
-
-#### use-brotli
-
-Enables or disables compression of HTTP responses using the ["brotli" module](https://github.com/google/ngx_brotli).
-
-The default mime type list to compress is: `application/xml+rss application/atom+xml application/javascript application/x-javascript application/json application/rss+xml application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/svg+xml image/x-icon text/css text/plain text/x-component`.
-
-This is *enabled* by default
 
 
 #### use-gzip

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -335,7 +335,7 @@ type Configuration struct {
 
 	// Enables or disables the use of the NGINX Brotli Module for compression
 	// https://github.com/google/ngx_brotli
-	UseBrotli bool `json:"use-brotli,omitempty"`
+	EnableBrotli bool `json:"enable-brotli,omitempty"`
 
 	// Brotli Compression Level that will be used
 	BrotliLevel int `json:"brotli-level,omitempty"`
@@ -476,7 +476,7 @@ func NewDefault() Configuration {
 		SSLSessionCacheSize:        sslSessionCacheSize,
 		SSLSessionTickets:          true,
 		SSLSessionTimeout:          sslSessionTimeout,
-		UseBrotli:                  true,
+		EnableBrotli:               true,
 		UseGzip:                    true,
 		WorkerProcesses:            strconv.Itoa(runtime.NumCPU()),
 		WorkerShutdownTimeout:      "10s",

--- a/internal/ingress/controller/nginx.go
+++ b/internal/ingress/controller/nginx.go
@@ -25,6 +25,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -597,6 +598,15 @@ func (n *NGINXController) OnUpdate(ingressCfg ingress.Configuration) error {
 	}
 
 	cfg.SSLDHParam = sslDHParam
+
+	// disable features are not available in some platforms
+	switch runtime.GOARCH {
+	case "arm", "arm64", "ppc64le":
+		cfg.EnableModsecurity = false
+	case "s390x":
+		cfg.EnableModsecurity = false
+		cfg.EnableBrotli = false
+	}
 
 	tc := ngx_config.TemplateConfig{
 		ProxySetHeaders:         setHeaders,

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -113,7 +113,7 @@ http {
     include /etc/nginx/mime.types;
     default_type text/html;
     
-    {{ if $cfg.UseBrotli }}
+    {{ if $cfg.EnableBrotli }}
     brotli on;
     brotli_comp_level {{ $cfg.BrotliLevel }};
     brotli_types {{ $cfg.BrotliTypes }};


### PR DESCRIPTION
**What this PR does / why we need it**:

Some nginx modules are not available in specific platforms.
This PR disable the features to avoid runtime issues