### PR TITLE
Add control of the configuration refresh interval

### DIFF
--- a/cmd/nginx/flags.go
+++ b/cmd/nginx/flags.go
@@ -56,7 +56,7 @@ func parseFlags() (bool, *controller.Configuration, error) {
 			`Name of the ConfigMap that contains the custom configuration to use`)
 
 		publishSvc = flags.String("publish-service", "",
-			`Service fronting the ingress controllers. Takes the form namespace/name. 
+			`Service fronting the ingress controllers. Takes the form namespace/name.
 		The controller will set the endpoint records on the ingress objects to reflect those on the service.`)
 
 		tcpConfigMapName = flags.String("tcp-services-configmap", "",
@@ -127,6 +127,9 @@ func parseFlags() (bool, *controller.Configuration, error) {
 			`Defines if the nginx ingress controller should check the secrets for missing intermediate CA certificates.
 		If the certificate contain issues chain issues is not possible to enable OCSP.
 		Default is true.`)
+
+		syncRateLimit = flags.Float32("sync-rate-limit", 0.3,
+			`Define the sync frequency upper limit`)
 	)
 
 	flag.Set("logtostderr", "true")
@@ -210,6 +213,7 @@ func parseFlags() (bool, *controller.Configuration, error) {
 		UpdateStatusOnShutdown:   *updateStatusOnShutdown,
 		SortBackends:             *sortBackends,
 		UseNodeInternalIP:        *useNodeInternalIP,
+		SyncRateLimit:            *syncRateLimit,
 		ListenPorts: &ngx_config.ListenPorts{
 			Default:  *defServerPort,
 			Health:   *healthzPort,

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -107,6 +107,8 @@ type Configuration struct {
 
 	FakeCertificatePath string
 	FakeCertificateSHA  string
+
+	SyncRateLimit float32
 }
 
 // GetDefaultBackend returns the default backend

--- a/internal/ingress/controller/nginx.go
+++ b/internal/ingress/controller/nginx.go
@@ -106,7 +106,7 @@ func NewNGINXController(config *Configuration, fs file.Filesystem) *NGINXControl
 		resolver:        h,
 		cfg:             config,
 		sslCertTracker:  store.NewSSLCertTracker(),
-		syncRateLimiter: flowcontrol.NewTokenBucketRateLimiter(0.3, 1),
+		syncRateLimiter: flowcontrol.NewTokenBucketRateLimiter(config.SyncRateLimit, 1),
 
 		recorder: eventBroadcaster.NewRecorder(scheme.Scheme, apiv1.EventSource{
 			Component: "nginx-ingress-controller",


### PR DESCRIPTION
**What this PR does / why we need it**:
Make the syncRateLimiter configurable, and therefore how the often the configuration might be reloaded. This value is tightly coupled with the all the upstream pods lifecycle and therefore should be configurable.


