### PR TITLE
Update documentation for nginx-ingress-role RBAC.

### DIFF
--- a/deploy/rbac.md
+++ b/deploy/rbac.md
@@ -43,7 +43,7 @@ These permissions are granted specific to the nginx-ingress namespace.  These
 permissions are granted to the Role named `nginx-ingress-role`
 
 * `configmaps`, `pods`, `secrets`: get
-* `endpoints`: create, get, update
+* `endpoints`: get
 
 Furthermore to support leader-election, the nginx-ingress-controller needs to
 have access to a `configmap` using the resourceName `ingress-controller-leader-nginx`


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**: For the Role named `nginx-ingress-role`, `endpoints` no longer needs or has `create` and `update` permissions.  This confused me, so I hope this helps!

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes confusing documentation that wasn't updated as part of https://github.com/kubernetes/ingress-nginx/commit/a9168f276e97e2922ebefb5a8a476aef659abd6a

**Special notes for your reviewer**:
