### PR TITLE
fix: Don't try and find local certs when secretName is not specified

### DIFF
--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -1120,6 +1120,12 @@ func extractTLSSecretName(host string, ing *extensions.Ingress,
 
 	// no TLS host matching host name, try each TLS host for matching SAN or CN
 	for _, tls := range ing.Spec.TLS {
+
+		if tls.SecretName == "" {
+			// There's no secretName specified, so it will never be available
+			continue
+		}
+
 		secrKey := fmt.Sprintf("%v/%v", ing.Namespace, tls.SecretName)
 
 		cert, err := getLocalSSLCert(secrKey)


### PR DESCRIPTION
Fixes #3048

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Stops the controller looking on disk for secrets that will never be there, so we don't get spurious warnings in the logs

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #3048 

**Special notes for your reviewer**:
