### PR TITLE
Allow auth headers to be set for GRPC backends

### DIFF
--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -346,7 +346,7 @@ func buildAuthResponseHeaders(input interface{}) []string {
 		hvar := strings.ToLower(h)
 		hvar = strings.NewReplacer("-", "_").Replace(hvar)
 		res = append(res, fmt.Sprintf("auth_request_set $authHeader%v $upstream_http_%v;", i, hvar))
-		res = append(res, fmt.Sprintf("proxy_set_header '%v' $authHeader%v;", h, i))
+		res = append(res, fmt.Sprintf("%v '%v' $authHeader%v;", proxySetHeader(location), h, i))
 	}
 	return res
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

When external auth is enabled, nginx can support both HTTP and GRPC backends. Currently, though, it is impossible to set headers for GRPC backend as we use `proxy_set_header` rather than relying on the function `proxySetHeader` which will decide what directive to use (grpc/proxy_set_header) based on the protocol used by the backend.

**Special notes for your reviewer**:

Look, to be honest I havent tested this as I'm using YDD -- YOLO Driven Development :smile: 

If anyone is able to get me an image that includes this fix I can easily test it locally, as I have an ingress in front of a grpc backend with external auth enabled.
