### PR TITLE
support configuring multi_accept directive via configmap

### DIFF
--- a/docs/user-guide/nginx-configuration/configmap.md
+++ b/docs/user-guide/nginx-configuration/configmap.md
@@ -58,6 +58,7 @@ The following table shows a configuration option's name, type, and the default v
 |[log-format-escape-json](#log-format-escape-json)|bool|"false"|
 |[log-format-upstream](#log-format-upstream)|string|`%v - [$the_real_ip] - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" $request_length $request_time [$proxy_upstream_name] $upstream_addr $upstream_response_length $upstream_response_time $upstream_status`|
 |[log-format-stream](#log-format-stream)|string|`[$time_local] $protocol $status $bytes_sent $bytes_received $session_time`|
+|[enable-multi-accept](#enable-multi-accept)|bool|"true"|
 |[max-worker-connections](#max-worker-connections)|int|16384|
 |[map-hash-bucket-size](#max-worker-connections)|int|64|
 |[nginx-status-ipv4-whitelist](#nginx-status-ipv4-whitelist)|[]string|"127.0.0.1"|
@@ -331,6 +332,14 @@ Please check the [log-format](log-format.md) for definition of each field.
 ## log-format-stream
 
 Sets the nginx [stream format](https://nginx.org/en/docs/stream/ngx_stream_log_module.html#log_format).
+
+## enable-multi-accept
+
+If disabled, a worker process will accept one new connection at a time. Otherwise, a worker process will accept all new connections at a time.
+_**default:**_ true
+
+_References:_
+[http://nginx.org/en/docs/ngx_core_module.html#multi_accept](http://nginx.org/en/docs/ngx_core_module.html#multi_accept)
 
 ## max-worker-connections
 

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -222,6 +222,12 @@ type Configuration struct {
 	// http://nginx.org/en/docs/http/ngx_http_log_module.html#log_format
 	LogFormatStream string `json:"log-format-stream,omitempty"`
 
+	// If disabled, a worker process will accept one new connection at a time.
+	// Otherwise, a worker process will accept all new connections at a time.
+	// http://nginx.org/en/docs/ngx_core_module.html#multi_accept
+	// Default: true
+	EnableMultiAccept bool `json:"enable-multi-accept,omitempty"`
+
 	// Maximum number of simultaneous connections that can be opened by each worker process
 	// http://nginx.org/en/docs/ngx_core_module.html#worker_connections
 	MaxWorkerConnections int `json:"max-worker-connections,omitempty"`
@@ -567,6 +573,7 @@ func NewDefault() Configuration {
 		LogFormatEscapeJSON:        false,
 		LogFormatStream:            logFormatStream,
 		LogFormatUpstream:          logFormatUpstream,
+		EnableMultiAccept:          true,
 		MaxWorkerConnections:       16384,
 		MapHashBucketSize:          64,
 		NginxStatusIpv4Whitelist:   defNginxStatusIpv4Whitelist,

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -36,7 +36,7 @@ worker_rlimit_nofile {{ .MaxOpenFiles }};
 worker_shutdown_timeout {{ $cfg.WorkerShutdownTimeout }} ;
 
 events {
-    multi_accept        on;
+    multi_accept        {{ if $cfg.EnableMultiAccept }}on{{ else }}off{{ end }};
     worker_connections  {{ $cfg.MaxWorkerConnections }};
     use                 epoll;
 }

--- a/test/e2e/settings/multi_accept.go
+++ b/test/e2e/settings/multi_accept.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package settings
+
+import (
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/ingress-nginx/test/e2e/framework"
+)
+
+var _ = framework.IngressNginxDescribe("Multi Accept", func() {
+	multiAccept := "enable-multi-accept"
+	f := framework.NewDefaultFramework(multiAccept)
+
+	It("should be enabled by default", func() {
+		expectedDirective := "multi_accept on;"
+		err := f.WaitForNginxConfiguration(
+			func(cfg string) bool {
+				return strings.Contains(cfg, expectedDirective)
+			})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should be enabled when set to true", func() {
+		expectedDirective := "multi_accept on;"
+		err := f.UpdateNginxConfigMapData(multiAccept, "true")
+		Expect(err).NotTo(HaveOccurred())
+
+		err = f.WaitForNginxConfiguration(
+			func(cfg string) bool {
+				return strings.Contains(cfg, expectedDirective)
+			})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should be disabled when set to false", func() {
+		expectedDirective := "multi_accept off;"
+		err := f.UpdateNginxConfigMapData(multiAccept, "false")
+		Expect(err).NotTo(HaveOccurred())
+
+		err = f.WaitForNginxConfiguration(
+			func(cfg string) bool {
+				return strings.Contains(cfg, expectedDirective)
+			})
+		Expect(err).NotTo(HaveOccurred())
+	})
+})


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the `enable-multi-accept` ConfigMap setting which controls the `multi_accept` directive in nginx.conf file, instead of the current hardcoded value. Default is set to `true`.

**Which issue this PR fixes**:
fixes #2684 
