### PR TITLE
fix: Use the correct opentracing plugin for Jaeger

### DIFF
--- a/images/nginx/Makefile
+++ b/images/nginx/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # 0.0.0 shouldn't clobber any released builds
-TAG ?= 0.53
+TAG ?= 0.54
 REGISTRY ?= quay.io/kubernetes-ingress-controller
 ARCH ?= $(shell go env GOARCH)
 DOCKER ?= docker

--- a/images/nginx/build.sh
+++ b/images/nginx/build.sh
@@ -300,11 +300,6 @@ cmake -DCMAKE_BUILD_TYPE=Release -DJAEGERTRACING_PLUGIN=ON -DBUILD_TESTING=OFF -
 make
 mv libjaegertracing_plugin.so /usr/local/lib/libjaegertracing_plugin.so
 
-export HUNTER_INSTALL_DIR=$(cat _3rdParty/Hunter/install-root-dir)
-echo "HUNTER_INSTALL_DIR: ${HUNTER_INSTALL_DIR}"
-cp $HUNTER_INSTALL_DIR/lib/libthrift* /usr/local/lib
-rm /usr/local/lib/libthrift*.a
-
 # build zipkin lib
 cd "$BUILD_PATH/zipkin-cpp-opentracing-$ZIPKIN_CPP_VERSION"
 mkdir .build

--- a/images/nginx/build.sh
+++ b/images/nginx/build.sh
@@ -283,14 +283,22 @@ cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF ..
 make
 make install
 
-# build zipkin lib
+# build jaeger lib
 cd "$BUILD_PATH/jaeger-client-cpp-$JAEGER_VERSION"
 sed -i 's/-Werror//' CMakeLists.txt
 mkdir .build
 cd .build
-cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=1 -DBUILD_TESTING=OFF -DJAEGERTRACING_WITH_YAML_CPP=OFF -DJAEGERTRACING_BUILD_EXAMPLES=OFF ..
+# Taken from https://github.com/jaegertracing/jaeger-client-cpp/blob/v0.4.1/scripts/build-plugin.sh
+cat <<EOF > export.map
+{
+    global:
+        OpenTracingMakeTracerFactory;
+    local: *;
+};
+EOF
+cmake -DCMAKE_BUILD_TYPE=Release -DJAEGERTRACING_PLUGIN=ON -DBUILD_TESTING=OFF -DJAEGERTRACING_BUILD_EXAMPLES=OFF -DHUNTER_CONFIGURATION_TYPES=Release ..
 make
-make install
+mv libjaegertracing_plugin.so /usr/local/lib/libjaegertracing_plugin.so
 
 export HUNTER_INSTALL_DIR=$(cat _3rdParty/Hunter/install-root-dir)
 echo "HUNTER_INSTALL_DIR: ${HUNTER_INSTALL_DIR}"

--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -855,7 +855,7 @@ func buildOpentracing(input interface{}) string {
 	if cfg.ZipkinCollectorHost != "" {
 		buf.WriteString("opentracing_load_tracer /usr/local/lib/libzipkin_opentracing.so /etc/nginx/opentracing.json;")
 	} else if cfg.JaegerCollectorHost != "" {
-		buf.WriteString("opentracing_load_tracer /usr/local/lib/libjaegertracing.so 	 /etc/nginx/opentracing.json;")
+		buf.WriteString("opentracing_load_tracer /usr/local/lib/libjaegertracing_plugin.so 	 /etc/nginx/opentracing.json;")
 	}
 
 	buf.WriteString("\r\n")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Uses the correct opentracing plugin for Jaeger - without this there is a regression and that feature doesn't work in 0.16.2

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: part of #2738

**Special notes for your reviewer**:
