### PR TITLE
Clean JSON before post request to update configuration

### DIFF
--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -188,7 +188,7 @@ func (n *NGINXController) syncIngress(interface{}) error {
 				// it takes time for Nginx to start listening on the port
 				time.Sleep(1 * time.Second)
 			}
-			err := n.ConfigureDynamically(&pcfg)
+			err := configureDynamically(&pcfg, n.cfg.ListenPorts.Status)
 			if err == nil {
 				glog.Infof("dynamic reconfiguration succeeded")
 			} else {

--- a/internal/ingress/controller/endpoints.go
+++ b/internal/ingress/controller/endpoints.go
@@ -99,7 +99,6 @@ func getEndpoints(
 				targetPort = epPort.Port
 			}
 
-			glog.Infof("TP: %v", targetPort)
 			// check for invalid port value
 			if targetPort <= 0 {
 				continue

--- a/internal/ingress/controller/nginx_test.go
+++ b/internal/ingress/controller/nginx_test.go
@@ -17,8 +17,15 @@ limitations under the License.
 package controller
 
 import (
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
+	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/ingress-nginx/internal/ingress"
 )
 
@@ -86,6 +93,85 @@ func TestIsDynamicConfigurationEnough(t *testing.T) {
 
 	if !newConfig.Equal(&ingress.Configuration{Backends: []*ingress.Backend{{Name: "a-backend-8080"}}, Servers: servers}) {
 		t.Errorf("Expected new config to not change")
+	}
+}
+
+func TestConfigureDynamically(t *testing.T) {
+	target := &apiv1.ObjectReference{}
+
+	backends := []*ingress.Backend{{
+		Name:    "fakenamespace-myapp-80",
+		Service: &apiv1.Service{},
+		Endpoints: []ingress.Endpoint{
+			{
+				Address: "10.0.0.1",
+				Port:    "8080",
+				Target:  target,
+			},
+			{
+				Address: "10.0.0.2",
+				Port:    "8080",
+				Target:  target,
+			},
+		},
+	}}
+
+	servers := []*ingress.Server{{
+		Hostname: "myapp.fake",
+		Locations: []*ingress.Location{
+			{
+				Path:    "/",
+				Backend: "fakenamespace-myapp-80",
+				Service: &apiv1.Service{},
+			},
+		},
+	}}
+
+	commonConfig := &ingress.Configuration{
+		Backends: backends,
+		Servers:  servers,
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+
+		if r.Method != "POST" {
+			t.Errorf("expected a 'POST' request, got '%s'", r.Method)
+		}
+
+		b, err := ioutil.ReadAll(r.Body)
+		if err != nil && err != io.EOF {
+			t.Fatal(err)
+		}
+		body := string(b)
+		if strings.Index(body, "target") != -1 {
+			t.Errorf("unexpected target reference in JSON content: %v", body)
+		}
+
+		if strings.Index(body, "service") != -1 {
+			t.Errorf("unexpected service reference in JSON content: %v", body)
+		}
+
+	}))
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Errorf("unexpected error listening on a random port: %v", err)
+	}
+	defer listener.Close()
+
+	port := listener.Addr().(*net.TCPAddr).Port
+
+	ts.Listener = listener
+	defer ts.Close()
+
+	err = configureDynamically(commonConfig, port)
+	if err != nil {
+		t.Errorf("unexpected error posting dynamic configuration: %v", err)
+	}
+
+	if commonConfig.Backends[0].Endpoints[0].Target != target {
+		t.Errorf("unexpected change in the configuration object after configureDynamically invocation")
 	}
 }
 

--- a/internal/ingress/resolver/main.go
+++ b/internal/ingress/resolver/main.go
@@ -52,6 +52,13 @@ type AuthSSLCert struct {
 
 // Equal tests for equality between two AuthSSLCert types
 func (asslc1 *AuthSSLCert) Equal(assl2 *AuthSSLCert) bool {
+	if asslc1 == assl2 {
+		return true
+	}
+	if asslc1 == nil || assl2 == nil {
+		return false
+	}
+
 	if asslc1.Secret != assl2.Secret {
 		return false
 	}

--- a/test/e2e/lua/dynamic_configuration.go
+++ b/test/e2e/lua/dynamic_configuration.go
@@ -58,7 +58,7 @@ var _ = framework.IngressNginxDescribe("Dynamic Configuration", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		// give some time for Lua to sync the backend
-		time.Sleep(2 * time.Second)
+		time.Sleep(5 * time.Second)
 
 		resp, _, errs := gorequest.New().
 			Get(f.IngressController.HTTPURL).


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove Target object reference from endpoints (this is not used for the dynamic configuration)