### PR TITLE
Added permanent-redirect-code

### DIFF
--- a/docs/user-guide/nginx-configuration/annotations.md
+++ b/docs/user-guide/nginx-configuration/annotations.md
@@ -43,6 +43,7 @@ You can add these Kubernetes annotations to specific Ingress objects to customiz
 |[nginx.ingress.kubernetes.io/limit-connections](#rate-limiting)|number|
 |[nginx.ingress.kubernetes.io/limit-rps](#rate-limiting)|number|
 |[nginx.ingress.kubernetes.io/permanent-redirect](#permanent-redirect)|string|
+|[nginx.ingress.kubernetes.io/permanent-redirect-code](#permanent-redirect-code)|number|
 |[nginx.ingress.kubernetes.io/proxy-body-size](#custom-max-body-size)|string|
 |[nginx.ingress.kubernetes.io/proxy-cookie-domain](#proxy-cookie-domain)|string|
 |[nginx.ingress.kubernetes.io/proxy-connect-timeout](#custom-timeouts)|number|
@@ -365,6 +366,10 @@ To configure this setting globally for all Ingress rules, the `limit-rate-after`
 ### Permanent Redirect
 
 This annotation allows to return a permanent redirect instead of sending data to the upstream.  For example `nginx.ingress.kubernetes.io/permanent-redirect: https://www.google.com` would redirect everything to Google.
+
+### Permanent Redirect Code
+
+This annotation allows you to modify the status code used for permanent redirects.  For example `nginx.ingress.kubernetes.io/permanent-redirect-code: '308'` would return your permanet-redirect with a 308.
 
 ### SSL Passthrough
 

--- a/internal/ingress/annotations/redirect/redirect.go
+++ b/internal/ingress/annotations/redirect/redirect.go
@@ -50,7 +50,7 @@ func NewParser(r resolver.Resolver) parser.IngressAnnotation {
 // rule used to create a redirect in the paths defined in the rule.
 // If the Ingress contains both annotations the execution order is
 // temporal and then permanent
-func (a redirect) Parse(ing *extensions.Ingress) (interface{}, error) {
+func (r redirect) Parse(ing *extensions.Ingress) (interface{}, error) {
 	r3w, _ := parser.GetBoolAnnotation("from-to-www-redirect", ing)
 
 	tr, err := parser.GetStringAnnotation("temporal-redirect", ing)
@@ -84,20 +84,10 @@ func (a redirect) Parse(ing *extensions.Ingress) (interface{}, error) {
 		prc = defaultPermanentRedirectCode
 	}
 
-	if pr != "" {
-		if err := isValidURL(pr); err != nil {
-			return nil, err
-		}
-
+	if pr != "" || r3w {
 		return &Config{
 			URL:       pr,
 			Code:      prc,
-			FromToWWW: r3w,
-		}, nil
-	}
-
-	if r3w {
-		return &Config{
 			FromToWWW: r3w,
 		}, nil
 	}

--- a/internal/ingress/annotations/redirect/redirect_test.go
+++ b/internal/ingress/annotations/redirect/redirect_test.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package redirect
+
+import (
+	"net/http"
+	"strconv"
+	"testing"
+
+	api "k8s.io/api/core/v1"
+	extensions "k8s.io/api/extensions/v1beta1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
+	"k8s.io/ingress-nginx/internal/ingress/defaults"
+	"k8s.io/ingress-nginx/internal/ingress/resolver"
+)
+
+const (
+	defRedirect = "http://some-site.com"
+	defCode     = http.StatusMovedPermanently
+)
+
+func buildIngress() *extensions.Ingress {
+	defaultBackend := extensions.IngressBackend{
+		ServiceName: "default-backend",
+		ServicePort: intstr.FromInt(80),
+	}
+
+	return &extensions.Ingress{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      "foo",
+			Namespace: api.NamespaceDefault,
+		},
+		Spec: extensions.IngressSpec{
+			Backend: &extensions.IngressBackend{
+				ServiceName: "default-backend",
+				ServicePort: intstr.FromInt(80),
+			},
+			Rules: []extensions.IngressRule{
+				{
+					Host: "foo.bar.com",
+					IngressRuleValue: extensions.IngressRuleValue{
+						HTTP: &extensions.HTTPIngressRuleValue{
+							Paths: []extensions.HTTPIngressPath{
+								{
+									Path:    "/foo",
+									Backend: defaultBackend,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+type mockBackend struct {
+	resolver.Mock
+	redirect bool
+}
+
+func (m mockBackend) GetDefaultBackend() defaults.Backend {
+	return defaults.Backend{SSLRedirect: m.redirect}
+}
+func TestPermanentRedirectWithDefaultCode(t *testing.T) {
+	ing := buildIngress()
+
+	data := map[string]string{}
+	data[parser.GetAnnotationWithPrefix("permanent-redirect")] = defRedirect
+	ing.SetAnnotations(data)
+
+	i, err := NewParser(mockBackend{}).Parse(ing)
+	if err != nil {
+		t.Errorf("Unexpected error with ingress: %v", err)
+	}
+	redirect, ok := i.(*Config)
+	if !ok {
+		t.Errorf("expected a Redirect type")
+	}
+	if redirect.URL != defRedirect {
+		t.Errorf("Expected %v as redirect but returned %s", defRedirect, redirect.URL)
+	}
+	if redirect.Code != defCode {
+		t.Errorf("Expected %v as redirect to have a code %s but had %s", defRedirect, strconv.Itoa(defCode), strconv.Itoa(redirect.Code))
+	}
+}
+
+func TestPermanentRedirectWithCustomCode(t *testing.T) {
+	ing := buildIngress()
+
+	data := map[string]string{}
+	data[parser.GetAnnotationWithPrefix("permanent-redirect")] = defRedirect
+	data[parser.GetAnnotationWithPrefix("permanent-redirect-code")] = "308"
+	ing.SetAnnotations(data)
+
+	i, err := NewParser(mockBackend{}).Parse(ing)
+	if err != nil {
+		t.Errorf("Unexpected error with ingress: %v", err)
+	}
+	redirect, ok := i.(*Config)
+	if !ok {
+		t.Errorf("expected a Redirect type")
+	}
+	if redirect.URL != defRedirect {
+		t.Errorf("Expected %v as redirect but returned %s", defRedirect, redirect.URL)
+	}
+	if redirect.Code != http.StatusPermanentRedirect {
+		t.Errorf("Expected %v as redirect to have a code %s but had %s", defRedirect, strconv.Itoa(http.StatusPermanentRedirect), strconv.Itoa(redirect.Code))
+	}
+}

--- a/test/e2e/annotations/redirect.go
+++ b/test/e2e/annotations/redirect.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package annotations
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/parnurzeal/gorequest"
+
+	"k8s.io/ingress-nginx/test/e2e/framework"
+)
+
+func noRedirectPolicyFunc(gorequest.Request, []gorequest.Request) error {
+	return http.ErrUseLastResponse
+}
+
+var _ = framework.IngressNginxDescribe("Annotations - Redirect", func() {
+	f := framework.NewDefaultFramework("redirect")
+
+	BeforeEach(func() {
+	})
+
+	AfterEach(func() {
+	})
+
+	It("should respond with a standard redirect code", func() {
+		By("setting permanent-redirect annotation")
+
+		host := "redirect"
+		redirectPath := "/something"
+		redirectURL := "http://redirect.example.com"
+
+		annotations := map[string]string{"nginx.ingress.kubernetes.io/permanent-redirect": redirectURL}
+
+		ing := framework.NewSingleIngress(host, redirectPath, host, f.IngressController.Namespace, "http-svc", 80, &annotations)
+		_, err := f.EnsureIngress(ing)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ing).NotTo(BeNil())
+
+		err = f.WaitForNginxServer(host,
+			func(server string) bool {
+				return strings.Contains(server, fmt.Sprintf("if ($uri ~* %s) {", redirectPath)) &&
+					strings.Contains(server, fmt.Sprintf("return 301 %s;", redirectURL))
+			})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("sending request to redirected URL path")
+
+		resp, body, errs := gorequest.New().
+			Get(f.IngressController.HTTPURL+redirectPath).
+			Set("Host", host).
+			RedirectPolicy(noRedirectPolicyFunc).
+			End()
+
+		Expect(errs).To(BeNil())
+		Expect(resp.StatusCode).Should(BeNumerically("==", http.StatusMovedPermanently))
+		Expect(resp.Header.Get("Location")).Should(Equal(redirectURL))
+		Expect(body).Should(ContainSubstring("nginx/"))
+	})
+
+	It("should respond with a custom redirect code", func() {
+		By("setting permanent-redirect-code annotation")
+
+		host := "redirect"
+		redirectPath := "/something"
+		redirectURL := "http://redirect.example.com"
+		redirectCode := http.StatusFound
+
+		annotations := map[string]string{
+			"nginx.ingress.kubernetes.io/permanent-redirect":      redirectURL,
+			"nginx.ingress.kubernetes.io/permanent-redirect-code": strconv.Itoa(redirectCode),
+		}
+
+		ing := framework.NewSingleIngress(host, redirectPath, host, f.IngressController.Namespace, "http-svc", 80, &annotations)
+		_, err := f.EnsureIngress(ing)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ing).NotTo(BeNil())
+
+		err = f.WaitForNginxServer(host,
+			func(server string) bool {
+				return strings.Contains(server, fmt.Sprintf("if ($uri ~* %s) {", redirectPath)) &&
+					strings.Contains(server, fmt.Sprintf("return %d %s;", redirectCode, redirectURL))
+			})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("sending request to redirected URL path")
+
+		resp, body, errs := gorequest.New().
+			Get(f.IngressController.HTTPURL+redirectPath).
+			Set("Host", host).
+			RedirectPolicy(noRedirectPolicyFunc).
+			End()
+
+		Expect(errs).To(BeNil())
+		Expect(resp.StatusCode).Should(BeNumerically("==", redirectCode))
+		Expect(resp.Header.Get("Location")).Should(Equal(redirectURL))
+		Expect(body).Should(ContainSubstring("nginx/"))
+	})
+})


### PR DESCRIPTION
Hey, 
This PR addresses https://github.com/kubernetes/ingress-nginx/issues/2715 (I hope).  
It makes the permanent redirect code 308 by default (as this is more aligned to a permanent redirect) but also gives the ability to override it.

<< Golang noob... so check with caution

Please could you do me a build so I can test it out?