### PR TITLE
Sample rate configmap option for zipkin in nginx-opentracing

### DIFF
--- a/docs/user-guide/nginx-configuration/configmap.md
+++ b/docs/user-guide/nginx-configuration/configmap.md
@@ -107,6 +107,7 @@ The following table shows a configuration option's name, type, and the default v
 |[zipkin-collector-host](#zipkin-collector-host)|string|""|
 |[zipkin-collector-port](#zipkin-collector-port)|int|9411|
 |[zipkin-service-name](#zipkin-service-name)|string|"nginx"|
+|[zipkin-sample-rate](#zipkin-sample-rate)|float|1.0|
 |[jaeger-collector-host](#jaeger-collector-host)|string|""|
 |[jaeger-collector-port](#jaeger-collector-port)|int|6831|
 |[jaeger-service-name](#jaeger-service-name)|string|"nginx"|
@@ -600,6 +601,10 @@ Specifies the port to use when uploading traces. _**default:**_ 9411
 ## zipkin-service-name
 
 Specifies the service name to use for any traces created. _**default:**_ nginx
+
+## zipkin-sample-rate
+
+Specifies sample rate for any traces created. _**default:**_ 1.0
 
 ## jaeger-collector-host
 

--- a/docs/user-guide/third-party-addons/opentracing.md
+++ b/docs/user-guide/third-party-addons/opentracing.md
@@ -31,6 +31,9 @@ zipkin-collector-port
 # specifies the service name to use for any traces created, Default: nginx
 zipkin-service-name
 
+# specifies sample rate for any traces created. Default: 1.0
+zipkin-sample-rate
+
 # specifies the port to use when uploading traces
 jaeger-collector-port
 

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -433,6 +433,10 @@ type Configuration struct {
 	// Default: nginx
 	ZipkinServiceName string `json:"zipkin-service-name"`
 
+	// ZipkinSampleRate specifies sampling rate for traces
+	// Default: 1.0
+	ZipkinSampleRate float32 `json:"zipkin-sample-rate"`
+
 	// JaegerCollectorHost specifies the host to use when uploading traces
 	JaegerCollectorHost string `json:"jaeger-collector-host"`
 
@@ -612,6 +616,7 @@ func NewDefault() Configuration {
 		BindAddressIpv6:              defBindAddress,
 		ZipkinCollectorPort:          9411,
 		ZipkinServiceName:            "nginx",
+		ZipkinSampleRate:             1.0,
 		JaegerCollectorPort:          6831,
 		JaegerServiceName:            "nginx",
 		JaegerSamplerType:            "const",

--- a/internal/ingress/controller/nginx.go
+++ b/internal/ingress/controller/nginx.go
@@ -787,7 +787,8 @@ func configureDynamically(pcfg *ingress.Configuration, port int) error {
 const zipkinTmpl = `{
   "service_name": "{{ .ZipkinServiceName }}",
   "collector_host": "{{ .ZipkinCollectorHost }}",
-  "collector_port": {{ .ZipkinCollectorPort }}
+  "collector_port": {{ .ZipkinCollectorPort }},
+  "sample_rate": {{ .ZipkinSampleRate }}
 }`
 
 const jaegerTmpl = `{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Currently it is not possible to specify sample rate for zipkin in opentracing plugin, which would be really usable as ingress is a first entrypoint in whole microservice chain

This pull request adds an option zipkin-sample-rate in ConfigMap