### PR TITLE
Updated log level to v2 for sysctlFSFileMax.

### DIFF
--- a/internal/ingress/controller/nginx.go
+++ b/internal/ingress/controller/nginx.go
@@ -551,7 +551,7 @@ func (n *NGINXController) OnUpdate(ingressCfg ingress.Configuration) error {
 		wp = 1
 	}
 	maxOpenFiles := (sysctlFSFileMax() / wp) - 1024
-	glog.V(3).Infof("maximum number of open file descriptors : %v", maxOpenFiles)
+	glog.V(2).Infof("maximum number of open file descriptors : %v", maxOpenFiles)
 	if maxOpenFiles < 1024 {
 		// this means the value of RLIMIT_NOFILE is too low.
 		maxOpenFiles = 1024

--- a/internal/ingress/controller/util.go
+++ b/internal/ingress/controller/util.go
@@ -61,6 +61,6 @@ func sysctlFSFileMax() int {
 		// returning 0 means don't render the value
 		return 0
 	}
-	glog.V(3).Infof("system fs.file-max=%v", fileMax)
+	glog.V(2).Infof("system fs.file-max=%v", fileMax)
 	return fileMax
 }


### PR DESCRIPTION
This is very importatnt log for trouble-shooting, we should update
it to v2 by default.

/cc @aledbf

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
