### PR TITLE
Build docs using local docker image [ci skip]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -223,8 +223,10 @@ dev-env:
 
 .PHONY: live-docs
 live-docs:
-	@docker run --rm -it -p 3000:3000 -v ${PWD}:/docs aledbf/mkdocs:0.1
+	@docker build --pull -t ingress-nginx/mkdocs build/mkdocs
+	@docker run --rm -it -p 3000:3000 -v ${PWD}:/docs ingress-nginx/mkdocs
 
 .PHONY: build-docs
 build-docs:
-	@docker run --rm -it -v ${PWD}:/docs aledbf/mkdocs:0.1 build
+	@docker build --pull -t ingress-nginx/mkdocs build/mkdocs
+	@docker run --rm -it -v ${PWD}:/docs ingress-nginx/mkdocs build

--- a/build/mkdocs/Dockerfile
+++ b/build/mkdocs/Dockerfile
@@ -1,0 +1,39 @@
+# Copyright 2018 The Kubernetes Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM alpine:3.7
+
+RUN apk update && apk add --no-cache \
+  git \
+  git-fast-import \
+  openssh \
+  python3 \
+  python3-dev \
+  curl \
+  && python3 -m ensurepip \
+  && rm -r /usr/lib/python*/ensurepip \
+  && pip3 install --upgrade pip setuptools \
+  && rm -r /root/.cache \
+  && rm -rf /var/cache/apk/*
+
+RUN curl -sSL https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/requirements-docs.txt -o requirements.txt \
+  && pip install -U -r requirements.txt
+
+WORKDIR /docs
+
+EXPOSE 3000
+
+ENTRYPOINT ["mkdocs"]
+
+CMD ["serve", "--dev-addr=0.0.0.0:3000", "--livereload"]


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes use of external image and allows keeping the up to date the dependencies without publishing
