### PR TITLE
Update get command on README file for verifying that deployment is successful

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -232,7 +232,7 @@ helm install stable/nginx-ingress --name my-nginx
 To check if the ingress controller pods have started, run the following command:
 
 ```console
-kubectl get pods --all-namespaces -l app=ingress-nginx --watch
+kubectl get pods --all-namespaces -l app=nginx-ingress-controller --watch
 ```
 
 Once the operator pods are running, you can cancel the above command by typing `Ctrl+C`.
@@ -244,7 +244,7 @@ To detect which version of the ingress controller is running, exec into the pod 
 
 ```console
 POD_NAMESPACE=ingress-nginx
-POD_NAME=$(kubectl get pods -n $POD_NAMESPACE -l app=ingress-nginx -o jsonpath={.items[0].metadata.name})
+POD_NAME=$(kubectl get pods -n $POD_NAMESPACE -l app=nginx-ingress-controller -o jsonpath={.items[0].metadata.name})
 kubectl exec -it $POD_NAME -n $POD_NAMESPACE -- /nginx-ingress-controller --version
 ```
 


### PR DESCRIPTION
Amending command that was filtering by a wrong app name

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**: This is to fix the instructions on how to verify that deployment was successful. Currently it shows no resources because it is filtering by the wrong app name.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
