### PR TITLE
Add redirect uri for oauth2 login

### DIFF
--- a/docs/examples/auth/oauth-external-auth/README.md
+++ b/docs/examples/auth/oauth-external-auth/README.md
@@ -24,8 +24,8 @@ Sample:
 metadata:
   name: application
   annotations:
-    "nginx.ingress.kubernetes.io/auth-url": "https://$host/oauth2/auth"
-    "nginx.ingress.kubernetes.io/auth-signin": "https://$host/oauth2/sign_in"
+    nginx.ingress.kubernetes.io/auth-url: "https://$host/oauth2/auth"
+    nginx.ingress.kubernetes.io/auth-signin: "https://$host/oauth2/start?rd=$request_uri"
 ...
 ```
 

--- a/docs/examples/auth/oauth-external-auth/dashboard-ingress.yaml
+++ b/docs/examples/auth/oauth-external-auth/dashboard-ingress.yaml
@@ -2,8 +2,8 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   annotations:
-    nginx.ingress.kubernetes.io/auth-signin: https://$host/oauth2/start
-    nginx.ingress.kubernetes.io/auth-url: https://$host/oauth2/auth
+    nginx.ingress.kubernetes.io/auth-url: "https://$host/oauth2/auth"
+    nginx.ingress.kubernetes.io/auth-signin: "https://$host/oauth2/start?rd=$request_uri"
   name: external-auth-oauth2
   namespace: kube-system
 spec:


### PR DESCRIPTION
**What this PR does / why we need it**:
This improves documentation by oauth2 redirect uri handling. This allows
signing in and keeping the path. It cost me a lot of time to research this until
i found it somewhere hidden in bitly repository (bitly/oauth2_proxy#558). This will reduce research
for other users.

**Which issue this PR fixes**
There is no open issue.

**Special notes for your reviewer**:
Thanks for reviewing 👍 

Greetings, Thomas
