### PR TITLE
Clarify log messages in controller package

### DIFF
--- a/internal/ingress/controller/tcp.go
+++ b/internal/ingress/controller/tcp.go
@@ -26,7 +26,7 @@ import (
 	"github.com/paultag/sniff/parser"
 )
 
-// TCPServer describes a server that works in passthrough mode
+// TCPServer describes a server that works in passthrough mode.
 type TCPServer struct {
 	Hostname      string
 	IP            string
@@ -34,13 +34,13 @@ type TCPServer struct {
 	ProxyProtocol bool
 }
 
-// TCPProxy describes the passthrough servers and a default as catch all
+// TCPProxy describes the passthrough servers and a default as catch all.
 type TCPProxy struct {
 	ServerList []*TCPServer
 	Default    *TCPServer
 }
 
-// Get returns the TCPServer to use
+// Get returns the TCPServer to use for a given host.
 func (p *TCPProxy) Get(host string) *TCPServer {
 	if p.ServerList == nil {
 		return p.Default
@@ -63,19 +63,19 @@ func (p *TCPProxy) Handle(conn net.Conn) {
 
 	length, err := conn.Read(data)
 	if err != nil {
-		glog.V(4).Infof("error reading the first 4k of the connection: %s", err)
+		glog.V(4).Infof("Error reading the first 4k of the connection: %s", err)
 		return
 	}
 
 	proxy := p.Default
 	hostname, err := parser.GetHostname(data[:])
 	if err == nil {
-		glog.V(4).Infof("parsed hostname from TLS Client Hello: %s", hostname)
+		glog.V(4).Infof("Parsed hostname from TLS Client Hello: %s", hostname)
 		proxy = p.Get(hostname)
 	}
 
 	if proxy == nil {
-		glog.V(4).Infof("there is no configured proxy for SSL connections")
+		glog.V(4).Infof("There is no configured proxy for SSL connections.")
 		return
 	}
 
@@ -86,7 +86,7 @@ func (p *TCPProxy) Handle(conn net.Conn) {
 	defer clientConn.Close()
 
 	if proxy.ProxyProtocol {
-		//Write out the proxy-protocol header
+		// write out the Proxy Protocol header
 		localAddr := conn.LocalAddr().(*net.TCPAddr)
 		remoteAddr := conn.RemoteAddr().(*net.TCPAddr)
 		protocol := "UNKNOWN"
@@ -96,16 +96,16 @@ func (p *TCPProxy) Handle(conn net.Conn) {
 			protocol = "TCP6"
 		}
 		proxyProtocolHeader := fmt.Sprintf("PROXY %s %s %s %d %d\r\n", protocol, remoteAddr.IP.String(), localAddr.IP.String(), remoteAddr.Port, localAddr.Port)
-		glog.V(4).Infof("Writing proxy protocol header - %s", proxyProtocolHeader)
+		glog.V(4).Infof("Writing Proxy Protocol header: %s", proxyProtocolHeader)
 		_, err = fmt.Fprintf(clientConn, proxyProtocolHeader)
 	}
 	if err != nil {
-		glog.Errorf("unexpected error writing proxy-protocol header: %s", err)
+		glog.Errorf("Error writing Proxy Protocol header: %s", err)
 		clientConn.Close()
 	} else {
 		_, err = clientConn.Write(data[:length])
 		if err != nil {
-			glog.Errorf("unexpected error writing first 4k of proxy data: %s", err)
+			glog.Errorf("Error writing the first 4k of proxy data: %s", err)
 			clientConn.Close()
 		}
 	}

--- a/internal/ingress/controller/util.go
+++ b/internal/ingress/controller/util.go
@@ -41,27 +41,26 @@ func newUpstream(name string) *ingress.Backend {
 	}
 }
 
-// sysctlSomaxconn returns the value of net.core.somaxconn, i.e.
-// maximum number of connections that can be queued for acceptance
+// sysctlSomaxconn returns the maximum number of connections that can be queued
+// for acceptance (value of net.core.somaxconn)
 // http://nginx.org/en/docs/http/ngx_http_core_module.html#listen
 func sysctlSomaxconn() int {
 	maxConns, err := sysctl.New().GetSysctl("net/core/somaxconn")
 	if err != nil || maxConns < 512 {
-		glog.V(3).Infof("system net.core.somaxconn=%v (using system default)", maxConns)
+		glog.V(3).Infof("net.core.somaxconn=%v (using system default)", maxConns)
 		return 511
 	}
 
 	return maxConns
 }
 
-// sysctlFSFileMax returns the value of fs.file-max, i.e.
-// maximum number of open file descriptors
+// sysctlFSFileMax returns the maximum number of open file descriptors (value
+// of fs.file-max) or 0 in case of error.
 func sysctlFSFileMax() int {
 	var rLimit syscall.Rlimit
 	err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rLimit)
 	if err != nil {
-		glog.Errorf("unexpected error reading system maximum number of open file descriptors (RLIMIT_NOFILE): %v", err)
-		// returning 0 means don't render the value
+		glog.Errorf("Error reading system maximum number of open file descriptors (RLIMIT_NOFILE): %v", err)
 		return 0
 	}
 	glog.V(2).Infof("rlimit.max=%v", rLimit.Max)


### PR DESCRIPTION
**What this PR does / why we need it**:

This is an attempt to clarify most messages logged by the `controller` package and add details when I felt it was necessary (eg. what object a given message is related to, or why do we default to a particular value)

I also took the liberty of rephrasing some methods documentation as I went through the code, and to remove comments where the logic is self-explanatory.

See https://github.com/kubernetes/ingress-nginx/pull/2368#issuecomment-396038027

**Cherry-picked examples**:

```
controller.go:922] Ingress "nginx/examples" defines both a backend and rules. Using backend as default upstream for all its rules.
controller.go:1002] Ingress "nginx/examples" does not contains a TLS section.
controller.go:461] Adding location "/foo1" for server "host1" with upstream "nginx-echoheaders2-http" (Ingress "nginx/examples")
controller.go:461] Adding location "/foo2" for server "host1" with upstream "nginx-echoheaders2-http" (Ingress "nginx/examples")
controller.go:209] Obtaining information about TCP stream services from ConfigMap "nginx/tcp-services"
controller.go:289] Searching Endpoints with TCP port name "http" for Service "nginx/echoheaders"
```