### PR TITLE
[deploy doc images] apps api is now stable, use it and add accurate a…

### DIFF
--- a/deploy/default-backend.yaml
+++ b/deploy/default-backend.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1 #  for k8s versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use extensions/v1beta1
 kind: Deployment
 metadata:
   name: default-http-backend

--- a/deploy/provider/patch-service-with-rbac.yaml
+++ b/deploy/provider/patch-service-with-rbac.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1 #  for k8s versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use extensions/v1beta1
 kind: Deployment
 metadata:
   name: nginx-ingress-controller

--- a/deploy/provider/patch-service-without-rbac.yaml
+++ b/deploy/provider/patch-service-without-rbac.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1 #  for k8s versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use extensions/v1beta1
 kind: Deployment
 metadata:
   name: nginx-ingress-controller

--- a/deploy/with-rbac.yaml
+++ b/deploy/with-rbac.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1 #  for k8s versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use extensions/v1beta1
 kind: Deployment
 metadata:
   name: nginx-ingress-controller

--- a/deploy/without-rbac.yaml
+++ b/deploy/without-rbac.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1 #  for k8s versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use extensions/v1beta1
 kind: Deployment
 metadata:
   name: nginx-ingress-controller

--- a/docs/examples/customization/external-auth-headers/deploy/auth-service.yaml
+++ b/docs/examples/customization/external-auth-headers/deploy/auth-service.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1 #  for k8s versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use extensions/v1beta1
 kind: Deployment
 metadata:
   name: demo-auth-service

--- a/docs/examples/customization/external-auth-headers/deploy/echo-service.yaml
+++ b/docs/examples/customization/external-auth-headers/deploy/echo-service.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1 #  for k8s versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use extensions/v1beta1
 kind: Deployment
 metadata:
   name: demo-echo-service

--- a/docs/examples/docker-registry/deployment.yaml
+++ b/docs/examples/docker-registry/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
 
 ---
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1 #  for k8s versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use extensions/v1beta1
 kind: Deployment
 metadata:
   name: docker-registry

--- a/docs/examples/external-auth/oauth2-proxy.yaml
+++ b/docs/examples/external-auth/oauth2-proxy.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1 #  for k8s versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use extensions/v1beta1
 kind: Deployment
 metadata:
   labels:

--- a/docs/examples/http-svc.yaml
+++ b/docs/examples/http-svc.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1 #  for k8s versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use extensions/v1beta1
 kind: Deployment
 metadata:
   name: http-svc

--- a/docs/examples/static-ip/nginx-ingress-controller.yaml
+++ b/docs/examples/static-ip/nginx-ingress-controller.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1 #  for k8s versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use extensions/v1beta1
 kind: Deployment
 metadata:
   name: nginx-ingress-controller

--- a/images/echoheaders/echo-app.yaml
+++ b/images/echoheaders/echo-app.yaml
@@ -14,7 +14,7 @@ spec:
   selector:
     app: echoheaders
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1 #  for k8s versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use extensions/v1beta1
 kind: Deployment
 metadata:
   name: echoheaders


### PR DESCRIPTION
…nnotations for the old version of k8s how to use old API version

Signed-off-by: LinWengang <linwengang@chinacloud.com.cn>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:  no PR

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
update update apps api extensions/v1beta1 to apps/v1 in k8s v1.9.0  and add accurate annotations for the old version of k8s how to use old API version

