### PR TITLE
Do not wait informer initialization to read configuration

### DIFF
--- a/internal/ingress/controller/store/store.go
+++ b/internal/ingress/controller/store/store.go
@@ -494,6 +494,13 @@ func New(checkOCSP bool,
 	store.informers.ConfigMap.AddEventHandler(cmEventHandler)
 	store.informers.Service.AddEventHandler(cache.ResourceEventHandlerFuncs{})
 
+	// do not wait for informers to read the configmap configuration
+	cm, err := client.CoreV1().ConfigMaps(namespace).Get(configmap, metav1.GetOptions{})
+	if err != nil {
+		glog.Warningf("Unexpected error reading configuration configmap: %v", err)
+	}
+	store.setConfig(cm)
+
 	return store
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Read configuration configmap while the controller is being initialized. This avoids passing health checks without having applied the configuration defined in the configmap.

**Which issue this PR fixes**:

fixes #2629
