### PR TITLE
Ignore default certificate during server initialization TLS loop

### DIFF
--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -990,8 +990,8 @@ func (n *NGINXController) createServers(data []*extensions.Ingress,
 				servers[host].SSLCiphers = anns.SSLCiphers
 			}
 
-			// only add a certificate if the server does not have one previously configured
-			if servers[host].SSLCert.PemFileName != "" {
+			// only add a certificate if the server does not have one previously configured that is not the default
+			if servers[host].SSLCert.PemFileName != "" && servers[host].SSLCert.PemFileName != defaultPemFileName {
 				continue
 			}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

Currently, for each host, if the first (lowest resourceVersion) ingress configuration does not contain a TLS secret, the default certificate is set. This causes the controller to ignore newer ingress configurations that may reference a TLS secret.

This change allows configurations, where multiple ingress configurations exist for a host, with only one of them containing a TLS secret, to work more reliably.
