### PR TITLE
Don't automatically squash the authorization header.

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -762,7 +762,6 @@ stream {
             auth_digest "{{ $location.BasicDigestAuth.Realm }}";
             auth_digest_user_file {{ $location.BasicDigestAuth.File }};
             {{ end }}
-            proxy_set_header Authorization "";
             {{ end }}
 
             {{ if $location.CorsConfig.CorsEnabled }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
This pull request remove the nginx configuration line
```
proxy_set_header Authorization "";
```
as this prevents us from setting up applications which insist on using their own http-basic-auth. Any annotations we us to configure the ingress have no effect as this prevents the Authorization header being sent.

**Special notes for your reviewer**:
I am creating this pull request so we can discuss how to handle this better.]

Many thanks :)