### PR TITLE
Add dynamic certificate serving feature to controller

### DIFF
--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -685,6 +685,7 @@ type TemplateConfig struct {
 	ListenPorts                 *ListenPorts
 	PublishService              *apiv1.Service
 	DynamicConfigurationEnabled bool
+	DynamicCertificatesEnabled  bool
 	DisableLua                  bool
 }
 

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -96,6 +96,8 @@ type Configuration struct {
 	DynamicConfigurationEnabled bool
 
 	DisableLua bool
+
+	DynamicCertificatesEnabled bool
 }
 
 // GetPublishService returns the Service used to set the load-balancer status of Ingresses.
@@ -197,7 +199,7 @@ func (n *NGINXController) syncIngress(interface{}) error {
 				// it takes time for NGINX to start listening on the configured ports
 				time.Sleep(1 * time.Second)
 			}
-			err := configureDynamically(pcfg, n.cfg.ListenPorts.Status)
+			err := configureDynamically(pcfg, n.cfg.ListenPorts.Status, n.cfg.DynamicCertificatesEnabled)
 			if err == nil {
 				glog.Infof("Dynamic reconfiguration succeeded.")
 			} else {
@@ -1069,6 +1071,12 @@ func (n *NGINXController) createServers(data []*extensions.Ingress,
 						secrKey, host, err)
 					continue
 				}
+			}
+
+			if n.cfg.DynamicCertificatesEnabled {
+				// useless placeholders: just to shut up NGINX configuration loader errors:
+				cert.PemFileName = defaultPemFileName
+				cert.PemSHA = defaultPemSHA
 			}
 
 			servers[host].SSLCert = *cert

--- a/internal/ingress/controller/nginx_test.go
+++ b/internal/ingress/controller/nginx_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controller
 
 import (
+	"encoding/json"
 	"io"
 	"io/ioutil"
 	"net"
@@ -52,6 +53,9 @@ func TestIsDynamicConfigurationEnough(t *testing.T) {
 				Backend: "fakenamespace-myapp-80",
 			},
 		},
+		SSLCert: ingress.SSLCert{
+			PemCertKey: "fake-certificate",
+		},
 	}}
 
 	commonConfig := &ingress.Configuration{
@@ -63,6 +67,9 @@ func TestIsDynamicConfigurationEnough(t *testing.T) {
 		runningConfig: &ingress.Configuration{
 			Backends: backends,
 			Servers:  servers,
+		},
+		cfg: &Configuration{
+			DynamicCertificatesEnabled: false,
 		},
 	}
 
@@ -87,11 +94,53 @@ func TestIsDynamicConfigurationEnough(t *testing.T) {
 		t.Errorf("Expected to be dynamically configurable when only backends change")
 	}
 
+	n.cfg.DynamicCertificatesEnabled = true
+
+	newServers := []*ingress.Server{{
+		Hostname: "myapp1.fake",
+		Locations: []*ingress.Location{
+			{
+				Path:    "/",
+				Backend: "fakenamespace-myapp-80",
+			},
+		},
+		SSLCert: ingress.SSLCert{
+			PemCertKey: "fake-certificate",
+		},
+	}}
+
+	newConfig = &ingress.Configuration{
+		Backends: backends,
+		Servers:  newServers,
+	}
+	if n.IsDynamicConfigurationEnough(newConfig) {
+		t.Errorf("Expected to not be dynamically configurable when dynamic certificates is enabled and a non-certificate field in servers is updated")
+	}
+
+	newServers[0].Hostname = "myapp.fake"
+	newServers[0].SSLCert.PemCertKey = "new-fake-certificate"
+
+	newConfig = &ingress.Configuration{
+		Backends: backends,
+		Servers:  newServers,
+	}
+	if !n.IsDynamicConfigurationEnough(newConfig) {
+		t.Errorf("Expected to be dynamically configurable when only SSLCert changes")
+	}
+
+	newConfig = &ingress.Configuration{
+		Backends: []*ingress.Backend{{Name: "a-backend-8080"}},
+		Servers:  newServers,
+	}
+	if !n.IsDynamicConfigurationEnough(newConfig) {
+		t.Errorf("Expected to be dynamically configurable when backend and SSLCert changes")
+	}
+
 	if !n.runningConfig.Equal(commonConfig) {
 		t.Errorf("Expected running config to not change")
 	}
 
-	if !newConfig.Equal(&ingress.Configuration{Backends: []*ingress.Backend{{Name: "a-backend-8080"}}, Servers: servers}) {
+	if !newConfig.Equal(&ingress.Configuration{Backends: []*ingress.Backend{{Name: "a-backend-8080"}}, Servers: newServers}) {
 		t.Errorf("Expected new config to not change")
 	}
 }
@@ -157,13 +206,63 @@ func TestConfigureDynamically(t *testing.T) {
 	port := ts.Listener.Addr().(*net.TCPAddr).Port
 	defer ts.Close()
 
-	err := configureDynamically(commonConfig, port)
+	err := configureDynamically(commonConfig, port, false)
 	if err != nil {
 		t.Errorf("unexpected error posting dynamic configuration: %v", err)
 	}
 
 	if commonConfig.Backends[0].Endpoints[0].Target != target {
 		t.Errorf("unexpected change in the configuration object after configureDynamically invocation")
+	}
+}
+
+func TestConfigureCertificates(t *testing.T) {
+
+	servers := []*ingress.Server{{
+		Hostname: "myapp.fake",
+		SSLCert: ingress.SSLCert{
+			PemCertKey: "fake-cert",
+		},
+	}}
+
+	commonConfig := &ingress.Configuration{
+		Servers: servers,
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+
+		if r.Method != "POST" {
+			t.Errorf("expected a 'POST' request, got '%s'", r.Method)
+		}
+
+		b, err := ioutil.ReadAll(r.Body)
+		if err != nil && err != io.EOF {
+			t.Fatal(err)
+		}
+		var postedServers []ingress.Server
+		err = json.Unmarshal(b, &postedServers)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(servers) != len(postedServers) {
+			t.Errorf("Expected servers to be the same length as the posted servers")
+		}
+
+		for i, server := range servers {
+			if !server.Equal(&postedServers[i]) {
+				t.Errorf("Expected servers and posted servers to be equal")
+			}
+		}
+	}))
+
+	port := ts.Listener.Addr().(*net.TCPAddr).Port
+	defer ts.Close()
+
+	err := configureCertificates(commonConfig, port)
+	if err != nil {
+		t.Errorf("unexpected error posting dynamic certificate configuration: %v", err)
 	}
 }
 

--- a/internal/ingress/controller/store/backend_ssl.go
+++ b/internal/ingress/controller/store/backend_ssl.go
@@ -98,11 +98,18 @@ func (s k8sStore) getPemCertificate(secretName string) (*ingress.SSLCert, error)
 			return nil, fmt.Errorf("key 'tls.key' missing from Secret %q", secretName)
 		}
 
-		// If 'ca.crt' is also present, it will allow this secret to be used in the
-		// 'nginx.ingress.kubernetes.io/auth-tls-secret' annotation
-		sslCert, err = ssl.AddOrUpdateCertAndKey(nsSecName, cert, key, ca, s.filesystem)
-		if err != nil {
-			return nil, err
+		if s.isDynamicCertificatesEnabled {
+			sslCert, err = ssl.CreateSSLCert(nsSecName, cert, key, ca)
+			if err != nil {
+				return nil, fmt.Errorf("unexpected error creating SSL Cert: %v", err)
+			}
+		} else {
+			// If 'ca.crt' is also present, it will allow this secret to be used in the
+			// 'nginx.ingress.kubernetes.io/auth-tls-secret' annotation
+			sslCert, err = ssl.AddOrUpdateCertAndKey(nsSecName, cert, key, ca, s.filesystem)
+			if err != nil {
+				return nil, fmt.Errorf("unexpected error creating pem file: %v", err)
+			}
 		}
 
 		msg := fmt.Sprintf("Configuring Secret %q for TLS encryption (CN: %v)", secretName, sslCert.CN)

--- a/internal/ingress/controller/store/store.go
+++ b/internal/ingress/controller/store/store.go
@@ -212,6 +212,8 @@ type k8sStore struct {
 	mu *sync.Mutex
 
 	defaultSSLCertificate string
+
+	isDynamicCertificatesEnabled bool
 }
 
 // New creates a new object store to be used in the ingress controller
@@ -220,19 +222,21 @@ func New(checkOCSP bool,
 	resyncPeriod time.Duration,
 	client clientset.Interface,
 	fs file.Filesystem,
-	updateCh *channels.RingChannel) Storer {
+	updateCh *channels.RingChannel,
+	isDynamicCertificatesEnabled bool) Storer {
 
 	store := &k8sStore{
-		isOCSPCheckEnabled:    checkOCSP,
-		informers:             &Informer{},
-		listers:               &Lister{},
-		sslStore:              NewSSLCertTracker(),
-		filesystem:            fs,
-		updateCh:              updateCh,
-		backendConfig:         ngx_config.NewDefault(),
-		mu:                    &sync.Mutex{},
-		secretIngressMap:      NewObjectRefMap(),
-		defaultSSLCertificate: defaultSSLCertificate,
+		isOCSPCheckEnabled:           checkOCSP,
+		informers:                    &Informer{},
+		listers:                      &Lister{},
+		sslStore:                     NewSSLCertTracker(),
+		filesystem:                   fs,
+		updateCh:                     updateCh,
+		backendConfig:                ngx_config.NewDefault(),
+		mu:                           &sync.Mutex{},
+		secretIngressMap:             NewObjectRefMap(),
+		defaultSSLCertificate:        defaultSSLCertificate,
+		isDynamicCertificatesEnabled: isDynamicCertificatesEnabled,
 	}
 
 	eventBroadcaster := record.NewBroadcaster()

--- a/internal/ingress/controller/store/store_test.go
+++ b/internal/ingress/controller/store/store_test.go
@@ -68,7 +68,8 @@ func TestStore(t *testing.T) {
 			10*time.Minute,
 			clientSet,
 			fs,
-			updateCh)
+			updateCh,
+			false)
 
 		storer.Run(stopCh)
 
@@ -155,7 +156,8 @@ func TestStore(t *testing.T) {
 			10*time.Minute,
 			clientSet,
 			fs,
-			updateCh)
+			updateCh,
+			false)
 
 		storer.Run(stopCh)
 
@@ -302,7 +304,8 @@ func TestStore(t *testing.T) {
 			10*time.Minute,
 			clientSet,
 			fs,
-			updateCh)
+			updateCh,
+			false)
 
 		storer.Run(stopCh)
 
@@ -390,7 +393,8 @@ func TestStore(t *testing.T) {
 			10*time.Minute,
 			clientSet,
 			fs,
-			updateCh)
+			updateCh,
+			false)
 
 		storer.Run(stopCh)
 
@@ -501,7 +505,8 @@ func TestStore(t *testing.T) {
 			10*time.Minute,
 			clientSet,
 			fs,
-			updateCh)
+			updateCh,
+			false)
 
 		storer.Run(stopCh)
 

--- a/internal/ingress/sslcert.go
+++ b/internal/ingress/sslcert.go
@@ -42,6 +42,8 @@ type SSLCert struct {
 	CN []string `json:"cn"`
 	// ExpiresTime contains the expiration of this SSL certificate in timestamp format
 	ExpireTime time.Time `json:"expires"`
+	// Pem encoded certificate and key concatenated
+	PemCertKey string `json:"pemCertKey"`
 }
 
 // GetObjectKind implements the ObjectKind interface as a noop

--- a/internal/ingress/types_equals.go
+++ b/internal/ingress/types_equals.go
@@ -505,6 +505,9 @@ func (s1 *SSLCert) Equal(s2 *SSLCert) bool {
 	if s1.FullChainPemFileName != s2.FullChainPemFileName {
 		return false
 	}
+	if s1.PemCertKey != s2.PemCertKey {
+		return false
+	}
 
 	for _, cn1 := range s1.CN {
 		found := false


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is a part of adding dynamic certificate serving functionality. It adds a new flag `enable-dynamic-certificates`. When enabled, the controller will POST certificates to a Lua endpoint (https://github.com/kubernetes/ingress-nginx/pull/2889), avoid reloading NGINX when certificates are updated, and avoid writing certificates on disk. There will be another PR following this to serve the certificates that are POSTed.

**Special notes for your reviewer**:

This feature currently does not support OCSP because the future PR that will serve the certificates will use Open Resty's ngx.ssl module (https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/ssl.md), which does not support  OCSP.