### PR TITLE
#2529 Adds a cli flag to skip checks at startup.

### DIFF
--- a/cmd/nginx/flags.go
+++ b/cmd/nginx/flags.go
@@ -201,7 +201,7 @@ Feature backed by OpenResty Lua libraries.`)
 		if !ing_net.IsIPv6Enabled() && ing_net.IsIPV6(ip) {
 			glog.Warningf("IPv6 is disabled, skipping IPv6 address: %s", ipAddressStr)
 		} else {
-			if ing_net.IsIPV6(ip){
+			if ing_net.IsIPV6(ip) {
 				ipAddressStr = fmt.Sprintf("[%v]", ipAddressStr)
 			}
 			bindIpAddresses = append(bindIpAddresses, ipAddressStr)

--- a/cmd/nginx/flags.go
+++ b/cmd/nginx/flags.go
@@ -150,7 +150,7 @@ Requires the update-status parameter.`)
 Feature backed by OpenResty Lua libraries.`)
 
 		bindAddresses = flags.String("bind-addresses", "0.0.0.0,::",
-			`Comma separated list of IPv4/IPv6 address to bind to.`)
+			`Comma separated list of IPv4/IPv6 addresses to bind to.`)
 		httpPort      = flags.Int("http-port", 80, `Port to use for servicing HTTP traffic.`)
 		httpsPort     = flags.Int("https-port", 443, `Port to use for servicing HTTPS traffic.`)
 		statusPort    = flags.Int("status-port", 18080, `Port to use for exposing NGINX status pages.`)

--- a/cmd/nginx/flags.go
+++ b/cmd/nginx/flags.go
@@ -149,8 +149,8 @@ Requires the update-status parameter.`)
 			`Dynamically refresh backends on topology changes instead of reloading NGINX.
 Feature backed by OpenResty Lua libraries.`)
 
-		bindAddresses = flags.String("bind-addresses", "0.0.0.0,[::]",
-			`Comma separated list of IPv4/IPv6 address to bind to. Default 0.0.0.0,[::]`)
+		bindAddresses = flags.String("bind-addresses", "0.0.0.0,::",
+			`Comma separated list of IPv4/IPv6 address to bind to.`)
 		httpPort      = flags.Int("http-port", 80, `Port to use for servicing HTTP traffic.`)
 		httpsPort     = flags.Int("https-port", 443, `Port to use for servicing HTTPS traffic.`)
 		statusPort    = flags.Int("status-port", 18080, `Port to use for exposing NGINX status pages.`)
@@ -194,43 +194,43 @@ Feature backed by OpenResty Lua libraries.`)
 
 	bindIpAddresses := make([]string, 0)
 	for _, ipAddressStr := range strings.Split(*bindAddresses, ",") {
-		ipAddressSanitized := strings.Replace(strings.Replace(ipAddressStr, "]", "", -1),
-			"[", "", -1)
-
-		ip := net.ParseIP(ipAddressSanitized)
+		ip := net.ParseIP(ipAddressStr)
 		if ip == nil {
 			return false, nil, fmt.Errorf("string %v is not an ip address", ipAddressStr)
 		}
 		if !ing_net.IsIPv6Enabled() && ing_net.IsIPV6(ip) {
 			glog.Warningf("IPv6 is disabled, skipping IPv6 address: %s", ipAddressStr)
 		} else {
+			if ing_net.IsIPV6(ip){
+				ipAddressStr = fmt.Sprintf("[%v]", ipAddressStr)
+			}
 			bindIpAddresses = append(bindIpAddresses, ipAddressStr)
 		}
 	}
-	// check port collisions
+	// check port availability
 	for _, ipAddress := range bindIpAddresses {
 		if !ing_net.IsPortAvailable(ipAddress, *httpPort) {
-			return false, nil, fmt.Errorf("port %v:%v is already in use. Please check the flag --http-port",
+			return false, nil, fmt.Errorf("Port %s:%d is already in use. Please check the flag --http-port",
 				ipAddress, *httpPort)
 		}
 
 		if !ing_net.IsPortAvailable(ipAddress, *httpsPort) {
-			return false, nil, fmt.Errorf("port %v:%v is already in use. Please check the flag --https-port",
+			return false, nil, fmt.Errorf("Port %s:%d is already in use. Please check the flag --https-port",
 				ipAddress, *httpsPort)
 		}
 
 		if !ing_net.IsPortAvailable(ipAddress, *statusPort) {
-			return false, nil, fmt.Errorf("port %v:%v is already in use. Please check the flag --status-port",
+			return false, nil, fmt.Errorf("Port %s:%d is already in use. Please check the flag --status-port",
 				ipAddress, *statusPort)
 		}
 
 		if !ing_net.IsPortAvailable(ipAddress, *defServerPort) {
-			return false, nil, fmt.Errorf("port %v:%v is already in use. Please check the flag --default-server-port",
+			return false, nil, fmt.Errorf("Port %s:%d is already in use. Please check the flag --default-server-port",
 				ipAddress, *defServerPort)
 		}
 
 		if *enableSSLPassthrough && !ing_net.IsPortAvailable(ipAddress, *sslProxyPort) {
-			return false, nil, fmt.Errorf("port %v:%v is already in use. Please check the flag --ssl-passtrough-proxy-port",
+			return false, nil, fmt.Errorf("Port %s:%d is already in use. Please check the flag --ssl-passtrough-proxy-port",
 				ipAddress, *sslProxyPort)
 		}
 	}

--- a/docs/user-guide/cli-arguments.md
+++ b/docs/user-guide/cli-arguments.md
@@ -10,7 +10,7 @@ They are set in the container spec of the `nginx-ingress-controller` Deployment 
 | --alsologtostderr                 | log to standard error as well as files |
 | --annotations-prefix string       | Prefix of the Ingress annotations specific to the NGINX controller. (default "nginx.ingress.kubernetes.io") |
 | --apiserver-host string           | Address of the Kubernetes API server. Takes the form "protocol://address:port". If not specified, it is assumed the program runs inside a Kubernetes cluster and local discovery is attempted. |
-| --bind-addresses string           | Comma separated list of IPv4/IPV6 address to bind to. Defaults to 0.0.0.0,[::] |
+| --bind-addresses string           | Comma separated list of IPv4/IPv6 addresses to bind to. Defaults to "0.0.0.0,::" |
 | --configmap string                | Name of the ConfigMap containing custom global configurations for the controller. |
 | --default-backend-service string  | Service used to serve HTTP requests not matching any known server name (catch-all). Takes the form "namespace/name". The controller configures NGINX to forward requests to the first port of this Service. |
 | --default-server-port int         | Port to use for exposing the default server (catch-all). (default 8181) |

--- a/docs/user-guide/cli-arguments.md
+++ b/docs/user-guide/cli-arguments.md
@@ -32,6 +32,7 @@ They are set in the container spec of the `nginx-ingress-controller` Deployment 
 | --publish-service string          | Service fronting the Ingress controller. Takes the form "namespace/name". When used together with update-status, the controller mirrors the address of this service's endpoints to the load-balancer status of all Ingress objects it satisfies. |
 | --publish-status-address string   | Customized address to set as the load-balancer status of Ingress objects this controller satisfies. Requires the update-status parameter. |
 | --report-node-internal-ip-address | Set the load-balancer status of Ingress objects to internal Node addresses instead of external. Requires the update-status parameter. |
+| --skip-port-check                 | Skip all port availability checks at startup. (default false) |
 | --sort-backends                   | Sort servers inside NGINX upstreams. |
 | --ssl-passthrough-proxy-port int  | Port to use internally for SSL Passthrough. (default 442) |
 | --status-port int                 | Port to use for exposing NGINX status pages. (default 18080) |

--- a/docs/user-guide/cli-arguments.md
+++ b/docs/user-guide/cli-arguments.md
@@ -10,6 +10,7 @@ They are set in the container spec of the `nginx-ingress-controller` Deployment 
 | --alsologtostderr                 | log to standard error as well as files |
 | --annotations-prefix string       | Prefix of the Ingress annotations specific to the NGINX controller. (default "nginx.ingress.kubernetes.io") |
 | --apiserver-host string           | Address of the Kubernetes API server. Takes the form "protocol://address:port". If not specified, it is assumed the program runs inside a Kubernetes cluster and local discovery is attempted. |
+| --bind-addresses string           | Comma separated list of IPv4/IPV6 address to bind to. Defaults to 0.0.0.0,[::] |
 | --configmap string                | Name of the ConfigMap containing custom global configurations for the controller. |
 | --default-backend-service string  | Service used to serve HTTP requests not matching any known server name (catch-all). Takes the form "namespace/name". The controller configures NGINX to forward requests to the first port of this Service. |
 | --default-server-port int         | Port to use for exposing the default server (catch-all). (default 8181) |
@@ -32,7 +33,6 @@ They are set in the container spec of the `nginx-ingress-controller` Deployment 
 | --publish-service string          | Service fronting the Ingress controller. Takes the form "namespace/name". When used together with update-status, the controller mirrors the address of this service's endpoints to the load-balancer status of all Ingress objects it satisfies. |
 | --publish-status-address string   | Customized address to set as the load-balancer status of Ingress objects this controller satisfies. Requires the update-status parameter. |
 | --report-node-internal-ip-address | Set the load-balancer status of Ingress objects to internal Node addresses instead of external. Requires the update-status parameter. |
-| --skip-port-check                 | Skip all port availability checks at startup. (default false) |
 | --sort-backends                   | Sort servers inside NGINX upstreams. |
 | --ssl-passthrough-proxy-port int  | Port to use internally for SSL Passthrough. (default 442) |
 | --status-port int                 | Port to use for exposing NGINX status pages. (default 18080) |

--- a/docs/user-guide/cli-arguments.md
+++ b/docs/user-guide/cli-arguments.md
@@ -10,7 +10,7 @@ They are set in the container spec of the `nginx-ingress-controller` Deployment 
 | --alsologtostderr                 | log to standard error as well as files |
 | --annotations-prefix string       | Prefix of the Ingress annotations specific to the NGINX controller. (default "nginx.ingress.kubernetes.io") |
 | --apiserver-host string           | Address of the Kubernetes API server. Takes the form "protocol://address:port". If not specified, it is assumed the program runs inside a Kubernetes cluster and local discovery is attempted. |
-| --bind-addresses string           | Comma separated list of IPv4/IPv6 addresses to bind to. Defaults to "0.0.0.0,::" |
+| --bind-addresses string           | Comma separated list of IPv4/IPv6 addresses to bind to. (default "0.0.0.0,::") /
 | --configmap string                | Name of the ConfigMap containing custom global configurations for the controller. |
 | --default-backend-service string  | Service used to serve HTTP requests not matching any known server name (catch-all). Takes the form "namespace/name". The controller configures NGINX to forward requests to the first port of this Service. |
 | --default-server-port int         | Port to use for exposing the default server (catch-all). (default 8181) |

--- a/docs/user-guide/nginx-configuration/configmap.md
+++ b/docs/user-guide/nginx-configuration/configmap.md
@@ -99,7 +99,6 @@ The following table shows a configuration option's name, type, and the default v
 |[limit-conn-zone-variable](#limit-conn-zone-variable)|string|"$binary_remote_addr"|
 |[proxy-stream-timeout](#proxy-stream-timeout)|string|"600s"|
 |[proxy-stream-responses](#proxy-stream-responses)|int|1|
-|[bind-address](#bind-address)|[]string|""|
 |[forwarded-for-header](#forwarded-for-header)|string|"X-Forwarded-For"|
 |[compute-full-forwarded-for](#compute-full-forwarded-for)|bool|"false"|
 |[proxy-add-original-uri-header](#proxy-add-original-uri-header)|bool|"true"|
@@ -568,10 +567,6 @@ Sets the number of datagrams expected from the proxied server in response to the
 
 _References:_
 [http://nginx.org/en/docs/stream/ngx_stream_proxy_module.html#proxy_responses](http://nginx.org/en/docs/stream/ngx_stream_proxy_module.html#proxy_responses)
-
-## bind-address
-
-Sets the addresses on which the server will accept requests instead of *. It should be noted that these addresses must exist in the runtime environment or the controller will crash loop.
 
 ## forwarded-for-header
 

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -399,12 +399,6 @@ type Configuration struct {
 	// Default: 1
 	ProxyStreamResponses int `json:"proxy-stream-responses,omitempty"`
 
-	// Sets the ipv4 addresses on which the server will accept requests.
-	BindAddressIpv4 []string `json:"bind-address-ipv4,omitempty"`
-
-	// Sets the ipv6 addresses on which the server will accept requests.
-	BindAddressIpv6 []string `json:"bind-address-ipv6,omitempty"`
-
 	// Sets the header field for identifying the originating IP address of a client
 	// Default is X-Forwarded-For
 	ForwardedForHeader string `json:"forwarded-for-header,omitempty"`
@@ -521,7 +515,6 @@ type Configuration struct {
 // NewDefault returns the default nginx configuration
 func NewDefault() Configuration {
 	defIPCIDR := make([]string, 0)
-	defBindAddress := make([]string, 0)
 	defNginxStatusIpv4Whitelist := make([]string, 0)
 	defNginxStatusIpv6Whitelist := make([]string, 0)
 
@@ -616,8 +609,6 @@ func NewDefault() Configuration {
 		},
 		UpstreamKeepaliveConnections: 32,
 		LimitConnZoneVariable:        defaultLimitConnZoneVariable,
-		BindAddressIpv4:              defBindAddress,
-		BindAddressIpv6:              defBindAddress,
 		ZipkinCollectorPort:          9411,
 		ZipkinServiceName:            "nginx",
 		ZipkinSampleRate:             1.0,
@@ -674,13 +665,14 @@ type TemplateConfig struct {
 	DisableLua                  bool
 }
 
-// ListenPorts describe the ports required to run the
+// ListenPorts describe the ip addresses and ports that are required to run the
 // NGINX Ingress controller
 type ListenPorts struct {
-	HTTP     int
-	HTTPS    int
-	Status   int
-	Health   int
-	Default  int
-	SSLProxy int
+	Addresses []string
+	Default   int
+	HTTP      int
+	HTTPS     int
+	Health    int
+	SSLProxy  int
+	Status    int
 }

--- a/internal/ingress/controller/template/configmap.go
+++ b/internal/ingress/controller/template/configmap.go
@@ -18,7 +18,6 @@ package template
 
 import (
 	"fmt"
-	"net"
 	"strconv"
 	"strings"
 	"time"
@@ -38,7 +37,6 @@ const (
 	skipAccessLogUrls        = "skip-access-log-urls"
 	whitelistSourceRange     = "whitelist-source-range"
 	proxyRealIPCIDR          = "proxy-real-ip-cidr"
-	bindAddress              = "bind-address"
 	httpRedirectCode         = "http-redirect-code"
 	proxyStreamResponses     = "proxy-stream-responses"
 	hideHeaders              = "hide-headers"
@@ -65,9 +63,6 @@ func ReadConfig(src map[string]string) config.Configuration {
 	whiteList := make([]string, 0)
 	proxyList := make([]string, 0)
 	hideHeadersList := make([]string, 0)
-
-	bindAddressIpv4List := make([]string, 0)
-	bindAddressIpv6List := make([]string, 0)
 
 	if val, ok := conf[customHTTPErrors]; ok {
 		delete(conf, customHTTPErrors)
@@ -97,21 +92,6 @@ func ReadConfig(src map[string]string) config.Configuration {
 		proxyList = append(proxyList, strings.Split(val, ",")...)
 	} else {
 		proxyList = append(proxyList, "0.0.0.0/0")
-	}
-	if val, ok := conf[bindAddress]; ok {
-		delete(conf, bindAddress)
-		for _, i := range strings.Split(val, ",") {
-			ns := net.ParseIP(i)
-			if ns != nil {
-				if ing_net.IsIPV6(ns) {
-					bindAddressIpv6List = append(bindAddressIpv6List, fmt.Sprintf("[%v]", ns))
-				} else {
-					bindAddressIpv4List = append(bindAddressIpv4List, fmt.Sprintf("%v", ns))
-				}
-			} else {
-				glog.Warningf("%v is not a valid textual representation of an IP address", i)
-			}
-		}
 	}
 
 	if val, ok := conf[httpRedirectCode]; ok {
@@ -170,8 +150,6 @@ func ReadConfig(src map[string]string) config.Configuration {
 	to.SkipAccessLogURLs = skipUrls
 	to.WhitelistSourceRange = whiteList
 	to.ProxyRealIPCIDR = proxyList
-	to.BindAddressIpv4 = bindAddressIpv4List
-	to.BindAddressIpv6 = bindAddressIpv6List
 	to.HideHeaders = hideHeadersList
 	to.ProxyStreamResponses = streamResponses
 	to.DisableIpv6DNS = !ing_net.IsIPv6Enabled()

--- a/internal/ingress/controller/template/configmap_test.go
+++ b/internal/ingress/controller/template/configmap_test.go
@@ -18,7 +18,6 @@ package template
 
 import (
 	"fmt"
-	"reflect"
 	"testing"
 	"time"
 
@@ -66,7 +65,6 @@ func TestMergeConfigMapToStruct(t *testing.T) {
 		"gzip-level":                    "9",
 		"gzip-types":                    "text/html",
 		"proxy-real-ip-cidr":            "1.1.1.1/8,2.2.2.2/24",
-		"bind-address":                  "1.1.1.1,2.2.2.2,3.3.3,2001:db8:a0b:12f0::1,3731:54:65fe:2::a7,33:33:33::33::33",
 		"worker-shutdown-timeout":       "99s",
 		"nginx-status-ipv4-whitelist":   "127.0.0.1,10.0.0.0/24",
 		"nginx-status-ipv6-whitelist":   "::1,2001::/16",
@@ -85,8 +83,6 @@ func TestMergeConfigMapToStruct(t *testing.T) {
 	def.GzipLevel = 9
 	def.GzipTypes = "text/html"
 	def.ProxyRealIPCIDR = []string{"1.1.1.1/8", "2.2.2.2/24"}
-	def.BindAddressIpv4 = []string{"1.1.1.1", "2.2.2.2"}
-	def.BindAddressIpv6 = []string{"[2001:db8:a0b:12f0::1]", "[3731:54:65fe:2::a7]"}
 	def.WorkerShutdownTimeout = "99s"
 	def.NginxStatusIpv4Whitelist = []string{"127.0.0.1", "10.0.0.0/24"}
 	def.NginxStatusIpv6Whitelist = []string{"::1", "2001::/16"}
@@ -103,19 +99,6 @@ func TestMergeConfigMapToStruct(t *testing.T) {
 	to := ReadConfig(conf)
 	if diff := pretty.Compare(to, def); diff != "" {
 		t.Errorf("unexpected diff: (-got +want)\n%s", diff)
-	}
-
-	to = ReadConfig(conf)
-	def.BindAddressIpv4 = []string{}
-	def.BindAddressIpv6 = []string{}
-
-	if !reflect.DeepEqual(to.BindAddressIpv4, []string{"1.1.1.1", "2.2.2.2"}) {
-		t.Errorf("unexpected bindAddressIpv4")
-	}
-
-	if !reflect.DeepEqual(to.BindAddressIpv6, []string{"[2001:db8:a0b:12f0::1]", "[3731:54:65fe:2::a7]"}) {
-		t.Logf("%v", to.BindAddressIpv6)
-		t.Errorf("unexpected bindAddressIpv6")
 	}
 
 	def = config.NewDefault()

--- a/internal/net/net.go
+++ b/internal/net/net.go
@@ -28,8 +28,8 @@ func IsIPV6(ip _net.IP) bool {
 }
 
 // IsPortAvailable checks if a TCP port is available or not
-func IsPortAvailable(p int) bool {
-	ln, err := _net.Listen("tcp", fmt.Sprintf(":%v", p))
+func IsPortAvailable(address string, p int) bool {
+	ln, err := _net.Listen("tcp", fmt.Sprintf("%v:%v", address, p))
 	if err != nil {
 		return false
 	}

--- a/internal/net/net_test.go
+++ b/internal/net/net_test.go
@@ -43,7 +43,7 @@ func TestIsIPV6(t *testing.T) {
 }
 
 func TestIsPortAvailable(t *testing.T) {
-	if !IsPortAvailable(0) {
+	if !IsPortAvailable("0.0.0.0", 0) {
 		t.Fatal("expected port 0 to be available (random port) but returned false")
 	}
 
@@ -54,7 +54,7 @@ func TestIsPortAvailable(t *testing.T) {
 	defer ln.Close()
 
 	p := ln.Addr().(*net.TCPAddr).Port
-	if IsPortAvailable(p) {
+	if IsPortAvailable("0.0.0.0", p) {
 		t.Fatalf("expected port %v to not be available", p)
 	}
 }

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -6,6 +6,7 @@
 {{ $backends := .Backends }}
 {{ $proxyHeaders := .ProxySetHeaders }}
 {{ $addHeaders := .AddHeaders }}
+{{ $listenPorts := .ListenPorts }}
 
 # Configuration checksum: {{ $all.Cfg.Checksum }}
 
@@ -263,14 +264,14 @@ http {
     }
 
     {{ if $all.IsSSLPassthroughEnabled }}
-    # map port {{ $all.ListenPorts.SSLProxy }} to 443 for header X-Forwarded-Port
+    # map port {{ $listenPorts.SSLProxy }} to 443 for header X-Forwarded-Port
     map $pass_server_port $pass_port {
-        {{ $all.ListenPorts.SSLProxy }}              443;
+        {{ $listenPorts.SSLProxy }}              443;
         default          $pass_server_port;
     }
     {{ else }}
     map $pass_server_port $pass_port {
-        {{ $all.ListenPorts.HTTPS }}              443;
+        {{ $listenPorts.HTTPS }}              443;
         default          $pass_server_port;
     }
     {{ end }}
@@ -455,26 +456,15 @@ http {
     {{/* Build server redirects (from/to www) */}}
     {{ range $hostname, $to := .RedirectServers }}
     server {
-        {{ range $address := $all.Cfg.BindAddressIpv4 }}
-        listen {{ $address }}:{{ $all.ListenPorts.HTTP }}{{ if $all.Cfg.UseProxyProtocol }} proxy_protocol{{ end }};
-        listen {{ $address }}:{{ if $all.IsSSLPassthroughEnabled }}{{ $all.ListenPorts.SSLProxy }} proxy_protocol{{ else }}{{ $all.ListenPorts.HTTPS }}{{ if $all.Cfg.UseProxyProtocol }} proxy_protocol{{ end }}{{ end }} ssl;
-        {{ else }}
-        listen {{ $all.ListenPorts.HTTP }}{{ if $all.Cfg.UseProxyProtocol }} proxy_protocol{{ end }};
-        listen {{ if $all.IsSSLPassthroughEnabled }}{{ $all.ListenPorts.SSLProxy }} proxy_protocol{{ else }}{{ $all.ListenPorts.HTTPS }}{{ if $all.Cfg.UseProxyProtocol }} proxy_protocol{{ end }}{{ end }} ssl;
+        {{ range $address := $listenPorts.Addresses }}
+            listen {{ $address }}:{{ $listenPorts.HTTP }}{{ if $all.Cfg.UseProxyProtocol }} proxy_protocol{{ end }};
+            listen {{ $address }}:{{ if $all.IsSSLPassthroughEnabled }}{{ $listenPorts.SSLProxy }} proxy_protocol{{ else }}{{ $listenPorts.HTTPS }}{{ if $all.Cfg.UseProxyProtocol }} proxy_protocol{{ end }}{{ end }} ssl;
         {{ end }}
-        {{ if $IsIPV6Enabled }}
-        {{ range $address := $all.Cfg.BindAddressIpv6 }}
-        listen {{ $address }}:{{ $all.ListenPorts.HTTP }}{{ if $all.Cfg.UseProxyProtocol }} proxy_protocol{{ end }};
-        listen {{ $address }}:{{ if $all.IsSSLPassthroughEnabled }}{{ $all.ListenPorts.SSLProxy }} proxy_protocol{{ else }}{{ $all.ListenPorts.HTTPS }}{{ if $all.Cfg.UseProxyProtocol }} proxy_protocol{{ end }}{{ end }};
-        {{ else }}
-        listen [::]:{{ $all.ListenPorts.HTTP }}{{ if $all.Cfg.UseProxyProtocol }} proxy_protocol{{ end }};
-        listen [::]:{{ if $all.IsSSLPassthroughEnabled }}{{ $all.ListenPorts.SSLProxy }} proxy_protocol{{ else }}{{ $all.ListenPorts.HTTPS }}{{ if $all.Cfg.UseProxyProtocol }} proxy_protocol{{ end }}{{ end }};
-        {{ end }}
-        {{ end }}
+
         server_name {{ $hostname }};
 
-        {{ if ne $all.ListenPorts.HTTPS 443 }}
-        {{ $redirect_port := (printf ":%v" $all.ListenPorts.HTTPS) }}
+        {{ if ne $listenPorts.HTTPS 443 }}
+        {{ $redirect_port := (printf ":%v" $listenPorts.HTTPS) }}
         return {{ $all.Cfg.HTTPRedirectCode }} $scheme://{{ $to }}{{ $redirect_port }}$request_uri;
         {{ else }}
         return {{ $all.Cfg.HTTPRedirectCode }} $scheme://{{ $to }}$request_uri;
@@ -502,11 +492,12 @@ http {
 
     # default server, used for NGINX healthcheck and access to nginx stats
     server {
-        # Use the port {{ $all.ListenPorts.Status }} (random value just to avoid known ports) as default port for nginx.
+        # Use the port {{ $listenPorts.Status }} (random value just to avoid known ports) as default port for nginx.
         # Changing this value requires a change in:
         # https://github.com/kubernetes/ingress-nginx/blob/master/controllers/nginx/pkg/cmd/controller/nginx.go
-        listen {{ $all.ListenPorts.Status }} default_server {{ if $all.Cfg.ReusePort }}reuseport{{ end }} backlog={{ $all.BacklogSize }};
-        {{ if $IsIPV6Enabled }}listen [::]:{{ $all.ListenPorts.Status }} default_server {{ if $all.Cfg.ReusePort }}reuseport{{ end }} backlog={{ $all.BacklogSize }};{{ end }}
+        {{ range $address := $listenPorts.Addresses }}
+            listen {{ $address }}:{{ $listenPorts.Status }} default_server {{ if $all.Cfg.ReusePort }}reuseport{{ end }} backlog={{ $all.BacklogSize }};
+        {{ end }}
         set $proxy_upstream_name "-";
 
         location {{ $healthzURI }} {
@@ -604,17 +595,8 @@ stream {
     {{ end }}
     }
     server {
-        {{ range $address := $all.Cfg.BindAddressIpv4 }}
-        listen                  {{ $address }}:{{ $tcpServer.Port }}{{ if $tcpServer.Backend.ProxyProtocol.Decode }} proxy_protocol{{ end }};
-        {{ else }}
-        listen                  {{ $tcpServer.Port }}{{ if $tcpServer.Backend.ProxyProtocol.Decode }} proxy_protocol{{ end }};
-        {{ end }}
-        {{ if $IsIPV6Enabled }}
-        {{ range $address := $all.Cfg.BindAddressIpv6 }}
-        listen                  {{ $address }}:{{ $tcpServer.Port }}{{ if $tcpServer.Backend.ProxyProtocol.Decode }} proxy_protocol{{ end }};
-        {{ else }}
-        listen                  [::]:{{ $tcpServer.Port }}{{ if $tcpServer.Backend.ProxyProtocol.Decode }} proxy_protocol{{ end }};
-        {{ end }}
+        {{ range $address := $listenPorts.Addresses }}
+            listen                  {{ $address }}:{{ $tcpServer.Port }}{{ if $tcpServer.Backend.ProxyProtocol.Decode }} proxy_protocol{{ end }};
         {{ end }}
         proxy_timeout           {{ $cfg.ProxyStreamTimeout }};
         proxy_pass              tcp-{{ $tcpServer.Port }}-{{ $tcpServer.Backend.Namespace }}-{{ $tcpServer.Backend.Name }}-{{ $tcpServer.Backend.Port }};
@@ -634,17 +616,8 @@ stream {
     }
 
     server {
-        {{ range $address := $all.Cfg.BindAddressIpv4 }}
-        listen                  {{ $address }}:{{ $udpServer.Port }} udp;
-        {{ else }}
-        listen                  {{ $udpServer.Port }} udp;
-        {{ end }}
-        {{ if $IsIPV6Enabled }}
-        {{ range $address := $all.Cfg.BindAddressIpv6 }}
-        listen                  {{ $address }}:{{ $udpServer.Port }} udp;
-        {{ else }}
-        listen                  [::]:{{ $udpServer.Port }} udp;
-        {{ end }}
+        {{ range $address := $listenPorts.Addresses }}
+            listen                  {{ $address }}:{{ $udpServer.Port }} udp;
         {{ end }}
         proxy_responses         {{ $cfg.ProxyStreamResponses }};
         proxy_timeout           {{ $cfg.ProxyStreamTimeout }};
@@ -708,35 +681,19 @@ stream {
 {{/* definition of server-template to avoid repetitions with server-alias */}}
 {{ define "SERVER" }}
         {{ $all := .First }}
+        {{ $listenPorts := .First.ListenPorts }}
         {{ $server := .Second }}
-        {{ range $address := $all.Cfg.BindAddressIpv4 }}
-        listen {{ $address }}:{{ $all.ListenPorts.HTTP }}{{ if $all.Cfg.UseProxyProtocol }} proxy_protocol{{ end }}{{ if eq $server.Hostname "_"}} default_server {{ if $all.Cfg.ReusePort }}reuseport{{ end }} backlog={{ $all.BacklogSize }}{{end}};
-        {{ else }}
-        listen {{ $all.ListenPorts.HTTP }}{{ if $all.Cfg.UseProxyProtocol }} proxy_protocol{{ end }}{{ if eq $server.Hostname "_"}} default_server {{ if $all.Cfg.ReusePort }}reuseport{{ end }} backlog={{ $all.BacklogSize }}{{end}};
+        {{ range $address := $listenPorts.Addresses }}
+            listen {{ $address }}:{{ $listenPorts.HTTP }}{{ if $all.Cfg.UseProxyProtocol }} proxy_protocol{{ end }}{{ if eq $server.Hostname "_"}} default_server {{ if $all.Cfg.ReusePort }}reuseport{{ end }} backlog={{ $all.BacklogSize }}{{end}};
         {{ end }}
-        {{ if $all.IsIPV6Enabled }}
-        {{ range $address := $all.Cfg.BindAddressIpv6 }}
-        listen {{ $address }}:{{ $all.ListenPorts.HTTP }}{{ if $all.Cfg.UseProxyProtocol }} proxy_protocol{{ end }}{{ if eq $server.Hostname "_"}} default_server {{ if $all.Cfg.ReusePort }}reuseport{{ end }} backlog={{ $all.BacklogSize }}{{ end }};
-        {{ else }}
-        listen [::]:{{ $all.ListenPorts.HTTP }}{{ if $all.Cfg.UseProxyProtocol }} proxy_protocol{{ end }}{{ if eq $server.Hostname "_"}} default_server {{ if $all.Cfg.ReusePort }}reuseport{{ end }} backlog={{ $all.BacklogSize }}{{ end }};
-        {{ end }}
-        {{ end }}
+
         set $proxy_upstream_name "-";
 
-        {{/* Listen on {{ $all.ListenPorts.SSLProxy }} because port {{ $all.ListenPorts.HTTPS }} is used in the TLS sni server */}}
+        {{/* Listen on {{ $listenPorts.SSLProxy }} because port {{ $listenPorts.HTTPS }} is used in the TLS sni server */}}
         {{/* This listener must always have proxy_protocol enabled, because the SNI listener forwards on source IP info in it. */}}
         {{ if not (empty $server.SSLCert.PemFileName) }}
-        {{ range $address := $all.Cfg.BindAddressIpv4 }}
-        listen {{ $address }}:{{ if $all.IsSSLPassthroughEnabled }}{{ $all.ListenPorts.SSLProxy }} proxy_protocol {{ else }}{{ $all.ListenPorts.HTTPS }}{{ if $all.Cfg.UseProxyProtocol }} proxy_protocol{{ end }}{{ end }} {{ if eq $server.Hostname "_"}} default_server {{ if $all.Cfg.ReusePort }}reuseport{{ end }} backlog={{ $all.BacklogSize }}{{end}} ssl {{ if $all.Cfg.UseHTTP2 }}http2{{ end }};
-        {{ else }}
-        listen {{ if $all.IsSSLPassthroughEnabled }}{{ $all.ListenPorts.SSLProxy }} proxy_protocol {{ else }}{{ $all.ListenPorts.HTTPS }}{{ if $all.Cfg.UseProxyProtocol }} proxy_protocol{{ end }}{{ end }} {{ if eq $server.Hostname "_"}} default_server {{ if $all.Cfg.ReusePort }}reuseport{{ end }} backlog={{ $all.BacklogSize }}{{end}} ssl {{ if $all.Cfg.UseHTTP2 }}http2{{ end }};
-        {{ end }}
-        {{ if $all.IsIPV6Enabled }}
-        {{ range $address := $all.Cfg.BindAddressIpv6 }}
-        {{ if not (empty $server.SSLCert.PemFileName) }}listen {{ $address }}:{{ if $all.IsSSLPassthroughEnabled }}{{ $all.ListenPorts.SSLProxy }} proxy_protocol{{ else }}{{ $all.ListenPorts.HTTPS }}{{ if $all.Cfg.UseProxyProtocol }} proxy_protocol{{ end }}{{ end }}{{ end }} {{ if eq $server.Hostname "_"}} default_server {{ if $all.Cfg.ReusePort }}reuseport{{ end }} backlog={{ $all.BacklogSize }}{{end}} ssl {{ if $all.Cfg.UseHTTP2 }}http2{{ end }};
-        {{ else }}
-        {{ if not (empty $server.SSLCert.PemFileName) }}listen [::]:{{ if $all.IsSSLPassthroughEnabled }}{{ $all.ListenPorts.SSLProxy }} proxy_protocol{{ else }}{{ $all.ListenPorts.HTTPS }}{{ if $all.Cfg.UseProxyProtocol }} proxy_protocol{{ end }}{{ end }}{{ end }} {{ if eq $server.Hostname "_"}} default_server {{ if $all.Cfg.ReusePort }}reuseport{{ end }} backlog={{ $all.BacklogSize }}{{end}} ssl {{ if $all.Cfg.UseHTTP2 }}http2{{ end }};
-        {{ end }}
+        {{ range $address := $listenPorts.Addresses }}
+            listen {{ $address }}:{{ if $all.IsSSLPassthroughEnabled }}{{ $listenPorts.SSLProxy }} proxy_protocol {{ else }}{{ $listenPorts.HTTPS }}{{ if $all.Cfg.UseProxyProtocol }} proxy_protocol{{ end }}{{ end }} {{ if eq $server.Hostname "_"}} default_server {{ if $all.Cfg.ReusePort }}reuseport{{ end }} backlog={{ $all.BacklogSize }}{{end}} ssl {{ if $all.Cfg.UseHTTP2 }}http2{{ end }};
         {{ end }}
         {{/* comment PEM sha is required to detect changes in the generated configuration and force a reload */}}
         # PEM sha: {{ $server.SSLCert.PemSHA }}
@@ -938,7 +895,7 @@ stream {
             if ($redirect_to_https) {
                 {{ if $location.UsePortInRedirects }}
                 # using custom ports require a different rewrite directive
-                {{ $redirect_port := (printf ":%v" $all.ListenPorts.HTTPS) }}
+                {{ $redirect_port := (printf ":%v" $listenPorts.HTTPS) }}
                 error_page 497 ={{ $all.Cfg.HTTPRedirectCode }} https://$host{{ $redirect_port }}$request_uri;
 
                 return 497;
@@ -1127,7 +1084,7 @@ stream {
         {{ end }}
 
         {{ if eq $server.Hostname "_" }}
-        # health checks in cloud providers require the use of port {{ $all.ListenPorts.HTTP }}
+        # health checks in cloud providers require the use of port {{ $listenPorts.HTTP }}
         location {{ $all.HealthzURI }} {
             {{ if $all.Cfg.EnableOpentracing }}
             opentracing off;

--- a/test/data/config.json
+++ b/test/data/config.json
@@ -1,10 +1,11 @@
 {
 	"backlogSize": 32768,
 	"isIPV6Enabled": true,
+  "ListenPorts": {
+		"Addresses": "2.2.2.2,[2001:db8:a0b:12f0::1],[3731:54:65fe:2::a7]"
+	},
 	"cfg": {
 		"disable-ipv6": false,
-		"bind-address-ipv4": [ "1.1.1.1" , "2.2.2.2"],
-		"bind-address-ipv6": [ "[2001:db8:a0b:12f0::1]" ,"[3731:54:65fe:2::a7]" ,"[33:33:33::33::33]" ],
 		"backend": {
 			"custom-http-errors": [404],
 			"proxy-buffer-size": "4k",

--- a/test/data/config.json
+++ b/test/data/config.json
@@ -1,8 +1,8 @@
 {
 	"backlogSize": 32768,
 	"isIPV6Enabled": true,
-	"ListenPorts": {
-		"Addresses": [
+	"listenPorts": {
+		"addresses": [
 			"2.2.2.2",
 			"[2001:db8:a0b:12f0::1]",
 			"[3731:54:65fe:2::a7]"

--- a/test/data/config.json
+++ b/test/data/config.json
@@ -1,8 +1,12 @@
 {
 	"backlogSize": 32768,
 	"isIPV6Enabled": true,
-  "ListenPorts": {
-		"Addresses": "2.2.2.2,[2001:db8:a0b:12f0::1],[3731:54:65fe:2::a7]"
+	"ListenPorts": {
+		"Addresses": [
+			"2.2.2.2",
+			"[2001:db8:a0b:12f0::1]",
+			"[3731:54:65fe:2::a7]"
+		]
 	},
 	"cfg": {
 		"disable-ipv6": false,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
There are use cases when ingress is deployed with host networking and 80/443 ports are already bound on some ips, but not on the ip dedicated to ingress.
This allows for a cheap 'offload to user' workaround for that case.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #2529

**Special notes for your reviewer**:
