### PR TITLE
DOCS: Add clarification regarding ssl passthrough

### DIFF
--- a/docs/user-guide/annotations.md
+++ b/docs/user-guide/annotations.md
@@ -348,7 +348,7 @@ The annotation `nginx.ingress.kubernetes.io/ssl-passthrough` allows to configure
 **Important:**
 
 - Using the annotation `nginx.ingress.kubernetes.io/ssl-passthrough` invalidates all the other available annotations. This is because SSL Passthrough works in L4 (TCP).
-- The use of this annotation requires the flag `--enable-ssl-passthrough` (By default it is disabled)
+- The use of this annotation requires Proxy Protocol to be enabled in the load-balancer. For example enabling Proxy Protocol for AWS ELB is described [here](https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-proxy-protocol.html). If you're using ingress-controller without load balancer then the flag `--enable-ssl-passthrough` is required (by default it is disabled).
 
 ### Secure backends
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds clarification regarding using `--enable-ssl-passthrough` flag if external load balances are used.

I've plunged into the [issue](https://github.com/kubernetes/ingress-nginx/issues/2354) with Go-based SSL proxying done by ingress-controller. Finally i found out that i can safely disable built-in SSL proxying, if i already have proxy protocol enabled on load balancer. See my last [comment](https://github.com/kubernetes/ingress-nginx/issues/2354#issuecomment-382757307) for details.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
related: https://github.com/kubernetes/ingress-nginx/issues/2354  

**Special notes for your reviewer**:
None