### PR TITLE
Multiple optimizations to build targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,8 @@ site
 # temporal github pages
 gh-pages
 
-test/binaries
+# Docker-based builds
+/test/binaries
+/.env
+/.gocache/
+/bin/

--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ static-check:
 test:
 	@$(DEF_VARS)                 \
 	NODE_IP=$(NODE_IP)           \
-	DOCKER_OPTS="--net=host"     \
+	DOCKER_OPTS="-i --net=host"  \
 	build/go-in-docker.sh build/test.sh
 
 .PHONY: lua-test
@@ -182,14 +182,14 @@ e2e-test:
 	@$(DEF_VARS)                 \
 	FOCUS=$(FOCUS)               \
 	E2E_NODES=$(E2E_NODES)       \
-	DOCKER_OPTS="--net=host"     \
+	DOCKER_OPTS="-i --net=host"  \
 	NODE_IP=$(NODE_IP)           \
 	build/go-in-docker.sh build/e2e-tests.sh
 
 .PHONY: cover
 cover:
 	@$(DEF_VARS)                 \
-	DOCKER_OPTS="--net=host"     \
+	DOCKER_OPTS="-i --net=host"  \
 	build/go-in-docker.sh build/cover.sh
 
 	echo "Uploading coverage results..."

--- a/build/e2e-tests.sh
+++ b/build/e2e-tests.sh
@@ -52,6 +52,7 @@ fi
 
 ginkgo build ./test/e2e
 
+exec --                 \
 ginkgo                  \
     -randomizeSuites    \
     -randomizeAllSpecs  \

--- a/build/go-in-docker.sh
+++ b/build/go-in-docker.sh
@@ -72,6 +72,7 @@ docker run                                       \
     -v ${HOME}/.kube:/${HOME}/.kube              \
     -v ${HOME}/.minikube:${HOME}/.minikube       \
     -v ${PWD}:/go/src/${PKG}                     \
+    -v ${PWD}/.gocache:${HOME}/.cache/go-build   \
     -v ${PWD}/bin/${ARCH}:/go/bin/linux_${ARCH}  \
     -w /go/src/${PKG}                            \
     --env-file .env                              \

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -53,3 +53,9 @@ func RunE2ETests(t *testing.T) {
 	glog.Infof("Starting e2e run %q on Ginkgo node %d", framework.RunID, config.GinkgoConfig.ParallelNode)
 	ginkgo.RunSpecs(t, "nginx-ingress-controller e2e suite")
 }
+
+var _ = ginkgo.SynchronizedAfterSuite(func() {
+	// Run on all Ginkgo nodes
+	framework.Logf("Running AfterSuite actions on all nodes")
+	framework.RunCleanupActions()
+}, func() {})


### PR DESCRIPTION
**What this PR does / why we need it**:

* Clean up e2e test on interruption
      Currently, interrupting Ginkgo does not clean up the namespaces created as part of the e2e tests.
* Leverage GOCACHE for faster builds
      Speeds up Docker-based builds significantly.
* Forward container STDIN in make targets
      Actually do something when the user presses Ctrl+C.

/assign @aledbf @ElvinEfendi 