### PR TITLE
Remove initContainer from default deployment

### DIFF
--- a/deploy/with-rbac.yaml
+++ b/deploy/with-rbac.yaml
@@ -17,16 +17,6 @@ spec:
         prometheus.io/scrape: 'true'
     spec:
       serviceAccountName: nginx-ingress-serviceaccount
-      initContainers:
-      - command:
-        - sh
-        - -c
-        - sysctl -w net.core.somaxconn=32768; sysctl -w net.ipv4.ip_local_port_range="1024 65535"
-        image: alpine:3.6
-        imagePullPolicy: IfNotPresent
-        name: sysctl
-        securityContext:
-          privileged: true
       containers:
         - name: nginx-ingress-controller
           image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.10.2

--- a/deploy/without-rbac.yaml
+++ b/deploy/without-rbac.yaml
@@ -16,16 +16,6 @@ spec:
         prometheus.io/port: '10254'
         prometheus.io/scrape: 'true' 
     spec:
-      initContainers:
-      - command:
-        - sh
-        - -c
-        - sysctl -w net.core.somaxconn=32768; sysctl -w net.ipv4.ip_local_port_range="1024 65535"
-        image: alpine:3.6
-        imagePullPolicy: IfNotPresent
-        name: sysctl
-        securityContext:
-          privileged: true
       containers:
         - name: nginx-ingress-controller
           image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.10.2

--- a/docs/examples/customization/sysctl/README.md
+++ b/docs/examples/customization/sysctl/README.md
@@ -1,0 +1,9 @@
+# Sysctl tuning
+
+This example aims to demonstrate the use of an Init Container to adjust sysctl default values
+using `kubectl patch`
+
+```console
+kubectl patch deployment -n ingress-nginx nginx-ingress-controller --patch="$(cat patch.json)"
+```
+

--- a/docs/examples/customization/sysctl/patch.json
+++ b/docs/examples/customization/sysctl/patch.json
@@ -1,0 +1,16 @@
+{
+	"spec": {
+		"template": {
+			"spec": {
+				"initContainers": [{
+					"name": "sysctl",
+					"image": "alpine:3.6",
+					"securityContext": {
+						"privileged": true
+					},
+					"command": ["sh", "-c", "sysctl -w net.core.somaxconn=32768; sysctl -w net.ipv4.ip_local_port_range=1024 65535"]
+				}]
+			}
+		}
+	}
+}


### PR DESCRIPTION
This PR removes the init container used to adjust `sysctl` values because of the unexpected issues several users are having (Centos related)

**Which issue this PR fixes**: 

fixes #2053
