### PR TITLE
fix: Sort TCP/UDP upstream order

### DIFF
--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -337,6 +337,11 @@ func (n *NGINXController) getStreamServices(configmapName string, proto apiv1.Pr
 		})
 	}
 
+	// Keep upstream order sorted to reduce unnecessary nginx config reloads.
+	sort.SliceStable(svcs, func(i, j int) bool {
+		return svcs[i].Port < svcs[j].Port
+	})
+
 	return svcs
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**: Sorts the TCP/UDP upstream order, to reduce unnecessary config reloads

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #2721