### PR TITLE
If server_tokens is disabled remove the Server header

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -135,6 +135,9 @@ http {
     {{ end }}
 
     server_tokens {{ if $cfg.ShowServerTokens }}on{{ else }}off{{ end }};
+    {{ if not $cfg.ShowServerTokens }}
+    more_set_headers "Server: ";
+    {{ end }}
 
     # disable warnings
     uninitialized_variable_warn off;

--- a/test/e2e/settings/server_tokens.go
+++ b/test/e2e/settings/server_tokens.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package setting
+
+import (
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/ingress-nginx/test/e2e/framework"
+)
+
+var _ = framework.IngressNginxDescribe("Server Tokens", func() {
+	f := framework.NewDefaultFramework("server-tokens")
+
+	BeforeEach(func() {
+		err := f.NewEchoDeployment()
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+	})
+
+	It("should not exists Server header in the response", func() {
+		serverTokens := "server-tokens"
+		updateConfigmap(serverTokens, "false", f.KubeClientSet)
+		defer updateConfigmap(serverTokens, "false", f.KubeClientSet)
+
+		ing, err := f.EnsureIngress(&v1beta1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        serverTokens,
+				Namespace:   f.Namespace.Name,
+				Annotations: map[string]string{},
+			},
+			Spec: v1beta1.IngressSpec{
+				Rules: []v1beta1.IngressRule{
+					{
+						Host: serverTokens,
+						IngressRuleValue: v1beta1.IngressRuleValue{
+							HTTP: &v1beta1.HTTPIngressRuleValue{
+								Paths: []v1beta1.HTTPIngressPath{
+									{
+										Path: "/",
+										Backend: v1beta1.IngressBackend{
+											ServiceName: "http-svc",
+											ServicePort: intstr.FromInt(80),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ing).NotTo(BeNil())
+
+		err = f.WaitForNginxServer(serverTokens,
+			func(server string) bool {
+				return strings.Contains(server, "server_tokens off") &&
+					strings.Contains(server, "more_set_headers \"Server: \"")
+			})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should exists Server header in the response when is enabled", func() {
+		serverTokens := "server-tokens"
+		updateConfigmap(serverTokens, "true", f.KubeClientSet)
+		defer updateConfigmap(serverTokens, "false", f.KubeClientSet)
+
+		ing, err := f.EnsureIngress(&v1beta1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        serverTokens,
+				Namespace:   f.Namespace.Name,
+				Annotations: map[string]string{},
+			},
+			Spec: v1beta1.IngressSpec{
+				Rules: []v1beta1.IngressRule{
+					{
+						Host: serverTokens,
+						IngressRuleValue: v1beta1.IngressRuleValue{
+							HTTP: &v1beta1.HTTPIngressRuleValue{
+								Paths: []v1beta1.HTTPIngressPath{
+									{
+										Path: "/",
+										Backend: v1beta1.IngressBackend{
+											ServiceName: "http-svc",
+											ServicePort: intstr.FromInt(80),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ing).NotTo(BeNil())
+
+		err = f.WaitForNginxServer(serverTokens,
+			func(server string) bool {
+				return strings.Contains(server, "server_tokens on")
+			})
+		Expect(err).NotTo(HaveOccurred())
+	})
+})

--- a/test/e2e/settings/server_tokens.go
+++ b/test/e2e/settings/server_tokens.go
@@ -75,7 +75,7 @@ var _ = framework.IngressNginxDescribe("Server Tokens", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ing).NotTo(BeNil())
 
-		err = f.WaitForNginxServer(serverTokens,
+		err = f.WaitForNginxConfiguration(
 			func(server string) bool {
 				return strings.Contains(server, "server_tokens off") &&
 					strings.Contains(server, "more_set_headers \"Server: \"")
@@ -119,7 +119,7 @@ var _ = framework.IngressNginxDescribe("Server Tokens", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ing).NotTo(BeNil())
 
-		err = f.WaitForNginxServer(serverTokens,
+		err = f.WaitForNginxConfiguration(
 			func(server string) bool {
 				return strings.Contains(server, "server_tokens on")
 			})


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes the Server header when `server-tokens: false`. By default nginx only removes the version of nginx