### PR TITLE
Fix issue #2547 - missing lua-cjson dependency

### DIFF
--- a/images/nginx/install_lua_resty_waf.sh
+++ b/images/nginx/install_lua_resty_waf.sh
@@ -59,6 +59,7 @@ if [[ ${ARCH} != "x86_64" ]]; then
   luarocks install lrexlib-pcre 2.7.2-1 PCRE_LIBDIR=${PCRE_LIBDIR}
 else
   luarocks install lrexlib-pcre 2.7.2-1
+  luarocks install lua-cjson
 fi
 
 # and do the rest of what "make instal" does


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a missing lua-cjson dependency that is required in ARM builds of ingress-nginx.  When this dependency is not present, the nginx-ingress-controller fails to start due to the following error:
`nginx: [error] init_by_lua error: /usr/local/lib/lua/resty/waf/log.lua:4: module 'cjson' not found:
`

**Which issue this PR fixes** 
Addresses ##2547
