### PR TITLE
fix nginx conf test error when not found active service endpoints

### DIFF
--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -523,6 +523,7 @@ func (n *NGINXController) getBackendServers(ingresses []*extensions.Ingress) ([]
 				if upstream.Name == location.Backend {
 					if len(upstream.Endpoints) == 0 {
 						glog.V(3).Infof("Upstream %q does not have any active endpoints.", upstream.Name)
+						location.Backend = "" // for nginx.tmpl checking
 
 						// check if the location contains endpoints and a custom default backend
 						if location.DefaultBackend != nil {

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -33,6 +33,7 @@ import (
 	_ "k8s.io/ingress-nginx/test/e2e/annotations"
 	_ "k8s.io/ingress-nginx/test/e2e/defaultbackend"
 	_ "k8s.io/ingress-nginx/test/e2e/lua"
+	_ "k8s.io/ingress-nginx/test/e2e/servicebackend"
 	_ "k8s.io/ingress-nginx/test/e2e/settings"
 	_ "k8s.io/ingress-nginx/test/e2e/ssl"
 )

--- a/test/e2e/servicebackend/service_backend.go
+++ b/test/e2e/servicebackend/service_backend.go
@@ -1,0 +1,166 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package servicebackend
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/parnurzeal/gorequest"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/ingress-nginx/test/e2e/framework"
+	"strings"
+)
+
+var _ = framework.IngressNginxDescribe("Service backend - 503", func() {
+	f := framework.NewDefaultFramework("service-backend")
+
+	BeforeEach(func() {
+	})
+
+	AfterEach(func() {
+	})
+
+	It("should return 503 when backend service does not exist", func() {
+		host := "nonexistent.svc.com"
+
+		bi := buildIngressWithNonexistentService(host, f.IngressController.Namespace, "/")
+		ing, err := f.EnsureIngress(bi)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ing).NotTo(BeNil())
+
+		err = f.WaitForNginxServer(host,
+			func(server string) bool {
+				return strings.Contains(server, "return 503;")
+			})
+		Expect(err).NotTo(HaveOccurred())
+
+		resp, _, errs := gorequest.New().
+			Get(f.IngressController.HTTPURL).
+			Set("Host", host).
+			End()
+		Expect(len(errs)).Should(BeNumerically("==", 0))
+		Expect(resp.StatusCode).Should(Equal(503))
+	})
+
+	It("should return 503 when all backend service endpoints are unavailable", func() {
+		host := "unavailable.svc.com"
+
+		bi, bs := buildIngressWithUnavailableServiceEndpoints(host, f.IngressController.Namespace, "/")
+
+		svc, err := f.EnsureService(bs)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(svc).NotTo(BeNil())
+
+		ing, err := f.EnsureIngress(bi)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ing).NotTo(BeNil())
+
+		err = f.WaitForNginxServer(host,
+			func(server string) bool {
+				return strings.Contains(server, "return 503;")
+			})
+		Expect(err).NotTo(HaveOccurred())
+
+		resp, _, errs := gorequest.New().
+			Get(f.IngressController.HTTPURL).
+			Set("Host", host).
+			End()
+		Expect(len(errs)).Should(BeNumerically("==", 0))
+		Expect(resp.StatusCode).Should(Equal(503))
+	})
+
+})
+
+func buildIngressWithNonexistentService(host, namespace, path string) *v1beta1.Ingress {
+	backendService := "nonexistent-svc"
+	return &v1beta1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      host,
+			Namespace: namespace,
+		},
+		Spec: v1beta1.IngressSpec{
+			Rules: []v1beta1.IngressRule{
+				{
+					Host: host,
+					IngressRuleValue: v1beta1.IngressRuleValue{
+						HTTP: &v1beta1.HTTPIngressRuleValue{
+							Paths: []v1beta1.HTTPIngressPath{
+								{
+									Path: path,
+									Backend: v1beta1.IngressBackend{
+										ServiceName: backendService,
+										ServicePort: intstr.FromInt(80),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildIngressWithUnavailableServiceEndpoints(host, namespace, path string) (*v1beta1.Ingress, *corev1.Service) {
+	backendService := "unavailable-svc"
+	return &v1beta1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      host,
+				Namespace: namespace,
+			},
+			Spec: v1beta1.IngressSpec{
+				Rules: []v1beta1.IngressRule{
+					{
+						Host: host,
+						IngressRuleValue: v1beta1.IngressRuleValue{
+							HTTP: &v1beta1.HTTPIngressRuleValue{
+								Paths: []v1beta1.HTTPIngressPath{
+									{
+										Path: path,
+										Backend: v1beta1.IngressBackend{
+											ServiceName: backendService,
+											ServicePort: intstr.FromInt(80),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}, &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      backendService,
+				Namespace: namespace,
+			},
+			Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{
+				{
+					Name:       "tcp",
+					Port:       80,
+					TargetPort: intstr.FromInt(80),
+					Protocol:   "TCP",
+				},
+			},
+				Selector: map[string]string{
+					"app": backendService,
+				},
+			},
+		}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Fix nginx config file test error when found no active service endpoints. For example:

```
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: ingress-example
spec:
  rules:
  - host: www.example.com
    http:
      paths:
      - path: /
        backend:
          serviceName: not-exist-service
          servicePort: 80
```
Then the new nginx configuration file generated by ingress controller contains a proxy_pass that its upstream does not exist.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

