### PR TITLE
consistently fallback to default certificate when TLS is configured

### DIFF
--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -1055,7 +1055,9 @@ func (n *NGINXController) createServers(data []*extensions.Ingress,
 			secrKey := fmt.Sprintf("%v/%v", ing.Namespace, tlsSecretName)
 			cert, err := n.store.GetLocalSSLCert(secrKey)
 			if err != nil {
-				glog.Warningf("Error getting SSL certificate %q: %v", secrKey, err)
+				glog.Warningf("Error getting SSL certificate %q: %v. Using default certificate", secrKey, err)
+				servers[host].SSLCert.PemFileName = defaultPemFileName
+				servers[host].SSLCert.PemSHA = defaultPemSHA
 				continue
 			}
 
@@ -1069,6 +1071,9 @@ func (n *NGINXController) createServers(data []*extensions.Ingress,
 				if err != nil {
 					glog.Warningf("SSL certificate %q does not contain a Common Name or Subject Alternative Name for server %q: %v",
 						secrKey, host, err)
+					glog.Warningf("Using default certificate")
+					servers[host].SSLCert.PemFileName = defaultPemFileName
+					servers[host].SSLCert.PemSHA = defaultPemSHA
 					continue
 				}
 			}

--- a/test/e2e/annotations/luarestywaf.go
+++ b/test/e2e/annotations/luarestywaf.go
@@ -150,6 +150,8 @@ func createIngress(f *framework.Framework, host, service string, port int, annot
 		})
 	Expect(err).NotTo(HaveOccurred())
 
+	time.Sleep(1 * time.Second)
+
 	resp, body, errs := gorequest.New().
 		Get(f.IngressController.HTTPURL).
 		Set("Host", host).

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -385,8 +385,17 @@ func UpdateDeployment(kubeClientSet kubernetes.Interface, namespace string, name
 	return nil
 }
 
+// NewSingleIngressWithTLS creates a simple ingress rule with TLS spec included
+func NewSingleIngressWithTLS(name, path, host, ns, service string, port int, annotations *map[string]string) *extensions.Ingress {
+	return newSingleIngress(name, path, host, ns, service, port, annotations, true)
+}
+
 // NewSingleIngress creates a simple ingress rule
 func NewSingleIngress(name, path, host, ns, service string, port int, annotations *map[string]string) *extensions.Ingress {
+	return newSingleIngress(name, path, host, ns, service, port, annotations, false)
+}
+
+func newSingleIngress(name, path, host, ns, service string, port int, annotations *map[string]string, withTLS bool) *extensions.Ingress {
 	if annotations == nil {
 		annotations = &map[string]string{}
 	}
@@ -398,12 +407,6 @@ func NewSingleIngress(name, path, host, ns, service string, port int, annotation
 			Annotations: *annotations,
 		},
 		Spec: extensions.IngressSpec{
-			TLS: []extensions.IngressTLS{
-				{
-					Hosts:      []string{host},
-					SecretName: host,
-				},
-			},
 			Rules: []extensions.IngressRule{
 				{
 					Host: host,
@@ -423,6 +426,14 @@ func NewSingleIngress(name, path, host, ns, service string, port int, annotation
 				},
 			},
 		},
+	}
+	if withTLS {
+		ing.Spec.TLS = []extensions.IngressTLS{
+			{
+				Hosts:      []string{host},
+				SecretName: host,
+			},
+		}
 	}
 
 	return ing

--- a/test/e2e/settings/tls.go
+++ b/test/e2e/settings/tls.go
@@ -177,7 +177,7 @@ var _ = framework.IngressNginxDescribe("Settings - TLS)", func() {
 })
 
 func tlsEndpoint(f *framework.Framework, host string) (*tls.Config, error) {
-	ing, err := f.EnsureIngress(framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, nil))
+	ing, err := f.EnsureIngress(framework.NewSingleIngressWithTLS(host, "/", host, f.IngressController.Namespace, "http-svc", 80, nil))
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/ssl/secret_update.go
+++ b/test/e2e/ssl/secret_update.go
@@ -54,7 +54,7 @@ var _ = framework.IngressNginxDescribe("SSL", func() {
 		})
 		Expect(err).NotTo(HaveOccurred())
 
-		ing, err := f.EnsureIngress(framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, nil))
+		ing, err := f.EnsureIngress(framework.NewSingleIngressWithTLS(host, "/", host, f.IngressController.Namespace, "http-svc", 80, nil))
 		Expect(err).ToNot(HaveOccurred())
 		Expect(ing).ToNot(BeNil())
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently having TLS configured in an Ingress Spec does not guarantee that Nginx will be configured using SSL endpoint. Whenever TLS configured we first check the following three edge cases:
1. We extract secret name, and if the secret name is empty _we then fallback using default certificate and configure Nginx with HTTPS endpoint_
2. Otherwise we continue to check local SSL store and if there is no corresponding secret we don't configure `SSLCert` for the given server. _This means the controller configures Nginx using HTTP endpoint only_
3. If secret name is present and there corresponding secret in the SSL store, we match the hostname with the one in the certificate if it does not match, we again do not configure `SSLCert` for the server. _This again means the controller configures Nginx using HTTP endpoint only_

If everything is good we then use the configured certificate and configure Nginx with HTTPS endpoint.

As you can see there's inconsistency here. One option to resolve this inconsistency would be to make the edge case 1. to behave as other two, a.k.a always fallback to configuring HTTP endpoint only even though user has TLS Spec configured in their Ingress manifest. In my understanding doing this would be breaking the protocol between user and the ingress controller - what I mean is as a user when I include TLS Spec in my Ingress manifest I expect to have my server configured with HTTPS endpoint and have HTTP requests redirected to that endpoint (unless I explicitly opt-out). And I'd also expect the controller to follow the notion of default certificate it has and when there's an issue with the configured certificate (one of the three edge cases above) fallback to using the default certificate.
Another problem with this option is that we won't be able to handle certificate updates dynamically (https://github.com/kubernetes/ingress-nginx/pull/2965). Because with this option when user fixes their certificate (i.e edge case 2: user creates the missing secret) we would have to update Nginx configuration and include `listen 443 ssl ...` directive and others. Which means there's no way we can avoid reload.

Given above, this PR suggests to change the way controller handles edge cases 2. and 3. With this PR in all the edge cases where we can not successfully configure certificate we fallback to using default certificate. This solves all the issues mentioned above.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
