### PR TITLE
Fix minor documentation example

### DIFF
--- a/docs/examples/auth/oauth-external-auth/oauth2-proxy.yaml
+++ b/docs/examples/auth/oauth-external-auth/oauth2-proxy.yaml
@@ -28,7 +28,7 @@ spec:
           value: <Client ID>
         - name: OAUTH2_PROXY_CLIENT_SECRET
           value: <Client Secret>
-        # python -c 'import os,base64; print base64.b64encode(os.urandom(16))'
+        # docker run -ti --rm python:3-alpine python -c 'import secrets,base64; print(base64.b64encode(base64.b64encode(secrets.token_bytes(16))));'
         - name: OAUTH2_PROXY_COOKIE_SECRET
           value: SECRET
         image: docker.io/colemickens/oauth2_proxy:latest


### PR DESCRIPTION
`os.urandom` sometimes returns more bytes and its generally encouraged to use python3's `secrets` module for this kind of thing nowadays.