### PR TITLE
Set default value of report-node-internal-ip-address as true.

### DIFF
--- a/cmd/nginx/flags.go
+++ b/cmd/nginx/flags.go
@@ -106,7 +106,7 @@ func parseFlags() (bool, *controller.Configuration, error) {
 		sortBackends = flags.Bool("sort-backends", false,
 			`Defines if backends and it's endpoints should be sorted`)
 
-		useNodeInternalIP = flags.Bool("report-node-internal-ip-address", false,
+		useNodeInternalIP = flags.Bool("report-node-internal-ip-address", true,
 			`Defines if the nodes IP address to be returned in the ingress status should be the internal instead of the external IP address`)
 
 		showVersion = flags.Bool("version", false,


### PR DESCRIPTION
Using default value of report-node-internal-ip-address as true can
make sure the ingress can always return ADDRESS, this also keep
backward compatibility with ingress 0.9.0.beta.12 and its previous
releases.

/cc @aledbf 

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
