### PR TITLE
Change TrimLeft for TrimPrefix on the from-to-www redirect

### DIFF
--- a/internal/ingress/controller/nginx.go
+++ b/internal/ingress/controller/nginx.go
@@ -516,7 +516,7 @@ func (n *NGINXController) OnUpdate(ingressCfg ingress.Configuration) error {
 		if srv.RedirectFromToWWW {
 			var n string
 			if strings.HasPrefix(srv.Hostname, "www.") {
-				n = strings.TrimLeft(srv.Hostname, "www.")
+				n = strings.TrimPrefix(srv.Hostname, "www.")
 			} else {
 				n = fmt.Sprintf("www.%v", srv.Hostname)
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a fix for the redirect from to www functionality in combination with a domain that starts with a `w`
Right now it uses a `TrimLeft` which means `www.we-foo-bar.com` becomes `e-foo-bar.com`.
I think a better solution would be to use `TrimPrefix`