### PR TITLE
add --report-node-internal-ip-address describe to cli-arguments.md

### DIFF
--- a/docs/user-guide/cli-arguments.md
+++ b/docs/user-guide/cli-arguments.md
@@ -29,6 +29,9 @@ Usage of :
       --publish-service string           Service fronting the ingress controllers. Takes the form
  		namespace/name. The controller will set the endpoint records on the
  		ingress objects to reflect those on the service.
+      --report-node-internal-ip-address bool Falg to report node internal IP address in ingress status (default false). If your
+                node only has internal ip, this should set to true, or thre controller will report empty ips to ingress.
+		use like --report-node-internal-ip-address=true. more detail at https://github.com/kubernetes/ingress-nginx/pull/1503
       --sort-backends                    Defines if backends and it's endpoints should be sorted
       --ssl-passtrough-proxy-port int    Default port to use internally for SSL when SSL Passthgough is enabled (default 442)
       --status-port int                  Indicates the TCP port to use for exposing the nginx status page (default 18080)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**: a document fix, add --report-node-internal-ip-address config describe as added in  nginx-0.9.0-beta.16.  Without this describetion, users may got very confused when seeing empty ingress endpoints when node got only internal ip address.


**Special notes for your reviewer**: related to pull request of https://github.com/kubernetes/ingress-nginx/pull/1503
