### PR TITLE
[ci skip] bump nginx baseimage version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ IMAGE = $(REGISTRY)/$(IMGNAME)
 MULTI_ARCH_IMG = $(IMAGE)-$(ARCH)
 
 # Set default base image dynamically for each arch
-BASEIMAGE?=quay.io/kubernetes-ingress-controller/nginx-$(ARCH):0.44
+BASEIMAGE?=quay.io/kubernetes-ingress-controller/nginx-$(ARCH):0.45
 
 ifeq ($(ARCH),arm)
 	QEMUARCH=arm

--- a/images/nginx/Makefile
+++ b/images/nginx/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # 0.0.0 shouldn't clobber any released builds
-TAG ?= 0.44
+TAG ?= 0.45
 REGISTRY ?= quay.io/kubernetes-ingress-controller
 ARCH ?= $(shell go env GOARCH)
 DOCKER ?= docker


### PR DESCRIPTION
**What this PR does / why we need it**:
Nginx image tag in the master is 0.44 but in the docker repository 0.44 does not represent the latest Nginx image.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
