### PR TITLE
Use another port with GRPC

### DIFF
--- a/cmd/nginx/flags.go
+++ b/cmd/nginx/flags.go
@@ -114,6 +114,7 @@ func parseFlags() (bool, *controller.Configuration, error) {
 
 		httpPort      = flags.Int("http-port", 80, `Indicates the port to use for HTTP traffic`)
 		httpsPort     = flags.Int("https-port", 443, `Indicates the port to use for HTTPS traffic`)
+		grpcPort      = flags.Int("grpc-port", 9200, `Indicates the port to use for GRPC traffic`)
 		statusPort    = flags.Int("status-port", 18080, `Indicates the TCP port to use for exposing the nginx status page`)
 		sslProxyPort  = flags.Int("ssl-passtrough-proxy-port", 442, `Default port to use internally for SSL when SSL Passthgough is enabled`)
 		defServerPort = flags.Int("default-server-port", 8181, `Default port to use for exposing the default server (catch all)`)
@@ -179,6 +180,10 @@ func parseFlags() (bool, *controller.Configuration, error) {
 		return false, nil, fmt.Errorf("Port %v is already in use. Please check the flag --https-port", *httpsPort)
 	}
 
+	if !ing_net.IsPortAvailable(*grpcPort) {
+		return false, nil, fmt.Errorf("Port %v is already in use. Please check the flag --grpc-port", *grpcPort)
+	}
+
 	if !ing_net.IsPortAvailable(*statusPort) {
 		return false, nil, fmt.Errorf("Port %v is already in use. Please check the flag --status-port", *statusPort)
 	}
@@ -235,6 +240,7 @@ func parseFlags() (bool, *controller.Configuration, error) {
 			Health:   *healthzPort,
 			HTTP:     *httpPort,
 			HTTPS:    *httpsPort,
+			GRPC:     *grpcPort,
 			SSLProxy: *sslProxyPort,
 			Status:   *statusPort,
 		},

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -676,6 +676,7 @@ type TemplateConfig struct {
 type ListenPorts struct {
 	HTTP     int
 	HTTPS    int
+	GRPC     int
 	Status   int
 	Health   int
 	Default  int

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -230,6 +230,7 @@ func (n *NGINXController) getStreamServices(configmapName string, proto apiv1.Pr
 	rp := []int{
 		n.cfg.ListenPorts.HTTP,
 		n.cfg.ListenPorts.HTTPS,
+		n.cfg.ListenPorts.GRPC,
 		n.cfg.ListenPorts.SSLProxy,
 		n.cfg.ListenPorts.Status,
 		n.cfg.ListenPorts.Health,

--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -133,6 +133,7 @@ var (
 		"buildUpstreamName":          buildUpstreamName,
 		"isLocationInLocationList":   isLocationInLocationList,
 		"isLocationAllowed":          isLocationAllowed,
+		"isGrpcContained":            isGrpcContained,
 		"buildLogFormatUpstream":     buildLogFormatUpstream,
 		"buildDenyVariable":          buildDenyVariable,
 		"getenv":                     os.Getenv,
@@ -609,6 +610,20 @@ func isLocationAllowed(input interface{}) bool {
 	}
 
 	return loc.Denied == nil
+}
+
+func isGrpcContained(input interface{}) bool {
+	server, ok := input.(*ingress.Server)
+	if !ok {
+		glog.Errorf("expected an '*ingress.Server' type but %T was returned", input)
+		return false
+	}
+	for _, loc := range server.Locations {
+		if loc.GRPC {
+			return true
+		}
+	}
+	return false
 }
 
 var (

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -712,6 +712,20 @@ stream {
         listen [::]:{{ $all.ListenPorts.HTTP }}{{ if $all.Cfg.UseProxyProtocol }} proxy_protocol{{ end }}{{ if eq $server.Hostname "_"}} default_server {{ if $all.Cfg.ReusePort }}reuseport{{ end }} backlog={{ $all.BacklogSize }}{{ end }};
         {{ end }}
         {{ end }}
+        {{ if isGrpcContained $server }}
+        {{ range $address := $all.Cfg.BindAddressIpv4 }}
+        listen {{ $address }}:{{ $all.ListenPorts.GRPC }}{{ if $all.Cfg.UseProxyProtocol }} proxy_protocol{{ end }}{{ if eq $server.Hostname "_"}} default_server {{ if $all.Cfg.ReusePort }}reuseport{{ end }} backlog={{ $all.BacklogSize }}{{end}} http2;
+        {{ else }}
+        listen {{ $all.ListenPorts.GRPC }}{{ if $all.Cfg.UseProxyProtocol }} proxy_protocol{{ end }}{{ if eq $server.Hostname "_"}} default_server {{ if $all.Cfg.ReusePort }}reuseport{{ end }} backlog={{ $all.BacklogSize }}{{end}} http2;
+        {{ end }}
+        {{ if $all.IsIPV6Enabled }}
+        {{ range $address := $all.Cfg.BindAddressIpv6 }}
+        listen {{ $address }}:{{ $all.ListenPorts.GRPC }}{{ if $all.Cfg.UseProxyProtocol }} proxy_protocol{{ end }}{{ if eq $server.Hostname "_"}} default_server {{ if $all.Cfg.ReusePort }}reuseport{{ end }} backlog={{ $all.BacklogSize }}{{ end }} http2;
+        {{ else }}
+        listen [::]:{{ $all.ListenPorts.GRPC }}{{ if $all.Cfg.UseProxyProtocol }} proxy_protocol{{ end }}{{ if eq $server.Hostname "_"}} default_server {{ if $all.Cfg.ReusePort }}reuseport{{ end }} backlog={{ $all.BacklogSize }}{{ end }} http2;
+        {{ end }}
+        {{ end }}
+        {{ end }}
         set $proxy_upstream_name "-";
 
         {{/* Listen on {{ $all.ListenPorts.SSLProxy }} because port {{ $all.ListenPorts.HTTPS }} is used in the TLS sni server */}}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
http2 is required for GRPC. However, using 80 ports break http traffic. ( https://github.com/kubernetes/ingress-nginx/pull/2313 )
We should use a different port.
