### PR TITLE
enable dynamic backend configuration by default

### DIFF
--- a/cmd/nginx/flags.go
+++ b/cmd/nginx/flags.go
@@ -143,7 +143,7 @@ extension for this to succeed.`)
 			`Customized address to set as the load-balancer status of Ingress objects this controller satisfies.
 Requires the update-status parameter.`)
 
-		dynamicConfigurationEnabled = flags.Bool("enable-dynamic-configuration", false,
+		dynamicConfigurationEnabled = flags.Bool("enable-dynamic-configuration", true,
 			`Dynamically refresh backends on topology changes instead of reloading NGINX.
 Feature backed by OpenResty Lua libraries.`)
 

--- a/docs/user-guide/cli-arguments.md
+++ b/docs/user-guide/cli-arguments.md
@@ -15,7 +15,7 @@ They are set in the container spec of the `nginx-ingress-controller` Deployment 
 | --default-server-port int         | Port to use for exposing the default server (catch-all). (default 8181) |
 | --default-ssl-certificate string  | Secret containing a SSL certificate to be used by the default HTTPS server (catch-all). Takes the form "namespace/name". |
 | --election-id string              | Election id to use for Ingress status updates. (default "ingress-controller-leader") |
-| --enable-dynamic-configuration    | Dynamically refresh backends on topology changes instead of reloading NGINX. Feature backed by OpenResty Lua libraries. |
+| --enable-dynamic-configuration    | Dynamically refresh backends on topology changes instead of reloading NGINX. Feature backed by OpenResty Lua libraries. (enabled by default) |
 | --enable-ssl-chain-completion     | Autocomplete SSL certificate chains with missing intermediate CA certificates. A valid certificate chain is required to enable OCSP stapling. Certificates uploaded to Kubernetes must have the "Authority Information Access" X.509 v3 extension for this to succeed. (default true) |
 | --enable-ssl-passthrough          | Enable SSL Passthrough. |
 | --force-namespace-isolation       | Force namespace isolation. Prevents Ingress objects from referencing Secrets and ConfigMaps located in a different namespace than their own. May be used together with watch-namespace. |

--- a/docs/user-guide/nginx-configuration/configmap.md
+++ b/docs/user-guide/nginx-configuration/configmap.md
@@ -92,7 +92,7 @@ The following table shows a configuration option's name, type, and the default v
 |[worker-processes](#worker-processes)|string|`<Number of CPUs>`|
 |[worker-cpu-affinity](#worker-cpu-affinity)|string|""|
 |[worker-shutdown-timeout](#worker-shutdown-timeout)|string|"10s"|
-|[load-balance](#load-balance)|string|"least_conn"|
+|[load-balance](#load-balance)|string|"round_robin"|
 |[variables-hash-bucket-size](#variables-hash-bucket-size)|int|128|
 |[variables-hash-max-size](#variables-hash-max-size)|int|2048|
 |[upstream-keepalive-connections](#upstream-keepalive-connections)|int|32|
@@ -520,11 +520,11 @@ Sets the algorithm to use for load balancing.
 The value can either be:
 
 - round_robin: to use the default round robin loadbalancer
-- least_conn: to use the least connected method
-- ip_hash: to use a hash of the server for routing.
-- ewma: to use the peak ewma method for routing (only available with `enable-dynamic-configuration` flag) 
+- least_conn: to use the least connected method (_note_ that this is available only in non-dynamic mode: `--enable-dynamic-configuration=false`)
+- ip_hash: to use a hash of the server for routing (_note_ that this is available only in non-dynamic mode: `--enable-dynamic-configuration=false`, but alternatively you can consider using `nginx.ingress.kubernetes.io/upstream-hash-by`)
+- ewma: to use the Peak EWMA method for routing ([implementation](https://github.com/kubernetes/ingress-nginx/blob/master/rootfs/etc/nginx/lua/balancer/ewma.lua))
 
-The default is least_conn.
+The default is `round_robin`.
 
 _References:_
 [http://nginx.org/en/docs/http/load_balancing.html](http://nginx.org/en/docs/http/load_balancing.html)

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -77,7 +77,7 @@ const (
 	sslSessionCacheSize = "10m"
 
 	// Default setting for load balancer algorithm
-	defaultLoadBalancerAlgorithm = "least_conn"
+	defaultLoadBalancerAlgorithm = ""
 
 	// Parameters for a shared memory zone that will keep states for various keys.
 	// http://nginx.org/en/docs/http/ngx_http_limit_conn_module.html#limit_conn_zone

--- a/internal/ingress/controller/template/configmap_test.go
+++ b/internal/ingress/controller/template/configmap_test.go
@@ -155,7 +155,7 @@ func TestMergeConfigMapToStruct(t *testing.T) {
 func TestDefaultLoadBalance(t *testing.T) {
 	conf := map[string]string{}
 	to := ReadConfig(conf)
-	if to.LoadBalanceAlgorithm != "least_conn" {
+	if to.LoadBalanceAlgorithm != "" {
 		t.Errorf("default load balance algorithm wrong")
 	}
 }

--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -378,7 +378,7 @@ func buildLoadBalancingConfig(b interface{}, fallbackLoadBalancing string) strin
 		return fmt.Sprintf("%s;", backend.LoadBalancing)
 	}
 
-	if fallbackLoadBalancing == "round_robin" {
+	if fallbackLoadBalancing == "round_robin" || fallbackLoadBalancing == "" {
 		return ""
 	}
 

--- a/test/e2e/annotations/affinity.go
+++ b/test/e2e/annotations/affinity.go
@@ -32,11 +32,15 @@ import (
 	"k8s.io/ingress-nginx/test/e2e/framework"
 )
 
+// TODO(elvinefendi) merge this with Affinity tests in test/e2e/lua/dynamic_configuration.go
 var _ = framework.IngressNginxDescribe("Annotations - Affinity", func() {
 	f := framework.NewDefaultFramework("affinity")
 
 	BeforeEach(func() {
-		err := f.NewEchoDeploymentWithReplicas(2)
+		err := f.DisableDynamicConfiguration()
+		Expect(err).NotTo(HaveOccurred())
+
+		err = f.NewEchoDeploymentWithReplicas(2)
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -420,3 +420,19 @@ func NewSingleIngress(name, path, host, ns, service string, port int, annotation
 
 	return ing
 }
+
+// DisableDynamicConfiguration disables dynamic configuration
+func (f *Framework) DisableDynamicConfiguration() error {
+	return UpdateDeployment(f.KubeClientSet, f.IngressController.Namespace, "nginx-ingress-controller", 1,
+		func(deployment *appsv1beta1.Deployment) error {
+			args := deployment.Spec.Template.Spec.Containers[0].Args
+			args = append(args, "--enable-dynamic-configuration=false")
+			deployment.Spec.Template.Spec.Containers[0].Args = args
+			_, err := f.KubeClientSet.AppsV1beta1().Deployments(f.IngressController.Namespace).Update(deployment)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		})
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
We have introduced dynamic backend configuration feature at https://github.com/kubernetes/ingress-nginx/pull/2174 on 18th March and since then improved the initial implementation and fixed bugs. Several people/companies have already been successfully running ingress-nginx with this feature enabled. In this mode ingress-nginx also provides a more advanced load balancing algorithm that can be enabled using `load-balance` (set to `ewma`) configmap setting or annotation. However `least_conn` and `ip_hash` are not available in this mode. Also note https://github.com/kubernetes/ingress-nginx/issues/2662.

For an idea of how many reloads this feature can skip check out the following graph (EDT time):
<img width="1325" alt="screen shot 2018-07-16 at 9 43 42 pm" src="https://user-images.githubusercontent.com/1150042/42792049-87907194-8941-11e8-81a3-26f93aa53ef8.png">
As you can see during work hours on average 25 reloads every 5m. Note that this ingress-nginx instance has more than 500 upstreams and the app behind gets deployed dozens of times during working hours.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
