### PR TITLE
removing _total prefix from nginx guage metrics

### DIFF
--- a/internal/ingress/controller/metric/collector/nginx.go
+++ b/internal/ingress/controller/metric/collector/nginx.go
@@ -33,13 +33,9 @@ type (
 	}
 
 	nginxStatusData struct {
-		active   *prometheus.Desc
-		accepted *prometheus.Desc
-		handled  *prometheus.Desc
-		requests *prometheus.Desc
-		reading  *prometheus.Desc
-		writing  *prometheus.Desc
-		waiting  *prometheus.Desc
+		connectionsTotal *prometheus.Desc
+		requestsTotal    *prometheus.Desc
+		connections      *prometheus.Desc
 	}
 )
 
@@ -55,40 +51,20 @@ func NewNginxStatus(watchNamespace, ingressClass string, ngxHealthPort int, ngxV
 	}
 
 	p.data = &nginxStatusData{
-		active: prometheus.NewDesc(
-			prometheus.BuildFQName(ns, "", "active_connections_total"),
-			"total number of active connections",
-			[]string{"ingress_class", "namespace"}, nil),
+		connectionsTotal: prometheus.NewDesc(
+			prometheus.BuildFQName(ns, "", "connections_total"),
+			"total number of connections with state {active, accepted, handled}",
+			[]string{"ingress_class", "namespace", "state"}, nil),
 
-		accepted: prometheus.NewDesc(
-			prometheus.BuildFQName(ns, "", "accepted_connections_total"),
-			"total number of accepted client connections",
-			[]string{"ingress_class", "namespace"}, nil),
-
-		handled: prometheus.NewDesc(
-			prometheus.BuildFQName(ns, "", "handled_connections_total"),
-			"total number of handled connections",
-			[]string{"ingress_class", "namespace"}, nil),
-
-		requests: prometheus.NewDesc(
+		requestsTotal: prometheus.NewDesc(
 			prometheus.BuildFQName(ns, "", "requests_total"),
 			"total number of client requests",
 			[]string{"ingress_class", "namespace"}, nil),
 
-		reading: prometheus.NewDesc(
-			prometheus.BuildFQName(ns, "", "current_reading_connections_total"),
-			"current number of connections where nginx is reading the request header",
-			[]string{"ingress_class", "namespace"}, nil),
-
-		writing: prometheus.NewDesc(
-			prometheus.BuildFQName(ns, "", "current_writing_connections_total"),
-			"current number of connections where nginx is writing the response back to the client",
-			[]string{"ingress_class", "namespace"}, nil),
-
-		waiting: prometheus.NewDesc(
-			prometheus.BuildFQName(ns, "", "current_waiting_connections_total"),
-			"current number of idle client connections waiting for a request",
-			[]string{"ingress_class", "namespace"}, nil),
+		connections: prometheus.NewDesc(
+			prometheus.BuildFQName(ns, "", "connnections"),
+			"current number of client connections with state {reading, writing, waiting}",
+			[]string{"ingress_class", "namespace", "state"}, nil),
 	}
 
 	go p.start()
@@ -98,13 +74,9 @@ func NewNginxStatus(watchNamespace, ingressClass string, ngxHealthPort int, ngxV
 
 // Describe implements prometheus.Collector.
 func (p nginxStatusCollector) Describe(ch chan<- *prometheus.Desc) {
-	ch <- p.data.active
-	ch <- p.data.accepted
-	ch <- p.data.handled
-	ch <- p.data.requests
-	ch <- p.data.reading
-	ch <- p.data.writing
-	ch <- p.data.waiting
+	ch <- p.data.connectionsTotal
+	ch <- p.data.requestsTotal
+	ch <- p.data.connections
 }
 
 // Collect implements prometheus.Collector.
@@ -134,18 +106,18 @@ func (p nginxStatusCollector) scrape(ch chan<- prometheus.Metric) {
 		return
 	}
 
-	ch <- prometheus.MustNewConstMetric(p.data.active,
-		prometheus.GaugeValue, float64(s.Active), p.ingressClass, p.watchNamespace)
-	ch <- prometheus.MustNewConstMetric(p.data.accepted,
-		prometheus.GaugeValue, float64(s.Accepted), p.ingressClass, p.watchNamespace)
-	ch <- prometheus.MustNewConstMetric(p.data.handled,
-		prometheus.GaugeValue, float64(s.Handled), p.ingressClass, p.watchNamespace)
-	ch <- prometheus.MustNewConstMetric(p.data.requests,
-		prometheus.GaugeValue, float64(s.Requests), p.ingressClass, p.watchNamespace)
-	ch <- prometheus.MustNewConstMetric(p.data.reading,
-		prometheus.GaugeValue, float64(s.Reading), p.ingressClass, p.watchNamespace)
-	ch <- prometheus.MustNewConstMetric(p.data.writing,
-		prometheus.GaugeValue, float64(s.Writing), p.ingressClass, p.watchNamespace)
-	ch <- prometheus.MustNewConstMetric(p.data.waiting,
-		prometheus.GaugeValue, float64(s.Waiting), p.ingressClass, p.watchNamespace)
+	ch <- prometheus.MustNewConstMetric(p.data.connectionsTotal,
+		prometheus.CounterValue, float64(s.Active), p.ingressClass, p.watchNamespace, "active")
+	ch <- prometheus.MustNewConstMetric(p.data.connectionsTotal,
+		prometheus.CounterValue, float64(s.Accepted), p.ingressClass, p.watchNamespace, "accepted")
+	ch <- prometheus.MustNewConstMetric(p.data.connectionsTotal,
+		prometheus.CounterValue, float64(s.Handled), p.ingressClass, p.watchNamespace, "handled")
+	ch <- prometheus.MustNewConstMetric(p.data.requestsTotal,
+		prometheus.CounterValue, float64(s.Requests), p.ingressClass, p.watchNamespace)
+	ch <- prometheus.MustNewConstMetric(p.data.connections,
+		prometheus.GaugeValue, float64(s.Reading), p.ingressClass, p.watchNamespace, "reading")
+	ch <- prometheus.MustNewConstMetric(p.data.connections,
+		prometheus.GaugeValue, float64(s.Writing), p.ingressClass, p.watchNamespace, "writing")
+	ch <- prometheus.MustNewConstMetric(p.data.connections,
+		prometheus.GaugeValue, float64(s.Waiting), p.ingressClass, p.watchNamespace, "waiting")
 }


### PR DESCRIPTION
**What this PR does / why we need it**: This fixes #1509. We want to be following best practices! https://prometheus.io/docs/practices/naming/

**Which issue(s) this PR fixes**:
Fixes #1509 and corrects #1910 

**Release note**:
```release-note
action required: Changed the names of default Nginx ingress prometheus metrics. If you are scraping default Nginx ingress metrics with prometheus the metrics changes are as follows
nginx_active_connections_total -> nginx_connections_total{state="active"}
nginx_accepted_connections_total -> nginx_connections_total{state="accepted"}
nginx_handled_connections_total -> nginx_connections_total{state="handled"}
nginx_current_reading_connections_total -> nginx_connections{state="reading"}
nginx_current_writing_connections_total -> nginx_connections{state="writing"}
current_waiting_connections_total -> nginx_connections{state="waiting"}
```

I'm not sure if we would like to remove the `current_` prefix from the gauges if that's implied without some kind of total prefix, but I think this fixes the issues @discordianfish and @brancz had with #1910. 

Side note: does this need some kind of release note _action_ to notify people using these metrics since it could break their monitoring/alerting? 

tagging @kubernetes/sig-instrumentation-pr-reviews for input.