### PR TITLE
Enable Customization of Auth Request Redirect

### DIFF
--- a/docs/examples/auth/external-auth/README.md
+++ b/docs/examples/auth/external-auth/README.md
@@ -7,9 +7,11 @@ Use an external service (Basic Auth) located in `https://httpbin.org`
 ```
 $ kubectl create -f ingress.yaml
 ingress "external-auth" created
+
 $ kubectl get ing external-auth
 NAME            HOSTS                         ADDRESS       PORTS     AGE
 external-auth   external-auth-01.sample.com   172.17.4.99   80        13s
+
 $ kubectl get ing external-auth -o yaml
 apiVersion: extensions/v1beta1
 kind: Ingress

--- a/docs/user-guide/annotations.md
+++ b/docs/user-guide/annotations.md
@@ -282,11 +282,20 @@ For more information please see http://nginx.org/en/docs/http/ngx_http_core_modu
 ### External Authentication
 
 To use an existing service that provides authentication the Ingress rule can be annotated with `nginx.ingress.kubernetes.io/auth-url` to indicate the URL where the HTTP request should be sent.
-Additionally it is possible to set `nginx.ingress.kubernetes.io/auth-method` to specify the HTTP method to use (GET or POST).
 
 ```yaml
 nginx.ingress.kubernetes.io/auth-url: "URL to the authentication service"
 ```
+
+Additionally it is possible to set:
+
+`nginx.ingress.kubernetes.io/auth-method`: `<Method>` to specify the HTTP method to use.
+
+`nginx.ingress.kubernetes.io/auth-signin`: `<SignIn_URL>` to specify the location of the error page.
+
+`nginx.ingress.kubernetes.io/auth-response-headers`: `<Response_Header_1, ..., Response_Header_n>` to specify headers to pass to backend once authorization request completes.
+
+`nginx.ingress.kuberentes.io/auth-request-redirect`: `<Request_Redirect_URL>`  to specify the X-Auth-Request-Redirect header value.
 
 Please check the [external-auth](../examples/auth/external-auth/README.md) example.
 

--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -214,7 +214,6 @@ func buildLocation(input interface{}) string {
 	return path
 }
 
-// TODO: Needs Unit Tests
 func buildAuthLocation(input interface{}) string {
 	location, ok := input.(*ingress.Location)
 	if !ok {
@@ -227,7 +226,7 @@ func buildAuthLocation(input interface{}) string {
 	}
 
 	str := base64.URLEncoding.EncodeToString([]byte(location.Path))
-	// avoid locations containing the = char
+	// removes "=" after encoding
 	str = strings.Replace(str, "=", "", -1)
 	return fmt.Sprintf("/_external-auth-%v", str)
 }

--- a/internal/ingress/controller/template/template_test.go
+++ b/internal/ingress/controller/template/template_test.go
@@ -26,6 +26,8 @@ import (
 	"strings"
 	"testing"
 
+	"encoding/base64"
+	"fmt"
 	"k8s.io/ingress-nginx/internal/file"
 	"k8s.io/ingress-nginx/internal/ingress"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/authreq"
@@ -169,6 +171,26 @@ func TestBuildProxyPass(t *testing.T) {
 		if !strings.EqualFold(tc.ProxyPass, pp) {
 			t.Errorf("%s: expected \n'%v'\nbut returned \n'%v'", k, tc.ProxyPass, pp)
 		}
+	}
+}
+
+func TestBuildAuthLocation(t *testing.T) {
+	authURL := "foo.com/auth"
+
+	loc := &ingress.Location{
+		ExternalAuth: authreq.Config{
+			URL: authURL,
+		},
+		Path: "/cat",
+	}
+
+	str := buildAuthLocation(loc)
+
+	encodedAuthURL := strings.Replace(base64.URLEncoding.EncodeToString([]byte(loc.Path)), "=", "", -1)
+	expected := fmt.Sprintf("/_external-auth-%v", encodedAuthURL)
+
+	if str != expected {
+		t.Errorf("Expected \n'%v'\nbut returned \n'%v'", expected, str)
 	}
 }
 

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -316,7 +316,6 @@ http {
 
     {{ end }}
 
-
     upstream {{ $upstream.Name }} {
         {{ if $upstream.UpstreamHashBy }}
         hash {{ $upstream.UpstreamHashBy }} consistent;
@@ -623,7 +622,6 @@ stream {
         more_set_headers                        "Strict-Transport-Security: max-age={{ $all.Cfg.HSTSMaxAge }}{{ if $all.Cfg.HSTSIncludeSubdomains }}; includeSubDomains{{ end }};{{ if $all.Cfg.HSTSPreload }} preload{{ end }}";
         {{ end }}
 
-
         {{ if not (empty $server.CertificateAuth.CAFileName) }}
         # PEM sha: {{ $server.CertificateAuth.PemSHA }}
         ssl_client_certificate                  {{ $server.CertificateAuth.CAFileName }};
@@ -648,7 +646,7 @@ stream {
         }
         {{ end }}
 
-        {{ if not (empty $authPath) }}
+        {{ if $authPath }}
         location = {{ $authPath }} {
             internal;
             set $proxy_upstream_name "external-authentication";
@@ -656,7 +654,7 @@ stream {
             proxy_pass_request_body     off;
             proxy_set_header            Content-Length "";
 
-            {{ if not (empty $location.ExternalAuth.Method) }}
+            {{ if $location.ExternalAuth.Method }}
             proxy_method                {{ $location.ExternalAuth.Method }};
             proxy_set_header            X-Original-URI          $request_uri;
             proxy_set_header            X-Scheme                $pass_access_scheme;
@@ -665,8 +663,13 @@ stream {
             proxy_set_header            Host                    {{ $location.ExternalAuth.Host }};
             proxy_set_header            X-Original-URL          $scheme://$http_host$request_uri;
             proxy_set_header            X-Original-Method       $request_method;
-            proxy_set_header            X-Auth-Request-Redirect $request_uri;
             proxy_set_header            X-Sent-From             "nginx-ingress-controller";
+
+            {{ if $location.ExternalAuth.RequestRedirect }}
+            proxy_set_header            X-Auth-Request-Redirect {{ $location.ExternalAuth.RequestRedirect }};
+            {{ else }}
+            proxy_set_header            X-Auth-Request-Redirect $request_uri;
+            {{ end }}
 
             proxy_http_version          1.1;
             proxy_ssl_server_name       on;
@@ -726,7 +729,7 @@ stream {
             }
             {{ end }}
 
-            {{ if not (empty $authPath) }}
+            {{ if $authPath }}
             # this location requires authentication
             auth_request        {{ $authPath }};
             auth_request_set    $auth_cookie $upstream_http_set_cookie;
@@ -736,7 +739,7 @@ stream {
             {{- end }}
             {{ end }}
 
-            {{ if not (empty $location.ExternalAuth.SigninURL) }}
+            {{ if $location.ExternalAuth.SigninURL }}
             error_page 401 = {{ buildAuthSignURL $location.ExternalAuth.SigninURL }};
             {{ end }}
 
@@ -777,7 +780,6 @@ stream {
             {{ else }}
             proxy_set_header Host                   $host;
             {{ end }}
-
 
             # Pass the extracted client certificate to the backend
             {{ if not (empty $server.CertificateAuth.CAFileName) }}
@@ -860,7 +862,6 @@ stream {
             proxy_set_header       X-Ingress-Name     $ingress_name;
             proxy_set_header       X-Service-Name     $service_name;
             {{ end }}
-
 
             {{ if not (empty $location.Backend) }}
             {{ buildProxyPass $server.Hostname $all.Backends $location }}


### PR DESCRIPTION
Adds the 'nginx.ingress.kubernetes.io/auth-request-redirect' annotation, which allows the customization of the 'X-Auth-Request-Redirect' Header.

Fixes: #1979
