### PR TITLE
TLS tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ endif
 	$(DOCKER) build -t $(MULTI_ARCH_IMG):$(TAG) $(TEMP_DIR)/rootfs
 
 ifeq ($(ARCH), amd64)
-	# This is for to maintain the backward compatibility
+	# This is for maintaining backward compatibility
 	$(DOCKER) tag $(MULTI_ARCH_IMG):$(TAG) $(IMAGE):$(TAG)
 endif
 
@@ -159,7 +159,7 @@ lua-test:
 
 .PHONY: e2e-image
 e2e-image: sub-container-amd64
-	TAG=$(TAG) IMAGE=$(MULTI_ARCH_IMG) docker tag $(IMAGE):$(TAG) $(IMAGE):test
+	$(DOCKER) tag $(MULTI_ARCH_IMG):$(TAG) $(IMGNAME):e2e
 	docker images
 
 .PHONY: e2e-test

--- a/internal/ingress/controller/store/store_test.go
+++ b/internal/ingress/controller/store/store_test.go
@@ -304,7 +304,7 @@ func TestStore(t *testing.T) {
 		storer.Run(stopCh)
 
 		secretName := "not-referenced"
-		_, _, _, err = framework.CreateIngressTLSSecret(clientSet, []string{"foo"}, secretName, ns)
+		_, err = framework.CreateIngressTLSSecret(clientSet, []string{"foo"}, secretName, ns)
 		if err != nil {
 			t.Errorf("unexpected error creating secret: %v", err)
 		}
@@ -418,7 +418,7 @@ func TestStore(t *testing.T) {
 			t.Errorf("unexpected error waiting for secret: %v", err)
 		}
 
-		_, _, _, err = framework.CreateIngressTLSSecret(clientSet, []string{"foo"}, secretName, ns)
+		_, err = framework.CreateIngressTLSSecret(clientSet, []string{"foo"}, secretName, ns)
 		if err != nil {
 			t.Errorf("unexpected error creating secret: %v", err)
 		}
@@ -558,7 +558,7 @@ func TestStore(t *testing.T) {
 			t.Errorf("expected 0 events of type Delete but %v occurred", del)
 		}
 
-		_, _, _, err = framework.CreateIngressTLSSecret(clientSet, secretHosts, name, ns)
+		_, err = framework.CreateIngressTLSSecret(clientSet, secretHosts, name, ns)
 		if err != nil {
 			t.Errorf("unexpected error creating secret: %v", err)
 		}

--- a/test/e2e/framework/echo.go
+++ b/test/e2e/framework/echo.go
@@ -60,7 +60,7 @@ func (f *Framework) NewEchoDeploymentWithReplicas(replicas int32) error {
 					Containers: []corev1.Container{
 						{
 							Name:  "http-svc",
-							Image: "gcr.io/google_containers/echoserver:1.8",
+							Image: "gcr.io/google_containers/echoserver:1.10",
 							Env:   []corev1.EnvVar{},
 							Ports: []corev1.ContainerPort{
 								{

--- a/test/e2e/lua/dynamic_configuration.go
+++ b/test/e2e/lua/dynamic_configuration.go
@@ -184,7 +184,7 @@ var _ = framework.IngressNginxDescribe("Dynamic Configuration", func() {
 			},
 		}
 
-		_, _, _, err = framework.CreateIngressTLSSecret(f.KubeClientSet,
+		_, err = framework.CreateIngressTLSSecret(f.KubeClientSet,
 			ingress.Spec.TLS[0].Hosts,
 			ingress.Spec.TLS[0].SecretName,
 			ingress.Namespace)

--- a/test/e2e/settings/no_auth_locations.go
+++ b/test/e2e/settings/no_auth_locations.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package setting
+package settings
 
 import (
 	"fmt"

--- a/test/e2e/settings/proxy_protocol.go
+++ b/test/e2e/settings/proxy_protocol.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package setting
+package settings
 
 import (
 	"fmt"

--- a/test/e2e/settings/server_tokens.go
+++ b/test/e2e/settings/server_tokens.go
@@ -49,9 +49,9 @@ var _ = framework.IngressNginxDescribe("Server Tokens", func() {
 		Expect(ing).NotTo(BeNil())
 
 		err = f.WaitForNginxConfiguration(
-			func(server string) bool {
-				return strings.Contains(server, "server_tokens off") &&
-					strings.Contains(server, "more_set_headers \"Server: \"")
+			func(cfg string) bool {
+				return strings.Contains(cfg, "server_tokens off") &&
+					strings.Contains(cfg, "more_set_headers \"Server: \"")
 			})
 		Expect(err).NotTo(HaveOccurred())
 	})
@@ -92,8 +92,8 @@ var _ = framework.IngressNginxDescribe("Server Tokens", func() {
 		Expect(ing).NotTo(BeNil())
 
 		err = f.WaitForNginxConfiguration(
-			func(server string) bool {
-				return strings.Contains(server, "server_tokens on")
+			func(cfg string) bool {
+				return strings.Contains(cfg, "server_tokens on")
 			})
 		Expect(err).NotTo(HaveOccurred())
 	})

--- a/test/e2e/settings/server_tokens.go
+++ b/test/e2e/settings/server_tokens.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package setting
+package settings
 
 import (
 	"strings"

--- a/test/e2e/settings/tls.go
+++ b/test/e2e/settings/tls.go
@@ -1,0 +1,189 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package settings
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/parnurzeal/gorequest"
+
+	"k8s.io/ingress-nginx/test/e2e/framework"
+)
+
+var _ = framework.IngressNginxDescribe("Settings - TLS)", func() {
+	f := framework.NewDefaultFramework("settings-tls")
+	host := "settings-tls"
+
+	BeforeEach(func() {
+		err := f.NewEchoDeployment()
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+	})
+
+	It("should configure TLS protocol", func() {
+		sslCiphers := "ssl-ciphers"
+		sslProtocols := "ssl-protocols"
+
+		// Two ciphers supported by each of TLSv1.2 and TLSv1.
+		// https://www.openssl.org/docs/man1.1.0/apps/ciphers.html - "CIPHER SUITE NAMES"
+		testCiphers := "ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA"
+
+		tlsConfig, err := tlsEndpoint(f, host)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = framework.WaitForTLS(f.IngressController.HTTPSURL, tlsConfig)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("setting cipher suite")
+
+		err = f.UpdateNginxConfigMapData(sslCiphers, testCiphers)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = f.WaitForNginxConfiguration(
+			func(cfg string) bool {
+				return strings.Contains(cfg, fmt.Sprintf("ssl_ciphers '%s';", testCiphers))
+			})
+		Expect(err).NotTo(HaveOccurred())
+
+		resp, _, errs := gorequest.New().
+			Get(f.IngressController.HTTPSURL).
+			TLSClientConfig(tlsConfig).
+			Set("Host", host).
+			End()
+
+		Expect(len(errs)).Should(BeNumerically("==", 0))
+		Expect(resp.StatusCode).Should(Equal(http.StatusOK))
+		Expect(resp.TLS.Version).Should(BeNumerically("==", tls.VersionTLS12))
+		Expect(resp.TLS.CipherSuite).Should(BeNumerically("==", tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384))
+
+		By("enforcing TLS v1.0")
+
+		err = f.UpdateNginxConfigMapData(sslProtocols, "TLSv1")
+		Expect(err).NotTo(HaveOccurred())
+
+		err = f.WaitForNginxConfiguration(
+			func(cfg string) bool {
+				return strings.Contains(cfg, "ssl_protocols TLSv1;")
+			})
+		Expect(err).NotTo(HaveOccurred())
+
+		resp, _, errs = gorequest.New().
+			Get(f.IngressController.HTTPSURL).
+			TLSClientConfig(tlsConfig).
+			Set("Host", host).
+			End()
+
+		Expect(len(errs)).Should(BeNumerically("==", 0))
+		Expect(resp.StatusCode).Should(Equal(http.StatusOK))
+		Expect(resp.TLS.Version).Should(BeNumerically("==", tls.VersionTLS10))
+		Expect(resp.TLS.CipherSuite).Should(BeNumerically("==", tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA))
+	})
+
+	It("should configure HSTS policy header", func() {
+		hstsMaxAge := "hsts-max-age"
+		hstsIncludeSubdomains := "hsts-include-subdomains"
+		hstsPreload := "hsts-preload"
+
+		tlsConfig, err := tlsEndpoint(f, host)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = framework.WaitForTLS(f.IngressController.HTTPSURL, tlsConfig)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("setting max-age parameter")
+
+		err = f.UpdateNginxConfigMapData(hstsMaxAge, "86400")
+		Expect(err).NotTo(HaveOccurred())
+
+		err = f.WaitForNginxServer(host,
+			func(server string) bool {
+				return strings.Contains(server, "Strict-Transport-Security: max-age=86400; includeSubDomains\"")
+			})
+		Expect(err).NotTo(HaveOccurred())
+
+		resp, _, errs := gorequest.New().
+			Get(f.IngressController.HTTPSURL).
+			TLSClientConfig(tlsConfig).
+			Set("Host", host).
+			End()
+
+		Expect(len(errs)).Should(BeNumerically("==", 0))
+		Expect(resp.StatusCode).Should(Equal(http.StatusOK))
+		Expect(resp.Header.Get("Strict-Transport-Security")).Should(ContainSubstring("max-age=86400"))
+
+		By("setting includeSubDomains parameter")
+
+		err = f.UpdateNginxConfigMapData(hstsIncludeSubdomains, "false")
+		Expect(err).NotTo(HaveOccurred())
+
+		err = f.WaitForNginxServer(host,
+			func(server string) bool {
+				return strings.Contains(server, "Strict-Transport-Security: max-age=86400\"")
+			})
+		Expect(err).NotTo(HaveOccurred())
+
+		resp, _, errs = gorequest.New().
+			Get(f.IngressController.HTTPSURL).
+			TLSClientConfig(tlsConfig).
+			Set("Host", host).
+			End()
+
+		Expect(len(errs)).Should(BeNumerically("==", 0))
+		Expect(resp.StatusCode).Should(Equal(http.StatusOK))
+		Expect(resp.Header.Get("Strict-Transport-Security")).ShouldNot(ContainSubstring("includeSubDomains"))
+
+		By("setting preload parameter")
+
+		err = f.UpdateNginxConfigMapData(hstsPreload, "true")
+		Expect(err).NotTo(HaveOccurred())
+
+		err = f.WaitForNginxServer(host,
+			func(server string) bool {
+				return strings.Contains(server, "Strict-Transport-Security: max-age=86400; preload\"")
+			})
+		Expect(err).NotTo(HaveOccurred())
+
+		resp, _, errs = gorequest.New().
+			Get(f.IngressController.HTTPSURL).
+			TLSClientConfig(tlsConfig).
+			Set("Host", host).
+			End()
+
+		Expect(len(errs)).Should(BeNumerically("==", 0))
+		Expect(resp.StatusCode).Should(Equal(http.StatusOK))
+		Expect(resp.Header.Get("Strict-Transport-Security")).Should(ContainSubstring("preload"))
+	})
+})
+
+func tlsEndpoint(f *framework.Framework, host string) (*tls.Config, error) {
+	ing, err := f.EnsureIngress(framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, nil))
+	if err != nil {
+		return nil, err
+	}
+
+	return framework.CreateIngressTLSSecret(f.KubeClientSet,
+		ing.Spec.TLS[0].Hosts,
+		ing.Spec.TLS[0].SecretName,
+		ing.Namespace)
+}

--- a/test/e2e/ssl/secret_update.go
+++ b/test/e2e/ssl/secret_update.go
@@ -58,7 +58,7 @@ var _ = framework.IngressNginxDescribe("SSL", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(ing).ToNot(BeNil())
 
-		_, _, _, err = framework.CreateIngressTLSSecret(f.KubeClientSet,
+		_, err = framework.CreateIngressTLSSecret(f.KubeClientSet,
 			ing.Spec.TLS[0].Hosts,
 			ing.Spec.TLS[0].SecretName,
 			ing.Namespace)

--- a/test/manifests/ingress-controller/with-rbac.yaml
+++ b/test/manifests/ingress-controller/with-rbac.yaml
@@ -16,7 +16,7 @@ spec:
       #serviceAccountName: nginx-ingress-serviceaccount
       containers:
         - name: nginx-ingress-controller
-          image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.14.0
+          image: nginx-ingress-controller:e2e
           args:
             - /nginx-ingress-controller
             - --default-backend-service=$(POD_NAMESPACE)/default-http-backend


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds tests for global TLS settings.

**Special notes for your reviewer**:

~I observed some flaky test runs due to `x509: certificate is valid for ingress.local, not settings-tls`. A `framework.WaitForTLS` method may be a good addition.~
done