### PR TITLE
force external_auth requests to http/1.1

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -659,6 +659,7 @@ stream {
             proxy_set_header            X-Auth-Request-Redirect $request_uri;
             proxy_set_header            X-Sent-From             "nginx-ingress-controller";
 
+            proxy_http_version          1.1;
             proxy_ssl_server_name       on;
             proxy_pass_request_headers  on;
             client_max_body_size        "{{ $location.Proxy.BodySize }}";


### PR DESCRIPTION
**What this PR does / why we need it**:
forces external auth subrequests to use http 1.1

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1784 

**Special notes for your reviewer**:
