### PR TITLE
Remove ProxyPassParams setting

### DIFF
--- a/internal/ingress/annotations/proxy/main.go
+++ b/internal/ingress/annotations/proxy/main.go
@@ -33,7 +33,6 @@ type Config struct {
 	CookieDomain      string `json:"cookieDomain"`
 	CookiePath        string `json:"cookiePath"`
 	NextUpstream      string `json:"nextUpstream"`
-	PassParams        string `json:"passParams"`
 	ProxyRedirectFrom string `json:"proxyRedirectFrom"`
 	ProxyRedirectTo   string `json:"proxyRedirectTo"`
 	RequestBuffering  string `json:"requestBuffering"`
@@ -70,9 +69,6 @@ func (l1 *Config) Equal(l2 *Config) bool {
 		return false
 	}
 	if l1.NextUpstream != l2.NextUpstream {
-		return false
-	}
-	if l1.PassParams != l2.PassParams {
 		return false
 	}
 	if l1.RequestBuffering != l2.RequestBuffering {
@@ -145,11 +141,6 @@ func (a proxy) Parse(ing *extensions.Ingress) (interface{}, error) {
 		nu = defBackend.ProxyNextUpstream
 	}
 
-	pp, err := parser.GetStringAnnotation("proxy-pass-params", ing)
-	if err != nil || pp == "" {
-		pp = defBackend.ProxyPassParams
-	}
-
 	rb, err := parser.GetStringAnnotation("proxy-request-buffering", ing)
 	if err != nil || rb == "" {
 		rb = defBackend.ProxyRequestBuffering
@@ -170,5 +161,5 @@ func (a proxy) Parse(ing *extensions.Ingress) (interface{}, error) {
 		pb = defBackend.ProxyBuffering
 	}
 
-	return &Config{bs, ct, st, rt, bufs, cd, cp, nu, pp, prf, prt, rb, pb}, nil
+	return &Config{bs, ct, st, rt, bufs, cd, cp, nu, prf, prt, rb, pb}, nil
 }

--- a/internal/ingress/annotations/proxy/main_test.go
+++ b/internal/ingress/annotations/proxy/main_test.go
@@ -77,7 +77,6 @@ func (m mockBackend) GetDefaultBackend() defaults.Backend {
 		ProxyBufferSize:       "10k",
 		ProxyBodySize:         "3k",
 		ProxyNextUpstream:     "error",
-		ProxyPassParams:       "nocanon keepalive=On",
 		ProxyRequestBuffering: "on",
 		ProxyBuffering:        "off",
 	}
@@ -93,7 +92,6 @@ func TestProxy(t *testing.T) {
 	data[parser.GetAnnotationWithPrefix("proxy-buffer-size")] = "1k"
 	data[parser.GetAnnotationWithPrefix("proxy-body-size")] = "2k"
 	data[parser.GetAnnotationWithPrefix("proxy-next-upstream")] = "off"
-	data[parser.GetAnnotationWithPrefix("proxy-pass-params")] = "smax=5 max=10"
 	data[parser.GetAnnotationWithPrefix("proxy-request-buffering")] = "off"
 	data[parser.GetAnnotationWithPrefix("proxy-buffering")] = "on"
 	ing.SetAnnotations(data)
@@ -123,9 +121,6 @@ func TestProxy(t *testing.T) {
 	}
 	if p.NextUpstream != "off" {
 		t.Errorf("expected off as next-upstream but returned %v", p.NextUpstream)
-	}
-	if p.PassParams != "smax=5 max=10" {
-		t.Errorf("expected \"smax=5 max=10\" as pass-params but returned \"%v\"", p.PassParams)
 	}
 	if p.RequestBuffering != "off" {
 		t.Errorf("expected off as request-buffering but returned %v", p.RequestBuffering)
@@ -166,9 +161,6 @@ func TestProxyWithNoAnnotation(t *testing.T) {
 	}
 	if p.NextUpstream != "error" {
 		t.Errorf("expected error as next-upstream but returned %v", p.NextUpstream)
-	}
-	if p.PassParams != "nocanon keepalive=On" {
-		t.Errorf("expected \"nocanon keepalive=On\" as pass-params but returned \"%v\"", p.PassParams)
 	}
 	if p.RequestBuffering != "on" {
 		t.Errorf("expected on as request-buffering but returned %v", p.RequestBuffering)

--- a/internal/ingress/defaults/main.go
+++ b/internal/ingress/defaults/main.go
@@ -69,9 +69,6 @@ type Backend struct {
 	// http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_next_upstream
 	ProxyNextUpstream string `json:"proxy-next-upstream"`
 
-	// Parameters for proxy-pass directive (eg. Apache web server).
-	ProxyPassParams string `json:"proxy-pass-params"`
-
 	// Sets the original text that should be changed in the "Location" and "Refresh" header fields of a proxied server response.
 	// http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_redirect
 	// Default: off


### PR DESCRIPTION
**What this PR does / why we need it**:

TLDR: `ingress.kubernetes.io/proxy-pass-params` --> :door: 

This annotation made sense when the project was still a generic implementation, but `nginx` itself doesn't support such parameter, so there is no reason to keep it around.

Since I pushed that extra annotation, I feel responsible for removing it now :)

/assign @aledbf 