### PR TITLE
Change redirect from 301 to 308

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -390,9 +390,9 @@ http {
 
         {{ if ne $all.ListenPorts.HTTPS 443 }}
         {{ $redirect_port := (printf ":%v" $all.ListenPorts.HTTPS) }}
-        return 301 $scheme://{{ $to }}{{ $redirect_port }}$request_uri;
+        return 308 $scheme://{{ $to }}{{ $redirect_port }}$request_uri;
         {{ else }}
-        return 301 $scheme://{{ $to }}$request_uri;
+        return 308 $scheme://{{ $to }}$request_uri;
         {{ end }}
     }
     {{ end }}
@@ -687,9 +687,9 @@ stream {
             if ($pass_access_scheme = http) {
                 {{ if ne $all.ListenPorts.HTTPS 443 }}
                 {{ $redirect_port := (printf ":%v" $all.ListenPorts.HTTPS) }}
-                return 301 https://$best_http_host{{ $redirect_port }}$request_uri;
+                return 308 https://$best_http_host{{ $redirect_port }}$request_uri;
                 {{ else }}
-                return 301 https://$best_http_host$request_uri;
+                return 308 https://$best_http_host$request_uri;
                 {{ end }}
             }
             {{ end }}


### PR DESCRIPTION
Should fix #1772

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
It changes the default redirect from 301 to 308

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1772 

**Special notes for your reviewer**:
Still need to update documentation. Just wanted to start a PR