### PR TITLE
Typo fix "api server " -> "API server"

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -61,7 +61,7 @@ The Ingress controller needs information from apiserver. Therefore, authenticati
 2. _Kubeconfig file:_ In some Kubernetes environments service accounts are not available. In this case a manual configuration is required. The Ingress controller binary can be started with the `--kubeconfig` flag. The value of the flag is a path to a file specifying how to connect to the API server. Using the `--kubeconfig` does not requires the flag `--apiserver-host`.
 The format of the file is identical to `~/.kube/config` which is used by kubectl to connect to the API server. See 'kubeconfig' section for details.
 
-3. _Using the flag `--apiserver-host`:_ Using this flag `--apiserver-host=http://localhost:8080` it is possible to specify an unsecured api server or reach a remote kubernetes cluster using [kubectl proxy](https://kubernetes.io/docs/user-guide/kubectl/kubectl_proxy/).
+3. _Using the flag `--apiserver-host`:_ Using this flag `--apiserver-host=http://localhost:8080` it is possible to specify an unsecured API server or reach a remote kubernetes cluster using [kubectl proxy](https://kubernetes.io/docs/user-guide/kubectl/kubectl_proxy/).
 Please do not use this approach in production.
 
 In the diagram below you can see the full authentication flow with all options, starting with the browser


### PR DESCRIPTION
In this doc ,"API server" is written in capitals, but line 64 is not.
