### PR TITLE
Assert or install go-bindata before incanting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,6 +137,7 @@ clean:
 
 .PHONE: code-generator
 code-generator:
+		@go-bindata -version || go get -u github.com/jteeuwen/go-bindata/...
 		go-bindata -nometadata -o internal/file/bindata.go -prefix="rootfs" -pkg=file -ignore=Dockerfile -ignore=".DS_Store" rootfs/...
 
 .PHONY: build


### PR DESCRIPTION
**What this PR does / why we need it**:
* Small fix to make sure `go-bindata` exists or is installed before running the code-generator task.

**Special notes for your reviewer**:
cc @aledbf @ElvinEfendi 