### PR TITLE
fixes#2793 add options "escape=json" for log_format of stream module in nginx.tmpl

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -586,7 +586,7 @@ http {
 }
 
 stream {
-    log_format log_stream {{ $cfg.LogFormatStream }};
+    log_format log_stream {{ if $cfg.LogFormatEscapeJSON }}escape=json {{ end }}{{ $cfg.LogFormatStream }};
 
     {{ if $cfg.DisableAccessLog }}
     access_log off;


### PR DESCRIPTION
fixes #2793 
