### PR TITLE
Pass Host header for custom errors

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -609,6 +609,7 @@ http {
             proxy_set_header    X-Code 404;
             {{ end }}
             set $proxy_upstream_name "upstream-default-backend";
+            proxy_set_header    Host   $best_http_host;
             {{ if $all.DynamicConfigurationEnabled }}
             proxy_pass          http://upstream_balancer;
             {{ else }}
@@ -706,6 +707,7 @@ stream {
             proxy_set_header       X-Ingress-Name     $ingress_name;
             proxy_set_header       X-Service-Name     $service_name;
             proxy_set_header       X-Service-Port     $service_port;
+            proxy_set_header       Host               $best_http_host;
 
             set $proxy_upstream_name "upstream-default-backend";
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: With `custom-http-errors` enabled the current nginx.tmpl will `proxy_pass` to `http://upstream_balancer` which will result in nginx rewriting the `Host` header with a value `upstream_balancer` in which `_` is an invalid character as per [RFC952]: https://www.rfc-editor.org/rfc/rfc952.txt

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #3018

**Special notes for your reviewer**: Another way to fix it can be by not using an upstream name containing any invalid characters, however, I selected this approach since the Host header might be an useful information for the custom error backend.
