### PR TITLE
Disable access_log when using vts status

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -534,9 +534,9 @@ http {
             vhost_traffic_status_display_format html;
             vhost_traffic_status_display_sum_key {{ $cfg.VtsSumKey }};
             {{ else }}
-            access_log off;
             stub_status on;
             {{ end }}
+            access_log off;
         }
 
         {{ if $all.DynamicConfigurationEnabled }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Currently, log messages like `127.0.0.1 - [127.0.0.1] - - [05/Jun/2018:19:41:18 +0000] "GET /nginx_status/format/json HTTP/1.1" 200 2069 "-" "Go-http-client/1.1" 118 0.000 [internal] - - - - ` will be constantly emitted to the logs when scraping Prometheus metrics and `enable-vts-status` is set to `true`. This change ensures that `access_log off;` is always set for the `/nginx_status` block.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
