### PR TITLE
enable reuse port by default

### DIFF
--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -484,8 +484,7 @@ type Configuration struct {
 	// ReusePort instructs NGINX to create an individual listening socket for
 	// each worker process (using the SO_REUSEPORT socket option), allowing a
 	// kernel to distribute incoming connections between worker processes
-	// Default: false
-	// Reason for the default: https://trac.nginx.org/nginx/ticket/1300
+	// Default: true
 	ReusePort bool `json:"reuse-port"`
 
 	// HideHeaders sets additional header that will not be passed from the upstream
@@ -626,6 +625,7 @@ func NewDefault() Configuration {
 		SyslogPort:                   514,
 		NoTLSRedirectLocations:       "/.well-known/acme-challenge",
 		NoAuthLocations:              "/.well-known/acme-challenge",
+		ReusePort:                    true,
 	}
 
 	if glog.V(5) {


### PR DESCRIPTION

**What this PR does / why we need it**:

This enables the reuse port by default as https://trac.nginx.org/nginx/ticket/1300 seems to be fixed.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

N/A

**Special notes for your reviewer**:

I tested it using steps on the ticket with ingress controller version 0.14.0, with nginx/1.13.12 and it seems to be working fine.

![screen shot 2018-05-03 at 9 29 08 am](https://user-images.githubusercontent.com/612092/39591173-cb4e742c-4eb7-11e8-8eb5-9ba3fda68fe0.png)
