### PR TITLE
Bumped updateCh limit to fix #2022

### DIFF
--- a/internal/ingress/controller/nginx.go
+++ b/internal/ingress/controller/nginx.go
@@ -106,7 +106,7 @@ func NewNGINXController(config *Configuration, fs file.Filesystem) *NGINXControl
 		}),
 
 		stopCh:   make(chan struct{}),
-		updateCh: make(chan store.Event, 1024),
+		updateCh: make(chan store.Event, 99999),
 
 		stopLock: &sync.Mutex{},
 


### PR DESCRIPTION
**What this PR does / why we need it**:
For larger clusters, updateCh with 1024 is not enough and prevents nginx from starting. I bumped updateCh limit to 99999. Ideally this will be auto sized or adjusted to start popping items off during original startup.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #2022 

**Special notes for your reviewer**:
Ideally a longer term solution should exist to support even larger clusters.
