### PR TITLE
Silence unnecessary MissingAnnotations errors

### DIFF
--- a/internal/ingress/controller/store/store.go
+++ b/internal/ingress/controller/store/store.go
@@ -47,6 +47,7 @@ import (
 	ngx_config "k8s.io/ingress-nginx/internal/ingress/controller/config"
 	ngx_template "k8s.io/ingress-nginx/internal/ingress/controller/template"
 	"k8s.io/ingress-nginx/internal/ingress/defaults"
+	"k8s.io/ingress-nginx/internal/ingress/errors"
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
 	"k8s.io/ingress-nginx/internal/k8s"
 )
@@ -539,7 +540,7 @@ func (s *k8sStore) updateSecretIngressMap(ing *extensions.Ingress) {
 	}
 	for _, ann := range secretAnnotations {
 		secrKey, err := objectRefAnnotationNsKey(ann, ing)
-		if err != nil {
+		if err != nil && !errors.IsMissingAnnotations(err) {
 			glog.Errorf("error reading secret reference in annotation %q: %s", ann, err)
 			continue
 		}


### PR DESCRIPTION
**Why we need this:**

Silences the following error messages displayed on every call to `store.updateSecretIngressMap()` (unless these annotations are actually set):

```
E0420 16:06:35.692525   14631 store.go:722] Error reading secret reference in annotation "auth-secret": ingress rule without annotations
E0420 16:06:35.695298   14631 store.go:722] Error reading secret reference in annotation "auth-tls-secret": ingress rule without annotations
```

Continuity of #2382
See https://github.com/kubernetes/ingress-nginx/pull/2382/files#r183044272

