### PR TITLE
Add HTTPS port to echoheaders

### DIFF
--- a/images/echoheaders/Dockerfile
+++ b/images/echoheaders/Dockerfile
@@ -17,3 +17,7 @@ FROM BASEIMAGE
 ADD nginx.conf /etc/nginx/nginx.conf
 ADD template.lua /usr/local/share/lua/5.1/
 ADD README.md README.md
+ADD run.sh /usr/local/bin/run.sh
+RUN chmod +x /usr/local/bin/run.sh
+ENTRYPOINT ["/usr/local/bin/run.sh"]
+

--- a/images/echoheaders/Makefile
+++ b/images/echoheaders/Makefile
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-TAG = 1.8
-REGISTRY = gcr.io/google_containers
+TAG ?= 1.9
+REGISTRY ?= gcr.io/google_containers
 ARCH ?= $(shell go env GOARCH)
 ALL_ARCH = amd64 arm ppc64le
 

--- a/images/echoheaders/README.md
+++ b/images/echoheaders/README.md
@@ -2,6 +2,7 @@
 
 This is a simple server that responds with the http headers it received.
 
+Image Versions >= 1.9 expose HTTPS endpoint on :8443.
 Image versions >= 1.4 removes the redirect introduced in 1.3.  
 Image versions >= 1.3 redirect requests on :80 with `X-Forwarded-Proto: http` to :443.  
 Image versions > 1.0 run an nginx server, and implement the echoserver using lua in the nginx config.  

--- a/images/echoheaders/echo-app.yaml
+++ b/images/echoheaders/echo-app.yaml
@@ -11,6 +11,10 @@ spec:
     targetPort: 8080
     protocol: TCP
     name: http
+  - port: 443
+    targetPort: 8443
+    protocol: TCP
+    name: https
   selector:
     app: echoheaders
 ---
@@ -32,9 +36,10 @@ spec:
     spec:
       containers:
       - name: echoheaders
-        image: gcr.io/google_containers/echoserver:1.7
+        image: gcr.io/google_containers/echoserver:1.9
         ports:
         - containerPort: 8080
+        - containerPort: 8443
         env:
           - name: NODE_NAME
             valueFrom:

--- a/images/echoheaders/nginx.conf
+++ b/images/echoheaders/nginx.conf
@@ -43,6 +43,7 @@ Request Information:
 	real path={{ngx.var.request_uri}}
 	query={{ngx.var.query_string or ""}}
 	request_version={{ngx.req.http_version()}}
+	request_scheme={{ngx.var.scheme}}
 	request_uri={{ngx.var.scheme.."://"..ngx.var.host..":"..ngx.var.server_port..ngx.var.request_uri}}
 
 Request Headers:
@@ -60,6 +61,10 @@ Request Body:
 		# basically instructs to create an individual listening socket for each worker process (using the SO_REUSEPORT
 		# socket option), allowing a kernel to distribute incoming connections between worker processes.
 		listen 8080 default_server reuseport;
+		listen 8443 default_server ssl reuseport;
+
+		ssl_certificate /certs/certificate.crt;
+		ssl_certificate_key /certs/privateKey.key;
 
 		# Replace '_' with your hostname.
 		server_name _;

--- a/images/echoheaders/run.sh
+++ b/images/echoheaders/run.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+echo "Generating self-signed cert"
+mkdir -p /certs
+openssl req -x509 -sha256 -nodes -days 365 -newkey rsa:2048 \
+-keyout /certs/privateKey.key \
+-out /certs/certificate.crt \
+-subj "/C=UK/ST=Warwickshire/L=Leamington/O=OrgName/OU=IT Department/CN=example.com"
+
+echo "Starting nginx"
+nginx -g "daemon off;"


### PR DESCRIPTION
**What this PR does / why we need it**:
For other ingress implementations, backend HTTPS is a concern for users. The echoheaders image will now generate a certificate on container start and nginx will serve HTTPS on port 8443.

cc @MrHohn @ahmetb 