### PR TITLE
Change modsecurity directories

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -23,19 +23,32 @@ RUN clean-install \
   dumb-init \
   libcap2-bin 
 
-# Create symlinks to redirect nginx logs to stdout and stderr docker log collector
-# This only works if nginx is started with CMD or ENTRYPOINT
-RUN mkdir -p /var/log/nginx \
-  && ln -sf /dev/stdout /var/log/nginx/access.log \
-  && ln -sf /dev/stderr /var/log/nginx/error.log
-
 COPY . /
 
 RUN setcap cap_net_bind_service=+ep /usr/sbin/nginx \
   && setcap cap_net_bind_service=+ep /nginx-ingress-controller
 
-RUN mkdir -p /etc/ingress-controller/ssl /etc/ingress-controller/auth \
-  && chown -R www-data.www-data /etc/nginx /etc/ingress-controller
+RUN bash -eux -c ' \
+    writeDirs=( \
+        /etc/nginx \
+        /etc/ingress-controller/ssl \
+        /etc/ingress-controller/auth \
+        /var/log \
+        /var/log/nginx \
+        /opt/modsecurity/var/log \
+        /opt/modsecurity/var/upload \
+        /opt/modsecurity/var/audit \
+    ); \
+    for dir in "${writeDirs[@]}"; do \
+      mkdir -p ${dir}; \
+      chown -R www-data.www-data ${dir}; \
+    done \
+    '
+
+# Create symlinks to redirect nginx logs to stdout and stderr docker log collector
+# This only works if nginx is started with CMD or ENTRYPOINT
+RUN  ln -sf /dev/stdout /var/log/nginx/access.log \
+  && ln -sf /dev/stderr /var/log/nginx/error.log
 
 USER www-data
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Running as user prevents the start of modsecurity. Changing directories to fix this issue.