### PR TITLE
Add X-Forwarded-Prefix on rewrites

### DIFF
--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -51,6 +51,7 @@ Key:
 | `add-base-url` | Add `<base>` tag to HTML. | | nginx
 | `base-url-scheme` | Specify the scheme of the `<base>` tags. | | nginx
 | `preserve-host` | Whether to pass the client request host (`true`) or the origin hostname (`false`) in the HTTP Host field. | | trafficserver
+| `x-forwarded-prefix` | Add the non-standard `X-Forwarded-Prefix` header to the request with the value of the matched location. | | nginx
 
 ## CORS Related
 | Name | Meaning | Default | Controller

--- a/internal/ingress/annotations/annotations.go
+++ b/internal/ingress/annotations/annotations.go
@@ -47,6 +47,7 @@ import (
 	"k8s.io/ingress-nginx/internal/ingress/annotations/upstreamhashby"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/upstreamvhost"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/vtsfilterkey"
+	"k8s.io/ingress-nginx/internal/ingress/annotations/xforwardedprefix"
 	"k8s.io/ingress-nginx/internal/ingress/errors"
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
 )
@@ -81,6 +82,7 @@ type Ingress struct {
 	UpstreamVhost        string
 	VtsFilterKey         string
 	Whitelist            ipwhitelist.SourceRange
+	XForwardedPrefix     bool
 }
 
 // Extractor defines the annotation parsers to be used in the extraction of annotations
@@ -115,6 +117,7 @@ func NewAnnotationExtractor(cfg resolver.Resolver) Extractor {
 			"UpstreamVhost":        upstreamvhost.NewParser(cfg),
 			"VtsFilterKey":         vtsfilterkey.NewParser(cfg),
 			"Whitelist":            ipwhitelist.NewParser(cfg),
+			"XForwardedPrefix":     xforwardedprefix.NewParser(cfg),
 		},
 	}
 }

--- a/internal/ingress/annotations/xforwardedprefix/main.go
+++ b/internal/ingress/annotations/xforwardedprefix/main.go
@@ -1,0 +1,23 @@
+package xforwardedprefix
+
+import (
+	extensions "k8s.io/api/extensions/v1beta1"
+
+	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
+	"k8s.io/ingress-nginx/internal/ingress/resolver"
+)
+
+type xforwardedprefix struct {
+	r resolver.Resolver
+}
+
+// NewParser creates a new xforwardedprefix annotation parser
+func NewParser(r resolver.Resolver) parser.IngressAnnotation {
+	return xforwardedprefix{r}
+}
+
+// Parse parses the annotations contained in the ingress rule
+// used to add an x-forwarded-prefix header to the request
+func (cbbs xforwardedprefix) Parse(ing *extensions.Ingress) (interface{}, error) {
+	return parser.GetBoolAnnotation("x-forwarded-prefix", ing)
+}

--- a/internal/ingress/annotations/xforwardedprefix/main.go
+++ b/internal/ingress/annotations/xforwardedprefix/main.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package xforwardedprefix
 
 import (

--- a/internal/ingress/annotations/xforwardedprefix/main_test.go
+++ b/internal/ingress/annotations/xforwardedprefix/main_test.go
@@ -1,0 +1,46 @@
+package xforwardedprefix
+
+import (
+	"testing"
+
+	api "k8s.io/api/core/v1"
+	extensions "k8s.io/api/extensions/v1beta1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
+	"k8s.io/ingress-nginx/internal/ingress/resolver"
+)
+
+func TestParse(t *testing.T) {
+	annotation := parser.GetAnnotationWithPrefix("x-forwarded-prefix")
+	ap := NewParser(&resolver.Mock{})
+	if ap == nil {
+		t.Fatalf("expected a parser.IngressAnnotation but returned nil")
+	}
+
+	testCases := []struct {
+		annotations map[string]string
+		expected    bool
+	}{
+		{map[string]string{annotation: "true"}, true},
+		{map[string]string{annotation: "1"}, true},
+		{map[string]string{annotation: ""}, false},
+		{map[string]string{}, false},
+		{nil, false},
+	}
+
+	ing := &extensions.Ingress{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      "foo",
+			Namespace: api.NamespaceDefault,
+		},
+		Spec: extensions.IngressSpec{},
+	}
+
+	for _, testCase := range testCases {
+		ing.SetAnnotations(testCase.annotations)
+		result, _ := ap.Parse(ing)
+		if result != testCase.expected {
+			t.Errorf("expected %v but returned %v, annotations: %s", testCase.expected, result, testCase.annotations)
+		}
+	}
+}

--- a/internal/ingress/annotations/xforwardedprefix/main_test.go
+++ b/internal/ingress/annotations/xforwardedprefix/main_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package xforwardedprefix
 
 import (

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -473,6 +473,7 @@ func (n *NGINXController) getBackendServers(ingresses []*extensions.Ingress) ([]
 						loc.VtsFilterKey = anns.VtsFilterKey
 						loc.Whitelist = anns.Whitelist
 						loc.Denied = anns.Denied
+						loc.XForwardedPrefix = anns.XForwardedPrefix
 
 						if loc.Redirect.FromToWWW {
 							server.RedirectFromToWWW = true
@@ -503,6 +504,7 @@ func (n *NGINXController) getBackendServers(ingresses []*extensions.Ingress) ([]
 						VtsFilterKey:         anns.VtsFilterKey,
 						Whitelist:            anns.Whitelist,
 						Denied:               anns.Denied,
+						XForwardedPrefix:     anns.XForwardedPrefix,
 					}
 
 					if loc.Redirect.FromToWWW {

--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -324,20 +324,25 @@ func buildProxyPass(host string, b interface{}, loc interface{}) string {
 			}
 		}
 
+		xForwardedPrefix := ""
+		if location.XForwardedPrefix {
+			xForwardedPrefix = fmt.Sprintf(`proxy_set_header X-Forwarded-Prefix "%s";
+	    `, path)
+		}
 		if location.Rewrite.Target == slash {
 			// special case redirect to /
 			// ie /something to /
 			return fmt.Sprintf(`
 	    rewrite %s(.*) /$1 break;
 	    rewrite %s / break;
-	    proxy_pass %s://%s;
-	    %v`, path, location.Path, proto, upstreamName, abu)
+	    %vproxy_pass %s://%s;
+	    %v`, path, location.Path, xForwardedPrefix, proto, upstreamName, abu)
 		}
 
 		return fmt.Sprintf(`
 	    rewrite %s(.*) %s/$1 break;
-	    proxy_pass %s://%s;
-	    %v`, path, location.Rewrite.Target, proto, upstreamName, abu)
+	    %vproxy_pass %s://%s;
+	    %v`, path, location.Rewrite.Target, xForwardedPrefix, proto, upstreamName, abu)
 	}
 
 	// default proxy_pass

--- a/internal/ingress/types.go
+++ b/internal/ingress/types.go
@@ -259,6 +259,10 @@ type Location struct {
 	// DefaultBackend allows the use of a custom default backend for this location.
 	// +optional
 	DefaultBackend *apiv1.Service `json:"defaultBackend,omitempty"`
+	// XForwardedPrefix allows to add a header X-Forwarded-Prefix to the request with the
+	// original location.
+	// +optional
+	XForwardedPrefix bool `json:"xForwardedPrefix,omitempty"`
 }
 
 // SSLPassthroughBackend describes a SSL upstream server configured

--- a/internal/ingress/types_equals.go
+++ b/internal/ingress/types_equals.go
@@ -367,6 +367,9 @@ func (l1 *Location) Equal(l2 *Location) bool {
 	if l1.UpstreamVhost != l2.UpstreamVhost {
 		return false
 	}
+	if l1.XForwardedPrefix != l2.XForwardedPrefix {
+		return false
+	}
 
 	return true
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Add an annotation `x-forwarded-prefix` that activate the addition of a `X-Forwarded-Prefix` to the request sent to the upstream. This prefix has the value of the Nginx location that matched the rewrite.

**Which issue this PR fixes**
fixes https://github.com/kubernetes/ingress-nginx/issues/1774
