### PR TITLE
Fix custom errors for external auth requrest

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -804,6 +804,8 @@ stream {
         ssl_verify_depth                        {{ $server.CertificateAuth.ValidationDepth }};
         {{ if not (empty $server.CertificateAuth.ErrorPage)}}
         error_page 495 496 = {{ $server.CertificateAuth.ErrorPage }};
+        {{ range $errCode := $all.Cfg.CustomHTTPErrors }}
+        error_page {{ $errCode }} = @custom_{{ $errCode }};{{ end }}
         {{ end }}
         {{ end }}
 
@@ -900,6 +902,9 @@ stream {
             {{ if $all.Cfg.EnableOpentracing }}
             opentracing_propagate_context;
             {{ end }}
+
+            {{ range $errCode := $all.Cfg.CustomHTTPErrors }}
+            error_page {{ $errCode }} = @custom_{{ $errCode }};{{ end }}            
 
             {{ if not $all.DisableLua }}
             rewrite_by_lua_block {


### PR DESCRIPTION
## What
* When ingress use external auth request custom error pages do not work

## How to reproduce
* Config custom error pages following [docs](https://github.com/kubernetes/ingress-nginx/tree/master/docs/examples/customization/custom-errors)
* Create ingress with external with following [docs](https://github.com/kubernetes/ingress-nginx/tree/master/docs/examples/auth/oauth-external-auth)
* Make service that is target for ingress from previous step select existed pods (emulate 503 error)
* Open ingress endpoint in browser

### Expected
* To see custom error

### Exists 
* Default nginx error

## Explain fix
Following nginx [docs](http://nginx.org/en/docs/http/ngx_http_core_module.html#error_page)
```
These directives are inherited from the previous level if and only if there are no error_page directives defined on the current level. 
```
In case we use `external auth` we have define `error_page` on `location` level, so it broke inherit from 
`server` level for all custom error pages.
https://github.com/kubernetes/ingress-nginx/blob/master/rootfs/etc/nginx/template/nginx.tmpl#L1030
```
                  {{ if $location.ExternalAuth.SigninURL }}
                  error_page 401 = {{ buildAuthSignURL $location.ExternalAuth.SigninURL }};
                  {{ end }}
```

To fix that we need redefine custom error pages on the `location` level 

```
        location {{ $path }} {
            {{ $ing := (getIngressInformation $location.Ingress $location.Path) }}
            set $namespace      "{{ $ing.Namespace }}";
            set $ingress_name   "{{ $ing.Rule }}";
            set $service_name   "{{ $ing.Service }}";
            set $service_port   "{{ $location.Port }}";
            set $location_path  "{{ $location.Path }}";

            {{ if $all.Cfg.EnableOpentracing }}
            opentracing_propagate_context;
            {{ end }}

            {{ range $errCode := $all.Cfg.CustomHTTPErrors }}
            error_page {{ $errCode }} = @custom_{{ $errCode }};{{ end }} 
```

P.S.: The same for  CertificateAuth ErrorPage
https://github.com/kubernetes/ingress-nginx/blob/master/rootfs/etc/nginx/template/nginx.tmpl#L806