### PR TITLE
More lua dependencies

### DIFF
--- a/images/nginx/build.sh
+++ b/images/nginx/build.sh
@@ -86,6 +86,7 @@ clean-install \
   git g++ pkgconf flex bison doxygen libyajl-dev liblmdb-dev libtool dh-autoreconf libxml2 libpcre++-dev libxml2-dev \
   lua-cjson \
   python \
+  luarocks \
   || exit 1
 
 ln -s /usr/lib/x86_64-linux-gnu/liblua5.1.so /usr/lib/liblua.so
@@ -173,6 +174,15 @@ get_src eaf84f58b43289c1c3e0442ada9ed40406357f203adc96e2091638080cb8d361 \
 get_src 3917d506e2d692088f7b4035c589cc32634de4ea66e40fc51259fbae43c9258d \
         "https://github.com/hamishforbes/lua-resty-iputils/archive/v0.3.0.tar.gz"
 
+get_src 5d16e623d17d4f42cc64ea9cfb69ca960d313e12f5d828f785dd227cc483fcbd \
+        "https://github.com/openresty/lua-resty-upload/archive/v0.10.tar.gz"
+
+get_src feacc662fd7724741c2b3277b2d27b5ab2821bdb28b499d063dbd23414447249 \
+        "https://github.com/openresty/lua-resty-dns/archive/v0.21rc2.tar.gz"
+
+get_src 30a68f1828ed6a53ee6ed062132ea914201076058b1d126ea90ff8e55df09daf \
+        "https://github.com/openresty/lua-resty-string/archive/v0.11rc1.tar.gz"
+
 get_src 1ad2e34b111c802f9d0cdf019e986909123237a28c746b21295b63c9e785d9c3 \
         "http://luajit.org/download/LuaJIT-2.1.0-beta3.tar.gz"
 
@@ -203,6 +213,18 @@ cd "$BUILD_PATH/lua-resty-lrucache-0.07"
 make install
 
 cd "$BUILD_PATH/lua-resty-lock-0.07"
+make install
+
+cd "$BUILD_PATH/lua-resty-iputils-0.3.0"
+make install
+
+cd "$BUILD_PATH/lua-resty-upload-0.10"
+make install
+
+cd "$BUILD_PATH/lua-resty-dns-0.21rc2"
+make install
+
+cd "$BUILD_PATH/lua-resty-string-0.11rc1"
 make install
 
 # build and install lua-resty-waf with dependencies

--- a/images/nginx/install_lua_resty_waf.sh
+++ b/images/nginx/install_lua_resty_waf.sh
@@ -19,29 +19,35 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-# build and install lua-resty-waf
 cd "$BUILD_PATH"
 git clone --recursive --single-branch -b v0.11.1 https://github.com/p0pr0ck5/lua-resty-waf
+
 cd lua-resty-waf
 make
 make install-check
+
 # we can not use "make install" directly here because it also calls "install-deps" which requires OPM
 # to avoid that we install the libraries "install-deps" would install manually
-cd "$BUILD_PATH/lua-resty-iputils-0.3.0"
-make install
-# this library's latest version is not released therefore cloning directly
+
 git clone -b master --single-branch https://github.com/cloudflare/lua-resty-cookie.git "$BUILD_PATH/lua-resty-cookie"
 cd "$BUILD_PATH/lua-resty-cookie"
 make install
-# this library's latest version is not released therefore cloning directly
+
 git clone -b master --single-branch https://github.com/p0pr0ck5/lua-ffi-libinjection.git "$BUILD_PATH/lua-ffi-libinjection"
 cd "$BUILD_PATH/lua-ffi-libinjection"
 install lib/resty/*.lua "$LUA_LIB_DIR/resty/"
-# this library's latest version is not released therefore cloning directly
+
 git clone -b master --single-branch https://github.com/cloudflare/lua-resty-logger-socket.git "$BUILD_PATH/lua-resty-logger-socket"
 cd "$BUILD_PATH/lua-resty-logger-socket"
 install -d "$LUA_LIB_DIR/resty/logger"
 install lib/resty/logger/*.lua "$LUA_LIB_DIR/resty/logger/"
+
+git clone -b master --single-branch https://github.com/bungle/lua-resty-random.git "$BUILD_PATH/lua-resty-random"
+cd "$BUILD_PATH/lua-resty-cookie"
+make install
+
+luarocks install lrexlib-pcre 2.7.2-1
+
 # and do the rest of what "make instal" does
 cd "$BUILD_PATH/lua-resty-waf"
 install -d "$LUA_LIB_DIR/resty/waf/storage"


### PR DESCRIPTION
**What this PR does / why we need it**:
Include the rest of the lua-resty-waf dependencies in Nginx image. Continuation of https://github.com/kubernetes/ingress-nginx/pull/2301. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
