### PR TITLE
Reset Prometheus request tags on conf reload

### DIFF
--- a/cmd/nginx/main.go
+++ b/cmd/nginx/main.go
@@ -41,7 +41,7 @@ import (
 	"k8s.io/ingress-nginx/internal/file"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/class"
 	"k8s.io/ingress-nginx/internal/ingress/controller"
-	"k8s.io/ingress-nginx/internal/ingress/metric/collector"
+	metricCollector "k8s.io/ingress-nginx/internal/ingress/metric/collector"
 	"k8s.io/ingress-nginx/internal/k8s"
 	"k8s.io/ingress-nginx/internal/net/ssl"
 	"k8s.io/ingress-nginx/version"
@@ -127,13 +127,13 @@ func main() {
 	mux := http.NewServeMux()
 	go registerHandlers(conf.EnableProfiling, conf.ListenPorts.Health, ngx, mux)
 
-	err = collector.InitNGINXStatusCollector(conf.Namespace, class.IngressClass, conf.ListenPorts.Status)
+	err = metricCollector.InitNGINXStatusCollector(conf.Namespace, class.IngressClass, conf.ListenPorts.Status)
 
 	if err != nil {
 		glog.Fatalf("Error creating metric collector:  %v", err)
 	}
 
-	err = collector.NewInstance(conf.Namespace, class.IngressClass)
+	err = metricCollector.InitSocketCollector(conf.Namespace, class.IngressClass)
 	if err != nil {
 		glog.Fatalf("Error creating unix socket server:  %v", err)
 	}

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/ingress-nginx/internal/ingress/annotations/healthcheck"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/proxy"
 	ngx_config "k8s.io/ingress-nginx/internal/ingress/controller/config"
+	metricCollector "k8s.io/ingress-nginx/internal/ingress/metric/collector"
 	"k8s.io/ingress-nginx/internal/k8s"
 )
 
@@ -175,6 +176,8 @@ func (n *NGINXController) syncIngress(interface{}) error {
 			glog.Errorf("Unexpected failure reloading the backend:\n%v", err)
 			return err
 		}
+
+		metricCollector.CleanOldBackendMetrics()
 
 		glog.Infof("Backend successfully reloaded.")
 		ConfigSuccess(true)


### PR DESCRIPTION
**What this PR does**:
On every backend configuration reload, Prometheus collectors for
request metrics (bearing the `upstream_ip` tag) are being recreated to
avoid keeping on exposing metrics for dead upstreams on the `/metrics`
endpoint.

Also, we changed the structure of the collector.go file into a
singleton (to make it possible for the ingress controller to ask for a
Prometheus collector reset on these metrics on config. reloads).

**Why we need it**:

When an upstream pod dies (because of a scale down operation, a rolling
upgrade...), metrics associated with this given pod via the `upstream_ip`
tag remain exposed on the `/metrics` endpoints. This cause three
undesireable effects:
- Analyzing these metrics on Prometheus/Grafana can be impossible:
  queries easily tend to time out or frontends tend too freeze
  because too many timeseries are returned
- Payloads periodically fetched by Prometheus can get very big over
  time on production clusters, which also make them more expensive to
  ingest and store
- Since these metrics stay in memory, it means we're having a (slow)
  memory leak.

**Which issue this PR fixes**:
I didn't open an issue for that and filed a PR directly, but that can be done if required.

**Special notes for your reviewer**:
If the "singleton" design pattern bothers you (because you were intending to instantiate multiple collectors in the future for some reason), or anything else. I'll be happy to promptly refactor the PR.

**What could we break**:
On infrastructure where the config would be reloaded at a high pace (higher than the Prometheus `scrape_interval`, we introduce discontinuities in our timeseries. It's something that Prometheus `rate()` (and similar) function handle very well. However, if backend reconfiguration frequency is higher that the Prometheus `scrape_interval`, it's possible that we get incoherent.
If so, we may just rate-limit the metric flushing operation to 1 every "user-configurable amount of time" (ex. 5 minutes). As long as this time is superior to a couple of Prometheus `scrape_interval`s, we should be totally fine :) 

**PR Status**:
The PR compiles, and his being tested on our staging infrastructure. So far so good :) 
I'll try it on our production clusters today and compare the size of the payloads of the `/metrics` endpoint before and after the upgrade and also check that discontinuities during intense scale-in operations