### PR TITLE
Fixup #2970: Add Missing Label `app.kubernetes.io/part-of: ingress-nginx`

### DIFF
--- a/build/dev-env.sh
+++ b/build/dev-env.sh
@@ -52,5 +52,5 @@ echo "updating image..."
 kubectl set image \
     deployments \
     --namespace ingress-nginx \
-    --selector app=ingress-nginx \
+    --selector app.kubernetes.io/name=ingress-nginx \
     nginx-ingress-controller=${DEV_IMAGE}

--- a/deploy/default-backend.yaml
+++ b/deploy/default-backend.yaml
@@ -13,10 +13,12 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: default-http-backend
+      app.kubernetes.io/part-of: ingress-nginx
   template:
     metadata:
       labels:
         app.kubernetes.io/name: default-http-backend
+        app.kubernetes.io/part-of: ingress-nginx
     spec:
       terminationGracePeriodSeconds: 60
       containers:
@@ -57,3 +59,4 @@ spec:
     targetPort: 8080
   selector:
     app.kubernetes.io/name: default-http-backend
+    app.kubernetes.io/part-of: ingress-nginx

--- a/deploy/mandatory.yaml
+++ b/deploy/mandatory.yaml
@@ -19,6 +19,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: default-http-backend
+      app.kubernetes.io/part-of: ingress-nginx
   template:
     metadata:
       labels:
@@ -64,6 +65,7 @@ spec:
     targetPort: 8080
   selector:
     app.kubernetes.io/name: default-http-backend
+    app.kubernetes.io/part-of: ingress-nginx
 ---
 
 kind: ConfigMap
@@ -259,10 +261,12 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: ingress-nginx
+      app.kubernetes.io/part-of: ingress-nginx
   template:
     metadata:
       labels:
         app.kubernetes.io/name: ingress-nginx
+        app.kubernetes.io/part-of: ingress-nginx
       annotations:
         prometheus.io/port: '10254'
         prometheus.io/scrape: 'true'

--- a/deploy/provider/aws/service-l4.yaml
+++ b/deploy/provider/aws/service-l4.yaml
@@ -15,6 +15,7 @@ spec:
   type: LoadBalancer
   selector:
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
   ports:
   - name: http
     port: 80

--- a/deploy/provider/aws/service-l7.yaml
+++ b/deploy/provider/aws/service-l7.yaml
@@ -19,6 +19,7 @@ spec:
   type: LoadBalancer
   selector:
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
   ports:
   - name: http
     port: 80

--- a/deploy/provider/aws/service-nlb.yaml
+++ b/deploy/provider/aws/service-nlb.yaml
@@ -15,6 +15,7 @@ spec:
   type: LoadBalancer
   selector:
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
   ports:
   - name: http
     port: 80

--- a/deploy/provider/baremetal/service-nodeport.yaml
+++ b/deploy/provider/baremetal/service-nodeport.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-
 spec:
   type: NodePort
   ports:
@@ -20,3 +19,4 @@ spec:
     protocol: TCP
   selector:
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx

--- a/deploy/provider/cloud-generic.yaml
+++ b/deploy/provider/cloud-generic.yaml
@@ -11,6 +11,7 @@ spec:
   type: LoadBalancer
   selector:
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
   ports:
   - name: http
     port: 80

--- a/docs/deploy/index.md
+++ b/docs/deploy/index.md
@@ -141,7 +141,7 @@ kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/mast
 To check if the ingress controller pods have started, run the following command:
 
 ```console
-kubectl get pods --all-namespaces -l app=ingress-nginx --watch
+kubectl get pods --all-namespaces -l app.kubernetes.io/name=ingress-nginx --watch
 ```
 
 Once the operator pods are running, you can cancel the above command by typing `Ctrl+C`.
@@ -153,7 +153,7 @@ To detect which version of the ingress controller is running, exec into the pod 
 
 ```console
 POD_NAMESPACE=ingress-nginx
-POD_NAME=$(kubectl get pods -n $POD_NAMESPACE -l app=ingress-nginx -o jsonpath='{.items[0].metadata.name}')
+POD_NAME=$(kubectl get pods -n $POD_NAMESPACE -l app.kubernetes.io/name=ingress-nginx -o jsonpath='{.items[0].metadata.name}')
 kubectl exec -it $POD_NAME -n $POD_NAMESPACE -- /nginx-ingress-controller --version
 ```
 
@@ -175,7 +175,7 @@ helm install stable/nginx-ingress --name my-nginx --set rbac.create=true
 Detect installed version:
 
 ```console
-POD_NAME=$(kubectl get pods -l app=nginx-ingress -o jsonpath='{.items[0].metadata.name}')
+POD_NAME=$(kubectl get pods -l app.kubernetes.io/name=ingress-nginx -o jsonpath='{.items[0].metadata.name}')
 kubectl exec -it $POD_NAME -- /nginx-ingress-controller --version
 ```
 

--- a/docs/examples/customization/custom-configuration/configmap.yaml
+++ b/docs/examples/customization/custom-configuration/configmap.yaml
@@ -4,7 +4,8 @@ metadata:
   name: nginx-configuration
   namespace: ingress-nginx
   labels:
-    app: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
 data:
   proxy-connect-timeout: "10"
   proxy-read-timeout: "120"

--- a/docs/examples/customization/custom-errors/custom-default-backend.yaml
+++ b/docs/examples/customization/custom-errors/custom-default-backend.yaml
@@ -4,10 +4,12 @@ kind: Service
 metadata:
   name: nginx-errors
   labels:
-    app: nginx-errors
+    app.kubernetes.io/name: nginx-errors
+    app.kubernetes.io/part-of: ingress-nginx
 spec:
   selector:
-    app: nginx-errors
+    app.kubernetes.io/name: nginx-errors
+    app.kubernetes.io/part-of: ingress-nginx
   ports:
   - port: 80
     targetPort: 8080
@@ -18,15 +20,20 @@ kind: Deployment
 apiVersion: apps/v1beta2
 metadata:
   name: nginx-errors
+  labels:
+    app.kubernetes.io/name: nginx-errors
+    app.kubernetes.io/part-of: ingress-nginx
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: nginx-errors
+      app.kubernetes.io/name: nginx-errors
+      app.kubernetes.io/part-of: ingress-nginx
   template:
     metadata:
       labels:
-        app: nginx-errors
+        app.kubernetes.io/name: nginx-errors
+        app.kubernetes.io/part-of: ingress-nginx
     spec:
       containers:
       - name: nginx-error-server

--- a/docs/examples/customization/custom-headers/configmap.yaml
+++ b/docs/examples/customization/custom-headers/configmap.yaml
@@ -6,4 +6,5 @@ metadata:
   name: nginx-configuration
   namespace: ingress-nginx
   labels:
-    app: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx

--- a/docs/examples/customization/ssl-dh-param/README.md
+++ b/docs/examples/customization/ssl-dh-param/README.md
@@ -16,7 +16,8 @@ metadata:
   name: nginx-configuration
   namespace: ingress-nginx
   labels:
-    app: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
 ```
 
 ```console
@@ -40,7 +41,8 @@ metadata:
   name: nginx-configuration
   namespace: ingress-nginx
   labels:
-    app: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
 ```
 
 ```console

--- a/docs/examples/customization/ssl-dh-param/configmap.yaml
+++ b/docs/examples/customization/ssl-dh-param/configmap.yaml
@@ -6,4 +6,5 @@ metadata:
   name: nginx-configuration
   namespace: ingress-nginx
   labels:
-    app: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx

--- a/docs/examples/multi-tls/multi-tls.yaml
+++ b/docs/examples/multi-tls/multi-tls.yaml
@@ -3,7 +3,8 @@ kind: Service
 metadata:
   name: nginx
   labels:
-    app: nginx
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
 spec:
   ports:
   - port: 80
@@ -11,18 +12,23 @@ spec:
     protocol: TCP
     name: http
   selector:
-    app: nginx
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
 ---
 apiVersion: v1
 kind: ReplicationController
 metadata:
   name: nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
 spec:
   replicas: 1
   template:
     metadata:
       labels:
-        app: nginx
+        app.kubernetes.io/name: ingress-nginx
+        app.kubernetes.io/part-of: ingress-nginx
     spec:
       containers:
       - name: nginx
@@ -35,7 +41,8 @@ kind: Service
 metadata:
   name: http-svc
   labels:
-    app: http-svc
+    app.kubernetes.io/name: http-svc
+    app.kubernetes.io/part-of: ingress-nginx
 spec:
   ports:
   - port: 80
@@ -43,18 +50,23 @@ spec:
     protocol: TCP
     name: http
   selector:
-    app: http-svc
+    app.kubernetes.io/name: http-svc
+    app.kubernetes.io/part-of: ingress-nginx
 ---
 apiVersion: v1
 kind: ReplicationController
 metadata:
   name: http-svc
+  labels:
+    app.kubernetes.io/name: http-svc
+    app.kubernetes.io/part-of: ingress-nginx
 spec:
   replicas: 1
   template:
     metadata:
       labels:
-        app: http-svc
+        app.kubernetes.io/name: http-svc
+        app.kubernetes.io/part-of: ingress-nginx
     spec:
       containers:
       - name: http-svc

--- a/docs/examples/static-ip/nginx-ingress-controller.yaml
+++ b/docs/examples/static-ip/nginx-ingress-controller.yaml
@@ -3,16 +3,19 @@ kind: Deployment
 metadata:
   name: nginx-ingress-controller
   labels:
-    k8s-app: nginx-ingress-controller
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
 spec:
   replicas: 1
   selector:
     matchLabels:
-      k8s-app: nginx-ingress-controller
+      app.kubernetes.io/name: ingress-nginx
+      app.kubernetes.io/part-of: ingress-nginx
   template:
     metadata:
       labels:
-        k8s-app: nginx-ingress-controller
+        app.kubernetes.io/name: ingress-nginx
+        app.kubernetes.io/part-of: ingress-nginx
     spec:
       # hostNetwork makes it possible to use ipv6 and to preserve the source IP correctly regardless of docker configuration
       # however, it is not a hard dependency of the nginx-ingress-controller itself and it may cause issues if port 10254 already is taken on the host

--- a/docs/examples/static-ip/static-ip-svc.yaml
+++ b/docs/examples/static-ip/static-ip-svc.yaml
@@ -4,7 +4,8 @@ kind: Service
 metadata:
   name: nginx-ingress-lb
   labels:
-    app: nginx-ingress-lb
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
 spec:
   externalTrafficPolicy: Local
   type: LoadBalancer
@@ -18,5 +19,5 @@ spec:
     targetPort: 443
   selector:
     # Selects nginx-ingress-controller pods
-    k8s-app: nginx-ingress-controller
-
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx

--- a/images/nginx/rc.yaml
+++ b/images/nginx/rc.yaml
@@ -3,7 +3,8 @@ kind: Service
 metadata:
   name: nginxsvc
   labels:
-    app: nginx
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
 spec:
   type: NodePort
   ports:
@@ -14,20 +15,26 @@ spec:
     protocol: TCP
     name: https
   selector:
-    app: nginx
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
 ---
 apiVersion: v1
 kind: ReplicationController
 metadata:
   name: nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
 spec:
   replicas: 1
   selector:
-    app: nginx
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
   template:
     metadata:
       labels:
-        app: nginx
+        app.kubernetes.io/name: ingress-nginx
+        app.kubernetes.io/part-of: ingress-nginx
     spec:
       containers:
       - name: nginx

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -108,7 +108,7 @@ func (f *Framework) BeforeEach() {
 	Expect(err).NotTo(HaveOccurred())
 
 	err = WaitForPodsReady(f.KubeClientSet, 5*time.Minute, 1, f.IngressController.Namespace, metav1.ListOptions{
-		LabelSelector: "app=ingress-nginx",
+		LabelSelector: "app.kubernetes.io/name=ingress-nginx",
 	})
 	Expect(err).NotTo(HaveOccurred())
 
@@ -200,7 +200,7 @@ func (f *Framework) WaitForNginxConfiguration(matcher func(cfg string) bool) err
 // NginxLogs returns the logs of the nginx ingress controller pod running
 func (f *Framework) NginxLogs() (string, error) {
 	l, err := f.KubeClientSet.CoreV1().Pods(f.IngressController.Namespace).List(metav1.ListOptions{
-		LabelSelector: "app=ingress-nginx",
+		LabelSelector: "app.kubernetes.io/name=ingress-nginx",
 	})
 	if err != nil {
 		return "", err
@@ -220,7 +220,7 @@ func (f *Framework) NginxLogs() (string, error) {
 func (f *Framework) matchNginxConditions(name string, matcher func(cfg string) bool) wait.ConditionFunc {
 	return func() (bool, error) {
 		l, err := f.KubeClientSet.CoreV1().Pods(f.IngressController.Namespace).List(metav1.ListOptions{
-			LabelSelector: "app=ingress-nginx",
+			LabelSelector: "app.kubernetes.io/name=ingress-nginx",
 		})
 		if err != nil {
 			return false, err

--- a/test/e2e/wait-for-nginx.sh
+++ b/test/e2e/wait-for-nginx.sh
@@ -28,7 +28,7 @@ function on_exit {
     test $error_code == 0 && return;
 
     echo "Obtaining ingress controller pod logs..."
-    kubectl logs -l app=ingress-nginx -n $NAMESPACE
+    kubectl logs -l app.kubernetes.io/name=ingress-nginx -n $NAMESPACE
 }
 trap on_exit EXIT
 

--- a/test/manifests/ingress-controller/mandatory.yaml
+++ b/test/manifests/ingress-controller/mandatory.yaml
@@ -5,16 +5,19 @@ kind: Deployment
 metadata:
   name: default-http-backend
   labels:
-    app: default-http-backend
+    app.kubernetes.io/name: default-http-backend
+    app.kubernetes.io/part-of: ingress-nginx
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: default-http-backend
+      app.kubernetes.io/name: default-http-backend
+      app.kubernetes.io/part-of: ingress-nginx
   template:
     metadata:
       labels:
-        app: default-http-backend
+        app.kubernetes.io/name: default-http-backend
+        app.kubernetes.io/part-of: ingress-nginx
     spec:
       terminationGracePeriodSeconds: 60
       containers:
@@ -46,13 +49,15 @@ kind: Service
 metadata:
   name: default-http-backend
   labels:
-    app: default-http-backend
+    app.kubernetes.io/name: default-http-backend
+    app.kubernetes.io/part-of: ingress-nginx
 spec:
   ports:
   - port: 80
     targetPort: 8080
   selector:
-    app: default-http-backend
+    app.kubernetes.io/name: default-http-backend
+    app.kubernetes.io/part-of: ingress-nginx
 ---
 
 kind: ConfigMap
@@ -60,32 +65,44 @@ apiVersion: v1
 metadata:
   name: nginx-configuration
   labels:
-    app: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
 ---
 
 kind: ConfigMap
 apiVersion: v1
 metadata:
   name: tcp-services
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
 ---
 
 kind: ConfigMap
 apiVersion: v1
 metadata:
   name: udp-services
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
 ---
 
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: nginx-ingress-serviceaccount
-
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: nginx-ingress-clusterrole
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
 rules:
   - apiGroups:
       - ""
@@ -140,6 +157,9 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
   name: nginx-ingress-role
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
 rules:
   - apiGroups:
       - ""
@@ -182,6 +202,9 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   name: nginx-ingress-role-${NAMESPACE}
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -197,6 +220,9 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: nginx-ingress-clusterrole-${NAMESPACE}
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -212,15 +238,20 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: nginx-ingress-controller
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: ingress-nginx
+      app.kubernetes.io/name: ingress-nginx
+      app.kubernetes.io/part-of: ingress-nginx
   template:
     metadata:
       labels:
-        app: ingress-nginx
+        app.kubernetes.io/name: ingress-nginx
+        app.kubernetes.io/part-of: ingress-nginx
       annotations:
         prometheus.io/port: '10254'
         prometheus.io/scrape: 'true'
@@ -251,6 +282,14 @@ spec:
             - --publish-service=$(POD_NAMESPACE)/ingress-nginx
             - --annotations-prefix=nginx.ingress.kubernetes.io
             - --watch-namespace=${NAMESPACE}
+          securityContext:
+            capabilities:
+                drop:
+                - ALL
+                add:
+                - NET_BIND_SERVICE
+            # www-data -> 33
+            runAsUser: 33
           env:
             - name: POD_NAME
               valueFrom:
@@ -260,14 +299,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          securityContext:
-            capabilities:
-                drop:
-                - ALL
-                add:
-                - NET_BIND_SERVICE
-            # www-data -> 33
-            runAsUser: 33
           ports:
           - name: http
             containerPort: 80

--- a/test/manifests/ingress-controller/service-nodeport.yaml
+++ b/test/manifests/ingress-controller/service-nodeport.yaml
@@ -14,4 +14,5 @@ spec:
     targetPort: 443
     protocol: TCP
   selector:
-    app: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
  
-    Add missing label `app.kubernetes.io/part-of: ingress-nginx` for deploy example
-    Update new labels for docs/deploy and docs/examples
-    Update new labels for test/e2e and test/manifests
-    Update new labels for images/nginx

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

fixes #2970
fixes #3001

**Special notes for your reviewer**:
