### PR TITLE
Ingress custom backend

### DIFF
--- a/images/custom-error-pages/main.go
+++ b/images/custom-error-pages/main.go
@@ -60,6 +60,8 @@ func errorHandler(path string) func(http.ResponseWriter, *http.Request) {
 		cext, err := mime.ExtensionsByType(mediaType)
 		if err != nil {
 			log.Printf("unexpected error reading media type extension: %v. Using %v\n", err, ext)
+		} else if len(cext) == 0 {
+			log.Printf("couldn't get media type extension. Using %v\n", ext)
 		} else {
 			ext = cext[0]
 		}

--- a/images/custom-error-pages/main.go
+++ b/images/custom-error-pages/main.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -52,7 +53,6 @@ func main() {
 
 	http.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprint(w, "ok")
 	})
 
 	http.ListenAndServe(fmt.Sprintf(":8080"), nil)
@@ -88,6 +88,9 @@ func errorHandler(path string) func(http.ResponseWriter, *http.Request) {
 		}
 		w.WriteHeader(code)
 
+		if !strings.HasPrefix(ext, ".") {
+			ext = "." + ext
+		}
 		file := fmt.Sprintf("%v/%v%v", path, code, ext)
 		f, err := os.Open(file)
 		if err != nil {
@@ -112,7 +115,7 @@ func errorHandler(path string) func(http.ResponseWriter, *http.Request) {
 		duration := time.Now().Sub(start).Seconds()
 
 		proto := strconv.Itoa(r.ProtoMajor)
-		proto = proto + "." + strconv.Itoa(r.ProtoMinor)
+		proto = fmt.Sprintf("%s.%s", proto, strconv.Itoa(r.ProtoMinor))
 
 		requestCount.WithLabelValues(proto).Inc()
 		requestDuration.WithLabelValues(proto).Observe(duration)

--- a/images/custom-error-pages/metrics.go
+++ b/images/custom-error-pages/metrics.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Collect and display prometheus metrics
+
+package main
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	namespace = "default_http_backend"
+	subsystem = "http"
+)
+
+var (
+	requestCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: namespace,
+		Subsystem: subsystem,
+		Name:      "request_count_total",
+		Help:      "Counter of HTTP requests made.",
+	}, []string{"proto"})
+
+	requestDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: namespace,
+		Subsystem: subsystem,
+		Name:      "request_duration_milliseconds",
+		Help:      "Histogram of the time (in milliseconds) each request took.",
+		Buckets:   append([]float64{.001, .003}, prometheus.DefBuckets...),
+	}, []string{"proto"})
+)


### PR DESCRIPTION
**What this PR does / why we need it**:

(1) fixes missing dot before file extension. The backend logs this with `unexpected error opening file: open /www/4xxhtml: no such file or directory` 

(2) fixes out of range:
```
http: panic serving 192.168.0.72:36388: runtime error: index out of range
goroutine 104487 [running]:
net/http.(*conn).serve.func1(0xc42008a8c0)
	/usr/local/opt/go/libexec/src/net/http/server.go:1697 +0xd0
panic(0x6d4520, 0x8d3ae0)
	/usr/local/opt/go/libexec/src/runtime/panic.go:491 +0x283
main.errorHandler.func1(0x8a9660, 0xc4201182a0, 0xc420166300)
	/Users/d064935/.go/src/k8s.io/ingress-nginx/images/custom-error-pages/main.go:69 +0xeba
net/http.HandlerFunc.ServeHTTP(0xc42011a0e0, 0x8a9660, 0xc4201182a0, 0xc420166300)
	/usr/local/opt/go/libexec/src/net/http/server.go:1918 +0x44
net/http.(*ServeMux).ServeHTTP(0x8de700, 0x8a9660, 0xc4201182a0, 0xc420166300)
	/usr/local/opt/go/libexec/src/net/http/server.go:2254 +0x130
net/http.serverHandler.ServeHTTP(0xc4201260d0, 0x8a9660, 0xc4201182a0, 0xc420166300)
	/usr/local/opt/go/libexec/src/net/http/server.go:2619 +0xb4
net/http.(*conn).serve(0xc42008a8c0, 0x8a9d60, 0xc4201ae6c0)
	/usr/local/opt/go/libexec/src/net/http/server.go:1801 +0x71d
created by net/http.(*Server).Serve
	/usr/local/opt/go/libexec/src/net/http/server.go:2720 +0x288
```

(3) adds basic metrics `request_count_total`, `request_duration_milliseconds`