### PR TITLE
Expose SSL client cert data to external auth provider.

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -677,6 +677,21 @@ stream {
             client_body_buffer_size     {{ $location.ClientBodyBufferSize }};
             {{ end }}
 
+            # Pass the extracted client certificate to the auth provider
+            {{ if not (empty $server.CertificateAuth.CAFileName) }}
+            {{ if $server.CertificateAuth.PassCertToUpstream }}
+            proxy_set_header ssl-client-cert        $ssl_client_escaped_cert;
+            {{ else }}
+            proxy_set_header ssl-client-cert        "";
+            {{ end }}
+            proxy_set_header ssl-client-verify      $ssl_client_verify;
+            proxy_set_header ssl-client-dn          $ssl_client_s_dn;
+            {{ else }}
+            proxy_set_header ssl-client-cert        "";
+            proxy_set_header ssl-client-verify      "";
+            proxy_set_header ssl-client-dn          "";
+            {{ end }}
+
             set $target {{ $location.ExternalAuth.URL }};
             proxy_pass $target;
         }


### PR DESCRIPTION
**What this PR does / why we need it**: Exposing validated TLS client cert information to back-ends was added in 0.10.0.  For applications that take advantage of an authorization\authentication sidecar (i.e. nginx external auth provider), it would be extremely helpful to expose this information to the sidecar as well.

**Which issue this PR fixes**: N/A

**Special notes for your reviewer**: First k8s PR.  CLA signed.

**Release note**: 
```release-note
SSL client cert information send to back-ends is also sent to the external
auth provider, if any.
```