### PR TITLE
Add use-forwarded-headers configmap option.

### DIFF
--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -400,6 +400,9 @@ type Configuration struct {
 	// Sets the ipv6 addresses on which the server will accept requests.
 	BindAddressIpv6 []string `json:"bind-address-ipv6,omitempty"`
 
+	// Sets whether to use incoming X-Forwarded headers.
+	UseForwardedHeaders bool `json:"use-forwarded-headers"`
+
 	// Sets the header field for identifying the originating IP address of a client
 	// Default is X-Forwarded-For
 	ForwardedForHeader string `json:"forwarded-for-header,omitempty"`
@@ -456,6 +459,7 @@ func NewDefault() Configuration {
 		EnableDynamicTLSRecords:    true,
 		EnableUnderscoresInHeaders: false,
 		ErrorLogLevel:              errorLevel,
+		UseForwardedHeaders:        true,
 		ForwardedForHeader:         "X-Forwarded-For",
 		ComputeFullForwardedFor:    false,
 		HTTP2MaxFieldSize:          "4k",

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -38,7 +38,9 @@ events {
 }
 
 http {
-    {{/* we use the value of the header X-Forwarded-For to be able to use the geo_ip module */}}
+    {{/* Enable the real_ip module only if we use either X-Forwarded headers or Proxy Protocol. */}}
+    {{/* we use the value of the real IP for the geo_ip module */}}
+    {{ if or $cfg.UseForwardedHeaders $cfg.UseProxyProtocol }}
     {{ if $cfg.UseProxyProtocol }}
     real_ip_header      proxy_protocol;
     {{ else }}
@@ -48,6 +50,7 @@ http {
     real_ip_recursive   on;
     {{ range $trusted_ip := $cfg.ProxyRealIPCIDR }}
     set_real_ip_from    {{ $trusted_ip }};
+    {{ end }}
     {{ end }}
 
     {{/* databases used to determine the country depending on the client IP address */}}
@@ -112,7 +115,7 @@ http {
 
     include /etc/nginx/mime.types;
     default_type text/html;
-    
+
     {{ if $cfg.EnableBrotli }}
     brotli on;
     brotli_comp_level {{ $cfg.BrotliLevel }};
@@ -174,7 +177,7 @@ http {
         ''               close;
     }
 
-    map {{ buildForwardedFor $cfg.ForwardedForHeader }} $the_real_ip {
+    map 'dummy' $the_real_ip {
     {{ if $cfg.UseProxyProtocol }}
         # Get IP address from Proxy Protocol
         default          $proxy_protocol_addr;
@@ -183,16 +186,11 @@ http {
     {{ end }}
     }
 
+    {{ if $cfg.UseForwardedHeaders }}
     # trust http_x_forwarded_proto headers correctly indicate ssl offloading
     map $http_x_forwarded_proto $pass_access_scheme {
         default          $http_x_forwarded_proto;
         ''               $scheme;
-    }
-
-    # validate $pass_access_scheme and $scheme are http to force a redirect
-    map "$scheme:$pass_access_scheme" $redirect_to_https {
-        default          0;
-        "http:http"      1;
     }
 
     map $http_x_forwarded_port $pass_server_port {
@@ -203,6 +201,25 @@ http {
     map $http_x_forwarded_host $best_http_host {
         default          $http_x_forwarded_host;
         ''               $this_host;
+    }
+    {{ else }}
+    map 'dummy' $pass_access_scheme {
+        default          $scheme;
+    }
+
+    map 'dummy' $pass_server_port {
+        default          $server_port;
+    }
+
+    map 'dummy' $best_http_host {
+        default          $this_host;
+    }
+    {{ end }}
+
+    # validate $pass_access_scheme and $scheme are http to force a redirect
+    map "$scheme:$pass_access_scheme" $redirect_to_https {
+        default          0;
+        "http:http"      1;
     }
 
     {{ if $all.IsSSLPassthroughEnabled }}
@@ -224,17 +241,21 @@ http {
         ''               $host;
     }
 
-    {{ if $cfg.ComputeFullForwardedFor }}
+    {{ if and $cfg.UseForwardedHeaders $cfg.ComputeFullForwardedFor }}
     # We can't use $proxy_add_x_forwarded_for because the realip module
     # replaces the remote_addr too soon
-    map $http_x_forwarded_for $full_x_forwarded_for {
+    map {{ buildForwardedFor $all.Cfg.ForwardedForHeader }} $full_x_forwarded_for {
         {{ if $all.Cfg.UseProxyProtocol }}
         default          "$http_x_forwarded_for, $proxy_protocol_addr";
         ''               "$proxy_protocol_addr";
         {{ else }}
         default          "$http_x_forwarded_for, $realip_remote_addr";
         ''               "$realip_remote_addr";
-        {{ end}}
+        {{ end }}
+    }
+    {{ else }}
+    map 'dummy' $full_x_forwarded_for {
+        default          $remote_addr;
     }
     {{ end }}
 
@@ -792,11 +813,7 @@ stream {
             proxy_set_header                        Connection        $connection_upgrade;
 
             proxy_set_header X-Real-IP              $the_real_ip;
-            {{ if $all.Cfg.ComputeFullForwardedFor }}
             proxy_set_header X-Forwarded-For        $full_x_forwarded_for;
-            {{ else }}
-            proxy_set_header X-Forwarded-For        $the_real_ip;
-            {{ end }}
             proxy_set_header X-Forwarded-Host       $best_http_host;
             proxy_set_header X-Forwarded-Port       $pass_port;
             proxy_set_header X-Forwarded-Proto      $pass_access_scheme;


### PR DESCRIPTION
This PR adds a configmap option `use-forwarded-headers` to enable/disable trust of incoming `X-Forwarded-*` headers. 

It is set to `true` by default, which corresponds to the current ingress behavior, so this change is backwards compatible.

Fixes #1815