### PR TITLE
use format "range v := iterative object" and "range k, v := iterative object" when the type of iterative object is slice and map in the file nginx.tmpl

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -370,7 +370,7 @@ http {
     {{ end }}
 
     {{ if not $all.DynamicConfigurationEnabled }}
-    {{ range $name, $upstream := $backends }}
+    {{ range  $upstream := $backends }}
     {{ if eq $upstream.SessionAffinity.AffinityType "cookie" }}
     upstream sticky-{{ $upstream.Name }} {
         sticky hash={{ $upstream.SessionAffinity.CookieSessionAffinity.Hash }} name={{ $upstream.SessionAffinity.CookieSessionAffinity.Name }}{{if eq (len $upstream.SessionAffinity.CookieSessionAffinity.Locations) 1 }}{{ range $locationName, $locationPaths := $upstream.SessionAffinity.CookieSessionAffinity.Locations }}{{ if eq (len $locationPaths) 1 }} path={{ index $locationPaths 0 }}{{ end }}{{ end }}{{ end }} httponly;
@@ -412,7 +412,7 @@ http {
     {{ end }}
 
     {{/* build the maps that will be use to validate the Whitelist */}}
-    {{ range $index, $server := $servers }}
+    {{ range $server := $servers }}
     {{ range $location := $server.Locations }}
     {{ $path := buildLocation $location }}
 
@@ -482,7 +482,7 @@ http {
     }
     {{ end }}
 
-    {{ range $index, $server := $servers }}
+    {{ range $server := $servers }}
 
     ## start server {{ $server.Hostname }}
     server {
@@ -597,9 +597,9 @@ stream {
     error_log  {{ $cfg.ErrorLogPath }};
 
     # TCP services
-    {{ range $i, $tcpServer := .TCPBackends }}
+    {{ range $tcpServer := .TCPBackends }}
     upstream tcp-{{ $tcpServer.Port }}-{{ $tcpServer.Backend.Namespace }}-{{ $tcpServer.Backend.Name }}-{{ $tcpServer.Backend.Port }} {
-    {{ range $j, $endpoint := $tcpServer.Endpoints }}
+    {{ range $endpoint := $tcpServer.Endpoints }}
         server                  {{ $endpoint.Address | formatIP }}:{{ $endpoint.Port }};
     {{ end }}
     }
@@ -626,9 +626,9 @@ stream {
     {{ end }}
 
     # UDP services
-    {{ range $i, $udpServer := .UDPBackends }}
+    {{ range $udpServer := .UDPBackends }}
     upstream udp-{{ $udpServer.Port }}-{{ $udpServer.Backend.Namespace }}-{{ $udpServer.Backend.Name }}-{{ $udpServer.Backend.Port }} {
-    {{ range $j, $endpoint := $udpServer.Endpoints }}
+    {{ range $endpoint := $udpServer.Endpoints }}
         server                  {{ $endpoint.Address | formatIP }}:{{ $endpoint.Port }};
     {{ end }}
     }
@@ -971,7 +971,7 @@ stream {
             auth_request        {{ $authPath }};
             auth_request_set    $auth_cookie $upstream_http_set_cookie;
             add_header          Set-Cookie $auth_cookie;
-            {{- range $idx, $line := buildAuthResponseHeaders $location }}
+            {{- range $line := buildAuthResponseHeaders $location }}
             {{ $line }}
             {{- end }}
             {{ end }}


### PR DESCRIPTION
unified the format of the nginx.tmpl，use format "range v := iterative object" and "range k, v := iterative
object" when the type of iterative object is slice and map。