### PR TITLE
Wait the result of the controller deployment before running any test

### DIFF
--- a/test/e2e/wait-for-nginx.sh
+++ b/test/e2e/wait-for-nginx.sh
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -e
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 export NAMESPACE=$1
@@ -22,3 +24,9 @@ echo "deploying NGINX Ingress controller in namespace $NAMESPACE"
 
 sed "s@\${NAMESPACE}@${NAMESPACE}@" $DIR/../manifests/ingress-controller/mandatory.yaml | kubectl apply --namespace=$NAMESPACE -f -
 cat $DIR/../manifests/ingress-controller/service-nodeport.yaml | kubectl apply --namespace=$NAMESPACE -f -
+
+# wait for the deployment and fail if there is an error before starting the execution of any test
+kubectl rollout status \
+    --request-timeout=3m \
+    --namespace $NAMESPACE \
+    deployment nginx-ingress-controller


### PR DESCRIPTION
**What this PR does / why we need it**:

Avoid running any test if the ingress controller deployment is not working. This will help to avoid timeouts with e2e tests in case of startup failures.