### PR TITLE
Remove use of docker from minikube

### DIFF
--- a/build/dev-env.sh
+++ b/build/dev-env.sh
@@ -32,8 +32,6 @@ if [ -z "${SKIP_MINIKUBE_START}" ]; then
     test $(minikube status | grep Running | wc -l) -eq 2 && $(minikube status | grep -q 'Correctly Configured') || minikube start \
         --extra-config=kubelet.sync-frequency=1s \
         --extra-config=apiserver.authorization-mode=RBAC
-
-    eval $(minikube docker-env)
 fi
 
 echo "[dev-env] building container"


### PR DESCRIPTION
**What this PR does / why we need it**:

This is not required anymore since we started using docker to run makefile tasks