### PR TITLE
use resty-cli for running lua unit tests

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -44,6 +44,17 @@ RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
 
 WORKDIR $GOPATH
 
+ENV RESTY_CLI_VERSION 0.22rc2
+ENV RESTY_CLI_SHA     1ec64d204469a04da553c95eaafb2e5601a03acb8f26cc10ae16b15525228c12
+RUN set -eux; \
+  url="https://github.com/openresty/resty-cli/archive/v${RESTY_CLI_VERSION}.tar.gz"; \
+  wget -O resty_cli.tgz "$url"; \
+  echo "${RESTY_CLI_SHA} *resty_cli.tgz" | sha256sum -c -; \
+  tar -C /tmp -xzf resty_cli.tgz; \
+  rm resty_cli.tgz; \
+  mv /tmp/resty-cli-${RESTY_CLI_VERSION}/bin/* /usr/local/bin/; \
+  resty -V
+
 RUN  luarocks install luacheck \
   && luarocks install busted 2.0.rc12
 

--- a/build/busted
+++ b/build/busted
@@ -1,0 +1,3 @@
+#!/usr/bin/env resty
+
+require "busted.runner"({ standalone = false })

--- a/build/test-lua.sh
+++ b/build/test-lua.sh
@@ -18,4 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-busted ${BUSTED_ARGS} ./rootfs/etc/nginx/lua/test;
+export LUA_PATH="/usr/local/lib/lua/?.lua;;"
+export LUA_CPATH="/usr/local/lib/lua/?.so;/usr/lib/lua-platform-path/lua/5.1/?.so;;"
+
+resty ./build/busted ${BUSTED_ARGS} ./rootfs/etc/nginx/lua/test;


### PR DESCRIPTION
**What this PR does / why we need it**:
This way we will run Lua tests inside a headless Nginx process. That means we won't have to mock most of the dependencies and the test environment will be very close to production environment.
resty-cli runs the Lua code in timer phase so only the APIs that aren't available in timer phase won't be available.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
