### PR TITLE
Remove most of the time.Sleep from the e2e tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,6 @@ jobs:
     - if ! go get github.com/jteeuwen/go-bindata/...; then github.com/jteeuwen/go-bindata/...;fi
     - make e2e-image
     - test/e2e/up.sh
-    - test/e2e/wait-for-nginx.sh
     script:
     - make e2e-test
   # split builds to avoid job timeouts

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -865,6 +865,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "37155c2e5c2212237cff4f2cc220127e9aff6205e2b7cd05af11c42d4d0062ea"
+  inputs-digest = "262bd1cf8d4735c8d09a6f6d83fed25ad9e1478443a7f6368210e7c3fbb58977"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ e2e-image: sub-container-amd64
 .PHONY: e2e-test
 e2e-test:
 	@go test -o e2e-tests -c ./test/e2e
-	@KUBECONFIG=${HOME}/.kube/config ./e2e-tests -test.parallel 1
+	@KUBECONFIG=${HOME}/.kube/config ./e2e-tests -alsologtostderr -test.v -logtostderr -ginkgo.trace
 
 .PHONY: cover
 cover:

--- a/internal/ingress/controller/store/store_test.go
+++ b/internal/ingress/controller/store/store_test.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"github.com/eapache/channels"
-	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	extensions "k8s.io/api/extensions/v1beta1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
@@ -67,10 +66,10 @@ func TestStore(t *testing.T) {
 
 		fs := newFS(t)
 		storer := New(true,
-			ns.Name,
-			fmt.Sprintf("%v/config", ns.Name),
-			fmt.Sprintf("%v/tcp", ns.Name),
-			fmt.Sprintf("%v/udp", ns.Name),
+			ns,
+			fmt.Sprintf("%v/config", ns),
+			fmt.Sprintf("%v/tcp", ns),
+			fmt.Sprintf("%v/udp", ns),
 			"",
 			10*time.Minute,
 			clientSet,
@@ -79,7 +78,7 @@ func TestStore(t *testing.T) {
 
 		storer.Run(stopCh)
 
-		key := fmt.Sprintf("%v/anything", ns.Name)
+		key := fmt.Sprintf("%v/anything", ns)
 		ing, err := storer.GetIngress(key)
 		if err == nil {
 			t.Errorf("expected an error but none returned")
@@ -154,10 +153,10 @@ func TestStore(t *testing.T) {
 
 		fs := newFS(t)
 		storer := New(true,
-			ns.Name,
-			fmt.Sprintf("%v/config", ns.Name),
-			fmt.Sprintf("%v/tcp", ns.Name),
-			fmt.Sprintf("%v/udp", ns.Name),
+			ns,
+			fmt.Sprintf("%v/config", ns),
+			fmt.Sprintf("%v/tcp", ns),
+			fmt.Sprintf("%v/udp", ns),
 			"",
 			10*time.Minute,
 			clientSet,
@@ -169,7 +168,7 @@ func TestStore(t *testing.T) {
 		ing, err := ensureIngress(&v1beta1.Ingress{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "dummy",
-				Namespace: ns.Name,
+				Namespace: ns,
 			},
 			Spec: v1beta1.IngressSpec{
 				Rules: []v1beta1.IngressRule{
@@ -200,7 +199,7 @@ func TestStore(t *testing.T) {
 		_, err = ensureIngress(&v1beta1.Ingress{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "custom-class",
-				Namespace: ns.Name,
+				Namespace: ns,
 				Annotations: map[string]string{
 					"kubernetes.io/ingress.class": "something",
 				},
@@ -295,10 +294,10 @@ func TestStore(t *testing.T) {
 
 		fs := newFS(t)
 		storer := New(true,
-			ns.Name,
-			fmt.Sprintf("%v/config", ns.Name),
-			fmt.Sprintf("%v/tcp", ns.Name),
-			fmt.Sprintf("%v/udp", ns.Name),
+			ns,
+			fmt.Sprintf("%v/config", ns),
+			fmt.Sprintf("%v/tcp", ns),
+			fmt.Sprintf("%v/udp", ns),
 			"",
 			10*time.Minute,
 			clientSet,
@@ -308,12 +307,12 @@ func TestStore(t *testing.T) {
 		storer.Run(stopCh)
 
 		secretName := "not-referenced"
-		_, _, _, err = framework.CreateIngressTLSSecret(clientSet, []string{"foo"}, secretName, ns.Name)
+		_, _, _, err = framework.CreateIngressTLSSecret(clientSet, []string{"foo"}, secretName, ns)
 		if err != nil {
 			t.Errorf("unexpected error creating secret: %v", err)
 		}
 
-		err = framework.WaitForSecretInNamespace(clientSet, ns.Name, secretName)
+		err = framework.WaitForSecretInNamespace(clientSet, ns, secretName)
 		if err != nil {
 			t.Errorf("unexpected error waiting for secret: %v", err)
 		}
@@ -328,7 +327,7 @@ func TestStore(t *testing.T) {
 			t.Errorf("expected 0 events of type Delete but %v occurred", del)
 		}
 
-		err = clientSet.CoreV1().Secrets(ns.Name).Delete(secretName, &metav1.DeleteOptions{})
+		err = clientSet.CoreV1().Secrets(ns).Delete(secretName, &metav1.DeleteOptions{})
 		if err != nil {
 			t.Errorf("unexpected error deleting secret: %v", err)
 		}
@@ -384,10 +383,10 @@ func TestStore(t *testing.T) {
 
 		fs := newFS(t)
 		storer := New(true,
-			ns.Name,
-			fmt.Sprintf("%v/config", ns.Name),
-			fmt.Sprintf("%v/tcp", ns.Name),
-			fmt.Sprintf("%v/udp", ns.Name),
+			ns,
+			fmt.Sprintf("%v/config", ns),
+			fmt.Sprintf("%v/tcp", ns),
+			fmt.Sprintf("%v/udp", ns),
 			"",
 			10*time.Minute,
 			clientSet,
@@ -402,7 +401,7 @@ func TestStore(t *testing.T) {
 		_, err := ensureIngress(&v1beta1.Ingress{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      ingressName,
-				Namespace: ns.Name,
+				Namespace: ns,
 			},
 			Spec: v1beta1.IngressSpec{
 				TLS: []v1beta1.IngressTLS{
@@ -420,17 +419,17 @@ func TestStore(t *testing.T) {
 			t.Errorf("unexpected error creating ingress: %v", err)
 		}
 
-		err = framework.WaitForIngressInNamespace(clientSet, ns.Name, ingressName)
+		err = framework.WaitForIngressInNamespace(clientSet, ns, ingressName)
 		if err != nil {
 			t.Errorf("unexpected error waiting for secret: %v", err)
 		}
 
-		_, _, _, err = framework.CreateIngressTLSSecret(clientSet, []string{"foo"}, secretName, ns.Name)
+		_, _, _, err = framework.CreateIngressTLSSecret(clientSet, []string{"foo"}, secretName, ns)
 		if err != nil {
 			t.Errorf("unexpected error creating secret: %v", err)
 		}
 
-		err = framework.WaitForSecretInNamespace(clientSet, ns.Name, secretName)
+		err = framework.WaitForSecretInNamespace(clientSet, ns, secretName)
 		if err != nil {
 			t.Errorf("unexpected error waiting for secret: %v", err)
 		}
@@ -446,7 +445,7 @@ func TestStore(t *testing.T) {
 			t.Errorf("expected 1 events of type Update but %v occurred", upd)
 		}
 
-		err = clientSet.CoreV1().Secrets(ns.Name).Delete(secretName, &metav1.DeleteOptions{})
+		err = clientSet.CoreV1().Secrets(ns).Delete(secretName, &metav1.DeleteOptions{})
 		if err != nil {
 			t.Errorf("unexpected error deleting secret: %v", err)
 		}
@@ -496,10 +495,10 @@ func TestStore(t *testing.T) {
 
 		fs := newFS(t)
 		storer := New(true,
-			ns.Name,
-			fmt.Sprintf("%v/config", ns.Name),
-			fmt.Sprintf("%v/tcp", ns.Name),
-			fmt.Sprintf("%v/udp", ns.Name),
+			ns,
+			fmt.Sprintf("%v/config", ns),
+			fmt.Sprintf("%v/tcp", ns),
+			fmt.Sprintf("%v/udp", ns),
 			"",
 			10*time.Minute,
 			clientSet,
@@ -514,7 +513,7 @@ func TestStore(t *testing.T) {
 		_, err := ensureIngress(&v1beta1.Ingress{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
-				Namespace: ns.Name,
+				Namespace: ns,
 			},
 			Spec: v1beta1.IngressSpec{
 				TLS: []v1beta1.IngressTLS{
@@ -547,7 +546,7 @@ func TestStore(t *testing.T) {
 			t.Errorf("unexpected error creating ingress: %v", err)
 		}
 
-		err = framework.WaitForIngressInNamespace(clientSet, ns.Name, name)
+		err = framework.WaitForIngressInNamespace(clientSet, ns, name)
 		if err != nil {
 			t.Errorf("unexpected error waiting for ingress: %v", err)
 		}
@@ -568,26 +567,26 @@ func TestStore(t *testing.T) {
 			t.Errorf("expected 0 events of type Delete but %v occurred", del)
 		}
 
-		_, _, _, err = framework.CreateIngressTLSSecret(clientSet, secretHosts, name, ns.Name)
+		_, _, _, err = framework.CreateIngressTLSSecret(clientSet, secretHosts, name, ns)
 		if err != nil {
 			t.Errorf("unexpected error creating secret: %v", err)
 		}
 
 		t.Run("should exists a secret in the local store and filesystem", func(t *testing.T) {
-			err := framework.WaitForSecretInNamespace(clientSet, ns.Name, name)
+			err := framework.WaitForSecretInNamespace(clientSet, ns, name)
 			if err != nil {
 				t.Errorf("unexpected error waiting for secret: %v", err)
 			}
 
 			time.Sleep(5 * time.Second)
 
-			pemFile := fmt.Sprintf("%v/%v-%v.pem", file.DefaultSSLDirectory, ns.Name, name)
+			pemFile := fmt.Sprintf("%v/%v-%v.pem", file.DefaultSSLDirectory, ns, name)
 			err = framework.WaitForFileInFS(pemFile, fs)
 			if err != nil {
 				t.Errorf("unexpected error waiting for file to exist on the file system: %v", err)
 			}
 
-			secretName := fmt.Sprintf("%v/%v", ns.Name, name)
+			secretName := fmt.Sprintf("%v/%v", ns, name)
 			sslCert, err := storer.GetLocalSSLCert(secretName)
 			if err != nil {
 				t.Errorf("unexpected error reading local secret %v: %v", secretName, err)
@@ -615,24 +614,24 @@ func TestStore(t *testing.T) {
 	// check invalid secret (missing ca)
 }
 
-func createNamespace(clientSet *kubernetes.Clientset, t *testing.T) *apiv1.Namespace {
+func createNamespace(clientSet *kubernetes.Clientset, t *testing.T) string {
 	t.Log("creating temporal namespace")
 	ns, err := framework.CreateKubeNamespace("store-test", clientSet)
 	if err != nil {
 		t.Errorf("unexpected error creating ingress client: %v", err)
 	}
-	t.Logf("temporal namespace %v created", ns.Name)
+	t.Logf("temporal namespace %v created", ns)
 
 	return ns
 }
 
-func deleteNamespace(ns *apiv1.Namespace, clientSet *kubernetes.Clientset, t *testing.T) {
-	t.Logf("deleting temporal namespace %v created", ns.Name)
-	err := framework.DeleteKubeNamespace(clientSet, ns.Name)
+func deleteNamespace(ns string, clientSet *kubernetes.Clientset, t *testing.T) {
+	t.Logf("deleting temporal namespace %v created", ns)
+	err := framework.DeleteKubeNamespace(clientSet, ns)
 	if err != nil {
 		t.Errorf("unexpected error creating ingress client: %v", err)
 	}
-	t.Logf("temporal namespace %v deleted", ns.Name)
+	t.Logf("temporal namespace %v deleted", ns)
 }
 
 func ensureIngress(ingress *extensions.Ingress, clientSet *kubernetes.Clientset) (*extensions.Ingress, error) {

--- a/test/e2e/annotations/affinity.go
+++ b/test/e2e/annotations/affinity.go
@@ -49,7 +49,7 @@ var _ = framework.IngressNginxDescribe("Annotations - Affinity", func() {
 		ing, err := f.EnsureIngress(&v1beta1.Ingress{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      host,
-				Namespace: f.Namespace.Name,
+				Namespace: f.IngressController.Namespace,
 				Annotations: map[string]string{
 					"nginx.ingress.kubernetes.io/affinity":            "cookie",
 					"nginx.ingress.kubernetes.io/session-cookie-name": "SERVERID",
@@ -81,12 +81,12 @@ var _ = framework.IngressNginxDescribe("Annotations - Affinity", func() {
 
 		err = f.WaitForNginxServer(host,
 			func(server string) bool {
-				return strings.Contains(server, "proxy_pass http://sticky-"+f.Namespace.Name+"-http-svc-80;")
+				return strings.Contains(server, "proxy_pass http://sticky-"+f.IngressController.Namespace+"-http-svc-80;")
 			})
 		Expect(err).NotTo(HaveOccurred())
 
 		resp, _, errs := gorequest.New().
-			Get(f.NginxHTTPURL).
+			Get(f.IngressController.HTTPURL).
 			Set("Host", host).
 			End()
 
@@ -101,7 +101,7 @@ var _ = framework.IngressNginxDescribe("Annotations - Affinity", func() {
 		ing, err := f.EnsureIngress(&v1beta1.Ingress{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      host,
-				Namespace: f.Namespace.Name,
+				Namespace: f.IngressController.Namespace,
 				Annotations: map[string]string{
 					"nginx.ingress.kubernetes.io/affinity":            "cookie",
 					"nginx.ingress.kubernetes.io/session-cookie-name": "SERVERID",
@@ -135,12 +135,12 @@ var _ = framework.IngressNginxDescribe("Annotations - Affinity", func() {
 
 		err = f.WaitForNginxServer(host,
 			func(server string) bool {
-				return strings.Contains(server, "proxy_pass http://sticky-"+f.Namespace.Name+"-http-svc-80;")
+				return strings.Contains(server, "proxy_pass http://sticky-"+f.IngressController.Namespace+"-http-svc-80;")
 			})
 		Expect(err).NotTo(HaveOccurred())
 
 		resp, body, errs := gorequest.New().
-			Get(f.NginxHTTPURL).
+			Get(f.IngressController.HTTPURL).
 			Set("Host", host).
 			End()
 

--- a/test/e2e/annotations/alias.go
+++ b/test/e2e/annotations/alias.go
@@ -48,7 +48,7 @@ var _ = framework.IngressNginxDescribe("Annotations - Alias", func() {
 		ing, err := f.EnsureIngress(&v1beta1.Ingress{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      host,
-				Namespace: f.Namespace.Name,
+				Namespace: f.IngressController.Namespace,
 			},
 			Spec: v1beta1.IngressSpec{
 				Rules: []v1beta1.IngressRule{
@@ -83,7 +83,7 @@ var _ = framework.IngressNginxDescribe("Annotations - Alias", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		resp, body, errs := gorequest.New().
-			Get(f.NginxHTTPURL).
+			Get(f.IngressController.HTTPURL).
 			Set("Host", host).
 			End()
 
@@ -92,7 +92,7 @@ var _ = framework.IngressNginxDescribe("Annotations - Alias", func() {
 		Expect(body).Should(ContainSubstring(fmt.Sprintf("host=%v", host)))
 
 		resp, body, errs = gorequest.New().
-			Get(f.NginxHTTPURL).
+			Get(f.IngressController.HTTPURL).
 			Set("Host", "bar").
 			End()
 
@@ -106,7 +106,7 @@ var _ = framework.IngressNginxDescribe("Annotations - Alias", func() {
 		ing, err := f.EnsureIngress(&v1beta1.Ingress{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      host,
-				Namespace: f.Namespace.Name,
+				Namespace: f.IngressController.Namespace,
 				Annotations: map[string]string{
 					"nginx.ingress.kubernetes.io/server-alias": "bar",
 				},
@@ -146,7 +146,7 @@ var _ = framework.IngressNginxDescribe("Annotations - Alias", func() {
 		hosts := []string{"foo", "bar"}
 		for _, host := range hosts {
 			resp, body, errs := gorequest.New().
-				Get(f.NginxHTTPURL).
+				Get(f.IngressController.HTTPURL).
 				Set("Host", host).
 				End()
 

--- a/test/e2e/defaultbackend/default_backend.go
+++ b/test/e2e/defaultbackend/default_backend.go
@@ -76,9 +76,9 @@ var _ = framework.IngressNginxDescribe("Default backend", func() {
 
 			switch test.Scheme {
 			case framework.HTTP:
-				cm = request.CustomMethod(test.Method, f.NginxHTTPURL)
+				cm = request.CustomMethod(test.Method, f.IngressController.HTTPURL)
 			case framework.HTTPS:
-				cm = request.CustomMethod(test.Method, f.NginxHTTPSURL)
+				cm = request.CustomMethod(test.Method, f.IngressController.HTTPSURL)
 				// the default backend uses a self generated certificate
 				cm.Transport = &http.Transport{
 					TLSClientConfig: &tls.Config{

--- a/test/e2e/defaultbackend/ssl.go
+++ b/test/e2e/defaultbackend/ssl.go
@@ -38,7 +38,7 @@ var _ = framework.IngressNginxDescribe("Default backend - SSL", func() {
 	It("should return a self generated SSL certificate", func() {
 		By("checking SSL Certificate using the NGINX IP address")
 		resp, _, errs := gorequest.New().
-			Post(f.NginxHTTPSURL).
+			Post(f.IngressController.HTTPSURL).
 			TLSClientConfig(&tls.Config{
 				// the default backend uses a self generated certificate
 				InsecureSkipVerify: true,
@@ -53,7 +53,7 @@ var _ = framework.IngressNginxDescribe("Default backend - SSL", func() {
 
 		By("checking SSL Certificate using the NGINX catch all server")
 		resp, _, errs = gorequest.New().
-			Post(f.NginxHTTPSURL).
+			Post(f.IngressController.HTTPSURL).
 			TLSClientConfig(&tls.Config{
 				// the default backend uses a self generated certificate
 				InsecureSkipVerify: true,

--- a/test/e2e/framework/echo.go
+++ b/test/e2e/framework/echo.go
@@ -40,7 +40,7 @@ func (f *Framework) NewEchoDeploymentWithReplicas(replicas int32) error {
 	deployment := &extensions.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "http-svc",
-			Namespace: f.Namespace.Name,
+			Namespace: f.IngressController.Namespace,
 		},
 		Spec: extensions.DeploymentSpec{
 			Replicas: NewInt32(replicas),
@@ -84,7 +84,7 @@ func (f *Framework) NewEchoDeploymentWithReplicas(replicas int32) error {
 		return fmt.Errorf("unexpected error creating deployement for echoserver")
 	}
 
-	err = f.WaitForPodsReady(10*time.Second, int(replicas), metav1.ListOptions{
+	err = WaitForPodsReady(f.KubeClientSet, 5*time.Minute, int(replicas), f.IngressController.Namespace, metav1.ListOptions{
 		LabelSelector: fields.SelectorFromSet(fields.Set(d.Spec.Template.ObjectMeta.Labels)).String(),
 	})
 	if err != nil {
@@ -94,7 +94,7 @@ func (f *Framework) NewEchoDeploymentWithReplicas(replicas int32) error {
 	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "http-svc",
-			Namespace: f.Namespace.Name,
+			Namespace: f.IngressController.Namespace,
 		},
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{

--- a/test/e2e/framework/exec.go
+++ b/test/e2e/framework/exec.go
@@ -47,3 +47,26 @@ func (f *Framework) ExecCommand(pod *v1.Pod, command string) (string, error) {
 
 	return execOut.String(), nil
 }
+
+// NewIngressController deploys a new NGINX Ingress controller in a namespace
+func (f *Framework) NewIngressController(namespace string) error {
+	var (
+		execOut bytes.Buffer
+		execErr bytes.Buffer
+	)
+
+	cmd := exec.Command("test/e2e/wait-for-nginx.sh", namespace)
+	cmd.Stdout = &execOut
+	cmd.Stderr = &execErr
+
+	err := cmd.Run()
+	if err != nil {
+		return fmt.Errorf("could not execute: %v", err)
+	}
+
+	if execErr.Len() > 0 {
+		return fmt.Errorf("stderr: %v", execErr.String())
+	}
+
+	return nil
+}

--- a/test/e2e/framework/k8s.go
+++ b/test/e2e/framework/k8s.go
@@ -17,6 +17,7 @@ limitations under the License.
 package framework
 
 import (
+	"fmt"
 	"time"
 
 	api "k8s.io/api/core/v1"
@@ -26,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
+	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 )
 
 // EnsureSecret creates a Secret object or returns it if it already exists.
@@ -45,10 +47,19 @@ func (f *Framework) EnsureIngress(ingress *extensions.Ingress) (*extensions.Ingr
 	s, err := f.KubeClientSet.ExtensionsV1beta1().Ingresses(ingress.Namespace).Update(ingress)
 	if err != nil {
 		if k8sErrors.IsNotFound(err) {
-			return f.KubeClientSet.ExtensionsV1beta1().Ingresses(ingress.Namespace).Create(ingress)
+			s, err = f.KubeClientSet.ExtensionsV1beta1().Ingresses(ingress.Namespace).Create(ingress)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			return nil, err
 		}
-		return nil, err
 	}
+
+	if s.Annotations == nil {
+		s.Annotations = make(map[string]string)
+	}
+
 	return s, nil
 }
 
@@ -76,14 +87,9 @@ func (f *Framework) EnsureDeployment(deployment *extensions.Deployment) (*extens
 	return d, nil
 }
 
-// WaitForPodsReady waits for a given amount of time until a group of Pods is running in the framework's namespace.
-func (f *Framework) WaitForPodsReady(timeout time.Duration, expectedReplicas int, opts metav1.ListOptions) error {
-	return WaitForPodsReady(f.KubeClientSet, timeout, expectedReplicas, f.Namespace.Name, opts)
-}
-
 // WaitForPodsReady waits for a given amount of time until a group of Pods is running in the given namespace.
 func WaitForPodsReady(kubeClientSet kubernetes.Interface, timeout time.Duration, expectedReplicas int, namespace string, opts metav1.ListOptions) error {
-	return wait.Poll(time.Second, timeout, func() (bool, error) {
+	return wait.Poll(2*time.Second, timeout, func() (bool, error) {
 		pl, err := kubeClientSet.CoreV1().Pods(namespace).List(opts)
 		if err != nil {
 			return false, err
@@ -91,10 +97,9 @@ func WaitForPodsReady(kubeClientSet kubernetes.Interface, timeout time.Duration,
 
 		r := 0
 		for _, p := range pl.Items {
-			if p.Status.Phase != core.PodRunning {
-				continue
+			if isRunning, _ := podRunningReady(&p); isRunning {
+				r++
 			}
-			r++
 		}
 
 		if r == expectedReplicas {
@@ -103,4 +108,20 @@ func WaitForPodsReady(kubeClientSet kubernetes.Interface, timeout time.Duration,
 
 		return false, nil
 	})
+}
+
+// podRunningReady checks whether pod p's phase is running and it has a ready
+// condition of status true.
+func podRunningReady(p *core.Pod) (bool, error) {
+	// Check the phase is running.
+	if p.Status.Phase != core.PodRunning {
+		return false, fmt.Errorf("want pod '%s' on '%s' to be '%v' but was '%v'",
+			p.ObjectMeta.Name, p.Spec.NodeName, core.PodRunning, p.Status.Phase)
+	}
+	// Check the ready condition is true.
+	if !podutil.IsPodReady(p) {
+		return false, fmt.Errorf("pod '%s' on '%s' didn't have condition {%v %v}; conditions: %v",
+			p.ObjectMeta.Name, p.Spec.NodeName, core.PodReady, core.ConditionTrue, p.Status.Conditions)
+	}
+	return true, nil
 }

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -46,6 +46,10 @@ func RegisterCommonFlags() {
 	// Randomize specs as well as suites
 	config.GinkgoConfig.RandomizeAllSpecs = true
 
+	// Default SlowSpecThreshold is 5 seconds.
+	// Too low for the kind of operations we need to tests
+	config.DefaultReporterConfig.SlowSpecThreshold = 20
+
 	flag.StringVar(&TestContext.KubeHost, "kubernetes-host", "http://127.0.0.1:8080", "The kubernetes host, or apiserver, to connect to")
 	flag.StringVar(&TestContext.KubeConfig, "kubernetes-config", os.Getenv(clientcmd.RecommendedConfigPathEnvVar), "Path to config containing embedded authinfo for kubernetes. Default value is from environment variable "+clientcmd.RecommendedConfigPathEnvVar)
 	flag.StringVar(&TestContext.KubeContext, "kubernetes-context", "", "config context to use for kubernetes. If unset, will use value from 'current-context'")

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -100,7 +100,7 @@ func LoadConfig(config, context string) (*rest.Config, error) {
 var RunID = uuid.NewUUID()
 
 // CreateKubeNamespace creates a new namespace in the cluster
-func CreateKubeNamespace(baseName string, c kubernetes.Interface) (*v1.Namespace, error) {
+func CreateKubeNamespace(baseName string, c kubernetes.Interface) (string, error) {
 	ts := time.Now().UnixNano()
 	ns := &v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -120,9 +120,9 @@ func CreateKubeNamespace(baseName string, c kubernetes.Interface) (*v1.Namespace
 		return true, nil
 	})
 	if err != nil {
-		return nil, err
+		return "", err
 	}
-	return got, nil
+	return got.Name, nil
 }
 
 // DeleteKubeNamespace deletes a namespace and all the objects inside
@@ -140,7 +140,7 @@ func ExpectNoError(err error, explain ...interface{}) {
 
 // WaitForKubeNamespaceNotExist waits until a namespaces is not present in the cluster
 func WaitForKubeNamespaceNotExist(c kubernetes.Interface, namespace string) error {
-	return wait.PollImmediate(Poll, time.Minute*2, namespaceNotExist(c, namespace))
+	return wait.PollImmediate(Poll, time.Minute*5, namespaceNotExist(c, namespace))
 }
 
 func namespaceNotExist(c kubernetes.Interface, namespace string) wait.ConditionFunc {
@@ -158,7 +158,7 @@ func namespaceNotExist(c kubernetes.Interface, namespace string) wait.ConditionF
 
 // WaitForNoPodsInNamespace waits until there are no pods running in a namespace
 func WaitForNoPodsInNamespace(c kubernetes.Interface, namespace string) error {
-	return wait.PollImmediate(Poll, time.Minute*2, noPodsInNamespace(c, namespace))
+	return wait.PollImmediate(Poll, time.Minute*5, noPodsInNamespace(c, namespace))
 }
 
 func noPodsInNamespace(c kubernetes.Interface, namespace string) wait.ConditionFunc {

--- a/test/e2e/settings/no_auth_locations.go
+++ b/test/e2e/settings/no_auth_locations.go
@@ -46,7 +46,7 @@ var _ = framework.IngressNginxDescribe("No Auth locations", func() {
 		err := f.NewEchoDeployment()
 		Expect(err).NotTo(HaveOccurred())
 
-		s, err := f.EnsureSecret(buildSecret(username, password, secretName, f.Namespace.Name))
+		s, err := f.EnsureSecret(buildSecret(username, password, secretName, f.IngressController.Namespace))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(s).NotTo(BeNil())
 		Expect(s.ObjectMeta).NotTo(BeNil())
@@ -54,7 +54,7 @@ var _ = framework.IngressNginxDescribe("No Auth locations", func() {
 		err = f.UpdateNginxConfigMapData(setting, noAuthPath)
 		Expect(err).NotTo(HaveOccurred())
 
-		bi := buildBasicAuthIngressWithSecondPath(host, f.Namespace.Name, s.Name, noAuthPath)
+		bi := buildBasicAuthIngressWithSecondPath(host, f.IngressController.Namespace, s.Name, noAuthPath)
 		ing, err := f.EnsureIngress(bi)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ing).NotTo(BeNil())
@@ -71,7 +71,7 @@ var _ = framework.IngressNginxDescribe("No Auth locations", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		resp, body, errs := gorequest.New().
-			Get(f.NginxHTTPURL).
+			Get(f.IngressController.HTTPURL).
 			Set("Host", host).
 			End()
 
@@ -88,7 +88,7 @@ var _ = framework.IngressNginxDescribe("No Auth locations", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		resp, _, errs := gorequest.New().
-			Get(f.NginxHTTPURL).
+			Get(f.IngressController.HTTPURL).
 			Set("Host", host).
 			SetBasicAuth(username, password).
 			End()
@@ -105,7 +105,7 @@ var _ = framework.IngressNginxDescribe("No Auth locations", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		resp, _, errs := gorequest.New().
-			Get(fmt.Sprintf("%s/noauth", f.NginxHTTPURL)).
+			Get(fmt.Sprintf("%s/noauth", f.IngressController.HTTPURL)).
 			Set("Host", host).
 			End()
 

--- a/test/e2e/settings/proxy_protocol.go
+++ b/test/e2e/settings/proxy_protocol.go
@@ -25,9 +25,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"k8s.io/api/extensions/v1beta1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/ingress-nginx/test/e2e/framework"
 )
 
@@ -53,34 +50,7 @@ var _ = framework.IngressNginxDescribe("Proxy Protocol", func() {
 		err := f.UpdateNginxConfigMapData(setting, "true")
 		Expect(err).NotTo(HaveOccurred())
 
-		ing, err := f.EnsureIngress(&v1beta1.Ingress{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:        host,
-				Namespace:   f.Namespace.Name,
-				Annotations: map[string]string{},
-			},
-			Spec: v1beta1.IngressSpec{
-				Rules: []v1beta1.IngressRule{
-					{
-						Host: host,
-						IngressRuleValue: v1beta1.IngressRuleValue{
-							HTTP: &v1beta1.HTTPIngressRuleValue{
-								Paths: []v1beta1.HTTPIngressPath{
-									{
-										Path: "/",
-										Backend: v1beta1.IngressBackend{
-											ServiceName: "http-svc",
-											ServicePort: intstr.FromInt(80),
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		})
-
+		ing, err := f.EnsureIngress(framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, nil))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ing).NotTo(BeNil())
 

--- a/test/e2e/settings/server_tokens.go
+++ b/test/e2e/settings/server_tokens.go
@@ -44,34 +44,7 @@ var _ = framework.IngressNginxDescribe("Server Tokens", func() {
 		err := f.UpdateNginxConfigMapData(serverTokens, "false")
 		Expect(err).NotTo(HaveOccurred())
 
-		ing, err := f.EnsureIngress(&v1beta1.Ingress{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:        serverTokens,
-				Namespace:   f.Namespace.Name,
-				Annotations: map[string]string{},
-			},
-			Spec: v1beta1.IngressSpec{
-				Rules: []v1beta1.IngressRule{
-					{
-						Host: serverTokens,
-						IngressRuleValue: v1beta1.IngressRuleValue{
-							HTTP: &v1beta1.HTTPIngressRuleValue{
-								Paths: []v1beta1.HTTPIngressPath{
-									{
-										Path: "/",
-										Backend: v1beta1.IngressBackend{
-											ServiceName: "http-svc",
-											ServicePort: intstr.FromInt(80),
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		})
-
+		ing, err := f.EnsureIngress(framework.NewSingleIngress(serverTokens, "/", serverTokens, f.IngressController.Namespace, nil))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ing).NotTo(BeNil())
 
@@ -90,7 +63,7 @@ var _ = framework.IngressNginxDescribe("Server Tokens", func() {
 		ing, err := f.EnsureIngress(&v1beta1.Ingress{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        serverTokens,
-				Namespace:   f.Namespace.Name,
+				Namespace:   f.IngressController.Namespace,
 				Annotations: map[string]string{},
 			},
 			Spec: v1beta1.IngressSpec{

--- a/test/e2e/up.sh
+++ b/test/e2e/up.sh
@@ -26,8 +26,8 @@ curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.25.2/minik
     sudo mv minikube /usr/local/bin/
 
 echo "starting minikube..."
-# Using sync-frequency=5s helps to speed up the tests (during the cleanup of resources inside a namespace)
-sudo minikube start --vm-driver=none --kubernetes-version=$KUBERNETES_VERSION --extra-config=kubelet.sync-frequency=5s
+# Using a lower value for sync-frequency to speed up the tests (during the cleanup of resources inside a namespace)
+sudo minikube start --vm-driver=none --kubernetes-version=$KUBERNETES_VERSION --extra-config=kubelet.sync-frequency=1s
 
 minikube update-context
 

--- a/test/e2e/wait-for-nginx.sh
+++ b/test/e2e/wait-for-nginx.sh
@@ -14,48 +14,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-echo "deploying NGINX Ingress controller"
-cat deploy/namespace.yaml | kubectl apply -f -
-cat deploy/default-backend.yaml | kubectl apply -f -
-cat deploy/configmap.yaml | kubectl apply -f -
-cat deploy/tcp-services-configmap.yaml | kubectl apply -f -
-cat deploy/udp-services-configmap.yaml | kubectl apply -f -
-cat deploy/without-rbac.yaml | kubectl apply -f -
-cat deploy/provider/baremetal/service-nodeport.yaml | kubectl apply -f -
+NAMESPACE=$1
 
-echo "updating image..."
-kubectl set image \
-    deployments \
-    --namespace ingress-nginx \
-	--selector app=ingress-nginx \
-    nginx-ingress-controller=quay.io/kubernetes-ingress-controller/nginx-ingress-controller:test
+echo "deploying NGINX Ingress controller in namespace $NAMESPACE"
 
-sleep 5
-
-echo "waiting NGINX ingress pod..."
-
-function waitForPod() {
-    until kubectl get pods -n ingress-nginx -l app=ingress-nginx -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True";
-    do
-        sleep 1;
-    done
-}
-
-export -f waitForPod
-
-timeout 30s bash -c waitForPod
-
-if kubectl get pods -n ingress-nginx -l app=ingress-nginx -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True";
-then
-    echo "Kubernetes deployments started"
-else
-    echo "Kubernetes deployments with issues:"
-    kubectl get pods -n ingress-nginx
-
-    echo "Reason:"
-    kubectl describe pods -n ingress-nginx
-    kubectl logs -n ingress-nginx -l app=ingress-nginx
-    exit 1
-fi
+cat $DIR/../manifests/ingress-controller/default-backend.yaml            | kubectl create --namespace=$NAMESPACE -f -
+cat $DIR/../manifests/ingress-controller/configmap.yaml                  | kubectl create --namespace=$NAMESPACE -f -
+cat $DIR/../manifests/ingress-controller/tcp-services-configmap.yaml     | kubectl create --namespace=$NAMESPACE -f -
+cat $DIR/../manifests/ingress-controller/udp-services-configmap.yaml     | kubectl create --namespace=$NAMESPACE -f -
+cat $DIR/../manifests/ingress-controller/with-rbac.yaml                  | kubectl create --namespace=$NAMESPACE -f -
+cat $DIR/../manifests/ingress-controller/service-nodeport.yaml           | kubectl create --namespace=$NAMESPACE -f -

--- a/test/manifests/ingress-controller/configmap.yaml
+++ b/test/manifests/ingress-controller/configmap.yaml
@@ -1,0 +1,6 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: nginx-configuration
+  labels:
+    app: ingress-nginx

--- a/test/manifests/ingress-controller/default-backend.yaml
+++ b/test/manifests/ingress-controller/default-backend.yaml
@@ -1,0 +1,53 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: default-http-backend
+  labels:
+    app: default-http-backend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: default-http-backend
+  template:
+    metadata:
+      labels:
+        app: default-http-backend
+    spec:
+      terminationGracePeriodSeconds: 60
+      containers:
+      - name: default-http-backend
+        # Any image is permissible as long as:
+        # 1. It serves a 404 page at /
+        # 2. It serves 200 on a /healthz endpoint
+        image: gcr.io/google_containers/defaultbackend:1.4
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+        ports:
+        - containerPort: 8080
+        resources:
+          limits:
+            cpu: 10m
+            memory: 20Mi
+          requests:
+            cpu: 10m
+            memory: 20Mi
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: default-http-backend
+  labels:
+    app: default-http-backend
+spec:
+  ports:
+  - port: 80
+    targetPort: 8080
+  selector:
+    app: default-http-backend

--- a/test/manifests/ingress-controller/rbac.yaml
+++ b/test/manifests/ingress-controller/rbac.yaml
@@ -1,0 +1,130 @@
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nginx-ingress-serviceaccount
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: nginx-ingress-clusterrole
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - endpoints
+      - nodes
+      - pods
+      - secrets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "extensions"
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+        - events
+    verbs:
+        - create
+        - patch
+  - apiGroups:
+      - "extensions"
+    resources:
+      - ingresses/status
+    verbs:
+      - update
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: nginx-ingress-role  
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - pods
+      - secrets
+      - namespaces
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    resourceNames:
+      # Defaults to "<election-id>-<ingress-class>"
+      # Here: "<ingress-controller-leader>-<nginx>"
+      # This has to be adapted if you change either parameter
+      # when launching the nginx-ingress-controller.
+      - "ingress-controller-leader-nginx"
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+    verbs:
+      - get
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: nginx-ingress-role-nisa-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: nginx-ingress-role
+subjects:
+  - kind: ServiceAccount
+    name: nginx-ingress-serviceaccount
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: nginx-ingress-clusterrole-nisa-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nginx-ingress-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: nginx-ingress-serviceaccount

--- a/test/manifests/ingress-controller/service-nodeport.yaml
+++ b/test/manifests/ingress-controller/service-nodeport.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingress-nginx
+spec:
+  type: NodePort
+  ports:
+  - name: http
+    port: 80
+    targetPort: 80
+    protocol: TCP
+  - name: https
+    port: 443
+    targetPort: 443
+    protocol: TCP
+  selector:
+    app: ingress-nginx

--- a/test/manifests/ingress-controller/tcp-services-configmap.yaml
+++ b/test/manifests/ingress-controller/tcp-services-configmap.yaml
@@ -1,0 +1,4 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: tcp-services

--- a/test/manifests/ingress-controller/udp-services-configmap.yaml
+++ b/test/manifests/ingress-controller/udp-services-configmap.yaml
@@ -1,0 +1,4 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: udp-services

--- a/test/manifests/ingress-controller/with-rbac.yaml
+++ b/test/manifests/ingress-controller/with-rbac.yaml
@@ -1,0 +1,59 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: nginx-ingress-controller
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ingress-nginx
+  template:
+    metadata:
+      labels:
+        app: ingress-nginx
+    spec:
+      terminationGracePeriodSeconds: 0
+      #serviceAccountName: nginx-ingress-serviceaccount
+      containers:
+        - name: nginx-ingress-controller
+          image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.13.0
+          args:
+            - /nginx-ingress-controller
+            - --default-backend-service=$(POD_NAMESPACE)/default-http-backend
+            - --configmap=$(POD_NAMESPACE)/nginx-configuration
+            - --tcp-services-configmap=$(POD_NAMESPACE)/tcp-services
+            - --udp-services-configmap=$(POD_NAMESPACE)/udp-services
+            - --annotations-prefix=nginx.ingress.kubernetes.io
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          ports:
+          - name: http
+            containerPort: 80
+          - name: https
+            containerPort: 443
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 10254
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 10254
+              scheme: HTTP
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1


### PR DESCRIPTION
**What this PR does / why we need it**:

A first step to remove hardcoded `time.Sleep` from e2e tests

Changes:
- Before each test, a new namespace is created and a new ingress controller is deployed
- In case of validation errors, we get the Full Stack Trace
- The SlowSpecThreshold was adjusted to 20 seconds (default is 5)
- Now it is possible to just run `make e2e-test` against minikube (previous upload of the docker image)


After this PR we can start running the e2e tests in parallel