### PR TITLE
Allow referencing TLS secret from other namespace

### DIFF
--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -997,7 +997,13 @@ func (n *NGINXController) createServers(data []*extensions.Ingress,
 				continue
 			}
 
-			key := fmt.Sprintf("%v/%v", ing.Namespace, tlsSecretName)
+			key := ""
+
+			if strings.Contains(tlsSecretName, "/") {
+				key = tlsSecretName
+			} else {
+				key = fmt.Sprintf("%v/%v", ing.Namespace, tlsSecretName)
+			}
 			cert, err := n.store.GetLocalSecret(key)
 			if err != nil {
 				glog.Warningf("ssl certificate \"%v\" does not exist in local store", key)

--- a/internal/ingress/controller/store/backend_ssl.go
+++ b/internal/ingress/controller/store/backend_ssl.go
@@ -188,7 +188,7 @@ func (s k8sStore) checkMissingSecrets() {
 				continue
 			}
 
-			key := fmt.Sprintf("%v/%v", ing.Namespace, tls.SecretName)
+			key := getSecretKey(ing.Namespace, tls.SecretName)
 			if _, ok := s.sslStore.Get(key); !ok {
 				s.syncSecret(key)
 			}
@@ -212,7 +212,7 @@ func (s k8sStore) ReadSecrets(ing *extensions.Ingress) {
 			continue
 		}
 
-		key := fmt.Sprintf("%v/%v", ing.Namespace, tls.SecretName)
+		key := getSecretKey(ing.Namespace, tls.SecretName)
 		s.syncSecret(key)
 	}
 
@@ -235,4 +235,14 @@ func (s *k8sStore) sendDummyEvent() {
 			},
 		},
 	}
+}
+
+// getSecretKey gets a key in format namespace/secretName
+func getSecretKey(namespace, secretName string) (key string) {
+	if strings.Contains(secretName, "/") {
+		key = secretName
+	} else {
+		key = fmt.Sprintf("%v/%v", namespace, secretName)
+	}
+	return
 }

--- a/internal/ingress/controller/store/backend_ssl_test.go
+++ b/internal/ingress/controller/store/backend_ssl_test.go
@@ -18,6 +18,7 @@ package store
 
 import (
 	"encoding/base64"
+	"testing"
 
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -125,6 +126,26 @@ func buildCrtKeyAndCA() ([]byte, []byte, []byte, error) {
 	dCa := dCrt
 
 	return dCrt, dKey, dCa, nil
+}
+
+func TestGetSecretKey(t *testing.T) {
+	secretName := "secretNamespace/superSecret"
+	ingressNamespace := "ingressNamespace"
+
+	// Test when secret is in not in the same namespace as ingress.
+
+	secretKey := getSecretKey(ingressNamespace, secretName)
+	if secretKey != "secretNamespace/superSecret" {
+		t.Errorf("expected 0 items in the store but %v returned", secretKey)
+	}
+
+	// Test when secret resides in the same namespace as ingress.
+	secretName = "superSecret"
+
+	secretKey = getSecretKey(ingressNamespace, secretName)
+	if secretKey != "ingressNamespace/superSecret" {
+		t.Errorf("expected 0 items in the store but %v returned", secretKey)
+	}
 }
 
 /*


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**: Allow referencing TLS secret from other namespaces. When TLS secret referred to when creating an ingress is of pattern `<namespace>/<secretName>`, ingress controller will check the namespace specified rather than ingress' namespace for secret.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #2170

**Special notes for your reviewer**: NA
