### PR TITLE
Fix typo in command

### DIFF
--- a/docs/deploy/index.md
+++ b/docs/deploy/index.md
@@ -155,7 +155,7 @@ helm install stable/nginx-ingress --name my-nginx --set rbac.create=true
 To check if the ingress controller pods have started, run the following command:
 
 ```console
-kubectl get pods --all-namespaces -l app=ingress-nginx --watch
+kubectl get pods --all-namespaces -l app=nginx-ingress --watch
 ```
 
 Once the operator pods are running, you can cancel the above command by typing `Ctrl+C`.


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the command for checking if ingress controller pods have started.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
