### PR TITLE
Add the ability to exclude Prometheus metric tags

### DIFF
--- a/cmd/nginx/flags.go
+++ b/cmd/nginx/flags.go
@@ -147,6 +147,11 @@ Requires the update-status parameter.`)
 			`Dynamically refresh backends on topology changes instead of reloading NGINX.
 Feature backed by OpenResty Lua libraries.`)
 
+		excludeRequestMetricTags = flags.StringArray("exclude-request-metric-tags",
+			[]string{"remote_address", "real_ip_address", "remote_user", "uri"},
+			`Tags to exclude from HTTP request metrics.
+Use this to moderate the number of contexts created on your TSDB.`)
+
 		httpPort      = flags.Int("http-port", 80, `Port to use for servicing HTTP traffic.`)
 		httpsPort     = flags.Int("https-port", 443, `Port to use for servicing HTTPS traffic.`)
 		statusPort    = flags.Int("status-port", 18080, `Port to use for exposing NGINX status pages.`)
@@ -248,6 +253,7 @@ Feature backed by OpenResty Lua libraries.`)
 		SyncRateLimit:               *syncRateLimit,
 		DynamicConfigurationEnabled: *dynamicConfigurationEnabled,
 		DisableLua:                  disableLua,
+		ExcludeRequestMetricTags:    *excludeRequestMetricTags,
 		ListenPorts: &ngx_config.ListenPorts{
 			Default:  *defServerPort,
 			Health:   *healthzPort,

--- a/cmd/nginx/main.go
+++ b/cmd/nginx/main.go
@@ -133,7 +133,7 @@ func main() {
 		glog.Fatalf("Error creating metric collector:  %v", err)
 	}
 
-	err = collector.NewInstance(conf.Namespace, class.IngressClass)
+	err = collector.NewInstance(conf.Namespace, class.IngressClass, conf.ExcludeRequestMetricTags)
 	if err != nil {
 		glog.Fatalf("Error creating unix socket server:  %v", err)
 	}

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -95,6 +95,8 @@ type Configuration struct {
 	DynamicConfigurationEnabled bool
 
 	DisableLua bool
+
+	ExcludeRequestMetricTags []string
 }
 
 // GetPublishService returns the Service used to set the load-balancer status of Ingresses.


### PR DESCRIPTION
**What this PR does / why we need it**:

The new Prometheus metrics implementatation is great... however, it may
create a lot of metric contexts in prometheus, because some of the
reported tags have a very high cardinality on common production systems.

In particular the `remote_address`, `real_ip_address`, `remote_user` and - in
many cases - `path` tags' cardinality grows along with the number of
IPs/users connecting to our clusters and the number of API resources
we have on our clusters (when specified via URI).

My prometheus servers crashed a couple of times this weekend and I realized
earlier in the evening that this was due to the volume of metrics I was receiving
from my nginx ingress controllers.

This commit therefore offers to exclude some prometheus tags via a CLI
flag, with default values for the tags mentionned above (of course that's something
I'd be happy to change if you don't want to "break compatibility" with the current 
metric tag format but I thought using "saner" defaults may be better).

**Which issue this PR fixes**:
I didn't open an issue for that but that can easily be done if required :)

**Special notes for your reviewer**:
I'm currently testing this PR on my `staging` kubernetes clusters.
