### PR TITLE
Remove sendfile configuration

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -66,8 +66,6 @@ http {
     vhost_traffic_status_filter_by_set_key {{ $cfg.VtsDefaultFilterKey }};
     {{ end }}
 
-    sendfile            on;
-
     aio                 threads;
     aio_write           on;
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes the sendfile configuration from the nginx template because the ingress controller does not send local assets.