### PR TITLE
Improve logging

### DIFF
--- a/internal/ingress/controller/endpoints.go
+++ b/internal/ingress/controller/endpoints.go
@@ -27,11 +27,12 @@ import (
 
 	"k8s.io/ingress-nginx/internal/ingress"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/healthcheck"
+	"k8s.io/ingress-nginx/internal/k8s"
 )
 
 // getEndpoints returns a list of Endpoint structs for a given service/target port combination.
 func getEndpoints(s *corev1.Service, port *corev1.ServicePort, proto corev1.Protocol, hz *healthcheck.Config,
-	getServiceEndpoints func(*corev1.Service) (*corev1.Endpoints, error)) []ingress.Endpoint {
+	getServiceEndpoints func(string) (*corev1.Endpoints, error)) []ingress.Endpoint {
 
 	upsServers := []ingress.Endpoint{}
 
@@ -43,13 +44,15 @@ func getEndpoints(s *corev1.Service, port *corev1.ServicePort, proto corev1.Prot
 	// contains multiple port definitions sharing the same targetport
 	processedUpstreamServers := make(map[string]struct{})
 
+	svcKey := k8s.MetaNamespaceKey(s)
+
 	// ExternalName services
 	if s.Spec.Type == corev1.ServiceTypeExternalName {
-		glog.V(3).Infof("Ingress using Service %q of type ExternalName.", s.Name)
+		glog.V(3).Infof("Ingress using Service %q of type ExternalName.", svcKey)
 
 		targetPort := port.TargetPort.IntValue()
 		if targetPort <= 0 {
-			glog.Errorf("ExternalName Service %q has an invalid port (%v)", s.Name, targetPort)
+			glog.Errorf("ExternalName Service %q has an invalid port (%v)", svcKey, targetPort)
 			return upsServers
 		}
 
@@ -69,10 +72,10 @@ func getEndpoints(s *corev1.Service, port *corev1.ServicePort, proto corev1.Prot
 		})
 	}
 
-	glog.V(3).Infof("Getting Endpoints for Service \"%v/%v\" and port %v", s.Namespace, s.Name, port.String())
-	ep, err := getServiceEndpoints(s)
+	glog.V(3).Infof("Getting Endpoints for Service %q and port %v", svcKey, port.String())
+	ep, err := getServiceEndpoints(svcKey)
 	if err != nil {
-		glog.Warningf("Error obtaining Endpoints for Service \"%v/%v\": %v", s.Namespace, s.Name, err)
+		glog.Warningf("Error obtaining Endpoints for Service %q: %v", svcKey, err)
 		return upsServers
 	}
 
@@ -114,6 +117,6 @@ func getEndpoints(s *corev1.Service, port *corev1.ServicePort, proto corev1.Prot
 		}
 	}
 
-	glog.V(3).Infof("Endpoints found for Service \"%v/%v\": %v", s.Namespace, s.Name, upsServers)
+	glog.V(3).Infof("Endpoints found for Service %q: %v", svcKey, upsServers)
 	return upsServers
 }

--- a/internal/ingress/controller/endpoints_test.go
+++ b/internal/ingress/controller/endpoints_test.go
@@ -33,44 +33,44 @@ func TestGetEndpoints(t *testing.T) {
 		port   *corev1.ServicePort
 		proto  corev1.Protocol
 		hz     *healthcheck.Config
-		fn     func(*corev1.Service) (*corev1.Endpoints, error)
+		fn     func(string) (*corev1.Endpoints, error)
 		result []ingress.Endpoint
 	}{
 		{
-			"no service should return 0 endpoints",
+			"no service should return 0 endpoint",
 			nil,
 			nil,
 			corev1.ProtocolTCP,
 			nil,
-			func(*corev1.Service) (*corev1.Endpoints, error) {
+			func(string) (*corev1.Endpoints, error) {
 				return nil, nil
 			},
 			[]ingress.Endpoint{},
 		},
 		{
-			"no service port should return 0 endpoints",
+			"no service port should return 0 endpoint",
 			&corev1.Service{},
 			nil,
 			corev1.ProtocolTCP,
 			nil,
-			func(*corev1.Service) (*corev1.Endpoints, error) {
+			func(string) (*corev1.Endpoints, error) {
 				return nil, nil
 			},
 			[]ingress.Endpoint{},
 		},
 		{
-			"a service without endpoints should return 0 endpoints",
+			"a service without endpoint should return 0 endpoint",
 			&corev1.Service{},
 			&corev1.ServicePort{Name: "default"},
 			corev1.ProtocolTCP,
 			nil,
-			func(*corev1.Service) (*corev1.Endpoints, error) {
+			func(string) (*corev1.Endpoints, error) {
 				return &corev1.Endpoints{}, nil
 			},
 			[]ingress.Endpoint{},
 		},
 		{
-			"a service type ServiceTypeExternalName service with an invalid port should return 0 endpoints",
+			"a service type ServiceTypeExternalName service with an invalid port should return 0 endpoint",
 			&corev1.Service{
 				Spec: corev1.ServiceSpec{
 					Type: corev1.ServiceTypeExternalName,
@@ -79,7 +79,7 @@ func TestGetEndpoints(t *testing.T) {
 			&corev1.ServicePort{Name: "default"},
 			corev1.ProtocolTCP,
 			nil,
-			func(*corev1.Service) (*corev1.Endpoints, error) {
+			func(string) (*corev1.Endpoints, error) {
 				return &corev1.Endpoints{}, nil
 			},
 			[]ingress.Endpoint{},
@@ -107,7 +107,7 @@ func TestGetEndpoints(t *testing.T) {
 				MaxFails:    0,
 				FailTimeout: 0,
 			},
-			func(*corev1.Service) (*corev1.Endpoints, error) {
+			func(string) (*corev1.Endpoints, error) {
 				return &corev1.Endpoints{}, nil
 			},
 			[]ingress.Endpoint{
@@ -142,13 +142,13 @@ func TestGetEndpoints(t *testing.T) {
 				MaxFails:    0,
 				FailTimeout: 0,
 			},
-			func(*corev1.Service) (*corev1.Endpoints, error) {
+			func(string) (*corev1.Endpoints, error) {
 				return &corev1.Endpoints{}, nil
 			},
 			[]ingress.Endpoint{},
 		},
 		{
-			"should return no endpoints when there is an error searching for endpoints",
+			"should return no endpoint when there is an error searching for endpoints",
 			&corev1.Service{
 				Spec: corev1.ServiceSpec{
 					Type:      corev1.ServiceTypeClusterIP,
@@ -170,13 +170,13 @@ func TestGetEndpoints(t *testing.T) {
 				MaxFails:    0,
 				FailTimeout: 0,
 			},
-			func(*corev1.Service) (*corev1.Endpoints, error) {
+			func(string) (*corev1.Endpoints, error) {
 				return nil, fmt.Errorf("unexpected error")
 			},
 			[]ingress.Endpoint{},
 		},
 		{
-			"should return no endpoints when the protocol does not match",
+			"should return no endpoint when the protocol does not match",
 			&corev1.Service{
 				Spec: corev1.ServiceSpec{
 					Type:      corev1.ServiceTypeClusterIP,
@@ -198,7 +198,7 @@ func TestGetEndpoints(t *testing.T) {
 				MaxFails:    0,
 				FailTimeout: 0,
 			},
-			func(*corev1.Service) (*corev1.Endpoints, error) {
+			func(string) (*corev1.Endpoints, error) {
 				nodeName := "dummy"
 				return &corev1.Endpoints{
 					Subsets: []corev1.EndpointSubset{
@@ -221,7 +221,7 @@ func TestGetEndpoints(t *testing.T) {
 			[]ingress.Endpoint{},
 		},
 		{
-			"should return no endpoints when there is no ready Addresses",
+			"should return no endpoint when there is no ready Addresses",
 			&corev1.Service{
 				Spec: corev1.ServiceSpec{
 					Type:      corev1.ServiceTypeClusterIP,
@@ -243,7 +243,7 @@ func TestGetEndpoints(t *testing.T) {
 				MaxFails:    0,
 				FailTimeout: 0,
 			},
-			func(*corev1.Service) (*corev1.Endpoints, error) {
+			func(string) (*corev1.Endpoints, error) {
 				nodeName := "dummy"
 				return &corev1.Endpoints{
 					Subsets: []corev1.EndpointSubset{
@@ -266,7 +266,7 @@ func TestGetEndpoints(t *testing.T) {
 			[]ingress.Endpoint{},
 		},
 		{
-			"should return no endpoints when the name of the port name do not match any port in the endpoint Subsets",
+			"should return no endpoint when the name of the port name do not match any port in the endpoint Subsets",
 			&corev1.Service{
 				Spec: corev1.ServiceSpec{
 					Type:      corev1.ServiceTypeClusterIP,
@@ -288,7 +288,7 @@ func TestGetEndpoints(t *testing.T) {
 				MaxFails:    0,
 				FailTimeout: 0,
 			},
-			func(*corev1.Service) (*corev1.Endpoints, error) {
+			func(string) (*corev1.Endpoints, error) {
 				nodeName := "dummy"
 				return &corev1.Endpoints{
 					Subsets: []corev1.EndpointSubset{
@@ -335,7 +335,7 @@ func TestGetEndpoints(t *testing.T) {
 				MaxFails:    0,
 				FailTimeout: 0,
 			},
-			func(*corev1.Service) (*corev1.Endpoints, error) {
+			func(string) (*corev1.Endpoints, error) {
 				nodeName := "dummy"
 				return &corev1.Endpoints{
 					Subsets: []corev1.EndpointSubset{
@@ -389,7 +389,7 @@ func TestGetEndpoints(t *testing.T) {
 				MaxFails:    0,
 				FailTimeout: 0,
 			},
-			func(*corev1.Service) (*corev1.Endpoints, error) {
+			func(string) (*corev1.Endpoints, error) {
 				nodeName := "dummy"
 				return &corev1.Endpoints{
 					Subsets: []corev1.EndpointSubset{
@@ -431,7 +431,7 @@ func TestGetEndpoints(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			result := getEndpoints(testCase.svc, testCase.port, testCase.proto, testCase.hz, testCase.fn)
 			if len(testCase.result) != len(result) {
-				t.Errorf("expected %v Endpoints but got %v", testCase.result, len(result))
+				t.Errorf("Expected %d Endpoints but got %d", len(testCase.result), len(result))
 			}
 		})
 	}

--- a/internal/ingress/controller/store/configmap.go
+++ b/internal/ingress/controller/store/configmap.go
@@ -17,8 +17,6 @@ limitations under the License.
 package store
 
 import (
-	"fmt"
-
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -28,14 +26,14 @@ type ConfigMapLister struct {
 	cache.Store
 }
 
-// ByKey searches for a configmap in the local configmaps Store
+// ByKey returns the ConfigMap matching key in the local ConfigMap Store.
 func (cml *ConfigMapLister) ByKey(key string) (*apiv1.ConfigMap, error) {
 	s, exists, err := cml.GetByKey(key)
 	if err != nil {
 		return nil, err
 	}
 	if !exists {
-		return nil, fmt.Errorf("configmap %v was not found", key)
+		return nil, NotExistsError(key)
 	}
 	return s.(*apiv1.ConfigMap), nil
 }

--- a/internal/ingress/controller/store/endpoint.go
+++ b/internal/ingress/controller/store/endpoint.go
@@ -17,8 +17,6 @@ limitations under the License.
 package store
 
 import (
-	"fmt"
-
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -28,15 +26,14 @@ type EndpointLister struct {
 	cache.Store
 }
 
-// GetServiceEndpoints returns the endpoints of a service, matched on service name.
-func (s *EndpointLister) GetServiceEndpoints(svc *apiv1.Service) (*apiv1.Endpoints, error) {
-	key := fmt.Sprintf("%v/%v", svc.Namespace, svc.Name)
+// ByKey returns the Endpoints of the Service matching key in the local Endpoint Store.
+func (s *EndpointLister) ByKey(key string) (*apiv1.Endpoints, error) {
 	eps, exists, err := s.GetByKey(key)
 	if err != nil {
 		return nil, err
 	}
 	if !exists {
-		return nil, fmt.Errorf("could not find endpoints for service %v", key)
+		return nil, NotExistsError(key)
 	}
 	return eps.(*apiv1.Endpoints), nil
 }

--- a/internal/ingress/controller/store/ingress.go
+++ b/internal/ingress/controller/store/ingress.go
@@ -17,8 +17,6 @@ limitations under the License.
 package store
 
 import (
-	"fmt"
-
 	extensions "k8s.io/api/extensions/v1beta1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -28,14 +26,14 @@ type IngressLister struct {
 	cache.Store
 }
 
-// ByKey searches for an ingress in the local ingress Store
+// ByKey returns the Ingress matching key in the local Ingress Store.
 func (il IngressLister) ByKey(key string) (*extensions.Ingress, error) {
 	i, exists, err := il.GetByKey(key)
 	if err != nil {
 		return nil, err
 	}
 	if !exists {
-		return nil, fmt.Errorf("ingress %v was not found", key)
+		return nil, NotExistsError(key)
 	}
 	return i.(*extensions.Ingress), nil
 }

--- a/internal/ingress/controller/store/ingress_annotation.go
+++ b/internal/ingress/controller/store/ingress_annotation.go
@@ -18,9 +18,22 @@ package store
 
 import (
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/ingress-nginx/internal/ingress/annotations"
 )
 
 // IngressAnnotationsLister makes a Store that lists annotations in Ingress rules.
 type IngressAnnotationsLister struct {
 	cache.Store
+}
+
+// ByKey returns the Ingress annotations matching key in the local Ingress annotations Store.
+func (il IngressAnnotationsLister) ByKey(key string) (*annotations.Ingress, error) {
+	i, exists, err := il.GetByKey(key)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, NotExistsError(key)
+	}
+	return i.(*annotations.Ingress), nil
 }

--- a/internal/ingress/controller/store/secret.go
+++ b/internal/ingress/controller/store/secret.go
@@ -17,8 +17,6 @@ limitations under the License.
 package store
 
 import (
-	"fmt"
-
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -28,14 +26,14 @@ type SecretLister struct {
 	cache.Store
 }
 
-// ByKey searches for a secret in the local secrets Store
+// ByKey returns the Secret matching key in the local Secret Store.
 func (sl *SecretLister) ByKey(key string) (*apiv1.Secret, error) {
 	s, exists, err := sl.GetByKey(key)
 	if err != nil {
 		return nil, err
 	}
 	if !exists {
-		return nil, fmt.Errorf("secret %v was not found", key)
+		return nil, NotExistsError(key)
 	}
 	return s.(*apiv1.Secret), nil
 }

--- a/internal/ingress/controller/store/service.go
+++ b/internal/ingress/controller/store/service.go
@@ -17,8 +17,6 @@ limitations under the License.
 package store
 
 import (
-	"fmt"
-
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -28,14 +26,14 @@ type ServiceLister struct {
 	cache.Store
 }
 
-// ByKey searches for a service in the local secrets Store
+// ByKey returns the Service matching key in the local Service Store.
 func (sl *ServiceLister) ByKey(key string) (*apiv1.Service, error) {
 	s, exists, err := sl.GetByKey(key)
 	if err != nil {
 		return nil, err
 	}
 	if !exists {
-		return nil, fmt.Errorf("service %v was not found", key)
+		return nil, NotExistsError(key)
 	}
 	return s.(*apiv1.Service), nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Improves the overall clarity of existing log messages.

Includes some minor refactoring of the store's `Get...()` methods to use the same `func (key string) ...` signature consistently.

**Which issue this PR fixes**:

fixes #2712 
follow-up on #2639