### PR TITLE
If server_tokens is disabled completely remove the Server header

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -184,7 +184,7 @@ http {
 
     server_tokens {{ if $cfg.ShowServerTokens }}on{{ else }}off{{ end }};
     {{ if not $cfg.ShowServerTokens }}
-    more_set_headers "Server: ";
+    more_clear_headers Server;
     {{ end }}
 
     # disable warnings

--- a/test/e2e/settings/server_tokens.go
+++ b/test/e2e/settings/server_tokens.go
@@ -51,7 +51,7 @@ var _ = framework.IngressNginxDescribe("Server Tokens", func() {
 		err = f.WaitForNginxConfiguration(
 			func(cfg string) bool {
 				return strings.Contains(cfg, "server_tokens off") &&
-					strings.Contains(cfg, "more_set_headers \"Server: \"")
+					strings.Contains(cfg, "more_clear_headers Server;")
 			})
 		Expect(err).NotTo(HaveOccurred())
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:

Actually removes the `Server` header when `server-tokens: false`, instead of just setting a null value.

This PR makes use of the `more_clear_headers` directive instead of the `more_set_headers` directive, both of which are included in the headers-more-nginx-module that the controller is already built with. The `more_set_headers` directive is currently used to set a null value for the `Server` header, but the `more_clear_headers` directive can completely remove it.

Module reference: [https://github.com/openresty/headers-more-nginx-module#more_clear_headers](https://github.com/openresty/headers-more-nginx-module#more_clear_headers)

**Which issue this PR fixes**

Supersedes PR #1903 to fix #1094 more thoroughly.