### PR TITLE
GCE/GKE proxy mentioned for Azure

### DIFF
--- a/docs/deploy/index.md
+++ b/docs/deploy/index.md
@@ -125,7 +125,6 @@ kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/mast
 kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/provider/cloud-generic.yaml
 ```
 
-**Important Note:** proxy protocol is not supported in GCE/GKE
 
 ### Baremetal
 


### PR DESCRIPTION
GCE/GKE are part of Google cloud not azure, so the note "proxy protocol is not supported in GCE/GKE" does not apply for azure

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
