### PR TITLE
DOCS: Correct ssl-passthrough annotation description.

### DIFF
--- a/docs/user-guide/nginx-configuration/annotations.md
+++ b/docs/user-guide/nginx-configuration/annotations.md
@@ -368,10 +368,7 @@ The annotation `nginx.ingress.kubernetes.io/ssl-passthrough` allows to configure
     This is because SSL Passthrough works on level 4 of the OSI stack (TCP), not on the HTTP/HTTPS level.
 
 !!! attention
-    The use of this annotation requires the Proxy Protocol to be enabled in the front-end load-balancer.
-    For example enabling Proxy Protocol for AWS ELB is described [here](https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-proxy-protocol.html).
-    If you're using ingress-controller without load balancer then the flag
-    `--enable-ssl-passthrough` is required (by default it is disabled).
+    The use of this annotation requires the flag `--enable-ssl-passthrough` (By default it is disabled).
 
 ### Secure backends
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes incorrect description for `nginx.ingress.kubernetes.io/ssl-passthrough` annotation that was introduced by my other [change](https://github.com/kubernetes/ingress-nginx/pull/2377).

User actually needs flag `--enable-ssl-passthrough` anyway if he wants to use ssl passthru. In my [initial change](https://github.com/kubernetes/ingress-nginx/pull/2377) i incorrectly assumed (and missed while testing) that only thing TCPProxy does is PROXY protocol header. Now i see that it's also does [SNI](https://github.com/kubernetes/ingress-nginx/blob/f92f5f80e4fe6fbd08565affb509bed914163362/internal/ingress/controller/tcp.go#L71). This means `--enable-ssl-passthrough` always required, despite PROXY protocol in load balancer.

I also created [feature request](https://github.com/kubernetes/ingress-nginx/issues/2539) to do SNI by nginx and not by ingress-controller.

My initial [issue](https://github.com/kubernetes/ingress-nginx/issues/2354) was that Go routine (with TCPProxy) crashed silently on all replicas.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: none

**Special notes for your reviewer**:
