### PR TITLE
Basic-Auth doc misleading: fix double quotes leading to nginx config error

### DIFF
--- a/docs/examples/auth/basic/README.md
+++ b/docs/examples/auth/basic/README.md
@@ -40,7 +40,7 @@ metadata:
     # name of the secret that contains the user/password definitions
     nginx.ingress.kubernetes.io/auth-secret: basic-auth
     # message to display with an appropriate context why the authentication is required
-    nginx.ingress.kubernetes.io/auth-realm: "Authentication Required - foo"
+    nginx.ingress.kubernetes.io/auth-realm: Authentication Required - foo
 spec:
   rules:
   - host: foo.bar.com

--- a/docs/examples/auth/basic/README.md
+++ b/docs/examples/auth/basic/README.md
@@ -40,7 +40,7 @@ metadata:
     # name of the secret that contains the user/password definitions
     nginx.ingress.kubernetes.io/auth-secret: basic-auth
     # message to display with an appropriate context why the authentication is required
-    nginx.ingress.kubernetes.io/auth-realm: Authentication Required - foo
+    nginx.ingress.kubernetes.io/auth-realm: 'Authentication Required - foo'
 spec:
   rules:
   - host: foo.bar.com


### PR DESCRIPTION
Annotation value is being inserted in nginx config with something like "$var". If one inserts an annotation value like `"my basic auth message"` (with double quotes) the resulting nginx config will be `""my basic auth""`. But this config is wrong and basic-auth won´t work.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Special notes for your reviewer**: Documentation is misleading and suggests to use quotes for realm message with basic-auth annotations.
