### PR TITLE
fix tcp/udp exposing documentation

### DIFF
--- a/docs/user-guide/exposing-tcp-udp-services.md
+++ b/docs/user-guide/exposing-tcp-udp-services.md
@@ -12,7 +12,8 @@ The next example shows how to expose the service `example-go` running in the nam
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: tcp-configmap-example
+  name: tcp-services
+  namespace: ingress-nginx
 data:
   9000: "default/example-go:8080"
 ```
@@ -24,7 +25,8 @@ The next example shows how to expose the service `kube-dns` running in the names
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: udp-configmap-example
+  name: udp-services
+  namespace: ingress-nginx
 data:
   53: "kube-system/kube-dns:53"
 ```


### PR DESCRIPTION
**What this PR does / why we need it**: The old documentation is not working

**Special notes for your reviewer**: the configuration is changed based on [tcp services configmap](https://github.com/kubernetes/ingress-nginx/blob/master/deploy/tcp-services-configmap.yaml) and [udp services configmap](https://github.com/kubernetes/ingress-nginx/blob/master/deploy/udp-services-configmap.yaml)
