### PR TITLE
Disable resync period

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,10 +40,7 @@ jobs:
     script:
     - sudo luarocks install luacheck
     - make luacheck
-    - mkdir --parents $GOPATH/src/golang.org/x
-      && git clone --depth=1 https://go.googlesource.com/lint $GOPATH/src/golang.org/x/lint
-      && go get golang.org/x/lint/golint
-    - go get github.com/vbatts/git-validation
+    - go get golang.org/x/lint/golint
     - make verify-all
   - stage: Lua Unit Test
     before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,12 @@ jobs:
     script:
     - sudo luarocks install luacheck
     - make luacheck
-    - go get golang.org/x/lint/golint
+    - |
+      go get -d golang.org/x/lint/golint
+      cd $GOPATH/src/golang.org/x/tools
+      git checkout release-branch.go1.10
+      go install golang.org/x/lint/golint
+      cd -
     - make verify-all
   - stage: Lua Unit Test
     before_script:

--- a/cmd/nginx/flags.go
+++ b/cmd/nginx/flags.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"os"
 	"runtime"
-	"time"
 
 	"github.com/golang/glog"
 	"github.com/spf13/pflag"
@@ -79,8 +78,8 @@ The key in the map indicates the external port to be used. The value is a
 reference to a Service in the form "namespace/name:port", where "port" can
 either be a port name or number.`)
 
-		resyncPeriod = flags.Duration("sync-period", 600*time.Second,
-			`Period at which the controller forces the repopulation of its local object stores.`)
+		resyncPeriod = flags.Duration("sync-period", 0,
+			`Period at which the controller forces the repopulation of its local object stores. Disabled by default.`)
 
 		watchNamespace = flags.String("watch-namespace", apiv1.NamespaceAll,
 			`Namespace the controller watches for updates to Kubernetes objects.

--- a/cmd/nginx/main.go
+++ b/cmd/nginx/main.go
@@ -104,11 +104,6 @@ func main() {
 		}
 	}
 
-	minResyncPeriod := 10 * time.Second
-	if conf.ResyncPeriod < minResyncPeriod {
-		glog.Fatalf("Resync period should be at least %v (current: %v)", minResyncPeriod, conf.ResyncPeriod)
-	}
-
 	// create the default SSL certificate (dummy)
 	defCert, defKey := ssl.GetFakeSSLCert()
 	c, err := ssl.AddOrUpdateCertAndKey(fakeCertificate, defCert, defKey, []byte{}, fs)


### PR DESCRIPTION
**What this PR does / why we need it**:

Disables the resync period. The intended use of this setting is related to watch issues with etcd. This is not an issue anymore. Additionally, forcing a resync introduces some edge cases, like #2195.

Note: this was also recommended in the contributor summit in last Kubecon

**Which issue this PR fixes** : fixes #2195
