### PR TITLE
Allow the geoip2 module to be enabled by the configmap

### DIFF
--- a/docs/user-guide/nginx-configuration/configmap.md
+++ b/docs/user-guide/nginx-configuration/configmap.md
@@ -34,6 +34,7 @@ The following table shows a configuration option's name, type, and the default v
 |[error-log-path](#error-log-path)|string|"/var/log/nginx/error.log"|
 |[enable-dynamic-tls-records](#enable-dynamic-tls-records)|bool|"true"|
 |[enable-modsecurity](#enable-modsecurity)|bool|"false"|
+|[enable-geoip2](#enable-geoip2)|bool|"false"|
 |[enable-owasp-modsecurity-crs](#enable-owasp-modsecurity-crs)|bool|"false"|
 |[client-header-buffer-size](#client-header-buffer-size)|string|"1k"|
 |[client-header-timeout](#client-header-timeout)|int|60|
@@ -180,6 +181,13 @@ _References:_
 ## enable-modsecurity
 
 Enables the modsecurity module for NGINX. _**default:**_ is disabled
+
+## enable-geoip2
+
+Enables the geoip2 module for NGINX. By default this is disabled.
+
+_References:_
+- https://github.com/leev/ngx_http_geoip2_module
 
 ## enable-owasp-modsecurity-crs
 

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -120,6 +120,10 @@ type Configuration struct {
 	// By default this is disabled
 	EnableModsecurity bool `json:"enable-modsecurity"`
 
+	// EnableGeoIp2 enables the geoip2 module for NGINX
+	// By default this is disabled
+	EnableGeoIp2 bool `json:"enable-geoip2"`
+
 	// EnableModsecurity enables the OWASP ModSecurity Core Rule Set (CRS)
 	// By default this is disabled
 	EnableOWASPCoreRules bool `json:"enable-owasp-modsecurity-crs"`

--- a/internal/ingress/controller/template/configmap_test.go
+++ b/internal/ingress/controller/template/configmap_test.go
@@ -70,6 +70,7 @@ func TestMergeConfigMapToStruct(t *testing.T) {
 		"nginx-status-ipv4-whitelist":   "127.0.0.1,10.0.0.0/24",
 		"nginx-status-ipv6-whitelist":   "::1,2001::/16",
 		"proxy-add-original-uri-header": "false",
+		"enable-geoip2":                 "true",
 	}
 	def := config.NewDefault()
 	def.CustomHTTPErrors = []int{300, 400}
@@ -89,6 +90,7 @@ func TestMergeConfigMapToStruct(t *testing.T) {
 	def.NginxStatusIpv4Whitelist = []string{"127.0.0.1", "10.0.0.0/24"}
 	def.NginxStatusIpv6Whitelist = []string{"::1", "2001::/16"}
 	def.ProxyAddOriginalUriHeader = false
+	def.EnableGeoIp2 = true
 
 	hash, err := hashstructure.Hash(def, &hashstructure.HashOptions{
 		TagName: "json",

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -24,8 +24,6 @@ load_module /etc/nginx/modules/ngx_http_opentracing_module.so;
 load_module /etc/nginx/modules/ngx_http_geoip2_module.so;
 {{ end }}
 
-{{ buildOpentracingLoad $cfg }}
-
 daemon off;
 
 worker_processes {{ $cfg.WorkerProcesses }};

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -20,6 +20,12 @@ load_module /etc/nginx/modules/ngx_http_modsecurity_module.so;
 load_module /etc/nginx/modules/ngx_http_opentracing_module.so;
 {{ end }}
 
+{{ if $cfg.EnableGeoIp2 }}
+load_module /etc/nginx/modules/ngx_http_geoip2_module.so;
+{{ end }}
+
+{{ buildOpentracingLoad $cfg }}
+
 daemon off;
 
 worker_processes {{ $cfg.WorkerProcesses }};
@@ -108,6 +114,26 @@ http {
     geoip_city          /etc/nginx/geoip/GeoLiteCity.dat;
     geoip_org           /etc/nginx/geoip/GeoIPASNum.dat;
     geoip_proxy_recursive on;
+    {{ end }}
+
+    {{ if $cfg.EnableGeoIp2 }}
+	# https://github.com/section-io/ngx_http_geoip2_module#example-usage
+	geoip2 /etc/nginx/geoip/GeoLite2-City.mmdb {
+		# use `mmdblookup` to see the available fields
+		$geoip2_city_country_code source=$the_real_ip country iso_code;
+		$geoip2_city_country_name country names en;
+		$geoip2_city city names en;
+		$geoip2_postal_code postal code;
+		$geoip2_dma_code location metro_code;
+		$geoip2_latitude location latitude;
+		$geoip2_longitude location longitude;
+		$geoip2_region_code subdivisions 0 iso_code;
+		$geoip2_region_name subdivisions 0 names en;
+	}
+
+	geoip2 /etc/nginx/geoip/GeoLite2-ASN.mmdb {
+		$geoip2_asn source=$the_real_ip autonomous_system_number;
+	}
     {{ end }}
 
     aio                 threads;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: 
Allows the geoip2 module to be enabled via the configmap.  

**Special notes for your reviewer**:
The geoip2 module was included in the 0.16 build via this PR https://github.com/kubernetes/ingress-nginx/pull/2559

