### PR TITLE
fix wrong config generation when upstream-hash-by is set

### DIFF
--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -287,7 +287,7 @@ func buildLoadBalancingConfig(b interface{}, fallbackLoadBalancing string) strin
 	}
 
 	if backend.UpstreamHashBy != "" {
-		return "hash {{ $upstream.UpstreamHashBy }} consistent;"
+		return fmt.Sprintf("hash %s consistent;", backend.UpstreamHashBy)
 	}
 
 	if backend.LoadBalancing != "" {


### PR DESCRIPTION
**What this PR does / why we need it**:
fixes incorrect config generation when `upstream-hash-by` is set.

An incorrectly generated config looks like:
```
    upstream squawk-production-squawk-web-80 {
        hash {{ $upstream.UpstreamHashBy }} consistent;

        keepalive 32;
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
