### PR TITLE
add http/2

### DIFF
--- a/images/echoheaders/Makefile
+++ b/images/echoheaders/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-TAG ?= 1.9
+TAG ?= 1.10
 REGISTRY ?= gcr.io/google_containers
 ARCH ?= $(shell go env GOARCH)
 ALL_ARCH = amd64 arm ppc64le

--- a/images/echoheaders/README.md
+++ b/images/echoheaders/README.md
@@ -2,6 +2,7 @@
 
 This is a simple server that responds with the http headers it received.
 
+Image Versions >= 1.10 support HTTP2 on :8443.
 Image Versions >= 1.9 expose HTTPS endpoint on :8443.
 Image versions >= 1.4 removes the redirect introduced in 1.3.  
 Image versions >= 1.3 redirect requests on :80 with `X-Forwarded-Proto: http` to :443.  

--- a/images/echoheaders/echo-app.yaml
+++ b/images/echoheaders/echo-app.yaml
@@ -36,7 +36,7 @@ spec:
     spec:
       containers:
       - name: echoheaders
-        image: gcr.io/google_containers/echoserver:1.9
+        image: gcr.io/google_containers/echoserver:1.10
         ports:
         - containerPort: 8080
         - containerPort: 8443

--- a/images/echoheaders/nginx.conf
+++ b/images/echoheaders/nginx.conf
@@ -61,7 +61,7 @@ Request Body:
 		# basically instructs to create an individual listening socket for each worker process (using the SO_REUSEPORT
 		# socket option), allowing a kernel to distribute incoming connections between worker processes.
 		listen 8080 default_server reuseport;
-		listen 8443 default_server ssl reuseport;
+		listen 8443 default_server ssl http2 reuseport;
 
 		ssl_certificate /certs/certificate.crt;
 		ssl_certificate_key /certs/privateKey.key;


### PR DESCRIPTION
**What this PR does / why we need it**:
Enables HTTP2 on port 8443 for echoheaders.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Required to test HTTP/2 in Kubernetes Ingress