### PR TITLE
Add configuration option to toggle changing Host to X-Forwarded-Host

### DIFF
--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -420,6 +420,9 @@ type Configuration struct {
 	// Sets whether to use incoming X-Forwarded headers.
 	UseForwardedHeaders bool `json:"use-forwarded-headers"`
 
+	// Sets whether to use the incoming X-Forwarded-Host header.
+	UseForwardedHostHeader bool `json:"use-forwarded-host-header"`
+
 	// Sets the header field for identifying the originating IP address of a client
 	// Default is X-Forwarded-For
 	ForwardedForHeader string `json:"forwarded-for-header,omitempty"`
@@ -562,6 +565,7 @@ func NewDefault() Configuration {
 		EnableUnderscoresInHeaders: false,
 		ErrorLogLevel:              errorLevel,
 		UseForwardedHeaders:        true,
+		UseForwardedHostHeader:     true,
 		ForwardedForHeader:         "X-Forwarded-For",
 		ComputeFullForwardedFor:    false,
 		ProxyAddOriginalUriHeader:  true,

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -285,10 +285,17 @@ http {
         ''               $host;
     }
 
+    {{ if $cfg.UseForwardedHostHeader }}
     map $http_x_forwarded_host $best_http_host {
         default          $http_x_forwarded_host;
         ''               $this_host;
     }
+    {{ else }}
+    map '' $best_http_host {
+        default          $this_host;
+    }
+    {{ end }}
+
     {{ else }}
     map '' $pass_access_scheme {
         default          $scheme;
@@ -1097,7 +1104,11 @@ stream {
             {{ else }}
             {{ $proxySetHeader }} X-Forwarded-For        $the_real_ip;
             {{ end }}
+            {{ if and $all.Cfg.UseForwardedHeaders (not $all.Cfg.UseForwardedHostHeader) }}
+            {{ $proxySetHeader }} X-Forwarded-Host       $http_x_forwarded_host;
+            {{ else }}
             {{ $proxySetHeader }} X-Forwarded-Host       $best_http_host;
+            {{end}}
             {{ $proxySetHeader }} X-Forwarded-Port       $pass_port;
             {{ $proxySetHeader }} X-Forwarded-Proto      $pass_access_scheme;
             {{ if $all.Cfg.ProxyAddOriginalUriHeader }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows users to supply a `use-forwarded-host-header` boolean option in the `ConfigMap` for the ingress controller which toggles whether the `X-Forwarded-Host` header is placed into the `Host` header.

Many proxies in front of nginx-ingress may terminate SSL or similar and require usage of `X-Forwarded-Proto` or pass client IPs in `X-Forwarded-For` but very few will move the `Host` header to `X-Forwarded-Host` and require us to place `X-Forwarded-Host` back into the `Host` header in nginx-ingress. We could disable all `X-Forwarded-*` headers using `use-forwarded-headers` however processing `X-Forwarded-Proto` and `X-Forwarded-For` can still be useful even when `X-Forwarded-Host`should not be considered for placement into the `Host` header.

Further certain L7 proxies or CDNs (such as Fastly) will produce multi-valued `X-Forwarded-Host` headers which should never be placed into the `Host` header.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Fixes #2463

**Special notes for your reviewer**:
I think this is the most appropriate and generic way to resolve #2463 but I'm open to alternate approaches as I wrestled with this for a while. I'm also not 100% sold on my resolution for `{{ $proxySetHeader }} X-Forwarded-Host` but after talking with some co-workers we agreed that this is likely the correct approach in our opinion.