### PR TITLE
Add support for setting limit_conn_status from ConfigMap

### DIFF
--- a/docs/user-guide/nginx-configuration/configmap.md
+++ b/docs/user-guide/nginx-configuration/configmap.md
@@ -135,6 +135,7 @@ The following table shows a configuration option's name, type, and the default v
 |[http-redirect-code](#http-redirect-code)|int|308|
 |[proxy-buffering](#proxy-buffering)|string|"off"|
 |[limit-req-status-code](#limit-req-status-code)|int|503|
+|[limit-conn-status-code](#limit-conn-status-code)|int|503|
 |[no-tls-redirect-locations](#no-tls-redirect-locations)|string|"/.well-known/acme-challenge"|
 |[no-auth-locations](#no-auth-locations)|string|"/.well-known/acme-challenge"|
 
@@ -738,6 +739,10 @@ Enables or disables [buffering of responses from the proxied server](http://ngin
 ## limit-req-status-code
 
 Sets the [status code to return in response to rejected requests](http://nginx.org/en/docs/http/ngx_http_limit_req_module.html#limit_req_status). _**default:**_ 503
+
+## limit-conn-status-code
+
+Sets the [status code to return in response to rejected requests](https://nginx.org/en/docs/http/ngx_http_limit_conn_module.html#limit_conn_status). _**default:**_ 503
 
 ## no-tls-redirect-locations
 

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -483,6 +483,11 @@ type Configuration struct {
 	// Default: 503
 	LimitReqStatusCode int `json:"limit-req-status-code"`
 
+	// LimitConnStatusCode Sets the status code to return in response to rejected requests.
+	// http://nginx.org/en/docs/http/ngx_http_limit_conn_module.html#limit_conn_status
+	// Default: 503
+	LimitConnStatusCode int `json:"limit-conn-status-code"`
+
 	// EnableSyslog enables the configuration for remote logging in NGINX
 	EnableSyslog bool `json:"enable-syslog"`
 	// SyslogHost FQDN or IP address where the logs should be sent
@@ -614,6 +619,7 @@ func NewDefault() Configuration {
 		JaegerSamplerType:            "const",
 		JaegerSamplerParam:           "1",
 		LimitReqStatusCode:           503,
+		LimitConnStatusCode:          503,
 		SyslogPort:                   514,
 		NoTLSRedirectLocations:       "/.well-known/acme-challenge",
 		NoAuthLocations:              "/.well-known/acme-challenge",

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -147,6 +147,7 @@ http {
     ignore_invalid_headers          {{ if $cfg.IgnoreInvalidHeaders }}on{{ else }}off{{ end }};
 
     limit_req_status                {{ $cfg.LimitReqStatusCode }};
+    limit_conn_status               {{ $cfg.LimitConnStatusCode }};
 
     {{ if $cfg.EnableOpentracing }}
     opentracing on;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Add configmap option for setting `limit_conn_status`.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
