### PR TITLE
do not ignore $http_host and $http_x_forwarded_host

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -226,6 +226,17 @@ http {
     }
     {{ end }}
 
+    # Obtain best http host
+    map $http_host $this_host {
+        default          $http_host;
+        ''               $host;
+    }
+
+    map $http_x_forwarded_host $best_http_host {
+        default          $http_x_forwarded_host;
+        ''               $this_host;
+    }
+
     {{ if $cfg.ComputeFullForwardedFor }}
     # We can't use $proxy_add_x_forwarded_for because the realip module
     # replaces the remote_addr too soon
@@ -714,7 +725,7 @@ stream {
 
                 return 497;
                 {{ else }}
-                return {{ $all.Cfg.HTTPRedirectCode }} https://$host$request_uri;
+                return {{ $all.Cfg.HTTPRedirectCode }} https://$best_http_host$request_uri;
                 {{ end }}
             }
             {{ end }}
@@ -784,7 +795,7 @@ stream {
             {{ if not (empty $location.UpstreamVhost) }}
             proxy_set_header Host                   "{{ $location.UpstreamVhost }}";
             {{ else }}
-            proxy_set_header Host                   $host;
+            proxy_set_header Host                   $best_http_host;
             {{ end }}
 
             # Pass the extracted client certificate to the backend
@@ -816,7 +827,7 @@ stream {
             {{ else }}
             proxy_set_header X-Forwarded-For        $the_real_ip;
             {{ end }}
-            proxy_set_header X-Forwarded-Host       $host;
+            proxy_set_header X-Forwarded-Host       $best_http_host;
             proxy_set_header X-Forwarded-Port       $pass_port;
             proxy_set_header X-Forwarded-Proto      $pass_access_scheme;
             proxy_set_header X-Original-URI         $request_uri;


### PR DESCRIPTION
**What this PR does / why we need it**:
The changes done in https://github.com/kubernetes/ingress-nginx/pull/1926 resulted in Nginx ignoring `$http_host` and `$http_x_forwarded_host` variables when setting HTTP Host and X-Forwarded-Host headers for the upstream. It broke applications that rely on X-Forwarded-Host header. For the uses cases and importance of this header please refer to https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
I could not find any issue reported before.

**Special notes for your reviewer**:
Note that this PR is almost revert of https://github.com/kubernetes/ingress-nginx/pull/1926 except https://github.com/kubernetes/ingress-nginx/pull/1926/files#diff-980db9e4b88704f12338bd074839f94eL712.

**Release note**:
```release-note
`X-Forwarded-Host` header is supported again. The support for it was dropped at https://github.com/kubernetes/ingress-nginx/pull/1926.
```