### PR TITLE
Add limit-request-status-code option

### DIFF
--- a/docs/user-guide/configmap.md
+++ b/docs/user-guide/configmap.md
@@ -127,6 +127,7 @@ The following table shows a configuration option's name, type, and the default v
 |[limit&#8209;rate&#8209;after](#limit-rate-after)|int|0|
 |[http&#8209;redirect&#8209;code](#http-redirect-code)|int|308|
 |[proxy&#8209;buffering](#proxy-buffering)|string|"off"|
+|[limit&#8209;request&#8209;status&#8209;code](#limit-request-status-code)|int|503|
 
 ## add-headers
 
@@ -703,3 +704,7 @@ Why the default code is 308?
 ## proxy-buffering
 
 Enables or disables [buffering of responses from the proxied server](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffering).
+
+## limit-request-status-code
+
+Sets the [status code to return in response to rejected requests](http://nginx.org/en/docs/http/ngx_http_limit_req_module.html#limit_req_status).Default: 503

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -471,7 +471,7 @@ type Configuration struct {
 	// LargeClientHeaderBuffers Sets the status code to return in response to rejected requests.
 	// http://nginx.org/en/docs/http/ngx_http_limit_req_module.html#limit_req_status
 	// Default: 503
-	LimitReqStatus string `json:"limit-req-status"`
+	LimitReqStatusCode int `json:"limit-req-status-code"`
 }
 
 // NewDefault returns the default nginx configuration
@@ -565,7 +565,7 @@ func NewDefault() Configuration {
 		JaegerServiceName:            "nginx",
 		JaegerSamplerType:            "const",
 		JaegerSamplerParam:           "1",
-		LimitReqStatus:               "503",
+		LimitReqStatusCode:           503,
 	}
 
 	if glog.V(5) {

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -468,7 +468,7 @@ type Configuration struct {
 	// Default: empty
 	HideHeaders []string `json:"hide-headers"`
 
-	// LargeClientHeaderBuffers Sets the status code to return in response to rejected requests.
+	// LimitReqStatusCode Sets the status code to return in response to rejected requests.
 	// http://nginx.org/en/docs/http/ngx_http_limit_req_module.html#limit_req_status
 	// Default: 503
 	LimitReqStatusCode int `json:"limit-req-status-code"`

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -467,6 +467,11 @@ type Configuration struct {
 	// server to the client response
 	// Default: empty
 	HideHeaders []string `json:"hide-headers"`
+
+	// LargeClientHeaderBuffers Sets the status code to return in response to rejected requests.
+	// http://nginx.org/en/docs/http/ngx_http_limit_req_module.html#limit_req_status
+	// Default: 503
+	LimitReqStatus string `json:"limit-req-status"`
 }
 
 // NewDefault returns the default nginx configuration
@@ -560,6 +565,7 @@ func NewDefault() Configuration {
 		JaegerServiceName:            "nginx",
 		JaegerSamplerType:            "const",
 		JaegerSamplerParam:           "1",
+		LimitReqStatus:               "503",
 	}
 
 	if glog.V(5) {

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -102,6 +102,8 @@ http {
     underscores_in_headers          {{ if $cfg.EnableUnderscoresInHeaders }}on{{ else }}off{{ end }};
     ignore_invalid_headers          {{ if $cfg.IgnoreInvalidHeaders }}on{{ else }}off{{ end }};
 
+    limit_req_status                {{ $cfg.LimitReqStatus }};
+
     {{ if $cfg.EnableOpentracing }}
     opentracing on;
     {{ end }}

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -102,7 +102,7 @@ http {
     underscores_in_headers          {{ if $cfg.EnableUnderscoresInHeaders }}on{{ else }}off{{ end }};
     ignore_invalid_headers          {{ if $cfg.IgnoreInvalidHeaders }}on{{ else }}off{{ end }};
 
-    limit_req_status                {{ $cfg.LimitReqStatus }};
+    limit_req_status                {{ $cfg.LimitReqStatusCode }};
 
     {{ if $cfg.EnableOpentracing }}
     opentracing on;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

This PR adds configmap option to configure `limit_req_status` code. The nginx directive is set at the http level. It is set to `503` by default. (http://nginx.org/en/docs/http/ngx_http_limit_req_module.html#limit_req_status)

fixes #1955 