### PR TITLE
Fix grafana datasources

### DIFF
--- a/deploy/grafana/dashboards/README.md
+++ b/deploy/grafana/dashboards/README.md
@@ -13,3 +13,7 @@ This folder contains a dashboard that you can import:
   - Ingress P50, P95 and P99 percentile response times with IN/OUT throughput
   - SSL certificate expiry 
   - Annotational overlays to show when config reloads happened
+
+## Requirements
+
+  - **Grafana v5.2.0** (or newer)

--- a/deploy/grafana/dashboards/nginx.yaml
+++ b/deploy/grafana/dashboards/nginx.yaml
@@ -41,7 +41,7 @@
         "type": "dashboard"
       },
       {
-        "datasource": "Prometheus",
+        "datasource": "prometheus",
         "enable": true,
         "expr": "sum(changes(nginx_ingress_controller_config_last_reload_successful_timestamp_seconds{instance!=\"unknown\",controller_class=~\"$controller_class\",namespace=~\"$namespace\"}[30s])) by (controller_class)",
         "hide": false,
@@ -1117,7 +1117,7 @@
           "text": "All",
           "value": "$__all"
         },
-        "datasource": "Prometheus",
+        "datasource": "prometheus",
         "hide": 0,
         "includeAll": true,
         "label": "Namespace",
@@ -1140,7 +1140,7 @@
           "text": "All",
           "value": "$__all"
         },
-        "datasource": "Prometheus",
+        "datasource": "prometheus",
         "hide": 0,
         "includeAll": true,
         "label": "Controller Class",
@@ -1163,7 +1163,7 @@
           "text": "All",
           "value": "$__all"
         },
-        "datasource": "Prometheus",
+        "datasource": "prometheus",
         "hide": 0,
         "includeAll": true,
         "label": "Controller",

--- a/deploy/grafana/dashboards/nginx.yaml
+++ b/deploy/grafana/dashboards/nginx.yaml
@@ -72,7 +72,7 @@
         "rgba(237, 129, 40, 0.89)",
         "rgba(50, 172, 45, 0.97)"
       ],
-      "datasource": null,
+      "datasource": "prometheus",
       "format": "ops",
       "gauge": {
         "maxValue": 100,
@@ -154,7 +154,7 @@
         "rgba(237, 129, 40, 0.89)",
         "rgba(50, 172, 45, 0.97)"
       ],
-      "datasource": null,
+      "datasource": "prometheus",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -237,7 +237,7 @@
         "rgba(237, 129, 40, 0.89)",
         "rgba(50, 172, 45, 0.97)"
       ],
-      "datasource": null,
+      "datasource": "prometheus",
       "format": "percentunit",
       "gauge": {
         "maxValue": 100,
@@ -319,7 +319,7 @@
         "rgba(237, 129, 40, 0.89)",
         "rgba(50, 172, 45, 0.97)"
       ],
-      "datasource": null,
+      "datasource": "prometheus",
       "decimals": 0,
       "format": "none",
       "gauge": {
@@ -403,7 +403,7 @@
         "rgba(237, 129, 40, 0.89)",
         "rgba(50, 172, 45, 0.97)"
       ],
-      "datasource": null,
+      "datasource": "prometheus",
       "decimals": 0,
       "format": "none",
       "gauge": {
@@ -483,7 +483,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "prometheus",
       "decimals": 2,
       "editable": true,
       "error": false,
@@ -599,7 +599,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "prometheus",
       "decimals": 2,
       "editable": false,
       "error": false,
@@ -701,7 +701,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "prometheus",
       "decimals": 3,
       "editable": false,
       "error": false,
@@ -804,7 +804,7 @@
     },
     {
       "columns": [],
-      "datasource": null,
+      "datasource": "prometheus",
       "fontSize": "100%",
       "gridPos": {
         "h": 8,
@@ -1029,7 +1029,7 @@
           "value": "current"
         }
       ],
-      "datasource": null,
+      "datasource": "prometheus",
       "fontSize": "100%",
       "gridPos": {
         "h": 8,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

We need to assign the correct datasources in the grafana dashboard.

**Special notes for your reviewer**:

I have submitted two different commits. The first commit (2a3f03c) solves the problem of using default datasource which doesn't make sense in my opinion since in other parts of the file we use prometheus (like [here](https://github.com/kubernetes/ingress-nginx/blob/82bfcb0337942bebcb27c79b1a83c759a714a669/deploy/grafana/dashboards/nginx.yaml#L44-L56)). This leads to wrong data inputs and in addition to wrong visualization of the nginx metrics.

The second commit d1a38c2 fixes a bug which shows on the right corner of grafana the following message.

> Annotation Query Failed
> Datasource named Prometheus was not found

**FYI**: I'm using the following setup:
Grafana v5.2.1
Prometheus v2.3.1