### PR TITLE
Add GCB config to build defaultbackend

### DIFF
--- a/images/404-server/cloudbuild.yaml
+++ b/images/404-server/cloudbuild.yaml
@@ -1,0 +1,43 @@
+timeout: 10800s
+
+substitutions:
+  { "_ARCH": "amd64",
+    "_REGISTRY": "gcr.io/k8s-image-staging",
+    "_TAG": "1.4" }
+
+steps:
+- name: gcr.io/cloud-builders/git
+  id: git-clone
+  entrypoint: bash
+  args:
+  - "-c"
+  - |
+    set -ex
+    mkdir -p /workspace/src/k8s.io
+    cd /workspace/src/k8s.io
+    git clone https://github.com/kubernetes/ingress-nginx.git
+
+- name: gcr.io/cloud-builders/go:debian
+  id: make-server
+  entrypoint: bash
+  dir: "/workspace/src/k8s.io/ingress-nginx/images/404-server"
+  env:
+    - "GOPATH=/workspace/"
+  args:
+  - "-c"
+  - |
+    set -ex
+    ARCH=${_ARCH} make server
+
+- name: gcr.io/cloud-builders/docker
+  id: docker-build
+  entrypoint: bash
+  dir: "/workspace/src/k8s.io/ingress-nginx/images/404-server"
+  args:
+  - "-c"
+  - |
+    set -e
+    docker build -t ${_REGISTRY}/defaultbackend-${_ARCH}:${_TAG} .
+
+images:
+  - "${_REGISTRY}/defaultbackend-${_ARCH}:${_TAG}"


### PR DESCRIPTION
Uses Google Container Builder to build and push the defaultbackend
image.  This will be used for automated builds of Kubernetes addon
images.