### PR TITLE
Rollback nginx 1.15.0 to 1.13.12

### DIFF
--- a/images/nginx/build.sh
+++ b/images/nginx/build.sh
@@ -19,7 +19,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-export NGINX_VERSION=1.15.0
+export NGINX_VERSION=1.13.12
 export NDK_VERSION=0.3.0
 export SETMISC_VERSION=0.31
 export STICKY_SESSIONS_VERSION=08a395c66e42
@@ -138,7 +138,7 @@ mkdir --verbose -p "$BUILD_PATH"
 cd "$BUILD_PATH"
 
 # download, verify and extract the source files
-get_src b0b58c9a3fd73aa8b89edf5cfadc6641a352e0e6d3071db1eb3215d72b7fb516 \
+get_src fb92f5602cdb8d3ab1ad47dbeca151b185d62eedb67d347bbe9d79c1438c85de \
         "http://nginx.org/download/nginx-$NGINX_VERSION.tar.gz"
 
 get_src 88e05a99a8a7419066f5ae75966fb1efc409bad4522d14986da074554ae61619 \
@@ -376,6 +376,7 @@ Include /etc/nginx/owasp-modsecurity-crs/rules/RESPONSE-999-EXCLUSION-RULES-AFTE
 cd "$BUILD_PATH/nginx-$NGINX_VERSION"
 
 WITH_FLAGS="--with-debug \
+  --with-compat \
   --with-pcre-jit \
   --with-http_ssl_module \
   --with-http_stub_status_module \


### PR DESCRIPTION
**What this PR does / why we need it**:

lua-nginx-module only generates core dumps