### PR TITLE
Fix upstream hash lua test

### DIFF
--- a/test/e2e/lua/dynamic_configuration.go
+++ b/test/e2e/lua/dynamic_configuration.go
@@ -18,7 +18,6 @@ package lua
 
 import (
 	"fmt"
-	"math/rand"
 	"net/http"
 	"regexp"
 	"strings"
@@ -253,22 +252,6 @@ var _ = framework.IngressNginxDescribe("Dynamic Configuration", func() {
 			newUpstreamName := hostnamePattern.FindAllStringSubmatch(body, -1)[0][1]
 			Expect(newUpstreamName).Should(Equal(upstreamName))
 		}
-
-		notEqualFound := false
-		for i := 0; i < 5; i++ {
-			resp, body, errs = gorequest.New().
-				Get(fmt.Sprintf("%s?completely-different-path=%f", f.IngressController.HTTPURL, rand.Float64())).
-				Set("Host", "foo.com").
-				End()
-			Expect(len(errs)).Should(Equal(0))
-			Expect(resp.StatusCode).Should(Equal(http.StatusOK))
-			anotherUpstreamName := hostnamePattern.FindAllStringSubmatch(body, -1)[0][1]
-			notEqualFound = anotherUpstreamName != upstreamName
-			if notEqualFound {
-				break
-			}
-		}
-		Expect(notEqualFound).Should(Equal(true))
 	})
 
 	Context("when session affinity annotation is present", func() {

--- a/test/e2e/lua/dynamic_configuration.go
+++ b/test/e2e/lua/dynamic_configuration.go
@@ -18,6 +18,7 @@ package lua
 
 import (
 	"fmt"
+	"math/rand"
 	"net/http"
 	"regexp"
 	"strings"
@@ -253,14 +254,21 @@ var _ = framework.IngressNginxDescribe("Dynamic Configuration", func() {
 			Expect(newUpstreamName).Should(Equal(upstreamName))
 		}
 
-		resp, body, errs = gorequest.New().
-			Get(fmt.Sprintf("%s?completely-different-path", f.IngressController.HTTPURL)).
-			Set("Host", "foo.com").
-			End()
-		Expect(len(errs)).Should(Equal(0))
-		Expect(resp.StatusCode).Should(Equal(http.StatusOK))
-		anotherUpstreamName := hostnamePattern.FindAllStringSubmatch(body, -1)[0][1]
-		Expect(anotherUpstreamName).NotTo(Equal(upstreamName))
+		notEqualFound := false
+		for i := 0; i < 5; i++ {
+			resp, body, errs = gorequest.New().
+				Get(fmt.Sprintf("%s?completely-different-path=%f", f.IngressController.HTTPURL, rand.Float64())).
+				Set("Host", "foo.com").
+				End()
+			Expect(len(errs)).Should(Equal(0))
+			Expect(resp.StatusCode).Should(Equal(http.StatusOK))
+			anotherUpstreamName := hostnamePattern.FindAllStringSubmatch(body, -1)[0][1]
+			notEqualFound = anotherUpstreamName != upstreamName
+			if notEqualFound {
+				break
+			}
+		}
+		Expect(notEqualFound).Should(Equal(true))
 	})
 
 	Context("when session affinity annotation is present", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Consistent hashing algorithm is not guaranteed to choose a different upstream for a different key - we could have sent several requests with different keys and assert at least one of them ends up getting proxied to a different upstream but even that would theoretically be flaky (I've done that too in first commit for visibility but IMO it is OK to just ignore that case).

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
