### PR TITLE
Run one test at a time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,7 @@ e2e-image: sub-container-amd64
 .PHONY: e2e-test
 e2e-test:
 	@go test -o e2e-tests -c ./test/e2e
-	@KUBECONFIG=${HOME}/.kube/config INGRESSNGINXCONFIG=${HOME}/.kube/config ./e2e-tests
+	@KUBECONFIG=${HOME}/.kube/config INGRESSNGINXCONFIG=${HOME}/.kube/config ./e2e-tests -test.parallel 1
 
 .PHONY: cover
 cover:


### PR DESCRIPTION
Running in parallel could fail if one of the test changes the ConfigMap.

For example: [this test](https://travis-ci.org/kubernetes/ingress-nginx/jobs/339330612) failed with:
```
[nginx-ingress] Default backend - SSL
/home/travis/gopath/src/k8s.io/ingress-nginx/test/e2e/framework/framework.go:127
  should return a self generated SSL certificate [It]
  /home/travis/gopath/src/k8s.io/ingress-nginx/test/e2e/defaultbackend/ssl.go:38
  Expected
      <int>: 1
  to be ==
      <int>: 0
  /home/travis/gopath/src/k8s.io/ingress-nginx/test/e2e/defaultbackend/ssl.go:47
```
