### PR TITLE
Fix IP ACLs for proxy_protocol

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -32,12 +32,8 @@ events {
 }
 
 http {
-    {{/* we use the value of the header X-Forwarded-For to be able to use the geo_ip module */}}
-    {{ if $cfg.UseProxyProtocol }}
-    real_ip_header      proxy_protocol;
-    {{ else }}
-    real_ip_header      {{ $cfg.ForwardedForHeader }};
-    {{ end }}
+
+    real_ip_header      $real_ip_header;
 
     real_ip_recursive   on;
     {{ range $trusted_ip := $cfg.ProxyRealIPCIDR }}
@@ -168,13 +164,19 @@ http {
         ''               close;
     }
 
-    map {{ buildForwardedFor $cfg.ForwardedForHeader }} $the_real_ip {
-    {{ if $cfg.UseProxyProtocol }}
+    map $pass_server_port $real_ip_header {
+        {{ $all.ListenPorts.SSLProxy }} proxy_protocol;
+        default                         X-Forwarded-For;
+    }
+
+    map $real_ip_header $the_real_ip {
         # Get IP address from Proxy Protocol
+        proxy_protocol   $proxy_protocol_addr;
+        {{ if $all.Cfg.UseProxyProtocol }}
         default          $proxy_protocol_addr;
-    {{ else }}
+        {{ else }}
         default          $remote_addr;
-    {{ end }}
+        {{ end }}
     }
 
     # trust http_x_forwarded_proto headers correctly indicate ssl offloading

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -166,7 +166,7 @@ http {
 
     map $pass_server_port $real_ip_header {
         {{ $all.ListenPorts.SSLProxy }} proxy_protocol;
-        default                         X-Forwarded-For;
+        default                         {{ $cfg.ForwardedForHeader }};
     }
 
     map $real_ip_header $the_real_ip {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
When --enable-ssl-passthrough is enabled, proxy protocol is enabled in nginx. Nginx was set to
pull the IP from proxy_protocol for HTTP and HTTPS. The change ensures if we enable SSL passthrough, IP whitelist will still work for HTTP and HTTPS.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
