### PR TITLE
Update exposing-tcp-udp-services.md

### DIFF
--- a/docs/user-guide/exposing-tcp-udp-services.md
+++ b/docs/user-guide/exposing-tcp-udp-services.md
@@ -26,4 +26,5 @@ kind: ConfigMap
 metadata:
   name: udp-configmap-example
 data:
-  53: "kube-system/kube-dns:53"
+  53: "kube-system/kube-dns:53"
+```


### PR DESCRIPTION
**What this PR does / why we need it**:

Minor tick missing for syntax highlighting which makes it look ugly on https://kubernetes.github.io/ingress-nginx/user-guide/exposing-tcp-udp-services/

