### PR TITLE
Add configoption to exclude routes from tls upgrading

### DIFF
--- a/docs/user-guide/configmap.md
+++ b/docs/user-guide/configmap.md
@@ -132,7 +132,7 @@ The following table shows a configuration option's name, type, and the default v
 |[http-redirect-code](#http-redirect-code)|int|308|
 |[proxy-buffering](#proxy-buffering)|string|"off"|
 |[limit-req-status-code](#limit-req-status-code)|int|503|
-|[no-tls-redirect-locations](#no-tls-redirect-locations)|string|"/.well-known/acme-challenge/"|
+|[no-tls-redirect-locations](#no-tls-redirect-locations)|string|"/.well-known/acme-challenge"|
 
 ## add-headers
 
@@ -730,4 +730,4 @@ Sets the [status code to return in response to rejected requests](http://nginx.o
 ## no-tls-redirect-locations
 
 A comma-separated list of locations on which http requests will never get redirected to their https counterpart.
-Default: "/.well-known/acme-challenge/"
+Default: "/.well-known/acme-challenge"

--- a/docs/user-guide/configmap.md
+++ b/docs/user-guide/configmap.md
@@ -132,6 +132,7 @@ The following table shows a configuration option's name, type, and the default v
 |[http-redirect-code](#http-redirect-code)|int|308|
 |[proxy-buffering](#proxy-buffering)|string|"off"|
 |[limit-req-status-code](#limit-req-status-code)|int|503|
+|[no-tls-redirect-locations](#no-tls-redirect-locations)|string|"/.well-known/acme-challenge/"|
 
 ## add-headers
 
@@ -725,3 +726,8 @@ Enables or disables [buffering of responses from the proxied server](http://ngin
 ## limit-req-status-code
 
 Sets the [status code to return in response to rejected requests](http://nginx.org/en/docs/http/ngx_http_limit_req_module.html#limit_req_status).Default: 503
+
+## no-tls-redirect-locations
+
+A comma-separated list of locations on which http requests will never get redirected to their https counterpart.
+Default: "/.well-known/acme-challenge/"

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -487,8 +487,8 @@ type Configuration struct {
 	// SyslogPort port
 	SyslogPort int `json:"syslog-port",omitempty`
 
-	// NoTLSRedirectLocations is a "\n -" seperated list of locations
-	// that shall not get redirected to tls
+	// NoTLSRedirectLocations is a comma-seperated list of locations
+	// that should not get redirected to TLS
 	NoTLSRedirectLocations string `json:"no-tls-redirect-locations"`
 }
 

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -486,6 +486,10 @@ type Configuration struct {
 	SyslogHost string `json:"syslog-host"`
 	// SyslogPort port
 	SyslogPort int `json:"syslog-port",omitempty`
+
+	// NoTLSRedirectLocations is a "\n -" seperated list of locations
+	// that shall not get redirected to tls
+	NoTLSRedirectLocations string `json:"no-tls-redirect-locations"`
 }
 
 // NewDefault returns the default nginx configuration

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -487,7 +487,7 @@ type Configuration struct {
 	// SyslogPort port
 	SyslogPort int `json:"syslog-port",omitempty`
 
-	// NoTLSRedirectLocations is a comma-seperated list of locations
+	// NoTLSRedirectLocations is a comma-separated list of locations
 	// that should not get redirected to TLS
 	NoTLSRedirectLocations string `json:"no-tls-redirect-locations"`
 }
@@ -586,6 +586,7 @@ func NewDefault() Configuration {
 		JaegerSamplerParam:           "1",
 		LimitReqStatusCode:           503,
 		SyslogPort:                   514,
+		NoTLSRedirectLocations:       "/.well-known/acme-challenge/",
 	}
 
 	if glog.V(5) {

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -586,7 +586,7 @@ func NewDefault() Configuration {
 		JaegerSamplerParam:           "1",
 		LimitReqStatusCode:           503,
 		SyslogPort:                   514,
-		NoTLSRedirectLocations:       "/.well-known/acme-challenge/",
+		NoTLSRedirectLocations:       "/.well-known/acme-challenge",
 	}
 
 	if glog.V(5) {

--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -515,10 +515,10 @@ func isLocationInLocationList(location interface{}, rawLocationList string) bool
 		return false
 	}
 
-	locationList := strings.Split(rawLocationList, "\n- ")
+	locationList := strings.Split(rawLocationList, ",")
 
 	for _, locationListItem := range locationList {
-		locationListItem = strings.TrimLeft(locationListItem, "- ")
+		locationListItem = strings.Trim(locationListItem, " ")
 		if locationListItem == "" {
 			continue
 		}

--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -129,6 +129,7 @@ var (
 		"buildRateLimit":           buildRateLimit,
 		"buildResolvers":           buildResolvers,
 		"buildUpstreamName":        buildUpstreamName,
+		"isLocationInLocationList": isLocationInLocationList,
 		"isLocationAllowed":        isLocationAllowed,
 		"buildLogFormatUpstream":   buildLogFormatUpstream,
 		"buildDenyVariable":        buildDenyVariable,
@@ -505,6 +506,25 @@ func buildRateLimit(input interface{}) []string {
 	}
 
 	return limits
+}
+
+func isLocationInLocationList(location interface{}, rawLocationList string) bool {
+	loc, ok := location.(*ingress.Location)
+	if !ok {
+		glog.Errorf("expected an '*ingress.Location' type but %T was returned", location)
+		return false
+	}
+
+	locationList := strings.Split(rawLocationList, "\n- ")
+
+	for _, locationListItem := range locationList {
+		locationListItem = strings.TrimLeft(locationListItem, "- ")
+		if strings.HasPrefix(loc.Path, locationListItem) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func isLocationAllowed(input interface{}) bool {

--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -519,6 +519,9 @@ func isLocationInLocationList(location interface{}, rawLocationList string) bool
 
 	for _, locationListItem := range locationList {
 		locationListItem = strings.TrimLeft(locationListItem, "- ")
+		if locationListItem == "" {
+			continue
+		}
 		if strings.HasPrefix(loc.Path, locationListItem) {
 			return true
 		}

--- a/internal/ingress/controller/template/template_test.go
+++ b/internal/ingress/controller/template/template_test.go
@@ -462,12 +462,12 @@ func TestIsLocationInLocationList(t *testing.T) {
 		rawLocationList string
 		expected        bool
 	}{
-		{&ingress.Location{Path: "/match"}, "- /match", true},
-		{&ingress.Location{Path: "/match"}, "\n- /match", true},
-		{&ingress.Location{Path: "/match"}, "- /dontmatch", false},
-		{&ingress.Location{Path: "/match"}, "\n- /dontmatch", false},
-		{&ingress.Location{Path: "/match"}, "- /dontmatch\n- /match", true},
-		{&ingress.Location{Path: "/match"}, "\n- /dontmatch\n- /dontmatcheither", false},
+		{&ingress.Location{Path: "/match"}, "/match", true},
+		{&ingress.Location{Path: "/match"}, ",/match", true},
+		{&ingress.Location{Path: "/match"}, "/dontmatch", false},
+		{&ingress.Location{Path: "/match"}, ",/dontmatch", false},
+		{&ingress.Location{Path: "/match"}, "/dontmatch,/match", true},
+		{&ingress.Location{Path: "/match"}, "/dontmatch,/dontmatcheither", false},
 	}
 
 	for _, testCase := range testCases {

--- a/internal/ingress/controller/template/template_test.go
+++ b/internal/ingress/controller/template/template_test.go
@@ -454,3 +454,26 @@ func TestBuildAuthSignURL(t *testing.T) {
 		}
 	}
 }
+
+func TestIsLocationInLocationList(t *testing.T) {
+
+	testCases := []struct {
+		location        *ingress.Location
+		rawLocationList string
+		expected        bool
+	}{
+		{&ingress.Location{Path: "/match"}, "- /match", true},
+		{&ingress.Location{Path: "/match"}, "\n- /match", true},
+		{&ingress.Location{Path: "/match"}, "- /dontmatch", false},
+		{&ingress.Location{Path: "/match"}, "\n- /dontmatch", false},
+		{&ingress.Location{Path: "/match"}, "- /dontmatch\n- /match", true},
+		{&ingress.Location{Path: "/match"}, "\n- /dontmatch\n- /dontmatcheither", false},
+	}
+
+	for _, testCase := range testCases {
+		result := isLocationInLocationList(testCase.location, testCase.rawLocationList)
+		if result != testCase.expected {
+			t.Errorf(" expected %v but return %v, path: '%s', rawLocation: '%s'", testCase.expected, result, testCase.location.Path, testCase.rawLocationList)
+		}
+	}
+}

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -102,7 +102,7 @@ http {
     {{ if $cfg.EnableOpentracing }}
     opentracing on;
     {{ end }}
-    
+
     {{ buildOpentracing $cfg }}
 
     include /etc/nginx/mime.types;
@@ -718,6 +718,7 @@ stream {
 
             {{/* redirect to HTTPS can be achieved forcing the redirect or having a SSL Certificate configured for the server */}}
             {{ if (or $location.Rewrite.ForceSSLRedirect (and (not (empty $server.SSLCertificate)) $location.Rewrite.SSLRedirect)) }}
+            {{ if not (isLocationInLocationList $location $all.Cfg.NoTLSRedirectLocations) }}
             # enforce ssl on server side
             if ($redirect_to_https) {
                 {{ if $location.UsePortInRedirects }}
@@ -730,6 +731,7 @@ stream {
                 return {{ $all.Cfg.HTTPRedirectCode }} https://$best_http_host$request_uri;
                 {{ end }}
             }
+            {{ end }}
             {{ end }}
 
             {{ if $all.Cfg.EnableModsecurity }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Allows configuring routes that shall not be upgraded to tls, e.G. because they are for a letsencrypt ACME challenge

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #2095

**Special notes for your reviewer**:
