### PR TITLE
Enable keep-alive requests to upstreams

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -171,7 +171,7 @@ http {
     # Retain the default nginx handling of requests without a "Connection" header
     map $http_upgrade $connection_upgrade {
         default          upgrade;
-        ''               close;
+        ''               {{ if (gt $cfg.UpstreamKeepaliveConnections 0) }}keep-alive{{ else }}close{{ end }};
     }
 
     map {{ buildForwardedFor $cfg.ForwardedForHeader }} $the_real_ip {


### PR DESCRIPTION
**What this PR does / why we need it**:
Set upstream proxy header "Connection: keep-alive" if upstream-keepalive-connections greater then 0 and we do not have Upgrade header in request. 


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #986 

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```