### PR TITLE
Always sort upstream list to provide stable iteration order

### DIFF
--- a/cmd/nginx/flags.go
+++ b/cmd/nginx/flags.go
@@ -101,8 +101,7 @@ func parseFlags() (bool, *controller.Configuration, error) {
 		ingress controller should update the Ingress status IP/hostname when the controller
 		is being stopped. Default is true`)
 
-		sortBackends = flags.Bool("sort-backends", false,
-			`Defines if backends and its endpoints should be sorted`)
+		sortBackends = flags.Bool("sort-backends", false, `Defines if servers inside NGINX upstream should be sorted`)
 
 		useNodeInternalIP = flags.Bool("report-node-internal-ip-address", false,
 			`Defines if the nodes IP address to be returned in the ingress status should be the internal instead of the external IP address`)

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -572,12 +572,6 @@ func (n *NGINXController) getBackendServers(ingresses []*extensions.Ingress) ([]
 		aUpstreams = append(aUpstreams, upstream)
 	}
 
-	if n.cfg.SortBackends {
-		sort.SliceStable(aUpstreams, func(a, b int) bool {
-			return aUpstreams[a].Name < aUpstreams[b].Name
-		})
-	}
-
 	aServers := make([]*ingress.Server, 0, len(servers))
 	for _, value := range servers {
 		sort.SliceStable(value.Locations, func(i, j int) bool {
@@ -585,6 +579,10 @@ func (n *NGINXController) getBackendServers(ingresses []*extensions.Ingress) ([]
 		})
 		aServers = append(aServers, value)
 	}
+
+	sort.SliceStable(aUpstreams, func(a, b int) bool {
+		return aUpstreams[a].Name < aUpstreams[b].Name
+	})
 
 	sort.SliceStable(aServers, func(i, j int) bool {
 		return aServers[i].Hostname < aServers[j].Hostname

--- a/internal/ingress/types_equals.go
+++ b/internal/ingress/types_equals.go
@@ -129,9 +129,6 @@ func (b1 *Backend) Equal(b2 *Backend) bool {
 		if b1.Service.GetName() != b2.Service.GetName() {
 			return false
 		}
-		if b1.Service.GetResourceVersion() != b2.Service.GetResourceVersion() {
-			return false
-		}
 	}
 
 	if b1.Port != b2.Port {
@@ -326,9 +323,6 @@ func (l1 *Location) Equal(l2 *Location) bool {
 		if l1.Service.GetName() != l2.Service.GetName() {
 			return false
 		}
-		if l1.Service.GetResourceVersion() != l2.Service.GetResourceVersion() {
-			return false
-		}
 	}
 
 	if l1.Port.StrVal != l2.Port.StrVal {
@@ -422,9 +416,6 @@ func (ptb1 *SSLPassthroughBackend) Equal(ptb2 *SSLPassthroughBackend) bool {
 			return false
 		}
 		if ptb1.Service.GetName() != ptb2.Service.GetName() {
-			return false
-		}
-		if ptb1.Service.GetResourceVersion() != ptb2.Service.GetResourceVersion() {
 			return false
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Using a sorted list avoids unnecessary reloads

**Which issue this PR fixes**: fixes #2596
