### PR TITLE
Move ConfigMap updating methods into e2e/framework

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -61,6 +61,9 @@ type Framework struct {
 	// should abort, the AfterSuite hook should run all Cleanup actions.
 	cleanupHandle CleanupActionHandle
 
+	// Map to hold the default nginx-configuration configmap data before a test run
+	DefaultNginxConfigMapData map[string]string
+
 	NginxHTTPURL  string
 	NginxHTTPSURL string
 }
@@ -69,7 +72,8 @@ type Framework struct {
 // you (you can write additional before/after each functions).
 func NewDefaultFramework(baseName string) *Framework {
 	f := &Framework{
-		BaseName: baseName,
+		BaseName:                  baseName,
+		DefaultNginxConfigMapData: nil,
 	}
 
 	BeforeEach(f.BeforeEach)
@@ -101,6 +105,13 @@ func (f *Framework) BeforeEach() {
 	By("Building NGINX HTTPS URL")
 	f.NginxHTTPSURL, err = f.GetNginxURL(HTTPS)
 	Expect(err).NotTo(HaveOccurred())
+
+	By("Persist nginx-configuration configMap Data")
+	if f.DefaultNginxConfigMapData == nil {
+		f.DefaultNginxConfigMapData, err = f.GetNginxConfigMapData()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(f.DefaultNginxConfigMapData).NotTo(BeNil())
+	}
 }
 
 // AfterEach deletes the namespace, after reading its events.
@@ -113,6 +124,10 @@ func (f *Framework) AfterEach() {
 
 	By("Waiting for test namespace to no longer exist")
 	err = WaitForNoPodsInNamespace(f.KubeClientSet, f.Namespace.Name)
+	Expect(err).NotTo(HaveOccurred())
+
+	By("Reset nginx-configuration configMap to default state")
+	err = f.SetNginxConfigMapData(f.DefaultNginxConfigMapData)
 	Expect(err).NotTo(HaveOccurred())
 }
 
@@ -259,8 +274,7 @@ func (f *Framework) matchNginxConditions(name string, matcher func(cfg string) b
 	}
 }
 
-// GetNginxConfigMap gets ingress-nginx's nginx-configuration map
-func (f *Framework) GetNginxConfigMap() (*v1.ConfigMap, error) {
+func (f *Framework) getNginxConfigMap() (*v1.ConfigMap, error) {
 	if f.KubeClientSet == nil {
 		return nil, fmt.Errorf("KubeClientSet not initialized")
 	}
@@ -270,22 +284,15 @@ func (f *Framework) GetNginxConfigMap() (*v1.ConfigMap, error) {
 		return nil, err
 	}
 
-	time.Sleep(1 * time.Second)
 	return config, err
 }
 
 // GetNginxConfigMapData gets ingress-nginx's nginx-configuration map's data
 func (f *Framework) GetNginxConfigMapData() (map[string]string, error) {
-	config, err := f.GetNginxConfigMap()
-
+	config, err := f.getNginxConfigMap()
 	if err != nil {
 		return nil, err
 	}
-
-	if config == nil {
-		return nil, fmt.Errorf("Unable to get nginx-configuration configMap")
-	}
-
 	if config.Data == nil {
 		config.Data = map[string]string{}
 	}
@@ -297,7 +304,7 @@ func (f *Framework) GetNginxConfigMapData() (map[string]string, error) {
 func (f *Framework) SetNginxConfigMapData(cmData map[string]string) error {
 	// Needs to do a Get and Set, Update will not take just the Data field
 	// or a configMap that is not the very last revision
-	config, err := f.GetNginxConfigMap()
+	config, err := f.getNginxConfigMap()
 	if err != nil {
 		return err
 	}

--- a/test/e2e/lua/dynamic_configuration.go
+++ b/test/e2e/lua/dynamic_configuration.go
@@ -210,6 +210,7 @@ var _ = framework.IngressNginxDescribe("Dynamic Configuration", func() {
 					return err
 				})
 			Expect(err).NotTo(HaveOccurred())
+			time.Sleep(5 * time.Second)
 
 			By("Making a first request")
 			host := "foo.com"

--- a/test/e2e/settings/no_auth_locations.go
+++ b/test/e2e/settings/no_auth_locations.go
@@ -41,7 +41,6 @@ var _ = framework.IngressNginxDescribe("No Auth locations", func() {
 	secretName := "test-secret"
 	host := "no-auth-locations"
 	noAuthPath := "/noauth"
-	var defaultNginxConfigMapData map[string]string = nil
 
 	BeforeEach(func() {
 		err := f.NewEchoDeployment()
@@ -52,24 +51,16 @@ var _ = framework.IngressNginxDescribe("No Auth locations", func() {
 		Expect(s).NotTo(BeNil())
 		Expect(s.ObjectMeta).NotTo(BeNil())
 
+		err = f.UpdateNginxConfigMapData(setting, noAuthPath)
+		Expect(err).NotTo(HaveOccurred())
+
 		bi := buildBasicAuthIngressWithSecondPath(host, f.Namespace.Name, s.Name, noAuthPath)
 		ing, err := f.EnsureIngress(bi)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ing).NotTo(BeNil())
-
-		if defaultNginxConfigMapData == nil {
-			defaultNginxConfigMapData, err = f.GetNginxConfigMapData()
-			Expect(err).NotTo(HaveOccurred())
-			Expect(defaultNginxConfigMapData).NotTo(BeNil())
-		}
-
-		err = f.UpdateNginxConfigMapData(setting, noAuthPath)
-		Expect(err).NotTo(HaveOccurred())
 	})
 
 	AfterEach(func() {
-		err := f.SetNginxConfigMapData(defaultNginxConfigMapData)
-		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should return status code 401 when accessing '/' unauthentication", func() {

--- a/test/e2e/settings/proxy_protocol.go
+++ b/test/e2e/settings/proxy_protocol.go
@@ -35,25 +35,16 @@ var _ = framework.IngressNginxDescribe("Proxy Protocol", func() {
 	f := framework.NewDefaultFramework("proxy-protocol")
 
 	setting := "use-proxy-protocol"
-	var defaultNginxConfigMapData map[string]string = nil
 
 	BeforeEach(func() {
 		err := f.NewEchoDeployment()
 		Expect(err).NotTo(HaveOccurred())
-
-		if defaultNginxConfigMapData == nil {
-			defaultNginxConfigMapData, err = f.GetNginxConfigMapData()
-			Expect(err).NotTo(HaveOccurred())
-			Expect(defaultNginxConfigMapData).NotTo(BeNil())
-		}
 
 		err = f.UpdateNginxConfigMapData(setting, "false")
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	AfterEach(func() {
-		err := f.SetNginxConfigMapData(defaultNginxConfigMapData)
-		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should respect port passed by the PROXY Protocol", func() {

--- a/test/e2e/settings/proxy_protocol.go
+++ b/test/e2e/settings/proxy_protocol.go
@@ -21,7 +21,6 @@ import (
 	"io/ioutil"
 	"net"
 	"strings"
-	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -29,7 +28,6 @@ import (
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/ingress-nginx/test/e2e/framework"
 )
 
@@ -37,20 +35,32 @@ var _ = framework.IngressNginxDescribe("Proxy Protocol", func() {
 	f := framework.NewDefaultFramework("proxy-protocol")
 
 	setting := "use-proxy-protocol"
+	var defaultNginxConfigMapData map[string]string = nil
 
 	BeforeEach(func() {
 		err := f.NewEchoDeployment()
 		Expect(err).NotTo(HaveOccurred())
+
+		if defaultNginxConfigMapData == nil {
+			defaultNginxConfigMapData, err = f.GetNginxConfigMapData()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(defaultNginxConfigMapData).NotTo(BeNil())
+		}
+
+		err = f.UpdateNginxConfigMapData(setting, "false")
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	AfterEach(func() {
-		updateConfigmap(setting, "false", f.KubeClientSet)
+		err := f.SetNginxConfigMapData(defaultNginxConfigMapData)
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should respect port passed by the PROXY Protocol", func() {
 		host := "proxy-protocol"
 
-		updateConfigmap(setting, "true", f.KubeClientSet)
+		err := f.UpdateNginxConfigMapData(setting, "true")
+		Expect(err).NotTo(HaveOccurred())
 
 		ing, err := f.EnsureIngress(&v1beta1.Ingress{
 			ObjectMeta: metav1.ObjectMeta{
@@ -111,19 +121,3 @@ var _ = framework.IngressNginxDescribe("Proxy Protocol", func() {
 		Expect(body).Should(ContainSubstring(fmt.Sprintf("x-forwarded-for=192.168.0.1")))
 	})
 })
-
-func updateConfigmap(k, v string, c kubernetes.Interface) {
-	By(fmt.Sprintf("updating configuration configmap setting %v to '%v'", k, v))
-	config, err := c.CoreV1().ConfigMaps("ingress-nginx").Get("nginx-configuration", metav1.GetOptions{})
-	Expect(err).NotTo(HaveOccurred())
-	Expect(config).NotTo(BeNil())
-
-	if config.Data == nil {
-		config.Data = map[string]string{}
-	}
-
-	config.Data[k] = v
-	_, err = c.CoreV1().ConfigMaps("ingress-nginx").Update(config)
-	Expect(err).NotTo(HaveOccurred())
-	time.Sleep(1 * time.Second)
-}

--- a/test/e2e/settings/server_tokens.go
+++ b/test/e2e/settings/server_tokens.go
@@ -31,18 +31,32 @@ import (
 var _ = framework.IngressNginxDescribe("Server Tokens", func() {
 	f := framework.NewDefaultFramework("server-tokens")
 	serverTokens := "server-tokens"
+	var defaultNginxConfigMapData map[string]string = nil
 
 	BeforeEach(func() {
 		err := f.NewEchoDeployment()
 		Expect(err).NotTo(HaveOccurred())
+
+		if defaultNginxConfigMapData == nil {
+			defaultNginxConfigMapData, err = f.GetNginxConfigMapData()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(defaultNginxConfigMapData).NotTo(BeNil())
+		}
 	})
 
 	AfterEach(func() {
-		updateConfigmap(serverTokens, "false", f.KubeClientSet)
+		err := f.SetNginxConfigMapData(defaultNginxConfigMapData)
+		Expect(err).NotTo(HaveOccurred())
 	})
 
+<<<<<<< HEAD
 	It("should not exist Server header in the response", func() {
 		updateConfigmap(serverTokens, "false", f.KubeClientSet)
+=======
+	It("should not exists Server header in the response", func() {
+		err := f.UpdateNginxConfigMapData(serverTokens, "false")
+		Expect(err).NotTo(HaveOccurred())
+>>>>>>> Introduce ConfigMap updating helpers into e2e/framework and retain default nginx-configuration state between tests
 
 		ing, err := f.EnsureIngress(&v1beta1.Ingress{
 			ObjectMeta: metav1.ObjectMeta{
@@ -83,8 +97,9 @@ var _ = framework.IngressNginxDescribe("Server Tokens", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	It("should exist Server header in the response when is enabled", func() {
-		updateConfigmap(serverTokens, "true", f.KubeClientSet)
+	It("should exists Server header in the response when is enabled", func() {
+		err := f.UpdateNginxConfigMapData(serverTokens, "true")
+		Expect(err).NotTo(HaveOccurred())
 
 		ing, err := f.EnsureIngress(&v1beta1.Ingress{
 			ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/settings/server_tokens.go
+++ b/test/e2e/settings/server_tokens.go
@@ -31,32 +31,18 @@ import (
 var _ = framework.IngressNginxDescribe("Server Tokens", func() {
 	f := framework.NewDefaultFramework("server-tokens")
 	serverTokens := "server-tokens"
-	var defaultNginxConfigMapData map[string]string = nil
 
 	BeforeEach(func() {
 		err := f.NewEchoDeployment()
 		Expect(err).NotTo(HaveOccurred())
-
-		if defaultNginxConfigMapData == nil {
-			defaultNginxConfigMapData, err = f.GetNginxConfigMapData()
-			Expect(err).NotTo(HaveOccurred())
-			Expect(defaultNginxConfigMapData).NotTo(BeNil())
-		}
 	})
 
 	AfterEach(func() {
-		err := f.SetNginxConfigMapData(defaultNginxConfigMapData)
-		Expect(err).NotTo(HaveOccurred())
 	})
 
-<<<<<<< HEAD
-	It("should not exist Server header in the response", func() {
-		updateConfigmap(serverTokens, "false", f.KubeClientSet)
-=======
 	It("should not exists Server header in the response", func() {
 		err := f.UpdateNginxConfigMapData(serverTokens, "false")
 		Expect(err).NotTo(HaveOccurred())
->>>>>>> Introduce ConfigMap updating helpers into e2e/framework and retain default nginx-configuration state between tests
 
 		ing, err := f.EnsureIngress(&v1beta1.Ingress{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
**What this PR does / why we need it**:
1. Problems with how the nginx-configuration configMap are updated in the e2e tests include: making the e2e test runs unreliable due to state leakage, and given that developers use the same controller deployment to test things during development - this makes the development workflow somewhat unpredictable as well. 
2. [The nginx-configuration configMap](https://github.com/kubernetes/ingress-nginx/blob/master/deploy/configmap.yaml) used by the nginx controller within the ingress-nginx namespace is updated and _toggled back_ during several e2e tests. This PR moves that code up into the e2e/framework to make it easier to reuse across these tests. 
3. Currently, in e2e tests, developers attempt to _reset_ the configMap to an initial state in the AfterEach handler, like so: https://github.com/kubernetes/ingress-nginx/blob/361e53ffa9d05f3ffdb4995ec7a6f34a1bf68115/test/e2e/settings/no_auth_locations.go#L63, however after running the e2e tests, if you were starting with an empty configMap, and then ran the no_auth_locations test for example - you would be left with configMap data different from when you started. 
4. This PR attempts to address this by introducing helper methods to make it easier to reset the configMap to its initial state. 

TL;DR: The way the nginx-configuration configMap is updated and _reset_ in the e2e tests leaks state! Issa fix.

**Special notes for your reviewer**:
* After talking with (my close personal friend) @ElvinEfendi, we realized that maybe a better alternative approach would ultimately be to decouple the e2e tests from the developer workflow, by having the e2e tests spawn an ephemeral ingress deployment for the lifecycle of the tests - similarly to how the backends are spawned just for the lifecycle of the tests. E.g. [EchoDeployment](https://github.com/kubernetes/ingress-nginx/blob/f732b4ea2ffe3741c3f04699f6ba9cd1d53c3859/test/e2e/framework/echo.go#L33)
* However, this is a step in the right direction, and we could always follow up with a PR with the ideas mentioned above.

Let me know what you guys think - happy to iterate or rework this.

cc @ElvinEfendi @zrdaley 