### PR TITLE
fix: empty ingress path

### DIFF
--- a/internal/ingress/controller/store/store.go
+++ b/internal/ingress/controller/store/store.go
@@ -111,6 +111,7 @@ const (
 	DeleteEvent EventType = "DELETE"
 	// ConfigurationEvent event associated when a configuration object is created or updated
 	ConfigurationEvent EventType = "CONFIGURATION"
+	slash                        = "/"
 )
 
 // Event holds the context of an event
@@ -516,7 +517,7 @@ func (s k8sStore) GetService(key string) (*apiv1.Service, error) {
 	return s.listers.Service.ByKey(key)
 }
 
-// GetSecret returns an Ingress using the namespace and name as key
+// GetIngress returns an Ingress using the namespace and name as key
 func (s k8sStore) GetIngress(key string) (*extensions.Ingress, error) {
 	return s.listers.Ingress.ByKey(key)
 }
@@ -530,7 +531,13 @@ func (s k8sStore) ListIngresses() []*extensions.Ingress {
 		if !class.IsValid(ing) {
 			continue
 		}
-
+		for ri, rule := range ing.Spec.Rules {
+			for pi, path := range rule.HTTP.Paths {
+				if path.Path == "" {
+					ing.Spec.Rules[ri].HTTP.Paths[pi].Path = slash
+				}
+			}
+		}
 		ingresses = append(ingresses, ing)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
If the origin ingress rule has no field `path`, the default value will be an empty string which will cause issues when rendering template as other place will use `/` as the default value.
Set the default value of path to `/` when retrieve ingress rules from api-server. 

This fix may also fix some hidden bugs that related to the default empty path. 
e.g.
https://github.com/kubernetes/ingress-nginx/blob/master/internal/ingress/controller/template/template.go#L728
https://github.com/kubernetes/ingress-nginx/blob/master/internal/ingress/controller/template/template.go#L616

Both of them compare path with origin ingress path, if there is no path field in ingress rules it will generate wrong nginx config.

**Which issue this PR fixes** : fixes #1980 

**Special notes for your reviewer**:


