### PR TITLE
clean backends data before sending to Lua endpoint

### DIFF
--- a/internal/ingress/controller/nginx.go
+++ b/internal/ingress/controller/nginx.go
@@ -763,7 +763,15 @@ func (n *NGINXController) IsDynamicallyConfigurable(pcfg *ingress.Configuration)
 // ConfigureDynamically JSON encodes new Backends and POSTs it to an internal HTTP endpoint
 // that is handled by Lua
 func (n *NGINXController) ConfigureDynamically(pcfg *ingress.Configuration) error {
-	buf, err := json.Marshal(pcfg.Backends)
+	backends := make([]*ingress.Backend, len(pcfg.Backends))
+
+	for i, backend := range pcfg.Backends {
+		cleanedupBackend := *backend
+		cleanedupBackend.Service = nil
+		backends[i] = &cleanedupBackend
+	}
+
+	buf, err := json.Marshal(backends)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
As can be seen at https://github.com/kubernetes/ingress-nginx/issues/2225#issuecomment-375083611 backends data the controller POSTs to Lua endpoint includes `Service` field for every backend that is not used in Lua balancer code at all. The PR strips it from the payload.

**Which issue this PR fixes** 
related to https://github.com/kubernetes/ingress-nginx/issues/2231

**Special notes for your reviewer**: