### PR TITLE
Tiny fix for stale URL in nginx.go comment

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -505,7 +505,7 @@ http {
     server {
         # Use the port {{ $all.ListenPorts.Status }} (random value just to avoid known ports) as default port for nginx.
         # Changing this value requires a change in:
-        # https://github.com/kubernetes/ingress-nginx/blob/master/controllers/nginx/pkg/cmd/controller/nginx.go
+        # https://github.com/kubernetes/ingress-nginx/blob/master/internal/ingress/controller/nginx.go
         listen {{ $all.ListenPorts.Status }} default_server {{ if $all.Cfg.ReusePort }}reuseport{{ end }} backlog={{ $all.BacklogSize }};
         {{ if $IsIPV6Enabled }}listen [::]:{{ $all.ListenPorts.Status }} default_server {{ if $all.Cfg.ReusePort }}reuseport{{ end }} backlog={{ $all.BacklogSize }};{{ end }}
         set $proxy_upstream_name "-";


### PR DESCRIPTION
I was reviewing the `nginx.go` source today and discovered that a link in the comments:
`https://github.com/kubernetes/ingress-nginx/blob/master/controllers/nginx/pkg/cmd/controller/nginx.go`
is currently 404-ing. 
![image](https://user-images.githubusercontent.com/182515/43341724-a3078316-91e0-11e8-862e-f8a526102bed.png)
Ostensibly it used to work but the source has moved around since then. Negligible as it is I updated to what I believe is the correct URL in hopes it smooths out future readers' experience a bit :)