### PR TITLE
Fix binding to privileged ports 1 to 1023

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -21,6 +21,7 @@ WORKDIR  /etc/nginx
 RUN clean-install \
   diffutils \
   valgrind \
+  libcap2-bin \
   dumb-init
 
 COPY . /
@@ -39,9 +40,17 @@ RUN bash -eu -c ' \
   for dir in "${writeDirs[@]}"; do \
     mkdir -p ${dir}; \
     chown -R www-data.www-data ${dir}; \
+  done \
+  && for value in {1..1023};do \
+    touch /etc/authbind/byport/$value; \
+    chown www-data /etc/authbind/byport/$value; \
+    chmod 755 /etc/authbind/byport/$value; \
   done' \
   && chown www-data.www-data /etc/nginx/nginx.conf \
   && chown www-data.www-data /etc/nginx/opentracing.json
+
+RUN  setcap    cap_net_bind_service=+ep /nginx-ingress-controller \
+  && setcap -v cap_net_bind_service=+ep /nginx-ingress-controller
 
 # Create symlinks to redirect nginx logs to stdout and stderr docker log collector
 # This only works if nginx is started with CMD or ENTRYPOINT


### PR DESCRIPTION
**What this PR does / why we need it**:

When SSL passthrough is enabled (flag `--enable-ssl-passthrough`), the traffic on port 443 goes through the Go binary. The issue with this is that Go does not work with authbind.
Also, this PR adds the mapping to all the privileged ports to allow nginx to bind any port, not only 80 and 443

**Which issue this PR fixes**: 

fixes #2994
fixes #3037
fixes #3036

Edit: add note that --enable-ssl-passthrough requires a docker graph with support for setcap