### PR TITLE
Better and working configuration-snippet example

### DIFF
--- a/docs/user-guide/nginx-configuration/annotations.md
+++ b/docs/user-guide/nginx-configuration/annotations.md
@@ -215,7 +215,7 @@ Using this annotation you can add additional configuration to the NGINX location
 
 ```yaml
 nginx.ingress.kubernetes.io/configuration-snippet: |
-  more_set_headers "Request-Id: $req_id";
+  more_set_input_headers "X-Request-ID: $request_id";
 ```
 
 ### Default Backend


### PR DESCRIPTION
The previous example did not work because the `$req_id` variable is not commonly aviable on newer nginx versions whereas `$request_id` is since version 1.11 in the standard nginx. 
Also did the previous example set the `request-id` header in the response to the client, which is only partly reasonable. The new example does set the header in the forwarded request to the upstream service where it could be used to implement request tracing.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Improved documentation
