### PR TITLE
Add support for valgrind

### DIFF
--- a/internal/ingress/controller/util.go
+++ b/internal/ingress/controller/util.go
@@ -74,14 +74,29 @@ const (
 	cfgPath   = "/etc/nginx/nginx.conf"
 )
 
+var valgrind = []string{
+	"valgrind",
+	"--tool=memcheck",
+	"--leak-check=full",
+	"--show-leak-kinds=all",
+	"--leak-check=yes",
+}
+
 func nginxExecCommand(args ...string) *exec.Cmd {
 	ngx := os.Getenv("NGINX_BINARY")
 	if ngx == "" {
 		ngx = defBinary
 	}
 
-	cmdArgs := []string{"--deep", ngx, "-c", cfgPath}
+	cmdArgs := []string{"--deep"}
+
+	if os.Getenv("RUN_WITH_VALGRIND") == "true" {
+		cmdArgs = append(cmdArgs, valgrind...)
+	}
+
+	cmdArgs = append(cmdArgs, ngx, "-c", cfgPath)
 	cmdArgs = append(cmdArgs, args...)
+
 	return exec.Command("authbind", cmdArgs...)
 }
 

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -20,6 +20,7 @@ WORKDIR  /etc/nginx
 
 RUN clean-install \
   diffutils \
+  valgrind \
   dumb-init
 
 COPY . /


### PR DESCRIPTION
When the env variable `RUN_WITH_VALGRIND=true` is present, [valgrind](http://valgrind.org/) is started as parent of the nginx process. Example: https://gist.github.com/aledbf/bc51c6cd02bd8942438070683198b8ba