### PR TITLE
[WIP]: use ing name in the key

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,5 +64,4 @@ By participating in this project you agree to abide by its terms.
 
 ## License
 
-
 [Apache License 2.0](https://github.com/kubernetes/ingress-nginx/blob/master/LICENSE)

--- a/README.md
+++ b/README.md
@@ -64,4 +64,5 @@ By participating in this project you agree to abide by its terms.
 
 ## License
 
+
 [Apache License 2.0](https://github.com/kubernetes/ingress-nginx/blob/master/LICENSE)

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -418,9 +418,8 @@ func (n *NGINXController) getBackendServers(ingresses []*extensions.Ingress) ([]
 			}
 
 			for _, path := range rule.HTTP.Paths {
-				upsName := fmt.Sprintf("%v-%v-%v-%v",
+				upsName := fmt.Sprintf("%v-%v-%v",
 					ing.Namespace,
-					ing.Name,
 					path.Backend.ServiceName,
 					path.Backend.ServicePort.String())
 
@@ -628,9 +627,8 @@ func (n *NGINXController) createUpstreams(data []*extensions.Ingress, du *ingres
 
 		var defBackend string
 		if ing.Spec.Backend != nil {
-			defBackend = fmt.Sprintf("%v-%v-%v-%v",
+			defBackend = fmt.Sprintf("%v-%v-%v",
 				ing.Namespace,
-				ing.Name,
 				ing.Spec.Backend.ServiceName,
 				ing.Spec.Backend.ServicePort.String())
 
@@ -677,9 +675,8 @@ func (n *NGINXController) createUpstreams(data []*extensions.Ingress, du *ingres
 			}
 
 			for _, path := range rule.HTTP.Paths {
-				name := fmt.Sprintf("%v-%v-%v-%v",
+				name := fmt.Sprintf("%v-%v-%v",
 					ing.Namespace,
-					ing.Name,
 					path.Backend.ServiceName,
 					path.Backend.ServicePort.String())
 
@@ -917,7 +914,7 @@ func (n *NGINXController) createServers(data []*extensions.Ingress,
 		un := du.Name
 
 		if ing.Spec.Backend != nil {
-			defUpstream := fmt.Sprintf("%v-%v-%v-%v", ing.Namespace, ing.Name, ing.Spec.Backend.ServiceName, ing.Spec.Backend.ServicePort.String())
+			defUpstream := fmt.Sprintf("%v-%v-%v", ing.Namespace, ing.Spec.Backend.ServiceName, ing.Spec.Backend.ServicePort.String())
 
 			if backendUpstream, ok := upstreams[defUpstream]; ok {
 				// use backend specified in Ingress as the default backend for all its rules

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -677,7 +677,7 @@ func (n *NGINXController) createUpstreams(data []*extensions.Ingress, du *ingres
 			}
 
 			for _, path := range rule.HTTP.Paths {
-				name := fmt.Sprintf("%v-%v,%v-%v",
+				name := fmt.Sprintf("%v-%v-%v-%v",
 					ing.Namespace,
 					ing.Name,
 					path.Backend.ServiceName,

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -418,8 +418,9 @@ func (n *NGINXController) getBackendServers(ingresses []*extensions.Ingress) ([]
 			}
 
 			for _, path := range rule.HTTP.Paths {
-				upsName := fmt.Sprintf("%v-%v-%v",
+				upsName := fmt.Sprintf("%v-%v-%v-%v",
 					ing.Namespace,
+					ing.Name,
 					path.Backend.ServiceName,
 					path.Backend.ServicePort.String())
 
@@ -627,8 +628,9 @@ func (n *NGINXController) createUpstreams(data []*extensions.Ingress, du *ingres
 
 		var defBackend string
 		if ing.Spec.Backend != nil {
-			defBackend = fmt.Sprintf("%v-%v-%v",
+			defBackend = fmt.Sprintf("%v-%v-%v-%v",
 				ing.Namespace,
+				ing.Name,
 				ing.Spec.Backend.ServiceName,
 				ing.Spec.Backend.ServicePort.String())
 
@@ -675,8 +677,9 @@ func (n *NGINXController) createUpstreams(data []*extensions.Ingress, du *ingres
 			}
 
 			for _, path := range rule.HTTP.Paths {
-				name := fmt.Sprintf("%v-%v-%v",
+				name := fmt.Sprintf("%v-%v,%v-%v",
 					ing.Namespace,
+					ing.Name,
 					path.Backend.ServiceName,
 					path.Backend.ServicePort.String())
 
@@ -914,7 +917,7 @@ func (n *NGINXController) createServers(data []*extensions.Ingress,
 		un := du.Name
 
 		if ing.Spec.Backend != nil {
-			defUpstream := fmt.Sprintf("%v-%v-%v", ing.Namespace, ing.Spec.Backend.ServiceName, ing.Spec.Backend.ServicePort.String())
+			defUpstream := fmt.Sprintf("%v-%v-%v-%v", ing.Namespace, ing.Name, ing.Spec.Backend.ServiceName, ing.Spec.Backend.ServicePort.String())
 
 			if backendUpstream, ok := upstreams[defUpstream]; ok {
 				// use backend specified in Ingress as the default backend for all its rules

--- a/internal/ingress/types.go
+++ b/internal/ingress/types.go
@@ -74,7 +74,7 @@ type Configuration struct {
 // Backend describes one or more remote server/s (endpoints) associated with a service
 // +k8s:deepcopy-gen=true
 type Backend struct {
-	// Name represents an unique apiv1.Service name formatted as <namespace>-<ingress-name><service-name>-<port>
+	// Name represents an unique apiv1.Service name formatted as <namespace>-<ingress-name>-<service-name>-<port>
 	Name    string             `json:"name"`
 	Service *apiv1.Service     `json:"service,omitempty"`
 	Port    intstr.IntOrString `json:"port"`

--- a/internal/ingress/types.go
+++ b/internal/ingress/types.go
@@ -74,7 +74,7 @@ type Configuration struct {
 // Backend describes one or more remote server/s (endpoints) associated with a service
 // +k8s:deepcopy-gen=true
 type Backend struct {
-	// Name represents an unique apiv1.Service name formatted as <namespace>-<name>-<port>
+	// Name represents an unique apiv1.Service name formatted as <namespace>-<ingress-name><service-name>-<port>
 	Name    string             `json:"name"`
 	Service *apiv1.Service     `json:"service,omitempty"`
 	Port    intstr.IntOrString `json:"port"`

--- a/test/e2e/annotations/affinity.go
+++ b/test/e2e/annotations/affinity.go
@@ -49,10 +49,11 @@ var _ = framework.IngressNginxDescribe("Annotations - Affinity", func() {
 
 	It("should set sticky cookie SERVERID", func() {
 		host := "sticky.foo.com"
+		ingName := host
 
 		ing, err := f.EnsureIngress(&v1beta1.Ingress{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      host,
+				Name:      ingName,
 				Namespace: f.IngressController.Namespace,
 				Annotations: map[string]string{
 					"nginx.ingress.kubernetes.io/affinity":            "cookie",
@@ -85,7 +86,7 @@ var _ = framework.IngressNginxDescribe("Annotations - Affinity", func() {
 
 		err = f.WaitForNginxServer(host,
 			func(server string) bool {
-				return strings.Contains(server, "proxy_pass http://sticky-"+f.IngressController.Namespace+"-http-svc-80;")
+				return strings.Contains(server, "proxy_pass http://sticky-"+f.IngressController.Namespace+"-"+ingName+"-http-svc-80;")
 			})
 		Expect(err).NotTo(HaveOccurred())
 
@@ -101,10 +102,11 @@ var _ = framework.IngressNginxDescribe("Annotations - Affinity", func() {
 
 	It("should redirect to '/something' with enabled affinity", func() {
 		host := "example.com"
+		ingName := host
 
 		ing, err := f.EnsureIngress(&v1beta1.Ingress{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      host,
+				Name:      ingName,
 				Namespace: f.IngressController.Namespace,
 				Annotations: map[string]string{
 					"nginx.ingress.kubernetes.io/affinity":            "cookie",
@@ -138,7 +140,7 @@ var _ = framework.IngressNginxDescribe("Annotations - Affinity", func() {
 
 		err = f.WaitForNginxServer(host,
 			func(server string) bool {
-				return strings.Contains(server, "proxy_pass http://sticky-"+f.IngressController.Namespace+"-http-svc-80;")
+				return strings.Contains(server, "proxy_pass http://sticky-"+f.IngressController.Namespace+"-"+ingName+"-http-svc-80;")
 			})
 		Expect(err).NotTo(HaveOccurred())
 
@@ -155,10 +157,11 @@ var _ = framework.IngressNginxDescribe("Annotations - Affinity", func() {
 
 	It("should set the path to /something on the generated cookie", func() {
 		host := "example.com"
+		ingName := host
 
 		ing, err := f.EnsureIngress(&v1beta1.Ingress{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      host,
+				Name:      ingName,
 				Namespace: f.IngressController.Namespace,
 				Annotations: map[string]string{
 					"nginx.ingress.kubernetes.io/affinity":            "cookie",
@@ -192,7 +195,7 @@ var _ = framework.IngressNginxDescribe("Annotations - Affinity", func() {
 
 		err = f.WaitForNginxServer(host,
 			func(server string) bool {
-				return strings.Contains(server, "proxy_pass http://sticky-"+f.IngressController.Namespace+"-http-svc-80;")
+				return strings.Contains(server, "proxy_pass http://sticky-"+f.IngressController.Namespace+"-"+ingName+"-http-svc-80;")
 			})
 		Expect(err).NotTo(HaveOccurred())
 
@@ -208,10 +211,11 @@ var _ = framework.IngressNginxDescribe("Annotations - Affinity", func() {
 
 	It("should set the path to / on the generated cookie if there's more than one rule referring to the same backend", func() {
 		host := "example.com"
+		ingName := host
 
 		ing, err := f.EnsureIngress(&v1beta1.Ingress{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      host,
+				Name:      ingName,
 				Namespace: f.IngressController.Namespace,
 				Annotations: map[string]string{
 					"nginx.ingress.kubernetes.io/affinity":            "cookie",
@@ -252,7 +256,7 @@ var _ = framework.IngressNginxDescribe("Annotations - Affinity", func() {
 
 		err = f.WaitForNginxServer(host,
 			func(server string) bool {
-				return strings.Contains(server, "proxy_pass http://sticky-"+f.IngressController.Namespace+"-http-svc-80;")
+				return strings.Contains(server, "proxy_pass http://sticky-"+f.IngressController.Namespace+"-"+ingName+"-http-svc-80;")
 			})
 		Expect(err).NotTo(HaveOccurred())
 

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -33,6 +33,7 @@ import (
 	_ "k8s.io/ingress-nginx/test/e2e/annotations"
 	_ "k8s.io/ingress-nginx/test/e2e/defaultbackend"
 	_ "k8s.io/ingress-nginx/test/e2e/lua"
+	_ "k8s.io/ingress-nginx/test/e2e/multipleingress"
 	_ "k8s.io/ingress-nginx/test/e2e/servicebackend"
 	_ "k8s.io/ingress-nginx/test/e2e/settings"
 	_ "k8s.io/ingress-nginx/test/e2e/ssl"

--- a/test/e2e/framework/k8s.go
+++ b/test/e2e/framework/k8s.go
@@ -87,6 +87,18 @@ func (f *Framework) EnsureService(service *core.Service) (*core.Service, error) 
 	return s, nil
 }
 
+// EnsureEndpoints creates a endpoint object or returns it if it already exists.
+func (f *Framework) EnsureEndpoints(endpoint *core.Endpoints) (*core.Endpoints, error) {
+	s, err := f.KubeClientSet.CoreV1().Endpoints(endpoint.Namespace).Update(endpoint)
+	if err != nil {
+		if k8sErrors.IsNotFound(err) {
+			return f.KubeClientSet.CoreV1().Endpoints(endpoint.Namespace).Create(endpoint)
+		}
+		return nil, err
+	}
+	return s, nil
+}
+
 // EnsureDeployment creates a Deployment object or returns it if it already exists.
 func (f *Framework) EnsureDeployment(deployment *extensions.Deployment) (*extensions.Deployment, error) {
 	d, err := f.KubeClientSet.Extensions().Deployments(deployment.Namespace).Update(deployment)

--- a/test/e2e/multipleingress/same_service.go
+++ b/test/e2e/multipleingress/same_service.go
@@ -56,7 +56,9 @@ var _ = framework.IngressNginxDescribe("Multiple Ingress - Same Service", func()
 
 		ingress2spec := buildIngress("ingress-2.example.com", f.IngressController.Namespace, "/", "some-service-name", 443)
 		//add secure-backend annotation to 2nd ingress
-		ingress2spec.Annotations["nginx.ingress.kubernetes.io/secure-backends"] = "true"
+		ingress2spec.Annotations = map[string]string{
+			"nginx.ingress.kubernetes.io/secure-backends": "true",
+		}
 
 		ingress2, err := f.EnsureIngress(ingress2spec)
 		Expect(err).NotTo(HaveOccurred())
@@ -64,7 +66,8 @@ var _ = framework.IngressNginxDescribe("Multiple Ingress - Same Service", func()
 
 		err = f.WaitForNginxServer("ingress-1.example.com",
 			func(server string) bool {
-				return strings.Contains(server, "return 503;")
+				fmt.Println(server)
+				return strings.Contains(server, "proxy_pass http://nginx-ingress-feature-echoserver-corp-tc4-8080")
 			})
 		Expect(err).NotTo(HaveOccurred())
 

--- a/test/e2e/multipleingress/same_service.go
+++ b/test/e2e/multipleingress/same_service.go
@@ -49,6 +49,11 @@ var _ = framework.IngressNginxDescribe("Multiple Ingress - Same Service", func()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(svc).NotTo(BeNil())
 
+		endpointspec := buildEndpoints("service-endpoints", f.IngressController.Namespace, 80, 443)
+		endpoint, err := f.EnsureEndpoints(endpointspec)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(endpoint).NotTo(BeNil())
+
 		ingress1spec := buildIngress("ingress-1.example.com", f.IngressController.Namespace, "/", "some-service-name", 80)
 		ingress1, err := f.EnsureIngress(ingress1spec)
 		Expect(err).NotTo(HaveOccurred())
@@ -103,6 +108,37 @@ func buildService(name, namespace string, port1, port2 int32) *corev1.Service {
 		},
 			Selector: map[string]string{
 				"app": name,
+			},
+		},
+	}
+}
+
+func buildEndpoints(name, namespace string, port1, port2 int32) *corev1.Endpoints {
+	return &corev1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app": name,
+			},
+		},
+		Subsets: []corev1.EndpointSubset{
+			{
+				Addresses: []corev1.EndpointAddress{
+					{
+						IP: "127.0.0.1",
+					},
+				},
+				Ports: []corev1.EndpointPort{
+					{
+						Port:     port1,
+						Protocol: "TCP",
+					},
+					{
+						Port:     port2,
+						Protocol: "TCP",
+					},
+				},
 			},
 		},
 	}

--- a/test/e2e/multipleingress/same_service.go
+++ b/test/e2e/multipleingress/same_service.go
@@ -72,6 +72,8 @@ var _ = framework.IngressNginxDescribe("Multiple Ingress - Same Service", func()
 
 		err = f.WaitForNginxServer("ingress-2.example.com",
 			func(server string) bool {
+				fmt.Println(server)
+				fmt.Println("")
 				return strings.Contains(server, fmt.Sprintf("return 301 %s;", redirectURL))
 			})
 		Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/multipleingress/same_service.go
+++ b/test/e2e/multipleingress/same_service.go
@@ -67,6 +67,7 @@ var _ = framework.IngressNginxDescribe("Multiple Ingress - Same Service", func()
 		err = f.WaitForNginxServer("ingress-1.example.com",
 			func(server string) bool {
 				fmt.Println(server)
+				fmt.Println("")
 				return strings.Contains(server, "proxy_pass http://nginx-ingress-feature-echoserver-corp-tc4-8080")
 			})
 		Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/multipleingress/same_service.go
+++ b/test/e2e/multipleingress/same_service.go
@@ -43,7 +43,7 @@ var _ = framework.IngressNginxDescribe("Multiple Ingress - Same Service", func()
 	AfterEach(func() {
 	})
 
-	It("should work for both the ingress", func() {
+	It("should add server entry for both the ingress", func() {
 		ingress1spec := buildIngress("ingress-1.example.com", f.IngressController.Namespace, "/", "http-svc", 80)
 		ingress1, err := f.EnsureIngress(ingress1spec)
 		Expect(err).NotTo(HaveOccurred())
@@ -63,7 +63,15 @@ var _ = framework.IngressNginxDescribe("Multiple Ingress - Same Service", func()
 			func(server string) bool {
 				fmt.Println(server)
 				fmt.Println("")
-				return strings.Contains(server, "proxy_pass http://nginx-ingress-feature-echoserver-corp-tc4-8080")
+				return strings.Contains(server, "proxy_pass http://upstream_balancer")
+			})
+		Expect(err).NotTo(HaveOccurred())
+
+		err = f.WaitForNginxServer("ingress-2.example.com",
+			func(server string) bool {
+				fmt.Println(server)
+				fmt.Println("")
+				return strings.Contains(server, "proxy_pass https://upstream_balancer")
 			})
 		Expect(err).NotTo(HaveOccurred())
 

--- a/test/e2e/multipleingress/same_service.go
+++ b/test/e2e/multipleingress/same_service.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package multipleingress
+
+import (
+	"fmt"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/parnurzeal/gorequest"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"k8s.io/ingress-nginx/test/e2e/framework"
+)
+
+var _ = framework.IngressNginxDescribe("Service backend - 503", func() {
+	f := framework.NewDefaultFramework("service-backend")
+
+	BeforeEach(func() {
+	})
+
+	AfterEach(func() {
+	})
+
+	It("should return 503 when backend service does not exist", func() {
+		//create a new service
+		service := buildService("some-service-name", "some-namespace", 80, 443)
+		svc, err := f.EnsureService(service)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(svc).NotTo(BeNil())
+
+		ingress1spec := buildIngress("ingress-1.example.com", "some-namespace", "/", "some-service-name", 80)
+		ingress1, err := f.EnsureIngress(ingress1spec)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ingress1).NotTo(BeNil())
+
+		ingress2spec := buildIngress("ingress-2.example.com", "some-namespace", "/", "some-service-name", 443)
+		//add secure-backend annotation to 2nd ingress
+		ingress2spec.Annotations["nginx.ingress.kubernetes.io/secure-backends"] = "true"
+
+		ingress2, err := f.EnsureIngress(ingress2spec)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ingress2).NotTo(BeNil())
+
+		err = f.WaitForNginxServer("ingress-1.example.com",
+			func(server string) bool {
+				return strings.Contains(server, "return 503;")
+			})
+		Expect(err).NotTo(HaveOccurred())
+
+		resp, _, errs := gorequest.New().
+			Get(f.IngressController.HTTPURL).
+			Set("Host", "ingress-1.example.com").
+			End()
+		Expect(len(errs)).Should(BeNumerically("==", 0))
+		Expect(resp.StatusCode).Should(Equal(503))
+	})
+})
+
+func buildService(name, namespace string, port1, port2 int32) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{
+			{
+				Name:       fmt.Sprintf("%s", port1),
+				Port:       port1,
+				TargetPort: intstr.FromInt(int(port1)),
+				Protocol:   "TCP",
+			},
+			{
+				Name:       fmt.Sprintf("%s", port2),
+				Port:       port2,
+				TargetPort: intstr.FromInt(int(port2)),
+				Protocol:   "TCP",
+			},
+		},
+			Selector: map[string]string{
+				"app": name,
+			},
+		},
+	}
+}
+
+func buildIngress(host, namespace, path, backendService string, port int) *v1beta1.Ingress {
+	return &v1beta1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      host,
+			Namespace: namespace,
+		},
+		Spec: v1beta1.IngressSpec{
+			Rules: []v1beta1.IngressRule{
+				{
+					Host: host,
+					IngressRuleValue: v1beta1.IngressRuleValue{
+						HTTP: &v1beta1.HTTPIngressRuleValue{
+							Paths: []v1beta1.HTTPIngressPath{
+								{
+									Path: path,
+									Backend: v1beta1.IngressBackend{
+										ServiceName: backendService,
+										ServicePort: intstr.FromInt(port),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/test/e2e/multipleingress/same_service.go
+++ b/test/e2e/multipleingress/same_service.go
@@ -131,10 +131,12 @@ func buildEndpoints(name, namespace string, port1, port2 int32) *corev1.Endpoint
 				},
 				Ports: []corev1.EndpointPort{
 					{
+						Name:     fmt.Sprintf("%d", port1),
 						Port:     port1,
 						Protocol: "TCP",
 					},
 					{
+						Name:     fmt.Sprintf("%d", port2),
 						Port:     port2,
 						Protocol: "TCP",
 					},

--- a/test/e2e/multipleingress/same_service.go
+++ b/test/e2e/multipleingress/same_service.go
@@ -44,17 +44,17 @@ var _ = framework.IngressNginxDescribe("Multiple Ingress - Same Service", func()
 
 	It("should work for both the ingress", func() {
 		//create a new service
-		service := buildService("some-service-name", "some-namespace", 80, 443)
+		service := buildService("some-service-name", f.IngressController.Namespace, 80, 443)
 		svc, err := f.EnsureService(service)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(svc).NotTo(BeNil())
 
-		ingress1spec := buildIngress("ingress-1.example.com", "some-namespace", "/", "some-service-name", 80)
+		ingress1spec := buildIngress("ingress-1.example.com", f.IngressController.Namespace, "/", "some-service-name", 80)
 		ingress1, err := f.EnsureIngress(ingress1spec)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ingress1).NotTo(BeNil())
 
-		ingress2spec := buildIngress("ingress-2.example.com", "some-namespace", "/", "some-service-name", 443)
+		ingress2spec := buildIngress("ingress-2.example.com", f.IngressController.Namespace, "/", "some-service-name", 443)
 		//add secure-backend annotation to 2nd ingress
 		ingress2spec.Annotations["nginx.ingress.kubernetes.io/secure-backends"] = "true"
 

--- a/test/e2e/multipleingress/same_service.go
+++ b/test/e2e/multipleingress/same_service.go
@@ -72,8 +72,6 @@ var _ = framework.IngressNginxDescribe("Multiple Ingress - Same Service", func()
 
 		err = f.WaitForNginxServer("ingress-2.example.com",
 			func(server string) bool {
-				fmt.Println(server)
-				fmt.Println("")
 				return strings.Contains(server, fmt.Sprintf("return 301 %s;", redirectURL))
 			})
 		Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/multipleingress/same_service.go
+++ b/test/e2e/multipleingress/same_service.go
@@ -33,8 +33,8 @@ import (
 	"k8s.io/ingress-nginx/test/e2e/framework"
 )
 
-var _ = framework.IngressNginxDescribe("Service backend - 503", func() {
-	f := framework.NewDefaultFramework("service-backend")
+var _ = framework.IngressNginxDescribe("Multiple Ingress - Same Service", func() {
+	f := framework.NewDefaultFramework("multiple-ingress")
 
 	BeforeEach(func() {
 	})
@@ -42,7 +42,7 @@ var _ = framework.IngressNginxDescribe("Service backend - 503", func() {
 	AfterEach(func() {
 	})
 
-	It("should return 503 when backend service does not exist", func() {
+	It("should work for both the ingress", func() {
 		//create a new service
 		service := buildService("some-service-name", "some-namespace", 80, 443)
 		svc, err := f.EnsureService(service)
@@ -85,13 +85,13 @@ func buildService(name, namespace string, port1, port2 int32) *corev1.Service {
 		},
 		Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{
 			{
-				Name:       fmt.Sprintf("%s", port1),
+				Name:       fmt.Sprintf("%d", port1),
 				Port:       port1,
 				TargetPort: intstr.FromInt(int(port1)),
 				Protocol:   "TCP",
 			},
 			{
-				Name:       fmt.Sprintf("%s", port2),
+				Name:       fmt.Sprintf("%d", port2),
 				Port:       port2,
 				TargetPort: intstr.FromInt(int(port2)),
 				Protocol:   "TCP",

--- a/test/e2e/multipleingress/same_service.go
+++ b/test/e2e/multipleingress/same_service.go
@@ -126,7 +126,7 @@ func buildEndpoints(name, namespace string, port1, port2 int32) *corev1.Endpoint
 			{
 				Addresses: []corev1.EndpointAddress{
 					{
-						IP: "127.0.0.1",
+						IP: "192.168.0.1",
 					},
 				},
 				Ports: []corev1.EndpointPort{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

This PR will include ing name in the key used for upstream endpoints map. 

This will fix scenario where we can have multiple ingress resources referring to same service resource. In today's setup, the behavior is unpredictable depending on which ingress gets processed last without any warning to the user.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

This is work in progress, i am still testing it to see if this would work as I expected.