### PR TITLE
Update Makefile to allow specifying tag from command line

### DIFF
--- a/images/404-server/Makefile
+++ b/images/404-server/Makefile
@@ -20,7 +20,7 @@
 
 all: push
 
-TAG=1.4
+TAG?=1.4
 PREFIX?=gcr.io/google_containers/defaultbackend
 ARCH?=amd64
 


### PR DESCRIPTION
The usage text in the Makefile suggests that you can specify TAG=1.4 to your make command to build with the specified tag.  This does not work, since TAG is hard coded in the Makefile and overwrites any value you pass on the command line.

$ GOPATH=/go TAG=notagforyou make container
docker build --pull -t gcr.io/google_containers/defaultbackend-amd64:1.4 .
Sending build context to Docker daemon  5.921MB
Step 1/4 : FROM scratch
 ---> 
Step 2/4 : USER 65534:65534
 ---> Using cache
 ---> 0f38024aa24e
Step 3/4 : COPY server /
 ---> f8509ce4595d
Step 4/4 : ENTRYPOINT /server
 ---> Running in 29b31420e648
 ---> 65818e326440
Removing intermediate container 29b31420e648
Successfully built 65818e326440
Successfully tagged gcr.io/google_containers/defaultbackend-amd64:1.4

Update the TAG variable to work as documented.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
