### PR TITLE
Get file max from fs/file-max.

### DIFF
--- a/internal/ingress/controller/util.go
+++ b/internal/ingress/controller/util.go
@@ -17,8 +17,6 @@ limitations under the License.
 package controller
 
 import (
-	"syscall"
-
 	"github.com/golang/glog"
 
 	api "k8s.io/api/core/v1"
@@ -57,12 +55,12 @@ func sysctlSomaxconn() int {
 // sysctlFSFileMax returns the value of fs.file-max, i.e.
 // maximum number of open file descriptors
 func sysctlFSFileMax() int {
-	var rLimit syscall.Rlimit
-	err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rLimit)
+	fileMax, err := sysctl.New().GetSysctl("fs/file-max")
 	if err != nil {
-		glog.Errorf("unexpected error reading system maximum number of open file descriptors (RLIMIT_NOFILE): %v", err)
+		glog.Errorf("unexpected error reading system maximum number of open file descriptors (fs.file-max): %v", err)
 		// returning 0 means don't render the value
 		return 0
 	}
-	return int(rLimit.Max)
+	glog.V(3).Infof("system fs.file-max=%v", fileMax)
+	return fileMax
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

Fixed issue https://github.com/kubernetes/ingress-nginx/issues/2048

This fix reverted https://github.com/kubernetes/ingress-nginx/pull/177/files

With this fix, end user can set file-max via `sysctl -w fs.file-max=xxx` in ingress controller initContainer.

/cc @aledbf 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
