### PR TITLE
Fixed typo in flags.go

### DIFF
--- a/cmd/nginx/flags.go
+++ b/cmd/nginx/flags.go
@@ -206,7 +206,7 @@ Feature backed by OpenResty Lua libraries.`)
 	}
 
 	if *enableSSLPassthrough && !ing_net.IsPortAvailable(*sslProxyPort) {
-		return false, nil, fmt.Errorf("Port %v is already in use. Please check the flag --ssl-passtrough-proxy-port", *sslProxyPort)
+		return false, nil, fmt.Errorf("Port %v is already in use. Please check the flag --ssl-passthrough-proxy-port", *sslProxyPort)
 	}
 
 	if !*enableSSLChainCompletion {


### PR DESCRIPTION
Noticed a small typo while changing different configs for ssl-passthrough.
Flags.go, ssl-passtrough-proxy-port -> ssl-passthrough-proxy-port.


**What this PR does / why we need it**: 
Fixed typo in flags.go (ssl-passthrough-proxy-port)

**Special notes for your reviewer**:
Not really a bug or anything but I guess I had to let you know just in case.