### PR TITLE
Release nginx ingress controller 0.9.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,18 @@
 # Changelog
 
+### 0.9.0
+
+**Image:**  `quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.9.0`
+
+*Changes:*
+
+- [X] [#1731](https://github.com/kubernetes/ingress-nginx/pull/1731) Allow configuration of proxy_responses value for tcp/udp configmaps
+- [X] [#1766](https://github.com/kubernetes/ingress-nginx/pull/1766) Fix ingress typo
+- [X] [#1768](https://github.com/kubernetes/ingress-nginx/pull/1768) Custom default backend must use annotations if present
+- [X] [#1769](https://github.com/kubernetes/ingress-nginx/pull/1769) Use custom https port in redirects
+- [X] [#1771](https://github.com/kubernetes/ingress-nginx/pull/1771) Add additional check for old SSL certificates
+- [X] [#1776](https://github.com/kubernetes/ingress-nginx/pull/1776) Add option to configure the redirect code
+
 ### 0.9-beta.19
 
 **Image:**  `quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.9.0-beta.19`

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ all: all-container
 BUILDTAGS=
 
 # Use the 0.0 tag for testing, it shouldn't clobber any release builds
-TAG?=0.9.0-beta.19
+TAG?=0.9.0
 REGISTRY?=quay.io/kubernetes-ingress-controller
 GOOS?=linux
 DOCKER?=gcloud docker --

--- a/deploy/provider/patch-service-with-rbac.yaml
+++ b/deploy/provider/patch-service-with-rbac.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: nginx-ingress-serviceaccount   
       containers:
         - name: nginx-ingress-controller
-          image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.9.0-beta.19
+          image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.9.0
           args:
             - /nginx-ingress-controller
             - --default-backend-service=$(POD_NAMESPACE)/default-http-backend

--- a/deploy/provider/patch-service-without-rbac.yaml
+++ b/deploy/provider/patch-service-without-rbac.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: nginx-ingress-controller
-          image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.9.0-beta.19
+          image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.9.0
           args:
             - /nginx-ingress-controller
             - --default-backend-service=$(POD_NAMESPACE)/default-http-backend

--- a/deploy/with-rbac.yaml
+++ b/deploy/with-rbac.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: nginx-ingress-serviceaccount
       containers:
         - name: nginx-ingress-controller
-          image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.9.0-beta.19
+          image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.9.0
           args:
             - /nginx-ingress-controller
             - --default-backend-service=$(POD_NAMESPACE)/default-http-backend

--- a/deploy/without-rbac.yaml
+++ b/deploy/without-rbac.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: nginx-ingress-controller
-          image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.9.0-beta.19
+          image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.9.0
           args:
             - /nginx-ingress-controller
             - --default-backend-service=$(POD_NAMESPACE)/default-http-backend

--- a/docs/examples/customization/custom-errors/rc-custom-errors.yaml
+++ b/docs/examples/customization/custom-errors/rc-custom-errors.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 60
       containers:
-      - image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.9.0-beta.19
+      - image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.9.0
         name: nginx-ingress-lb
         imagePullPolicy: Always
         readinessProbe:

--- a/docs/examples/static-ip/nginx-ingress-controller.yaml
+++ b/docs/examples/static-ip/nginx-ingress-controller.yaml
@@ -18,7 +18,7 @@ spec:
       # hostNetwork: true
       terminationGracePeriodSeconds: 60
       containers:
-      - image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.9.0-beta.19
+      - image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.9.0
         name: nginx-ingress-controller
         readinessProbe:
           httpGet:


### PR DESCRIPTION
Temporal image: `quay.io/aledbf/nginx-ingress-controller:0.300`

**What this PR does / why we need it**:

Release version 0.9.0

