### PR TITLE
(Bug/docs) Fix broked anchor link to GCE/GKE

### DIFF
--- a/docs/deploy/index.md
+++ b/docs/deploy/index.md
@@ -8,7 +8,7 @@
     - [Docker for Mac](#docker-for-mac)
     - [minikube](#minikube)
     - [AWS](#aws)
-    - [GCE - GKE](#gce---gke)
+    - [GCE - GKE](#gce-gke)
     - [Azure](#azure)
     - [Baremetal](#baremetal)
   - [Verify installation](#verify-installation)


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix broken anchor link of this page (https://kubernetes.github.io/ingress-nginx/deploy/#gce---gke)

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

No has issues.

**Special notes for your reviewer**:

Just a simple problem with `kubernetes/ingress-nginx` docs.