### PR TITLE
Add Timeout For TLS Passthrough

### DIFF
--- a/docs/user-guide/nginx-configuration/configmap.md
+++ b/docs/user-guide/nginx-configuration/configmap.md
@@ -84,6 +84,7 @@ The following table shows a configuration option's name, type, and the default v
 |[ssl-session-timeout](#ssl-session-timeout)|string|"10m"|
 |[ssl-buffer-size](#ssl-buffer-size)|string|"4k"|
 |[use-proxy-protocol](#use-proxy-protocol)|bool|"false"|
+|[proxy-protocol-header-timeout](#proxy-protocol-header-timeout)|string|"5s"|
 |[use-gzip](#use-gzip)|bool|"true"|
 |[use-geoip](#use-geoip)|bool|"true"|
 |[enable-brotli](#enable-brotli)|bool|"true"|
@@ -478,6 +479,11 @@ _References:_
 ## use-proxy-protocol
 
 Enables or disables the [PROXY protocol](https://www.nginx.com/resources/admin-guide/proxy-protocol/) to receive client connection (real IP address) information passed through proxy servers and load balancers such as HAProxy and Amazon Elastic Load Balancer (ELB).
+
+## proxy-protocol-header-timeout
+
+Sets the timeout value for receiving the proxy-protocol headers. The default of 5 seconds prevents the TLS passthrough handler from waiting indefinetly on a dropped connection.
+_**default:**_ 5s
 
 ## use-gzip
 

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"runtime"
 	"strconv"
+	"time"
 
 	"github.com/golang/glog"
 
@@ -346,6 +347,11 @@ type Configuration struct {
 	// https://www.nginx.com/resources/admin-guide/proxy-protocol/
 	UseProxyProtocol bool `json:"use-proxy-protocol,omitempty"`
 
+	// When use-proxy-protocol is enabled, sets the maximum time the connection handler will wait
+	// to receive proxy headers.
+	// Example '60s'
+	ProxyProtocolHeaderTimeout time.Duration `json:"proxy-protocol-header-timeout,omitempty"`
+
 	// Enables or disables the use of the nginx module that compresses responses using the "gzip" method
 	// http://nginx.org/en/docs/http/ngx_http_gzip_module.html
 	UseGzip bool `json:"use-gzip,omitempty"`
@@ -528,6 +534,7 @@ func NewDefault() Configuration {
 	defIPCIDR = append(defIPCIDR, "0.0.0.0/0")
 	defNginxStatusIpv4Whitelist = append(defNginxStatusIpv4Whitelist, "127.0.0.1")
 	defNginxStatusIpv6Whitelist = append(defNginxStatusIpv6Whitelist, "::1")
+	defProxyDeadlineDuration := time.Duration(5) * time.Second
 
 	cfg := Configuration{
 		AllowBackendServerHeader:   false,
@@ -566,6 +573,7 @@ func NewDefault() Configuration {
 		NginxStatusIpv4Whitelist:   defNginxStatusIpv4Whitelist,
 		NginxStatusIpv6Whitelist:   defNginxStatusIpv6Whitelist,
 		ProxyRealIPCIDR:            defIPCIDR,
+		ProxyProtocolHeaderTimeout: defProxyDeadlineDuration,
 		ServerNameHashMaxSize:      1024,
 		ProxyHeadersHashMaxSize:    512,
 		ProxyHeadersHashBucketSize: 64,

--- a/internal/ingress/controller/nginx.go
+++ b/internal/ingress/controller/nginx.go
@@ -704,6 +704,7 @@ func nextPowerOf2(v int) int {
 }
 
 func (n *NGINXController) setupSSLProxy() {
+	cfg := n.store.GetBackendConfiguration()
 	sslPort := n.cfg.ListenPorts.HTTPS
 	proxyPort := n.cfg.ListenPorts.SSLProxy
 
@@ -722,7 +723,7 @@ func (n *NGINXController) setupSSLProxy() {
 		glog.Fatalf("%v", err)
 	}
 
-	proxyList := &proxyproto.Listener{Listener: listener}
+	proxyList := &proxyproto.Listener{Listener: listener, ProxyHeaderTimeout: cfg.ProxyProtocolHeaderTimeout}
 
 	// start goroutine that accepts tcp connections in port 443
 	go func() {

--- a/internal/ingress/controller/template/configmap.go
+++ b/internal/ingress/controller/template/configmap.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/golang/glog"
 
@@ -42,6 +43,7 @@ const (
 	hideHeaders              = "hide-headers"
 	nginxStatusIpv4Whitelist = "nginx-status-ipv4-whitelist"
 	nginxStatusIpv6Whitelist = "nginx-status-ipv6-whitelist"
+	proxyHeaderTimeout       = "proxy-protocol-header-timeout"
 )
 
 var (
@@ -122,6 +124,17 @@ func ReadConfig(src map[string]string) config.Configuration {
 			} else {
 				glog.Warningf("The code %v is not a valid as HTTP redirect code. Using the default.", val)
 			}
+		}
+	}
+
+	// Verify that the configured timeout is parsable as a duration. if not, set the default value
+	if val, ok := conf[proxyHeaderTimeout]; ok {
+		delete(conf, proxyHeaderTimeout)
+		duration, err := time.ParseDuration(val)
+		if err != nil {
+			glog.Warningf("proxy-protocol-header-timeout of %v encounted an error while being parsed %v. Switching to use default value instead.", val, err)
+		} else {
+			to.ProxyProtocolHeaderTimeout = duration
 		}
 	}
 

--- a/internal/ingress/controller/template/configmap_test.go
+++ b/internal/ingress/controller/template/configmap_test.go
@@ -18,6 +18,7 @@ package template
 
 import (
 	"testing"
+	"time"
 
 	"github.com/kylelemons/godebug/pretty"
 
@@ -28,6 +29,22 @@ func TestFilterErrors(t *testing.T) {
 	e := filterErrors([]int{200, 300, 345, 500, 555, 999})
 	if len(e) != 4 {
 		t.Errorf("expected 4 elements but %v returned", len(e))
+	}
+}
+
+func TestProxytTimeoutParsing(t *testing.T) {
+	testCases := map[string]struct {
+		input  string
+		expect time.Duration // duration in seconds
+	}{
+		"valid duration":   {"35s", time.Duration(35) * time.Second},
+		"invalid duration": {"3zxs", time.Duration(5) * time.Second},
+	}
+	for n, tc := range testCases {
+		cfg := ReadConfig(map[string]string{"proxy-protocol-header-timeout": tc.input})
+		if cfg.ProxyProtocolHeaderTimeout.Seconds() != tc.expect.Seconds() {
+			t.Errorf("Testing %v. Expected %v seconds but got %v seconds", n, tc.expect, cfg.ProxyProtocolHeaderTimeout)
+		}
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Requests to the HTTPS port will hang indefintely under the following conditions:

1. --tls-passthrough is enabled
2. proxy protocol is enabled in the configmap
3. The incoming request does not include the PROXY header and just sends a request to open a TCP connection. This can occur if you are using, say an AWS NLB to bring traffic to the controller and do not have proxy protocol enabled because the current proxy-protocol library used by this ingress controller does not support v2. https://github.com/kubernetes/ingress-nginx/blob/master/vendor/github.com/armon/go-proxyproto/README.md

Since enabling proxy protocol support is a global setting and cannot be changed for HTTP and HTTPs independently, this causes users of the NLB to need to disable proxy protocol for HTTPS to avoid errors on header processing if they have tls-passthrough enabled.

**Which issue this PR fixes**:

The go-proxyproto library specifically recommends settings a deadline if you call before call RemoteAddr() before calling Read() or it could cause the thread to sit in i/o wait if the proxy headers never come through. This can happen just due to network disruptions when a client is sending a request without the proxy headers and the rest of the request never makes it through.

This PR adds a configurable timeout/deadline value, defaulting 5 seconds to prevent this from occurring. I should also note that the /healthz does not currently check for the liveness of the proxy pass process, so when this bug does occur, it will not self heal just with the kube liveness probe.

**Special notes for your reviewer**:

The bug is reproduced by running the ingress controller in master with the following settings

cli:
`--enable-tls-passthrough`

configMap:
`use-proxy-protocol:
true`

kubectl port-forward directly to a/the pod on port 443. Curls against the pod should return the default backend. To produce the bug. Telnet to the pod on 443 and do not put additional input. If you curl on a seperate terminal, might take a few attempts, you will see that the curl request will hang until clientside timeout. This is resolved by closing the telnet process or restarting the pod.
