### PR TITLE
Fix arm paths for liblua.so and lua_package_cpath

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ IMAGE = $(REGISTRY)/$(IMGNAME)
 MULTI_ARCH_IMG = $(IMAGE)-$(ARCH)
 
 # Set default base image dynamically for each arch
-BASEIMAGE?=quay.io/kubernetes-ingress-controller/nginx-$(ARCH):0.48
+BASEIMAGE?=quay.io/kubernetes-ingress-controller/nginx-$(ARCH):0.49
 
 ifeq ($(ARCH),arm)
 	QEMUARCH=arm

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -37,7 +37,7 @@ events {
 
 http {
     {{ if not $all.DisableLua }}
-    lua_package_cpath "/usr/local/lib/lua/?.so;/usr/lib/x86_64-linux-gnu/lua/5.1/?.so;;";
+    lua_package_cpath "/usr/local/lib/lua/?.so;/usr/lib/lua-platform-path/lua/5.1/?.so;;";
     lua_package_path "/etc/nginx/lua/?.lua;/etc/nginx/lua/vendor/?.lua;/usr/local/lib/lua/?.lua;;";
 
     {{ buildLuaSharedDictionaries $servers $all.DynamicConfigurationEnabled $all.Cfg.DisableLuaRestyWAF }}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR sets proper paths in ARM builds of ingress-nginx for liblua.so and lua_package_cpath. 

Without this fix, nginx.tmpl is always invalid for ARM devices due to assumption of `/usr/lib/x86_64-linux-gnu/lua/5.1/?.so;` as a valid path regardless of platform architecture. Similarly, build.sh assumes that `/usr/lib/x86_64-linux-gnu/liblua5.1.so` always exists, but this is not true for all platforms.   

**Explanation**:
[nginx.tmpl](https://github.com/kubernetes/ingress-nginx/blob/master/rootfs/etc/nginx/template/nginx.tmpl) is used to create the default nginx.conf for the nginx-ingress-controller.  As-is, this file references lua packages in a hard-coded platform-specific path `usr/lib/x86_64-linux-gnu/lua/5.1/?.so;`.  As a result, lua packages installed via clean-install were not being found on ARM builds as this path does not exist.  On ARM, the search path for lua packages installed via clean-install should be `usr/lib/rm-linux-gnueabihf/lua/5.1/?.so;` .  

This explains why cjson was already being installed via clean-install, but not found on ARM per commentary by @ElvinEfendi  on #2588.  The fix that was applied in #2588  installs lua-cjson in `/usr/local/lib/lua/5.1` (via luarocks) instead of `/usr/lib/linux-gnueabihf/lua/5.1` (via clean-install) which gets picked up in nginx.tmpl due to inclusion of the search path `/usr/local/lib/lua/?.so;.`  The clean-install method was already sufficient but nginx.tmpl was improperly referencing one of the search paths.    In summary, nginx.tmpl was the real culprit of #2547.

**Which issue this PR fixes** 
Addresses ##2547
