### PR TITLE
Fix flaky e2e tests 

### DIFF
--- a/test/e2e/lua/dynamic_configuration.go
+++ b/test/e2e/lua/dynamic_configuration.go
@@ -51,8 +51,6 @@ var _ = framework.IngressNginxDescribe("Dynamic Configuration", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ing).NotTo(BeNil())
 
-		time.Sleep(5 * time.Second)
-
 		err = f.WaitForNginxServer(host,
 			func(server string) bool {
 				return strings.Contains(server, "proxy_pass http://upstream_balancer;")
@@ -195,7 +193,11 @@ func enableDynamicConfiguration(kubeClientSet kubernetes.Interface) error {
 			args = append(args, "--enable-dynamic-configuration")
 			deployment.Spec.Template.Spec.Containers[0].Args = args
 			_, err := kubeClientSet.AppsV1beta1().Deployments("ingress-nginx").Update(deployment)
-			return err
+			if err != nil {
+				return err
+			}
+			time.Sleep(15 * time.Second)
+			return nil
 		})
 }
 
@@ -211,7 +213,11 @@ func disableDynamicConfiguration(kubeClientSet kubernetes.Interface) error {
 			}
 			deployment.Spec.Template.Spec.Containers[0].Args = newArgs
 			_, err := kubeClientSet.AppsV1beta1().Deployments("ingress-nginx").Update(deployment)
-			return err
+			if err != nil {
+				return err
+			}
+			time.Sleep(15 * time.Second)
+			return nil
 		})
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

e2e tests are currently flaky due to #2254 introducting tests that redeploy the ingress controller but only sometimes wait afterwards which may cause subsequent tests to fail.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
