### PR TITLE
Automate building developer environment 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -209,3 +209,7 @@ dep-ensure:
 	dep version || go get -u github.com/golang/dep/cmd/dep
 	dep ensure -v
 	dep prune -v
+
+.PHONY: dev-env
+dev-env:
+	@./hack/build-dev-env.sh

--- a/docs/development.md
+++ b/docs/development.md
@@ -3,6 +3,32 @@
 This document explains how to get started with developing for NGINX Ingress controller.
 It includes how to build, test, and release ingress controllers.
 
+## Quick Start
+
+### Initial developer environment build
+
+**Prequisites**: Minikube must be installed; See [releases](https://github.com/kubernetes/minikube/releases) for installation instructions. 
+
+If you are using **MacOS** and deploying to **minikube**, the following command will build the local nginx controller container image and deploy the ingress controller onto a minikube cluster with RBAC enabled in the namespace `ingress-nginx`:
+
+```
+$ make dev-env
+```
+
+### Updating the deployment
+
+The nginx controller container image can be rebuilt using:
+```
+$ ARCH=amd64 TAG=dev REGISTRY=$USER/ingress-controller make build container
+```
+
+The image will only be used by pods created after the rebuild. To delete old pods which will cause new ones to spin up:
+```
+$ kubectl get pods -n ingress-nginx
+$ kubectl delete pod -n ingress-nginx nginx-ingress-controller-<unique-pod-id>
+```
+
+
 ## Dependencies
 
 The build uses dependencies in the `vendor` directory, which

--- a/hack/build-dev-env.sh
+++ b/hack/build-dev-env.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+NAMESPACE=ingress-nginx
+
+minikube start
+eval $(minikube docker-env)
+
+echo "[dev-env] installing dependencies"
+go get -u github.com/golang/dep
+dep ensure
+
+echo "[dev-env] building container"
+ARCH=amd64 TAG=dev REGISTRY=$USER/ingress-controller make build container
+
+echo "[dev-env] installing kubectl"
+brew install kubectl
+
+echo "[dev-env] deploying NGINX Ingress controller in namespace $NAMESPACE"
+cat ./deploy/namespace.yaml                  | kubectl apply --namespace=$NAMESPACE -f -
+cat ./deploy/default-backend.yaml            | kubectl apply --namespace=$NAMESPACE -f -
+cat ./deploy/configmap.yaml                  | kubectl apply --namespace=$NAMESPACE -f -
+cat ./deploy/tcp-services-configmap.yaml     | kubectl apply --namespace=$NAMESPACE -f -
+cat ./deploy/udp-services-configmap.yaml     | kubectl apply --namespace=$NAMESPACE -f -
+cat ./deploy/rbac.yaml                       | kubectl apply --namespace=$NAMESPACE -f -
+cat ./deploy/with-rbac.yaml                  | kubectl apply --namespace=$NAMESPACE -f -
+
+echo "updating image..."
+kubectl set image \
+    deployments \
+    --namespace ingress-nginx \
+    --selector app=ingress-nginx \
+    nginx-ingress-controller=index.docker.io/$USER/ingress-controller/nginx-ingress-controller:dev


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

Setting up the development environment is quite time consuming and somewhat confusing. This script creates a quick command that will allow MacOS developers to set up their quickly by automating the following tasks:

~~1. Stop and uninstall minikube~~
~~2. Install minikube version 0.25.0~~
3. Start minikube
4. Dep ensure to get `vendor/` dependencies
5. Build the local ingress controller container
6. Install kubectl
7. Deploy the controller & update the image

**Which issue this PR fixes**: N/A

**Special notes for your reviewer**:

~~Minikube versions > 0.25.0 enable RBAC on the cluster. This will cause the e2e-tests to fail. Therefore a suitable development environment requires version 0.25.0 or less.~~
