### PR TITLE
support custom configuration to main context of nginx config

### DIFF
--- a/docs/user-guide/nginx-configuration/configmap.md
+++ b/docs/user-guide/nginx-configuration/configmap.md
@@ -114,6 +114,7 @@ The following table shows a configuration option's name, type, and the default v
 |[jaeger-service-name](#jaeger-service-name)|string|"nginx"|
 |[jaeger-sampler-type](#jaeger-sampler-type)|string|"const"|
 |[jaeger-sampler-param](#jaeger-sampler-param)|string|"1"|
+|[main-snippet](#main-snippet)|string|""|
 |[http-snippet](#http-snippet)|string|""|
 |[server-snippet](#server-snippet)|string|""|
 |[location-snippet](#location-snippet)|string|""|
@@ -633,20 +634,21 @@ Specifies the sampler to be used when sampling traces. The available samplers ar
 Specifies the argument to be passed to the sampler constructor. Must be a number.
 For const this should be 0 to never sample and 1 to always sample. _**default:**_ 1
 
+## main-snippet
+
+Adds custom configuration to the main section of the nginx configuration.
+
 ## http-snippet
 
 Adds custom configuration to the http section of the nginx configuration.
-_**default:**_ ""
 
 ## server-snippet
 
 Adds custom configuration to all the servers in the nginx configuration.
-_**default:**_ ""
 
 ## location-snippet
 
 Adds custom configuration to all the locations in the nginx configuration.
-_**default:**_ ""
 
 ## custom-http-errors
 

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -459,6 +459,9 @@ type Configuration struct {
 	// Default: 1
 	JaegerSamplerParam string `json:"jaeger-sampler-param"`
 
+	// MainSnippet adds custom configuration to the main section of the nginx configuration
+	MainSnippet string `json:"main-snippet"`
+
 	// HTTPSnippet adds custom configuration to the http section of the nginx configuration
 	HTTPSnippet string `json:"http-snippet"`
 

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -41,6 +41,10 @@ events {
     use                 epoll;
 }
 
+{{ if not (empty $cfg.MainSnippet) }}
+{{ $cfg.MainSnippet }}
+{{ end }}
+
 http {
     {{ if not $all.DisableLua }}
     lua_package_cpath "/usr/local/lib/lua/?.so;/usr/lib/lua-platform-path/lua/5.1/?.so;;";

--- a/test/e2e/settings/main_snippet.go
+++ b/test/e2e/settings/main_snippet.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package settings
+
+import (
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/ingress-nginx/test/e2e/framework"
+)
+
+var _ = framework.IngressNginxDescribe("Main Snippet", func() {
+	f := framework.NewDefaultFramework("main-snippet")
+	mainSnippet := "main-snippet"
+
+	It("should add value of main-snippet setting to nginx config", func() {
+		expectedComment := "# main snippet"
+		err := f.UpdateNginxConfigMapData(mainSnippet, expectedComment)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = f.WaitForNginxConfiguration(
+			func(cfg string) bool {
+				return strings.Contains(cfg, expectedComment)
+			})
+		Expect(err).NotTo(HaveOccurred())
+	})
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Adding custom configuration to the main context of the nginx config file is currently only possible by providing a custom template. IMO doing so should be considered a last resort since it could make the upgrade process more painful. This PR introduces the `main-snippet` ConfigMap option which enables addition of custom settings to the main context of the nginx config file.

**Release note**:
```release-note
Adds `main-snippet` ConfigMap option which enables adding custom settings to the main section of the nginx config file.
```

**Special notes for your reviewer**:
Didn't see any tests for similar functions (e.g. `http-snippet`). I assume this can be verified in the e2e tests but I wasn't entirely sure if that's the proper place to test it.
