### PR TITLE
docs: add secret scheme details to the example

### DIFF
--- a/docs/examples/auth/basic/README.md
+++ b/docs/examples/auth/basic/README.md
@@ -1,6 +1,7 @@
 # Basic Authentication
 
 This example shows how to add authentication in a Ingress rule using a secret that contains a file generated with `htpasswd`.
+It's important the file generated is named `auth` (actually - that the secret has a key `data.auth`), otherwise the ingress-controller returns a 503.
 
 ```console
 $ htpasswd -c auth foo


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
I'm not sure if this is a docs fix or a bug report (but I think it's the former): if you create a basic-auth secret from a file not named `auth` (i.e `myauth.htpasswd`) - the ingress controller returns a 503 (not writing anything to the error log, at least not on the default settings).

**Special notes for your reviewer**:
If this is a bug and not a docs issue, or I missed the relevant docs - sorry.