### PR TITLE
Add buffer configuration to external auth location config

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -802,6 +802,11 @@ stream {
             proxy_set_header            X-Auth-Request-Redirect $request_uri;
             {{ end }}
 
+            proxy_buffering                         "{{ $location.Proxy.ProxyBuffering }}";
+            proxy_buffer_size                       "{{ $location.Proxy.BufferSize }}";
+            proxy_buffers                           4 "{{ $location.Proxy.BufferSize }}";
+            proxy_request_buffering                 "{{ $location.Proxy.RequestBuffering }}";
+
             proxy_http_version          1.1;
             proxy_ssl_server_name       on;
             proxy_pass_request_headers  on;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
If the External Auth service returns for instance cookies that are bigger then 4Kb the request fails. 

This happens whenever external auth service returns cookies and other headers that exceed the default proxy buffer (4Kb). The configmap option `proxy-buffer-size` is completely ignored and its `proxy_buffer_size` equivalent is not propagated to the auth `location`.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
fixes #2427

**Special notes for your reviewer**:
no