### PR TITLE
add kube-system namespace for oauth2-proxy example

### DIFF
--- a/docs/examples/external-auth/oauth2-proxy.yaml
+++ b/docs/examples/external-auth/oauth2-proxy.yaml
@@ -46,6 +46,7 @@ metadata:
   labels:
     k8s-app: oauth2-proxy
   name: oauth2-proxy
+  namespace: kube-system
 spec:
   ports:
   - name: http


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
Small fix for external-auth example, the oauth2-proxy service needs to be within namespace kube-system

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
