### PR TITLE
Catch errors waiting for controller deployment

### DIFF
--- a/test/e2e/framework/exec.go
+++ b/test/e2e/framework/exec.go
@@ -50,22 +50,10 @@ func (f *Framework) ExecCommand(pod *v1.Pod, command string) (string, error) {
 
 // NewIngressController deploys a new NGINX Ingress controller in a namespace
 func (f *Framework) NewIngressController(namespace string) error {
-	var (
-		execOut bytes.Buffer
-		execErr bytes.Buffer
-	)
-
 	cmd := exec.Command("./wait-for-nginx.sh", namespace)
-	cmd.Stdout = &execOut
-	cmd.Stderr = &execErr
-
-	err := cmd.Run()
+	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("could not execute: %v", err)
-	}
-
-	if execErr.Len() > 0 {
-		return fmt.Errorf("stderr: %v", execErr.String())
+		return fmt.Errorf("Unexpected error waiting for ingress controller deployment: %v.\nLogs:\n%v", err, string(out))
 	}
 
 	return nil

--- a/test/e2e/wait-for-nginx.sh
+++ b/test/e2e/wait-for-nginx.sh
@@ -22,6 +22,16 @@ export NAMESPACE=$1
 
 echo "deploying NGINX Ingress controller in namespace $NAMESPACE"
 
+function on_exit {
+    local error_code="$?"
+
+    test $error_code == 0 && return;
+
+    echo "Obtaining ingress controller pod logs..."
+    kubectl logs -l app=ingress-nginx -n $NAMESPACE
+}
+trap on_exit EXIT
+
 sed "s@\${NAMESPACE}@${NAMESPACE}@" $DIR/../manifests/ingress-controller/mandatory.yaml | kubectl apply --namespace=$NAMESPACE -f -
 cat $DIR/../manifests/ingress-controller/service-nodeport.yaml | kubectl apply --namespace=$NAMESPACE -f -
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Catch errors running e2e tests (deploy of the ingress controller)