### PR TITLE
Increase keepalive_timeout for echoheaders

### DIFF
--- a/images/echoheaders/nginx.conf
+++ b/images/echoheaders/nginx.conf
@@ -69,6 +69,10 @@ Request Body:
 		# Replace '_' with your hostname.
 		server_name _;
 
+		# set long keepalive_timeout because some loadbalancer proxies expect the connection
+		# to remain open for at least ten minutes.
+		keepalive_timeout 620s;
+
 		location / {
 			lua_need_request_body on;
 			content_by_lua_block {


### PR DESCRIPTION
This is recommended configuration for GCP HTTP LB docs: https://cloud.google.com/compute/docs/load-balancing/http/#timeouts_and_retries