### PR TITLE
Correct the returned message

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -88,7 +88,7 @@ $ minikube addons disable ingress
 $ kubectl edit deployment nginx-ingress-controller -n ingress-nginx
 ```
 
-edit the following section:
+Edit the following section:
 
 ```yaml
 image: <IMAGE-NAME>:<TAG>
@@ -281,7 +281,7 @@ kubectl exec -it $POD_NAME -n $POD_NAMESPACE -- /nginx-ingress-controller --vers
 
 ## Deploying the config-map
 
-A config map can be used to configure system components for the nginx-controller. In order to begin using a config-map
+A config-map can be used to configure system components for the nginx-controller. In order to begin using a config-map
 make sure it has been created and is being used in the deployment.
 
 It is created as seen in the [Mandatory Commands](#mandatory-commands) section above.

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -859,7 +859,7 @@ func (n *NGINXController) createServers(data []*extensions.Ingress,
 	defaultPemSHA := n.cfg.FakeCertificateSHA
 
 	// Tries to fetch the default Certificate from nginx configuration.
-	// If it does not exists, use the ones generated on Start()
+	// If it does not exist, use the ones generated on Start()
 	defaultCertificate, err := n.store.GetLocalSSLCert(n.cfg.DefaultSSLCertificate)
 	if err == nil {
 		defaultPemFileName = defaultCertificate.PemFileName

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -226,7 +226,7 @@ func fileInFS(file string, fs file.Filesystem) wait.ConditionFunc {
 		}
 
 		if stat == nil {
-			return false, fmt.Errorf("file %v does not exists", file)
+			return false, fmt.Errorf("file %v does not exist", file)
 		}
 
 		if stat.Size() > 0 {


### PR DESCRIPTION
Correct the returned message
fmt.Errorf("file %v does not exists", file) -> fmt.Errorf("file %v does not exist", file)