### PR TITLE
fix variable parsing when key is number

### DIFF
--- a/rootfs/etc/nginx/lua/test/util_test.lua
+++ b/rootfs/etc/nginx/lua/test/util_test.lua
@@ -1,0 +1,35 @@
+local original_ngx = ngx
+local function reset_ngx()
+  _G.ngx = original_ngx
+end
+
+local function mock_ngx(mock)
+  local _ngx = mock
+  setmetatable(_ngx, { __index = ngx })
+  _G.ngx = _ngx
+end
+
+describe("lua_ngx_var", function()
+  local util = require("util")
+
+  before_each(function()
+    mock_ngx({ var = { remote_addr = "192.168.1.1", [1] = "nginx/regexp/1/group/capturing" } })
+  end)
+
+  after_each(function()
+    reset_ngx()
+    package.loaded["monitor"] = nil
+  end)
+
+  it("returns value of nginx var by key", function()
+    assert.equal("192.168.1.1", util.lua_ngx_var("$remote_addr"))
+  end)
+
+  it("returns value of nginx var when key is number", function()
+    assert.equal("nginx/regexp/1/group/capturing", util.lua_ngx_var("$1"))
+  end)
+
+  it("returns nil when variable is not defined", function()
+    assert.equal(nil, util.lua_ngx_var("$foo_bar"))
+  end)
+end)

--- a/rootfs/etc/nginx/lua/util.lua
+++ b/rootfs/etc/nginx/lua/util.lua
@@ -46,6 +46,10 @@ end
 -- it returns value of ngx.var[request_uri]
 function _M.lua_ngx_var(ngx_var)
   local var_name = string_sub(ngx_var, 2)
+  if var_name:match("^%d+$") then
+    var_name = tonumber(var_name)
+  end
+
   return ngx.var[var_name]
 end
 


### PR DESCRIPTION
**What this PR does / why we need it**:
As reported at https://github.com/kubernetes/ingress-nginx/issues/2552 turns out Nginx regex group capturing variables should be accessed by number keys rather than string keys. I changed variable parsing to take this into consideration also added test coverage for the helper function.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes https://github.com/kubernetes/ingress-nginx/issues/2552

**Special notes for your reviewer**:
