### PR TITLE
doc: comma helps clarify default backend doc

### DIFF
--- a/docs/user-guide/custom-errors.md
+++ b/docs/user-guide/custom-errors.md
@@ -1,6 +1,6 @@
 # Custom errors
 
-In case of an error in a request the body of the response is obtained from the `default backend`.
+In case of an error in a request, the body of the response is obtained from the `default backend`.
 Each request to the default backend includes two headers:
 
 - `X-Code` indicates the HTTP code to be returned to the client.


### PR DESCRIPTION
I had to read this sentence over several times before I understood that there was a comma missing. The comma helps clarify that you make a request, it has an error in it, and then the body that is returned is obtained from the `default backend`.