### PR TITLE
WIP: Scale demo to get prometheus metrics

### DIFF
--- a/hack/scale-demo/README.md
+++ b/hack/scale-demo/README.md
@@ -1,0 +1,23 @@
+# Prometheus memory usage
+
+This directory contains a set of test to measure the memory used by the ingress controller and the prometheus metrics.
+
+**Requirements:**
+
+- Running Kubernetes cluster
+- kubectl
+- Vegeta https://github.com/tsenart/vegeta
+
+**Scenarios:**
+
+The scripts in each scenario does the same thins:
+
+- _up.sh:_
+
+  - creates one service using the _echoheaders_ deployment scaled to 10 replicas
+  - creates 500 Ingress rules and 500 services pointing to the same deployment
+
+- _run.sh:_
+  - for each ingress executes vegeta using ten connections for five seconds (~250 requests)
+
+The only difference is `same-namespace` uses one namespace for the deployment, service and ingresses while `different-namespace` creates five hundred namespaces containing only one deployment, service and ingress.

--- a/hack/scale-demo/different-namespace/down.sh
+++ b/hack/scale-demo/different-namespace/down.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+COUNT=0
+
+while [ $COUNT -le 100 ]
+do
+  NAMESPACE=scale-demo-$COUNT
+
+  kubectl delete namespace $NAMESPACE
+
+  COUNT=$(( $COUNT + 1 ))
+done

--- a/hack/scale-demo/different-namespace/run.sh
+++ b/hack/scale-demo/different-namespace/run.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+NODE_IP=10.192.0.3
+
+NODEPORT=$(kubectl get svc -n ingress-nginx ingress-nginx -o go-template='{{range.spec.ports}}{{if .nodePort}}{{.nodePort}}{{"\n"}}{{end}}{{end}}' | head -1)
+
+COUNT=0
+
+while [ $COUNT -le 100 ]
+do
+  HOST="test-$COUNT.foo.bar"
+  echo "GET http://$NODE_IP:$NODEPORT" | vegeta attack -header "Host:$HOST" -connections=10 -duration=5s | tee results.bin | vegeta report
+  COUNT=$(( $COUNT + 1 ))
+done

--- a/hack/scale-demo/different-namespace/up.sh
+++ b/hack/scale-demo/different-namespace/up.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -e
+
+COUNT=0
+
+while [ $COUNT -le 100 ]
+do
+  NAMESPACE=scale-demo-$COUNT
+
+  echo "Installing the echoheaders application in namespace $NAMESPACE"
+
+  kubectl create namespace $NAMESPACE || true
+  kubectl apply --namespace $NAMESPACE -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/docs/examples/http-svc.yaml
+
+  kubectl scale deployment  --namespace $NAMESPACE http-svc --replicas=2
+
+
+  echo "
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: http-svc
+  name: http-svc-$COUNT
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: http-svc
+  
+---
+
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: batch-test-$COUNT
+spec:
+  rules:
+  - host: test-$COUNT.foo.bar
+    http:
+      paths:
+      -
+        path: /
+        backend:
+          serviceName: http-svc-$COUNT
+          servicePort: 80
+" | kubectl create --namespace $NAMESPACE -f -
+
+  COUNT=$(( $COUNT + 1 ))
+done

--- a/hack/scale-demo/same-namespace/down.sh
+++ b/hack/scale-demo/same-namespace/down.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+NAMESPACE=scale-demo
+
+kubectl delete ing --namespace $NAMESPACE --all
+kubectl delete svc --namespace $NAMESPACE --all

--- a/hack/scale-demo/same-namespace/run.sh
+++ b/hack/scale-demo/same-namespace/run.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+NODE_IP=10.192.0.3
+
+NODEPORT=$(kubectl get svc -n ingress-nginx ingress-nginx -o go-template='{{range.spec.ports}}{{if .nodePort}}{{.nodePort}}{{"\n"}}{{end}}{{end}}' | head -1)
+
+COUNT=0
+
+while [ $COUNT -le 500 ]
+do
+  HOST="test-$COUNT.foo.bar"
+  echo "GET http://$NODE_IP:$NODEPORT" | vegeta attack -header "Host:$HOST" -connections=10 -duration=5s | tee results.bin | vegeta report
+  COUNT=$(( $COUNT + 1 ))
+done

--- a/hack/scale-demo/same-namespace/up.sh
+++ b/hack/scale-demo/same-namespace/up.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+NAMESPACE=scale-demo
+
+echo "Installing the echoheaders application in namespace $NAMESPACE"
+
+kubectl create namespace $NAMESPACE
+kubectl apply --namespace $NAMESPACE -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/docs/examples/http-svc.yaml
+
+kubectl scale deployment  --namespace $NAMESPACE http-svc --replicas=10
+
+COUNT=0
+
+while [ $COUNT -le 500 ]
+do
+echo "
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: http-svc
+  name: http-svc-$COUNT
+  namespace: $NAMESPACE
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: http-svc
+  
+---
+
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: batch-test-$COUNT
+  namespace: $NAMESPACE
+spec:
+  rules:
+  - host: test-$COUNT.foo.bar
+    http:
+      paths:
+      -
+        path: /
+        backend:
+          serviceName: http-svc-$COUNT
+          servicePort: 80
+" | kubectl create -f -
+
+COUNT=$(( $COUNT + 1 ))
+done


### PR DESCRIPTION
**What this PR does / why we need it**:

Measure how much resources the prometheus metrics need from the ingress controller and how many metrics are generated.

Usually, the ingress controller (go) uses ~40MB of RAM

**Results:**

1. same namespace:

- time: 42 minutes
- ingress controller RAM usage: ~170MB (go) - ~130MB after 10 minutes after the test (gc)
- metrics https://gist.github.com/aledbf/0405bebaa1693f7c661fe878cb8ab9c9
