### PR TITLE
Docs: Fix stray closing bracket

### DIFF
--- a/docs/user-guide/nginx-configuration/configmap.md
+++ b/docs/user-guide/nginx-configuration/configmap.md
@@ -117,7 +117,7 @@ The following table shows a configuration option's name, type, and the default v
 |[http-snippet](#http-snippet)|string|""|
 |[server-snippet](#server-snippet)|string|""|
 |[location-snippet](#location-snippet)|string|""|
-|[custom-http-errors](#custom-http-errors)|[]int]|[]int{}|
+|[custom-http-errors](#custom-http-errors)|[]int|[]int{}|
 |[proxy-body-size](#proxy-body-size)|string|"1m"|
 |[proxy-connect-timeout](#proxy-connect-timeout)|int|5|
 |[proxy-read-timeout](#proxy-read-timeout)|int|60|


### PR DESCRIPTION
Obvious stray `]`.