### PR TITLE
Enabled the dynamic reload of GeoIP data

### DIFF
--- a/images/nginx/build.sh
+++ b/images/nginx/build.sh
@@ -99,7 +99,7 @@ fi
 GEOIP_FOLDER=/etc/nginx/geoip
 mkdir -p $GEOIP_FOLDER
 function geoip_get {
-  wget -O $GEOIP_FOLDER/$1 $2 || { echo 'Could not download $1, exiting.' ; exit 1; }
+  wget -O $GEOIP_FOLDER/$1 $2 || { echo "Could not download $1, exiting." ; exit 1; }
   gunzip $GEOIP_FOLDER/$1
 }
 geoip_get "GeoIP.dat.gz" "https://geolite.maxmind.com/download/geoip/database/GeoLiteCountry/GeoIP.dat.gz"

--- a/images/nginx/build.sh
+++ b/images/nginx/build.sh
@@ -95,14 +95,16 @@ if [[ ${ARCH} == "s390x" ]]; then
   git config --global pack.threads "1"
 fi
 
-# download GeoIP databases
-wget -O /etc/nginx/GeoIP.dat.gz https://geolite.maxmind.com/download/geoip/database/GeoLiteCountry/GeoIP.dat.gz || { echo 'Could not download GeoLiteCountry, exiting.' ; exit 1; }
-wget -O /etc/nginx/GeoLiteCity.dat.gz https://geolite.maxmind.com/download/geoip/database/GeoLiteCity.dat.gz || { echo 'Could not download GeoLiteCity, exiting.' ; exit 1; }
-wget -O /etc/nginx/GeoIPASNum.dat.gz http://download.maxmind.com/download/geoip/database/asnum/GeoIPASNum.dat.gz || { echo 'Could not download GeoLiteOrg, exiting.' ; exit 1; }
-
-gunzip /etc/nginx/GeoIP.dat.gz
-gunzip /etc/nginx/GeoLiteCity.dat.gz
-gunzip /etc/nginx/GeoIPASNum.dat.gz
+# Get the GeoIP data
+GEOIP_FOLDER=/etc/nginx/geoip
+mkdir -p $GEOIP_FOLDER
+function geoip_get {
+  wget -O $GEOIP_FOLDER/$1 $2 || { echo 'Could not download $1, exiting.' ; exit 1; }
+  gunzip $GEOIP_FOLDER/$1
+}
+geoip_get "GeoIP.dat.gz" "https://geolite.maxmind.com/download/geoip/database/GeoLiteCountry/GeoIP.dat.gz"
+geoip_get "GeoLiteCity.dat.gz" "https://geolite.maxmind.com/download/geoip/database/GeoLiteCity.dat.gz"
+geoip_get "GeoIPASNum.dat.gz" "http://download.maxmind.com/download/geoip/database/asnum/GeoIPASNum.dat.gz"
 
 mkdir --verbose -p "$BUILD_PATH"
 cd "$BUILD_PATH"

--- a/internal/ingress/controller/nginx.go
+++ b/internal/ingress/controller/nginx.go
@@ -69,7 +69,7 @@ const (
 
 var (
 	tmplPath    = "/etc/nginx/template/nginx.tmpl"
-	geoipPath	= "/etc/nginx/geoip"
+	geoipPath   = "/etc/nginx/geoip"
 	cfgPath     = "/etc/nginx/nginx.conf"
 	nginxBinary = "/usr/sbin/nginx"
 )
@@ -183,7 +183,6 @@ Error loading new template : %v
 	}
 
 	n.t = ngxTpl
-
 
 	// TODO: refactor
 	if _, ok := fs.(filesystem.DefaultFs); !ok {

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -47,9 +47,9 @@ http {
     {{/* databases used to determine the country depending on the client IP address */}}
     {{/* http://nginx.org/en/docs/http/ngx_http_geoip_module.html */}}
     {{/* this is require to calculate traffic for individual country using GeoIP in the status page */}}
-    geoip_country       /etc/nginx/GeoIP.dat;
-    geoip_city          /etc/nginx/GeoLiteCity.dat;
-    geoip_org           /etc/nginx/GeoIPASNum.dat;
+    geoip_country       /etc/nginx/geoip/GeoIP.dat;
+    geoip_city          /etc/nginx/geoip/GeoLiteCity.dat;
+    geoip_org           /etc/nginx/geoip/GeoIPASNum.dat;
     geoip_proxy_recursive on;
 
     {{ if $cfg.EnableVtsStatus }}


### PR DESCRIPTION
Hey, 
This attempts to fix https://github.com/kubernetes/ingress-nginx/issues/2100

In summary I have:
  - Moved the geoip data to `/etc/nginx/geoip`
  - Added Filesystem watchers on each of the files in that directory.

Things I don't like:
  - I've hard coded the files in `/etc/nginx/geoip`, it'd be nice to probably just enumerate the files in that directory and watch them all (in case they change name/are added/removed)
  - I've probably wrote terrible golang, this is literally my first golang change PR ever - so I apologise!

I've tested it on my controller, this was me modifying each file:

```
I0216 19:46:45.439078       7 nginx.go:158] Triggering NGINX reload
I0216 19:46:50.054260       7 controller.go:180] ingress backend successfully reloaded...
I0216 19:47:05.182746       7 nginx.go:158] Triggering NGINX reload
I0216 19:47:05.183088       7 controller.go:171] backend reload required
I0216 19:47:09.787091       7 controller.go:180] ingress backend successfully reloaded...
I0216 19:47:14.246166       7 nginx.go:158] Triggering NGINX reload
I0216 19:47:14.246540       7 controller.go:171] backend reload required
I0216 19:47:19.135127       7 controller.go:180] ingress backend successfully reloaded...
```