### PR TITLE
Add XFF header for external-auth requests

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -806,6 +806,7 @@ stream {
             proxy_set_header            X-Original-URL          $scheme://$http_host$request_uri;
             proxy_set_header            X-Original-Method       $request_method;
             proxy_set_header            X-Sent-From             "nginx-ingress-controller";
+            proxy_set_header            X-Forwarded-For         $the_real_ip;
 
             {{ if $location.ExternalAuth.RequestRedirect }}
             proxy_set_header            X-Auth-Request-Redirect {{ $location.ExternalAuth.RequestRedirect }};


### PR DESCRIPTION
**What this PR does / why we need it**:

The source IP of the request can be useful for the external-auth to make a decision.

**Special notes for your reviewer**:


fixes #2938