### PR TITLE
Cleanup prometheus metrics after a reload

### DIFF
--- a/cmd/nginx/main_test.go
+++ b/cmd/nginx/main_test.go
@@ -76,7 +76,7 @@ func TestHandleSigterm(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	ngx := controller.NewNGINXController(conf, fs)
+	ngx := controller.NewNGINXController(conf, nil, fs)
 
 	go handleSigterm(ngx, func(code int) {
 		if code != 1 {

--- a/internal/ingress/controller/nginx.go
+++ b/internal/ingress/controller/nginx.go
@@ -53,6 +53,7 @@ import (
 	"k8s.io/ingress-nginx/internal/ingress/controller/process"
 	"k8s.io/ingress-nginx/internal/ingress/controller/store"
 	ngx_template "k8s.io/ingress-nginx/internal/ingress/controller/template"
+	"k8s.io/ingress-nginx/internal/ingress/metric/collector"
 	"k8s.io/ingress-nginx/internal/ingress/status"
 	ing_net "k8s.io/ingress-nginx/internal/net"
 	"k8s.io/ingress-nginx/internal/net/dns"
@@ -70,7 +71,7 @@ var (
 )
 
 // NewNGINXController creates a new NGINX Ingress controller.
-func NewNGINXController(config *Configuration, fs file.Filesystem) *NGINXController {
+func NewNGINXController(config *Configuration, mc *collector.SocketCollector, fs file.Filesystem) *NGINXController {
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartLogging(glog.Infof)
 	eventBroadcaster.StartRecordingToSink(&v1core.EventSinkImpl{
@@ -103,6 +104,8 @@ func NewNGINXController(config *Configuration, fs file.Filesystem) *NGINXControl
 		runningConfig: new(ingress.Configuration),
 
 		Proxy: &TCPProxy{},
+
+		metricCollector: mc,
 	}
 
 	n.store = store.New(
@@ -243,6 +246,8 @@ type NGINXController struct {
 	store store.Storer
 
 	fileSystem filesystem.Filesystem
+
+	metricCollector *collector.SocketCollector
 }
 
 // Start starts a new NGINX master process running in the foreground.

--- a/internal/ingress/metric/collector/collector_test.go
+++ b/internal/ingress/metric/collector/collector_test.go
@@ -34,6 +34,7 @@ func TestNewUDPLogListener(t *testing.T) {
 	fn := func(message []byte) {
 		t.Logf("message: %v", string(message))
 		atomic.AddUint64(&count, 1)
+		time.Sleep(time.Millisecond)
 	}
 
 	tmpFile := fmt.Sprintf("/tmp/test-socket-%v", time.Now().Nanosecond())
@@ -64,8 +65,8 @@ func TestNewUDPLogListener(t *testing.T) {
 	conn.Close()
 
 	time.Sleep(1 * time.Millisecond)
-	if count != 1 {
-		t.Errorf("expected only one message from the UDP listern but %v returned", count)
+	if atomic.LoadUint64(&count) != 1 {
+		t.Errorf("expected only one message from the UDP listern but %v returned", atomic.LoadUint64(&count))
 	}
 }
 

--- a/internal/ingress/metric/collector/collector_test.go
+++ b/internal/ingress/metric/collector/collector_test.go
@@ -19,7 +19,10 @@ package collector
 import (
 	"fmt"
 	"net"
+	"os/exec"
+	"path"
 	"reflect"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -84,24 +87,26 @@ upstream_response_time_seconds_count{host="echoheaders",ingress="http-svc",metho
 `
 
 func TestExtractMetrics(t *testing.T) {
+	execCommand = mockRootForExecCommand
+	defer func() {
+		execCommand = exec.Command
+	}()
+
 	m := extractMetrics("172.17.0.4:8080", "upstream_response_time_seconds_bucket", metricExample)
 
 	em := []string{
-		`host="echoheaders",ingress="http-svc",method="GET",namespace="default",path="/",protocol="HTTP/1.1",service="http-svc",status="200",upstream_ip="172.17.0.4:8080",upstream_name="default-http-svc-80",upstream_status="200",le="0.005"`,
-		`host="echoheaders",ingress="http-svc",method="GET",namespace="default",path="/",protocol="HTTP/1.1",service="http-svc",status="200",upstream_ip="172.17.0.4:8080",upstream_name="default-http-svc-80",upstream_status="200",le="0.01"`,
-		`host="echoheaders",ingress="http-svc",method="GET",namespace="default",path="/",protocol="HTTP/1.1",service="http-svc",status="200",upstream_ip="172.17.0.4:8080",upstream_name="default-http-svc-80",upstream_status="200",le="0.025"`,
-		`host="echoheaders",ingress="http-svc",method="GET",namespace="default",path="/",protocol="HTTP/1.1",service="http-svc",status="200",upstream_ip="172.17.0.4:8080",upstream_name="default-http-svc-80",upstream_status="200",le="0.05"`,
-		`host="echoheaders",ingress="http-svc",method="GET",namespace="default",path="/",protocol="HTTP/1.1",service="http-svc",status="200",upstream_ip="172.17.0.4:8080",upstream_name="default-http-svc-80",upstream_status="200",le="0.1"`,
-		`host="echoheaders",ingress="http-svc",method="GET",namespace="default",path="/",protocol="HTTP/1.1",service="http-svc",status="200",upstream_ip="172.17.0.4:8080",upstream_name="default-http-svc-80",upstream_status="200",le="0.25"`,
-		`host="echoheaders",ingress="http-svc",method="GET",namespace="default",path="/",protocol="HTTP/1.1",service="http-svc",status="200",upstream_ip="172.17.0.4:8080",upstream_name="default-http-svc-80",upstream_status="200",le="0.5"`,
-		`host="echoheaders",ingress="http-svc",method="GET",namespace="default",path="/",protocol="HTTP/1.1",service="http-svc",status="200",upstream_ip="172.17.0.4:8080",upstream_name="default-http-svc-80",upstream_status="200",le="1"`,
-		`host="echoheaders",ingress="http-svc",method="GET",namespace="default",path="/",protocol="HTTP/1.1",service="http-svc",status="200",upstream_ip="172.17.0.4:8080",upstream_name="default-http-svc-80",upstream_status="200",le="2.5"`,
-		`host="echoheaders",ingress="http-svc",method="GET",namespace="default",path="/",protocol="HTTP/1.1",service="http-svc",status="200",upstream_ip="172.17.0.4:8080",upstream_name="default-http-svc-80",upstream_status="200",le="5"`,
-		`host="echoheaders",ingress="http-svc",method="GET",namespace="default",path="/",protocol="HTTP/1.1",service="http-svc",status="200",upstream_ip="172.17.0.4:8080",upstream_name="default-http-svc-80",upstream_status="200",le="10"`,
-		`host="echoheaders",ingress="http-svc",method="GET",namespace="default",path="/",protocol="HTTP/1.1",service="http-svc",status="200",upstream_ip="172.17.0.4:8080",upstream_name="default-http-svc-80",upstream_status="200",le="+Inf"`,
+		`host="echoheaders",ingress="http-svc",method="GET",namespace="default",path="/",protocol="HTTP/1.1",service="http-svc",status="200",upstream_ip="172.17.0.4:8080",upstream_name="default-http-svc-80",upstream_status="200"|`,
 	}
 
 	if !reflect.DeepEqual(em, m) {
 		t.Errorf("unexpected metrics extracted \n%v\n%v\n", em, m)
 	}
+}
+
+func mockRootForExecCommand(command string, args ...string) *exec.Cmd {
+	if strings.Index(command, ".sh") != -1 {
+		command = path.Join("../../../../rootfs", command)
+	}
+	cmd := exec.Command(command, args...)
+	return cmd
 }

--- a/rootfs/ingress-controller/extract-metrics.sh
+++ b/rootfs/ingress-controller/extract-metrics.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ENDPOINT="$1"
+METRIC="$2"
+
+grep upstream_ip=\"${ENDPOINT}\" | grep "${METRIC}" | sed 's/.*{\(.*\).*,le.*/\1|/p' | uniq


### PR DESCRIPTION
**What this PR does / why we need it**:

https://github.com/kubernetes/ingress-nginx/pull/2701#issuecomment-400671692

**Context:**
- we only have a list of endpoints to remove from the metrics
- we need all the label to delete a metric

**Process:**
- after a reload and before replacing the running model, create a list of endpoints not available anymore
- request to /metrics to get current metrics
- for each endpoint to remove, get the metric/s
- for each metric obtained in the previous step delete prometheus metric
