### PR TITLE
Add documentation for proxy-cookie-domain annotation (#2034)

### DIFF
--- a/docs/user-guide/nginx-configuration/annotations.md
+++ b/docs/user-guide/nginx-configuration/annotations.md
@@ -44,6 +44,7 @@ You can add these Kubernetes annotations to specific Ingress objects to customiz
 |[nginx.ingress.kubernetes.io/limit-rps](#rate-limiting)|number|
 |[nginx.ingress.kubernetes.io/permanent-redirect](#permanent-redirect)|string|
 |[nginx.ingress.kubernetes.io/proxy-body-size](#custom-max-body-size)|string|
+|[nginx.ingress.kubernetes.io/proxy-cookie-domain](#proxy-cookie-domain)|string|
 |[nginx.ingress.kubernetes.io/proxy-connect-timeout](#custom-timeouts)|number|
 |[nginx.ingress.kubernetes.io/proxy-send-timeout](#custom-timeouts)|number|
 |[nginx.ingress.kubernetes.io/proxy-read-timeout](#custom-timeouts)|number|
@@ -464,6 +465,12 @@ To use custom values in an Ingress rule define these annotation:
 ```yaml
 nginx.ingress.kubernetes.io/proxy-body-size: 8m
 ```
+
+### Proxy cookie domain
+
+Sets a text that [should be changed in the domain attribute](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_cookie_domain) of the "Set-Cookie" header fields of a proxied server response.
+
+To configure this setting globally for all Ingress rules, the `proxy-cookie-domain` value may be set in the [NGINX ConfigMap][configmap].
 
 ### Proxy buffering
 


### PR DESCRIPTION
Documentation for proxy-cookie-domain annotation was missing.
This fixes #2034 and solves the answers of @aledbf .