### PR TITLE
Revert deletion of dependency version override

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -20,6 +20,10 @@
 #  name = "github.com/x/y"
 #  version = "2.4.0"
 
+[[override]]
+  name = "github.com/docker/distribution"
+  revision = "edc3ab29cdff8694dd6feb85cfeb4b5f1b38ed9c"
+
 [[constraint]]
   name = "github.com/eapache/channels"
   branch = "master"


### PR DESCRIPTION
**What this PR does / why we need it**:

The version override on the "github.com/docker/distribution" package is necessary in order to avoid the following build error:
```
# k8s.io/ingress-nginx/vendor/k8s.io/kubernetes/pkg/util/parsers
vendor/k8s.io/kubernetes/pkg/util/parsers/parsers.go:36:16: undefined: reference.ParseNormalizedNamed
```

This partially reverts commit 9bcb5b08ea61a67845a0be1cf9feafab75862362.

`Gopkg.lock` is up-to-date.