### PR TITLE
the type of $backends is slice, so the first item of range is index n…

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -370,7 +370,7 @@ http {
     {{ end }}
 
     {{ if not $all.DynamicConfigurationEnabled }}
-    {{ range $name, $upstream := $backends }}
+    {{ range $index, $upstream := $backends }}
     {{ if eq $upstream.SessionAffinity.AffinityType "cookie" }}
     upstream sticky-{{ $upstream.Name }} {
         sticky hash={{ $upstream.SessionAffinity.CookieSessionAffinity.Hash }} name={{ $upstream.SessionAffinity.CookieSessionAffinity.Name }}{{if eq (len $upstream.SessionAffinity.CookieSessionAffinity.Locations) 1 }}{{ range $locationName, $locationPaths := $upstream.SessionAffinity.CookieSessionAffinity.Locations }}{{ if eq (len $locationPaths) 1 }} path={{ index $locationPaths 0 }}{{ end }}{{ end }}{{ end }} httponly;


### PR DESCRIPTION
modify nginx.tmpl: 
change the $name to $index in {{ range $index, $upstream := $backends }}
