### PR TITLE
start minikube before trying to build the image

### DIFF
--- a/build/dev-env.sh
+++ b/build/dev-env.sh
@@ -28,14 +28,16 @@ export REGISTRY=${REGISTRY:-ingress-controller}
 
 DEV_IMAGE=${REGISTRY}/nginx-ingress-controller:${TAG}
 
-echo "[dev-env] building container"
-make build container
-
 if [ -z "${SKIP_MINIKUBE_START}" ]; then
     test $(minikube status | grep Running | wc -l) -eq 2 && $(minikube status | grep -q 'Correctly Configured') || minikube start \
         --extra-config=kubelet.sync-frequency=1s \
         --extra-config=apiserver.authorization-mode=RBAC
+
+    eval $(minikube docker-env)
 fi
+
+echo "[dev-env] building container"
+make build container
 
 docker save "${DEV_IMAGE}" | (eval $(minikube docker-env) && docker load) || true
 


### PR DESCRIPTION
**What this PR does / why we need it**:
We need to start Minikube first before trying to build the image otherwise it fails saying docker daemon is not running.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
