### PR TITLE
include lua-resty-lock in nginx image

### DIFF
--- a/images/nginx/Makefile
+++ b/images/nginx/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # 0.0.0 shouldn't clobber any released builds
-TAG ?= 0.36
+TAG ?= 0.37
 REGISTRY ?= quay.io/kubernetes-ingress-controller
 ARCH ?= $(shell go env GOARCH)
 DOCKER ?= gcloud docker --

--- a/images/nginx/build.sh
+++ b/images/nginx/build.sh
@@ -32,7 +32,7 @@ export OPENTRACING_CPP_VERSION=1.2.0
 export ZIPKIN_CPP_VERSION=0.2.0
 export JAEGER_VERSION=0.2.0
 export MODSECURITY_VERSION=1.0.0
-export LUA_VERSION=0.10.12rc2
+export LUA_NGX_VERSION=0.10.12rc2
 export LUA_UPSTREAM_VERSION=0.07
 export COOKIE_FLAG_VERSION=1.1.0
 
@@ -155,7 +155,7 @@ get_src 9915ad1cf0734cc5b357b0d9ea92fec94764b4bf22f4dce185cbd65feda30ec1 \
         "https://github.com/AirisX/nginx_cookie_flag_module/archive/v$COOKIE_FLAG_VERSION.tar.gz"
 
 get_src 18edf2d18fa331265c36516a4a19ba75d26f46eafcc5e0c2d9aa6c237e8bc110 \
-        "https://github.com/openresty/lua-nginx-module/archive/v$LUA_VERSION.tar.gz"
+        "https://github.com/openresty/lua-nginx-module/archive/v$LUA_NGX_VERSION.tar.gz"
 
 get_src 2a69815e4ae01aa8b170941a8e1a10b6f6a9aab699dee485d58f021dd933829a \
         "https://github.com/openresty/lua-upstream-nginx-module/archive/v$LUA_UPSTREAM_VERSION.tar.gz"
@@ -165,6 +165,9 @@ get_src d4a9ed0d2405f41eb0178462b398afde8599c5115dcc1ff8f60e2f34a41a4c21 \
 
 get_src 92fd006d5ca3b3266847d33410eb280122a7f6c06334715f87acce064188a02e \
         "https://github.com/openresty/lua-resty-core/archive/v0.1.14rc1.tar.gz"
+
+get_src eaf84f58b43289c1c3e0442ada9ed40406357f203adc96e2091638080cb8d361 \
+        "https://github.com/openresty/lua-resty-lock/archive/v0.07.tar.gz"
 
 get_src 1ad2e34b111c802f9d0cdf019e986909123237a28c746b21295b63c9e785d9c3 \
         "http://luajit.org/download/LuaJIT-2.1.0-beta3.tar.gz"
@@ -195,6 +198,9 @@ cd "$BUILD_PATH/lua-resty-core-0.1.14rc1"
 make install
 
 cd "$BUILD_PATH/lua-resty-lrucache-0.07"
+make install
+
+cd "$BUILD_PATH/lua-resty-lock-0.07"
 make install
 
 # build opentracing lib
@@ -335,7 +341,7 @@ WITH_MODULES="--add-module=$BUILD_PATH/ngx_devel_kit-$NDK_VERSION \
   --add-module=$BUILD_PATH/nginx-goodies-nginx-sticky-module-ng-$STICKY_SESSIONS_VERSION \
   --add-module=$BUILD_PATH/nginx-http-auth-digest-$NGINX_DIGEST_AUTH \
   --add-module=$BUILD_PATH/ngx_http_substitutions_filter_module-$NGINX_SUBSTITUTIONS \
-  --add-module=$BUILD_PATH/lua-nginx-module-$LUA_VERSION \
+  --add-module=$BUILD_PATH/lua-nginx-module-$LUA_NGX_VERSION \
   --add-module=$BUILD_PATH/lua-upstream-nginx-module-$LUA_UPSTREAM_VERSION \
   --add-module=$BUILD_PATH/nginx_cookie_flag_module-$COOKIE_FLAG_VERSION \
   --add-dynamic-module=$BUILD_PATH/nginx-opentracing-$NGINX_OPENTRACING_VERSION/opentracing \


### PR DESCRIPTION
**What this PR does / why we need it**:
We need a synchronization/locking primitive available in Lua land to properly implement load balancing algorithms. You can see how is this being used for Round Robin implementation at https://github.com/Shopify/ingress/pull/16/files?w=1#diff-b00d77a6df9c8c05a483044b08e6bc50R38. But all the other algorithms that are in the roadmap will need some kind of locking. The PR adds https://github.com/openresty/lua-resty-lock to the Nginx image.

**Which issue this PR fixes**: N/A

**Special notes for your reviewer**: N/A