### PR TITLE
When a secret is updated read ingress annotations (again)

### DIFF
--- a/internal/ingress/annotations/auth/main.go
+++ b/internal/ingress/annotations/auth/main.go
@@ -47,6 +47,7 @@ type Config struct {
 	File    string `json:"file"`
 	Secured bool   `json:"secured"`
 	FileSHA string `json:"fileSha"`
+	Secret  string `json:"secret"`
 }
 
 // Equal tests for equality between two Config types
@@ -72,7 +73,9 @@ func (bd1 *Config) Equal(bd2 *Config) bool {
 	if bd1.FileSHA != bd2.FileSHA {
 		return false
 	}
-
+	if bd1.Secret != bd2.Secret {
+		return false
+	}
 	return true
 }
 
@@ -140,6 +143,7 @@ func (a auth) Parse(ing *extensions.Ingress) (interface{}, error) {
 		File:    passFile,
 		Secured: true,
 		FileSHA: file.SHA1(passFile),
+		Secret:  name,
 	}, nil
 }
 

--- a/test/e2e/framework/exec.go
+++ b/test/e2e/framework/exec.go
@@ -31,11 +31,12 @@ func (f *Framework) ExecCommand(pod *v1.Pod, command string) (string, error) {
 		execErr bytes.Buffer
 	)
 
+	args := fmt.Sprintf("kubectl exec --namespace %v %v -- %v", pod.Namespace, pod.Name, command)
 	if len(pod.Spec.Containers) != 1 {
-		return "", fmt.Errorf("could not determine which container to use")
+		args = fmt.Sprintf("kubectl exec --namespace %v %v --container nginx-ingress-controller -- %v", pod.Namespace, pod.Name, command)
 	}
 
-	args := fmt.Sprintf("kubectl exec -n %v %v -- %v", pod.Namespace, pod.Name, command)
+	log("DEBUG", "Executing command \"%v\"", args)
 	cmd := exec.Command("/bin/bash", "-c", args)
 	cmd.Stdout = &execOut
 	cmd.Stderr = &execErr

--- a/test/e2e/framework/exec.go
+++ b/test/e2e/framework/exec.go
@@ -31,12 +31,7 @@ func (f *Framework) ExecCommand(pod *v1.Pod, command string) (string, error) {
 		execErr bytes.Buffer
 	)
 
-	args := fmt.Sprintf("kubectl exec --namespace %v %v -- %v", pod.Namespace, pod.Name, command)
-	if len(pod.Spec.Containers) != 1 {
-		args = fmt.Sprintf("kubectl exec --namespace %v %v --container nginx-ingress-controller -- %v", pod.Namespace, pod.Name, command)
-	}
-
-	log("DEBUG", "Executing command \"%v\"", args)
+	args := fmt.Sprintf("kubectl exec --namespace %v %v --container nginx-ingress-controller -- %v", pod.Namespace, pod.Name, command)
 	cmd := exec.Command("/bin/bash", "-c", args)
 	cmd.Stdout = &execOut
 	cmd.Stderr = &execErr


### PR DESCRIPTION
**What this PR does / why we need it**:

There is no relation between ingress annotations and secret updates. This PR allows to read the ingress annotations when a referenced secret is updated or removed from the cluster.

**Which issue this PR fixes**: 

fixes #1941 
fixes #1947
