### PR TITLE
Allow gzip compress level to be controlled via ConfigMap

### DIFF
--- a/docs/user-guide/nginx-configuration/configmap.md
+++ b/docs/user-guide/nginx-configuration/configmap.md
@@ -87,6 +87,7 @@ The following table shows a configuration option's name, type, and the default v
 |[brotli-level](#brotli-level)|int|4|
 |[brotli-types](#brotli-types)|string|"application/xml+rss application/atom+xml application/javascript application/x-javascript application/json application/rss+xml application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/svg+xml image/x-icon text/css text/plain text/x-component"|
 |[use-http2](#use-http2)|bool|"true"|
+|[gzip-level](#gzip-level)|int|5|
 |[gzip-types](#gzip-types)|string|"application/atom+xml application/javascript application/x-javascript application/json application/rss+xml application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/svg+xml image/x-icon text/css text/plain text/x-component"|
 |[worker-processes](#worker-processes)|string|`<Number of CPUs>`|
 |[worker-cpu-affinity](#worker-cpu-affinity)|string|""|
@@ -485,6 +486,10 @@ _**default:**_ `application/xml+rss application/atom+xml application/javascript 
 ## use-http2
 
 Enables or disables [HTTP/2](http://nginx.org/en/docs/http/ngx_http_v2_module.html) support in secure connections.
+
+## gzip-level
+
+Sets the gzip Compression Level that will be used. _**default:**_ 5
 
 ## gzip-types
 

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -350,6 +350,9 @@ type Configuration struct {
 	// Default: true
 	UseHTTP2 bool `json:"use-http2,omitempty"`
 
+	// gzip Compression Level that will be used
+	GzipLevel int `json:"gzip-level,omitempty"`
+
 	// MIME types in addition to "text/html" to compress. The special value “*” matches any MIME type.
 	// Responses with the “text/html” type are always compressed if UseGzip is enabled
 	GzipTypes string `json:"gzip-types,omitempty"`
@@ -553,6 +556,7 @@ func NewDefault() Configuration {
 		HSTSMaxAge:                 hstsMaxAge,
 		HSTSPreload:                false,
 		IgnoreInvalidHeaders:       true,
+		GzipLevel:                  5,
 		GzipTypes:                  gzipTypes,
 		KeepAlive:                  75,
 		KeepAliveRequests:          100,

--- a/internal/ingress/controller/template/configmap_test.go
+++ b/internal/ingress/controller/template/configmap_test.go
@@ -63,6 +63,7 @@ func TestMergeConfigMapToStruct(t *testing.T) {
 		"error-log-path":                "/var/log/test/error.log",
 		"use-gzip":                      "true",
 		"enable-dynamic-tls-records":    "false",
+		"gzip-level":                    "9",
 		"gzip-types":                    "text/html",
 		"proxy-real-ip-cidr":            "1.1.1.1/8,2.2.2.2/24",
 		"bind-address":                  "1.1.1.1,2.2.2.2,3.3.3,2001:db8:a0b:12f0::1,3731:54:65fe:2::a7,33:33:33::33::33",
@@ -81,6 +82,7 @@ func TestMergeConfigMapToStruct(t *testing.T) {
 	def.ProxySendTimeout = 2
 	def.EnableDynamicTLSRecords = false
 	def.UseProxyProtocol = true
+	def.GzipLevel = 9
 	def.GzipTypes = "text/html"
 	def.ProxyRealIPCIDR = []string{"1.1.1.1/8", "2.2.2.2/24"}
 	def.BindAddressIpv4 = []string{"1.1.1.1", "2.2.2.2"}

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -169,7 +169,7 @@ http {
 
     {{ if $cfg.UseGzip }}
     gzip on;
-    gzip_comp_level 5;
+    gzip_comp_level {{ $cfg.GzipLevel }};
     gzip_http_version 1.1;
     gzip_min_length 256;
     gzip_types {{ $cfg.GzipTypes }};


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR allows the gzip compression level to be managed via the ConfigMap, just the same as the Brotli compression level is managed.

The historical default gzip compression level (5) is retained if the new `gzip-level` member of the ConfigMap is unspecified.
