### PR TITLE
Return real http error code instead of 200

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -341,7 +341,7 @@ http {
     {{ end }}
 
     {{ range $errCode := $cfg.CustomHTTPErrors }}
-    error_page {{ $errCode }} = @custom_{{ $errCode }};{{ end }}
+    error_page {{ $errCode }} @custom_{{ $errCode }};{{ end }}
 
     proxy_ssl_session_reuse on;
 


### PR DESCRIPTION
**What this PR does / why we need it**:
custom http error pages should return real error code instead of 200

**Which issue this PR fixes**
fixes #2621

**Special notes for your reviewer**:
related to #2285 
ref: http://muratknecht.de/tech/how-to-fix-nginx-soft-404-when-a-404-error-page-returns-200/