### PR TITLE
Include tests in golint checks, fix warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ e2e-image: sub-container-amd64
 .PHONY: e2e-test
 e2e-test:
 	@go test -o e2e-tests -c ./test/e2e
-	@KUBECONFIG=${HOME}/.kube/config INGRESSNGINXCONFIG=${HOME}/.kube/config ./e2e-tests -test.parallel 1
+	@KUBECONFIG=${HOME}/.kube/config ./e2e-tests -test.parallel 1
 
 .PHONY: cover
 cover:

--- a/hack/verify-golint.sh
+++ b/hack/verify-golint.sh
@@ -23,10 +23,10 @@ KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 cd "${KUBE_ROOT}"
 
 GOLINT=${GOLINT:-"golint"}
-PACKAGES=($(go list ./... | grep -v /vendor/ | grep -v /test\/e2e/))
+PACKAGES=($(go list ./... | grep -v /vendor/))
 bad_files=()
 for package in "${PACKAGES[@]}"; do
-  out=$("${GOLINT}" -min_confidence=0.9 "${package}")
+  out=$("${GOLINT}" -min_confidence=0.9 "${package}" | grep -v 'should not use dot imports' || :)
   if [[ -n "${out}" ]]; then
     bad_files+=("${out}")
   fi

--- a/test/e2e/framework/cleanup.go
+++ b/test/e2e/framework/cleanup.go
@@ -18,13 +18,14 @@ package framework
 
 import "sync"
 
+// CleanupActionHandle is a handle used to perform a cleanup action.
 type CleanupActionHandle *int
 
 var cleanupActionsLock sync.Mutex
 var cleanupActions = map[CleanupActionHandle]func(){}
 
 // AddCleanupAction installs a function that will be called in the event of the
-// whole test being terminated.  This allows arbitrary pieces of the overall
+// whole test being terminated. This allows arbitrary pieces of the overall
 // test to hook into SynchronizedAfterSuite().
 func AddCleanupAction(fn func()) CleanupActionHandle {
 	p := CleanupActionHandle(new(int))
@@ -41,7 +42,7 @@ func RemoveCleanupAction(p CleanupActionHandle) {
 	delete(cleanupActions, p)
 }
 
-// RunCleanupActions runs all functions installed by AddCleanupAction.  It does
+// RunCleanupActions runs all functions installed by AddCleanupAction. It does
 // not remove them (see RemoveCleanupAction) but it does run unlocked, so they
 // may remove themselves.
 func RunCleanupActions() {

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -32,16 +32,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-const (
-	podName           = "test-ingress-controller"
-	controllerPodName = "nginx-ingress-controller"
-)
-
-const (
-	MaxRetry = 200
-	NoRetry  = 1
-)
-
+// RequestScheme define a scheme used in a test request.
 type RequestScheme string
 
 // These are valid test request schemes.
@@ -63,7 +54,7 @@ type Framework struct {
 	Namespace *v1.Namespace
 
 	// To make sure that this framework cleans up after itself, no matter what,
-	// we install a Cleanup action before each test and clear it after.  If we
+	// we install a Cleanup action before each test and clear it after. If we
 	// should abort, the AfterSuite hook should run all Cleanup actions.
 	cleanupHandle CleanupActionHandle
 

--- a/test/e2e/framework/k8s.go
+++ b/test/e2e/framework/k8s.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
+// EnsureSecret creates a Secret object or returns it if it already exists.
 func (f *Framework) EnsureSecret(secret *api.Secret) (*api.Secret, error) {
 	s, err := f.KubeClientSet.CoreV1().Secrets(secret.Namespace).Create(secret)
 	if err != nil {
@@ -38,6 +39,7 @@ func (f *Framework) EnsureSecret(secret *api.Secret) (*api.Secret, error) {
 	return s, nil
 }
 
+// EnsureIngress creates an Ingress object or returns it if it already exists.
 func (f *Framework) EnsureIngress(ingress *extensions.Ingress) (*extensions.Ingress, error) {
 	s, err := f.KubeClientSet.ExtensionsV1beta1().Ingresses(ingress.Namespace).Update(ingress)
 	if err != nil {
@@ -49,6 +51,7 @@ func (f *Framework) EnsureIngress(ingress *extensions.Ingress) (*extensions.Ingr
 	return s, nil
 }
 
+// EnsureService creates a Service object or returns it if it already exists.
 func (f *Framework) EnsureService(service *core.Service) (*core.Service, error) {
 	s, err := f.KubeClientSet.CoreV1().Services(service.Namespace).Update(service)
 	if err != nil {
@@ -60,6 +63,7 @@ func (f *Framework) EnsureService(service *core.Service) (*core.Service, error) 
 	return s, nil
 }
 
+// EnsureDeployment creates a Deployment object or returns it if it already exists.
 func (f *Framework) EnsureDeployment(deployment *extensions.Deployment) (*extensions.Deployment, error) {
 	d, err := f.KubeClientSet.Extensions().Deployments(deployment.Namespace).Update(deployment)
 	if err != nil {
@@ -71,6 +75,7 @@ func (f *Framework) EnsureDeployment(deployment *extensions.Deployment) (*extens
 	return d, nil
 }
 
+// WaitForPodsReady waits for a given amount of time until a group of Pods is running.
 func (f *Framework) WaitForPodsReady(timeout time.Duration, expectedReplicas int, opts metav1.ListOptions) error {
 	return wait.Poll(time.Second, timeout, func() (bool, error) {
 		pl, err := f.KubeClientSet.CoreV1().Pods(f.Namespace.Name).List(opts)

--- a/test/e2e/framework/logs.go
+++ b/test/e2e/framework/logs.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/api/core/v1"
 )
 
+// Logs returns the log entries of a given Pod.
 func (f *Framework) Logs(pod *v1.Pod) (string, error) {
 	var (
 		execOut bytes.Buffer

--- a/test/e2e/framework/ssl.go
+++ b/test/e2e/framework/ssl.go
@@ -74,11 +74,11 @@ func CreateIngressTLSSecret(client kubernetes.Interface, hosts []string, secretN
 // of rsaBits, valid for validFor time.
 func generateRSACerts(host string, isCA bool, keyOut, certOut io.Writer) error {
 	if len(host) == 0 {
-		return fmt.Errorf("Require a non-empty host for client hello")
+		return fmt.Errorf("require a non-empty host for client hello")
 	}
 	priv, err := rsa.GenerateKey(rand.Reader, rsaBits)
 	if err != nil {
-		return fmt.Errorf("Failed to generate key: %v", err)
+		return fmt.Errorf("failed to generate key: %v", err)
 	}
 	notBefore := time.Now()
 	notAfter := notBefore.Add(validFor)
@@ -119,13 +119,13 @@ func generateRSACerts(host string, isCA bool, keyOut, certOut io.Writer) error {
 
 	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
 	if err != nil {
-		return fmt.Errorf("Failed to create certificate: %s", err)
+		return fmt.Errorf("failed to create certificate: %s", err)
 	}
 	if err := pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes}); err != nil {
-		return fmt.Errorf("Failed creating cert: %v", err)
+		return fmt.Errorf("failed creating cert: %v", err)
 	}
 	if err := pem.Encode(keyOut, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(priv)}); err != nil {
-		return fmt.Errorf("Failed creating keay: %v", err)
+		return fmt.Errorf("failed creating keay: %v", err)
 	}
 	return nil
 }

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -25,19 +25,17 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-const (
-	RecommendedConfigPathEnvVar = "INGRESSNGINXCONFIG"
-)
-
+// TestContextType describes the client context to use in communications with the Kubernetes API.
 type TestContextType struct {
 	KubeHost    string
 	KubeConfig  string
 	KubeContext string
 }
 
+// TestContext is the global client context for tests.
 var TestContext TestContextType
 
-// Register flags common to all e2e test suites.
+// RegisterCommonFlags registers flags common to all e2e test suites.
 func RegisterCommonFlags() {
 	// Turn on verbose by default to get spec names
 	config.DefaultReporterConfig.Verbose = true
@@ -53,6 +51,7 @@ func RegisterCommonFlags() {
 	flag.StringVar(&TestContext.KubeContext, "kubernetes-context", "", "config context to use for kubernetes. If unset, will use value from 'current-context'")
 }
 
+// RegisterParseFlags registers and parses flags for the test binary.
 func RegisterParseFlags() {
 	RegisterCommonFlags()
 	flag.Parse()

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -51,26 +51,30 @@ func log(level string, format string, args ...interface{}) {
 	fmt.Fprintf(GinkgoWriter, nowStamp()+": "+level+": "+format+"\n", args...)
 }
 
+// Logf logs to the INFO logs.
 func Logf(format string, args ...interface{}) {
 	log("INFO", format, args...)
 }
 
+// Failf logs to the INFO logs and fails the test.
 func Failf(format string, args ...interface{}) {
 	msg := fmt.Sprintf(format, args...)
 	log("INFO", msg)
 	Fail(nowStamp()+": "+msg, 1)
 }
 
+// Skipf logs to the INFO logs and skips the test.
 func Skipf(format string, args ...interface{}) {
 	msg := fmt.Sprintf(format, args...)
 	log("INFO", msg)
 	Skip(nowStamp() + ": " + msg)
 }
 
+// RestclientConfig deserializes the contents of a kubeconfig file into a Config object.
 func RestclientConfig(config, context string) (*api.Config, error) {
 	Logf(">>> config: %s\n", config)
 	if config == "" {
-		return nil, fmt.Errorf("Config file must be specified to load client config")
+		return nil, fmt.Errorf("config file must be specified to load client config")
 	}
 	c, err := clientcmd.LoadFromFile(config)
 	if err != nil {
@@ -83,8 +87,7 @@ func RestclientConfig(config, context string) (*api.Config, error) {
 	return c, nil
 }
 
-type ClientConfigGetter func() (*rest.Config, error)
-
+// LoadConfig deserializes the contents of a kubeconfig file into a REST configuration.
 func LoadConfig(config, context string) (*rest.Config, error) {
 	c, err := RestclientConfig(config, context)
 	if err != nil {
@@ -127,6 +130,7 @@ func DeleteKubeNamespace(c kubernetes.Interface, namespace string) error {
 	return c.CoreV1().Namespaces().Delete(namespace, metav1.NewDeleteOptions(0))
 }
 
+// ExpectNoError tests whether an error occured.
 func ExpectNoError(err error, explain ...interface{}) {
 	if err != nil {
 		Logf("Unexpected error occurred: %v", err)


### PR DESCRIPTION
**What this PR does / why we need it**:

`golint` enforces good practices for writing Go code, therefore it makes sense to run checks on test packages as well. Since "should not use dot imports" is the only warning we really want to ignore (`ginkgo` imports), it is simple enough to exclude these warnings from the `golint` output.

**List of lint warnings tackled by this PR**:

```
test/e2e/framework/cleanup.go:21:6: exported type CleanupActionHandle should have comment or be unexported
test/e2e/framework/framework.go:40:2: exported const MaxRetry should have comment (or a comment on this block) or be unexported
test/e2e/framework/framework.go:44:6: exported type RequestScheme should have comment or be unexported
test/e2e/framework/k8s.go:30:1: exported method Framework.EnsureSecret should have comment or be unexported
test/e2e/framework/k8s.go:41:1: exported method Framework.EnsureIngress should have comment or be unexported
test/e2e/framework/k8s.go:52:1: exported method Framework.EnsureService should have comment or be unexported
test/e2e/framework/k8s.go:63:1: exported method Framework.EnsureDeployment should have comment or be unexported
test/e2e/framework/k8s.go:74:1: exported method Framework.WaitForPodsReady should have comment or be unexported
test/e2e/framework/logs.go:27:1: exported method Framework.Logs should have comment or be unexported
test/e2e/framework/ssl.go:77:21: error strings should not be capitalized or end with punctuation or a newline
test/e2e/framework/ssl.go:81:21: error strings should not be capitalized or end with punctuation or a newline
test/e2e/framework/ssl.go:122:21: error strings should not be capitalized or end with punctuation or a newline
test/e2e/framework/ssl.go:125:21: error strings should not be capitalized or end with punctuation or a newline
test/e2e/framework/ssl.go:128:21: error strings should not be capitalized or end with punctuation or a newline
test/e2e/framework/test_context.go:28:6: exported type TestContextType should have comment or be unexported
test/e2e/framework/test_context.go:34:5: exported var TestContext should have comment or be unexported
test/e2e/framework/test_context.go:36:1: comment on exported function RegisterCommonFlags should be of the form "RegisterCommonFlags ..."
test/e2e/framework/test_context.go:52:1: exported function RegisterParseFlags should have comment or be unexported
test/e2e/framework/util.go:55:1: exported function Logf should have comment or be unexported
test/e2e/framework/util.go:59:1: exported function Failf should have comment or be unexported
test/e2e/framework/util.go:65:1: exported function Skipf should have comment or be unexported
test/e2e/framework/util.go:71:1: exported function RestclientConfig should have comment or be unexported
test/e2e/framework/util.go:74:26: error strings should not be capitalized or end with punctuation or a newline
test/e2e/framework/util.go:87:6: exported type ClientConfigGetter should have comment or be unexported
test/e2e/framework/util.go:89:1: exported function LoadConfig should have comment or be unexported
test/e2e/framework/util.go:131:1: exported function ExpectNoError should have comment or be unexported
```