### PR TITLE
Enable core dumps during tests

### DIFF
--- a/test/manifests/ingress-controller/mandatory.yaml
+++ b/test/manifests/ingress-controller/mandatory.yaml
@@ -226,6 +226,18 @@ spec:
     spec:
       terminationGracePeriodSeconds: 0
       serviceAccountName: nginx-ingress-serviceaccount
+      initContainers:
+      - name: enable-coredump
+        image: busybox
+        command:
+        - /bin/sh
+        - -c
+        - |
+          ulimit -c unlimited
+          echo "/tmp/core.%e.%p" > /proc/sys/kernel/core_pattern
+          sysctl -w fs.suid_dumpable=2
+        securityContext:
+          privileged: true
       containers:
         - name: nginx-ingress-controller
           image: ingress-controller/nginx-ingress-controller:dev
@@ -271,4 +283,4 @@ spec:
             successThreshold: 1
             timeoutSeconds: 1
           securityContext:
-            runAsNonRoot: false
+            privileged: true


### PR DESCRIPTION
**What this PR does / why we need it**:

Enable core dumps during e2e tests to be able to execute gdb an find the reason of the error