### PR TITLE
Add e2e tests for CORS

### DIFF
--- a/docs/user-guide/nginx-configuration/annotations.md
+++ b/docs/user-guide/nginx-configuration/annotations.md
@@ -235,37 +235,42 @@ This is a global configuration for the ingress controller. In some cases could b
 
 ### Enable CORS
 
-To enable Cross-Origin Resource Sharing (CORS) in an Ingress rule,
-add the annotation `nginx.ingress.kubernetes.io/enable-cors: "true"`.
-This will add a section in the server location enabling this functionality.
+To enable Cross-Origin Resource Sharing (CORS) in an Ingress rule, add the annotation
+`nginx.ingress.kubernetes.io/enable-cors: "true"`. This will add a section in the server
+location enabling this functionality.
 
 CORS can be controlled with the following annotations:
 
 * `nginx.ingress.kubernetes.io/cors-allow-methods`
-  controls which methods are accepted.
-  This is a multi-valued field, separated by ',' and accepts only letters (upper and lower case).
-  Example: `nginx.ingress.kubernetes.io/cors-allow-methods: "PUT, GET, POST, OPTIONS"`
+  controls which methods are accepted. This is a multi-valued field, separated by ',' and
+  accepts only letters (upper and lower case).
+  - Default: `GET, PUT, POST, DELETE, PATCH, OPTIONS`
+  - Example: `nginx.ingress.kubernetes.io/cors-allow-methods: "PUT, GET, POST, OPTIONS"`
 
 * `nginx.ingress.kubernetes.io/cors-allow-headers`
-  controls which headers are accepted.
-  This is a multi-valued field, separated by ',' and accepts letters, numbers, _ and -.
-  Example: `nginx.ingress.kubernetes.io/cors-allow-headers: "X-Forwarded-For, X-app123-XPTO"`
+  controls which headers are accepted. This is a multi-valued field, separated by ',' and accepts letters,
+  numbers, _ and -.
+  - Default: `DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization`
+  - Example: `nginx.ingress.kubernetes.io/cors-allow-headers: "X-Forwarded-For, X-app123-XPTO"`
 
 * `nginx.ingress.kubernetes.io/cors-allow-origin`
-  controls what's the accepted Origin for CORS and defaults to '*'.
+  controls what's the accepted Origin for CORS.
   This is a single field value, with the following format: `http(s)://origin-site.com` or `http(s)://origin-site.com:port`
-  Example: `nginx.ingress.kubernetes.io/cors-allow-origin: "https://origin-site.com:4443"`
+  - Default: `*`
+  - Example: `nginx.ingress.kubernetes.io/cors-allow-origin: "https://origin-site.com:4443"`
 
 * `nginx.ingress.kubernetes.io/cors-allow-credentials`
   controls if credentials can be passed during CORS operations.
-  Example: `nginx.ingress.kubernetes.io/cors-allow-credentials: "true"`
+  - Default: `true`
+  - Example: `nginx.ingress.kubernetes.io/cors-allow-credentials: "false"`
 
 * `nginx.ingress.kubernetes.io/cors-max-age`
   controls how long preflight requests can be cached.
+  Default: `1728000`
   Example: `nginx.ingress.kubernetes.io/cors-max-age: 600`
 
 !!! note
-    For more information please see [https://enable-cors.org](https://enable-cors.org/server_nginx.html)
+    For more information please see [https://enable-cors.org](https://enable-cors.org/server_nginx.html) as well as this [example](../../examples/cors/README.md).
 
 ### Server Alias
 


### PR DESCRIPTION
Adds the missing e2e test for Cross-Origin Resource Sharing(CORS). This will include all the CORS annotations.