### PR TITLE
Update module-vts = 0.1.16 to fix duration metrics

### DIFF
--- a/images/nginx/build.sh
+++ b/images/nginx/build.sh
@@ -21,7 +21,7 @@ set -o pipefail
 
 export NGINX_VERSION=1.13.12
 export NDK_VERSION=0.3.0
-export VTS_VERSION=0.1.15
+export VTS_VERSION=0.1.16
 export SETMISC_VERSION=0.31
 export STICKY_SESSIONS_VERSION=08a395c66e42
 export MORE_HEADERS_VERSION=0.33
@@ -124,7 +124,7 @@ get_src 88e05a99a8a7419066f5ae75966fb1efc409bad4522d14986da074554ae61619 \
 get_src 97946a68937b50ab8637e1a90a13198fe376d801dc3e7447052e43c28e9ee7de \
         "https://github.com/openresty/set-misc-nginx-module/archive/v$SETMISC_VERSION.tar.gz"
 
-get_src 5112a054b1b1edb4c0042a9a840ef45f22abb3c05c68174e28ebf483164fb7e1 \
+get_src c668d0ed38afbba12f0224cb8cf5d70dcb9388723766dfb40d00539f887186fa \
         "https://github.com/vozlt/nginx-module-vts/archive/v$VTS_VERSION.tar.gz"
 
 get_src a3dcbab117a9c103bc1ea5200fc00a7b7d2af97ff7fd525f16f8ac2632e30fbf \


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently the ingress image uses 0.1.15 which exposes broken duration
metrics on newer nginx versions like the one used in the ingress
controller (1.13.12).

See downstream issue: https://github.com/vozlt/nginx-module-vts/issues/121