### PR TITLE
include lua-resty-waf and its dependencies in the base Nginx image

### DIFF
--- a/images/nginx/Dockerfile
+++ b/images/nginx/Dockerfile
@@ -17,7 +17,7 @@ FROM BASEIMAGE
 
 CROSS_BUILD_COPY qemu-ARCH-static /usr/bin/
 
-COPY build.sh /
+COPY build.sh install_lua_resty_waf.sh /
 
 RUN clean-install bash
 

--- a/images/nginx/Makefile
+++ b/images/nginx/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # 0.0.0 shouldn't clobber any released builds
-TAG ?= 0.39
+TAG ?= 0.40
 REGISTRY ?= quay.io/kubernetes-ingress-controller
 ARCH ?= $(shell go env GOARCH)
 DOCKER ?= gcloud docker --

--- a/images/nginx/build.sh
+++ b/images/nginx/build.sh
@@ -85,6 +85,7 @@ clean-install \
   procps \
   git g++ pkgconf flex bison doxygen libyajl-dev liblmdb-dev libtool dh-autoreconf libxml2 libpcre++-dev libxml2-dev \
   lua-cjson \
+  python \
   || exit 1
 
 ln -s /usr/lib/x86_64-linux-gnu/liblua5.1.so /usr/lib/liblua.so
@@ -148,8 +149,8 @@ get_src b65bb78bcd8806cf11695b980577abb5379369929240414c75eb4623a4d45cc3 \
 get_src 8deee6d6f7128f58bd6ba2893bd69c1fdbc8a3ad2797ba45ef94b977255d181c \
         "https://github.com/SpiderLabs/ModSecurity-nginx/archive/v$MODSECURITY_VERSION.tar.gz"
 
-get_src 359274ebb0923c5a4d23e2e93d29262b2bc8a302ce37cf0a0b113fd4d623d389 \
-        "https://github.com/jaegertracing/cpp-client/archive/v$JAEGER_VERSION.tar.gz"
+get_src 841916d60fee16fe245b67fe6938ad861ddd3f3ecf0df561d764baeda8739362 \
+        "https://github.com/jaegertracing/jaeger-client-cpp/archive/v$JAEGER_VERSION.tar.gz"
 
 get_src 9915ad1cf0734cc5b357b0d9ea92fec94764b4bf22f4dce185cbd65feda30ec1 \
         "https://github.com/AirisX/nginx_cookie_flag_module/archive/v$COOKIE_FLAG_VERSION.tar.gz"
@@ -168,6 +169,9 @@ get_src 92fd006d5ca3b3266847d33410eb280122a7f6c06334715f87acce064188a02e \
 
 get_src eaf84f58b43289c1c3e0442ada9ed40406357f203adc96e2091638080cb8d361 \
         "https://github.com/openresty/lua-resty-lock/archive/v0.07.tar.gz"
+
+get_src 3917d506e2d692088f7b4035c589cc32634de4ea66e40fc51259fbae43c9258d \
+        "https://github.com/hamishforbes/lua-resty-iputils/archive/v0.3.0.tar.gz"
 
 get_src 1ad2e34b111c802f9d0cdf019e986909123237a28c746b21295b63c9e785d9c3 \
         "http://luajit.org/download/LuaJIT-2.1.0-beta3.tar.gz"
@@ -189,6 +193,7 @@ if [[ (${ARCH} != "ppc64le") && (${ARCH} != "s390x") ]]; then
 
   export LUAJIT_LIB=/usr/local/lib
   export LUAJIT_INC=/usr/local/include/luajit-2.1
+  export LUA_LIB_DIR="$LUAJIT_LIB/lua"
 fi
 
 cd "$BUILD_PATH/lua-resty-core-0.1.14rc1"
@@ -200,6 +205,9 @@ make install
 cd "$BUILD_PATH/lua-resty-lock-0.07"
 make install
 
+# build and install lua-resty-waf with dependencies
+/install_lua_resty_waf.sh
+
 # build opentracing lib
 cd "$BUILD_PATH/opentracing-cpp-$OPENTRACING_CPP_VERSION"
 mkdir .build
@@ -209,7 +217,7 @@ make
 make install
 
 # build zipkin lib
-cd "$BUILD_PATH/cpp-client-$JAEGER_VERSION"
+cd "$BUILD_PATH/jaeger-client-cpp-$JAEGER_VERSION"
 sed -i 's/-Werror//' CMakeLists.txt
 mkdir .build
 cd .build

--- a/images/nginx/install_lua_resty_waf.sh
+++ b/images/nginx/install_lua_resty_waf.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 
+# Copyright 2015 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 set -o errexit
 set -o nounset
 set -o pipefail

--- a/images/nginx/install_lua_resty_waf.sh
+++ b/images/nginx/install_lua_resty_waf.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# build and install lua-resty-waf
+cd "$BUILD_PATH"
+git clone --recursive --single-branch -b v0.11.1 https://github.com/p0pr0ck5/lua-resty-waf
+cd lua-resty-waf
+make
+make install-check
+# we can not use "make install" directly here because it also calls "install-deps" which requires OPM
+# to avoid that we install the libraries "install-deps" would install manually
+cd "$BUILD_PATH/lua-resty-iputils-0.3.0"
+make install
+# this library's latest version is not released therefore cloning directly
+git clone -b master --single-branch https://github.com/cloudflare/lua-resty-cookie.git "$BUILD_PATH/lua-resty-cookie"
+cd "$BUILD_PATH/lua-resty-cookie"
+make install
+# this library's latest version is not released therefore cloning directly
+git clone -b master --single-branch https://github.com/p0pr0ck5/lua-ffi-libinjection.git "$BUILD_PATH/lua-ffi-libinjection"
+cd "$BUILD_PATH/lua-ffi-libinjection"
+install lib/resty/*.lua "$LUA_LIB_DIR/resty/"
+# this library's latest version is not released therefore cloning directly
+git clone -b master --single-branch https://github.com/cloudflare/lua-resty-logger-socket.git "$BUILD_PATH/lua-resty-logger-socket"
+cd "$BUILD_PATH/lua-resty-logger-socket"
+install -d "$LUA_LIB_DIR/resty/logger"
+install lib/resty/logger/*.lua "$LUA_LIB_DIR/resty/logger/"
+# and do the rest of what "make instal" does
+cd "$BUILD_PATH/lua-resty-waf"
+install -d "$LUA_LIB_DIR/resty/waf/storage"
+install -d "$LUA_LIB_DIR/rules"
+install -m 644 lib/resty/*.lua "$LUA_LIB_DIR/resty/"
+install -m 644 lib/resty/waf/*.lua "$LUA_LIB_DIR/resty/waf/"
+install -m 644 lib/resty/waf/storage/*.lua "$LUA_LIB_DIR/resty/waf/storage/"
+install -m 644 lib/*.so $LUA_LIB_DIR
+install -m 644 rules/*.json "$LUA_LIB_DIR/rules/"


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a first step toward implementing the feature request at https://github.com/kubernetes/ingress-nginx/issues/2299.
The PR installs lua-resty-waf and its dependencies.

**Which issue this PR fixes**: n/a

**Special notes for your reviewer**:
related to https://github.com/kubernetes/ingress-nginx/issues/2299