### PR TITLE
Add basic security context to deployment YAMLs

### DIFF
--- a/deploy/provider/patch-service-with-rbac.yaml
+++ b/deploy/provider/patch-service-with-rbac.yaml
@@ -61,3 +61,5 @@ spec:
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
+          securityContext:
+            runAsNonRoot: false

--- a/deploy/provider/patch-service-without-rbac.yaml
+++ b/deploy/provider/patch-service-without-rbac.yaml
@@ -60,3 +60,5 @@ spec:
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
+          securityContext:
+            runAsNonRoot: false

--- a/deploy/with-rbac.yaml
+++ b/deploy/with-rbac.yaml
@@ -60,3 +60,5 @@ spec:
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
+          securityContext:
+            runAsNonRoot: false

--- a/deploy/without-rbac.yaml
+++ b/deploy/without-rbac.yaml
@@ -59,3 +59,5 @@ spec:
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
+          securityContext:
+            runAsNonRoot: false

--- a/docs/examples/customization/custom-errors/rc-custom-errors.yaml
+++ b/docs/examples/customization/custom-errors/rc-custom-errors.yaml
@@ -49,3 +49,5 @@ spec:
         args:
         - /nginx-ingress-controller
         - --default-backend-service=$(POD_NAMESPACE)/nginx-errors
+        securityContext:
+          runAsNonRoot: false

--- a/docs/examples/static-ip/nginx-ingress-controller.yaml
+++ b/docs/examples/static-ip/nginx-ingress-controller.yaml
@@ -53,3 +53,5 @@ spec:
         - /nginx-ingress-controller
         - --default-backend-service=$(POD_NAMESPACE)/default-http-backend
         - --publish-service=$(POD_NAMESPACE)/nginx-ingress-lb
+        securityContext:
+          runAsNonRoot: false

--- a/test/manifests/ingress-controller/with-rbac.yaml
+++ b/test/manifests/ingress-controller/with-rbac.yaml
@@ -58,3 +58,5 @@ spec:
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
+          securityContext:
+            runAsNonRoot: false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**: Adding a security context with `runAsNonRoot: false` to the pod template indicates the pod's intention to run as root, and will let Kubernetes decide upon the correct pod security policy.

**Which issue this PR fixes**: fixes #2400
