### PR TITLE
Fix Rewrite-Target Annotation Edge Case

### DIFF
--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -334,7 +334,7 @@ func buildLocation(input interface{}, rewrite bool) string {
 		return fmt.Sprintf(`~* ^%s%s`, path, baseuri)
 	}
 
-	if rewrite == true {
+	if rewrite {
 		if path == slash {
 			return path
 		}

--- a/internal/ingress/controller/template/template_test.go
+++ b/internal/ingress/controller/template/template_test.go
@@ -382,7 +382,7 @@ func TestBuildLocation(t *testing.T) {
 			Rewrite: rewrite.Config{Target: tc.Target, AddBaseURL: tc.AddBaseURL},
 		}
 
-		newLoc := buildLocation(loc)
+		newLoc := buildLocation(loc, tc.Path != tc.Target)
 		if tc.Location != newLoc {
 			t.Errorf("%s: expected '%v' but returned %v", k, tc.Location, newLoc)
 		}

--- a/internal/ingress/controller/template/template_test.go
+++ b/internal/ingress/controller/template/template_test.go
@@ -50,6 +50,7 @@ var (
 		XForwardedPrefix            bool
 		DynamicConfigurationEnabled bool
 		SecureBackend               bool
+		atLeastOneNeedsRewrite      bool
 	}{
 		"when secure backend enabled": {
 			"/",
@@ -61,7 +62,8 @@ var (
 			false,
 			false,
 			false,
-			true},
+			true,
+			false},
 		"when secure backend and stickeness enabled": {
 			"/",
 			"/",
@@ -72,7 +74,8 @@ var (
 			true,
 			false,
 			false,
-			true},
+			true,
+			false},
 		"when secure backend and dynamic config enabled": {
 			"/",
 			"/",
@@ -83,7 +86,8 @@ var (
 			false,
 			false,
 			true,
-			true},
+			true,
+			false},
 		"when secure backend, stickeness and dynamic config enabled": {
 			"/",
 			"/",
@@ -94,7 +98,8 @@ var (
 			true,
 			false,
 			true,
-			true},
+			true,
+			false},
 		"invalid redirect / to / with dynamic config enabled": {
 			"/",
 			"/",
@@ -105,6 +110,7 @@ var (
 			false,
 			false,
 			true,
+			false,
 			false},
 		"invalid redirect / to /": {
 			"/",
@@ -113,6 +119,7 @@ var (
 			"proxy_pass http://upstream-name;",
 			false,
 			"",
+			false,
 			false,
 			false,
 			false,
@@ -131,7 +138,8 @@ proxy_pass http://upstream-name;
 			false,
 			false,
 			false,
-			false},
+			false,
+			true},
 		"redirect /something to /": {
 			"/something",
 			"/",
@@ -146,7 +154,8 @@ proxy_pass http://upstream-name;
 			false,
 			false,
 			false,
-			false},
+			false,
+			true},
 		"redirect /end-with-slash/ to /not-root": {
 			"/end-with-slash/",
 			"/not-root",
@@ -161,7 +170,8 @@ proxy_pass http://upstream-name;
 			false,
 			false,
 			false,
-			false},
+			false,
+			true},
 		"redirect /something-complex to /not-root": {
 			"/something-complex",
 			"/not-root",
@@ -176,7 +186,8 @@ proxy_pass http://upstream-name;
 			false,
 			false,
 			false,
-			false},
+			false,
+			true},
 		"redirect / to /jenkins and rewrite": {
 			"/",
 			"/jenkins",
@@ -194,7 +205,8 @@ subs_filter '(<(?:H|h)(?:E|e)(?:A|a)(?:D|d)(?:[^">]|"[^"]*")*>)' '$1<base href="
 			false,
 			false,
 			false,
-			false},
+			false,
+			true},
 		"redirect /something to / and rewrite": {
 			"/something",
 			"/",
@@ -212,7 +224,8 @@ subs_filter '(<(?:H|h)(?:E|e)(?:A|a)(?:D|d)(?:[^">]|"[^"]*")*>)' '$1<base href="
 			false,
 			false,
 			false,
-			false},
+			false,
+			true},
 		"redirect /end-with-slash/ to /not-root and rewrite": {
 			"/end-with-slash/",
 			"/not-root",
@@ -230,7 +243,8 @@ subs_filter '(<(?:H|h)(?:E|e)(?:A|a)(?:D|d)(?:[^">]|"[^"]*")*>)' '$1<base href="
 			false,
 			false,
 			false,
-			false},
+			false,
+			true},
 		"redirect /something-complex to /not-root and rewrite": {
 			"/something-complex",
 			"/not-root",
@@ -248,7 +262,8 @@ subs_filter '(<(?:H|h)(?:E|e)(?:A|a)(?:D|d)(?:[^">]|"[^"]*")*>)' '$1<base href="
 			false,
 			false,
 			false,
-			false},
+			false,
+			true},
 		"redirect /something to / and rewrite with specific scheme": {
 			"/something",
 			"/",
@@ -266,7 +281,8 @@ subs_filter '(<(?:H|h)(?:E|e)(?:A|a)(?:D|d)(?:[^">]|"[^"]*")*>)' '$1<base href="
 			false,
 			false,
 			false,
-			false},
+			false,
+			true},
 		"redirect / to /something with sticky enabled": {
 			"/",
 			"/something",
@@ -281,7 +297,8 @@ proxy_pass http://sticky-upstream-name;
 			true,
 			false,
 			false,
-			false},
+			false,
+			true},
 		"redirect / to /something with sticky and dynamic config enabled": {
 			"/",
 			"/something",
@@ -296,7 +313,8 @@ proxy_pass http://upstream_balancer;
 			true,
 			false,
 			true,
-			false},
+			false,
+			true},
 		"add the X-Forwarded-Prefix header": {
 			"/there",
 			"/something",
@@ -312,7 +330,32 @@ proxy_pass http://sticky-upstream-name;
 			true,
 			true,
 			false,
-			false},
+			false,
+			true},
+		"do not use ^~ location modifier on index when ingress does not use rewrite target but at least one other ingress does": {
+			"/",
+			"/",
+			"/",
+			"proxy_pass http://upstream-name;",
+			false,
+			"",
+			false,
+			false,
+			false,
+			false,
+			true},
+		"use ^~ location modifier when ingress does not use rewrite target but at least one other ingress does": {
+			"/something",
+			"/something",
+			"^~ /something",
+			"proxy_pass http://upstream-name;",
+			false,
+			"",
+			false,
+			false,
+			false,
+			false,
+			true},
 	}
 )
 
@@ -382,7 +425,7 @@ func TestBuildLocation(t *testing.T) {
 			Rewrite: rewrite.Config{Target: tc.Target, AddBaseURL: tc.AddBaseURL},
 		}
 
-		newLoc := buildLocation(loc, tc.Path != tc.Target)
+		newLoc := buildLocation(loc, tc.atLeastOneNeedsRewrite)
 		if tc.Location != newLoc {
 			t.Errorf("%s: expected '%v' but returned %v", k, tc.Location, newLoc)
 		}

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -452,8 +452,9 @@ http {
 
     {{/* build the maps that will be use to validate the Whitelist */}}
     {{ range $server := $servers }}
+    {{ $usesRewrite := atLeastOneNeedsRewrite $server.Locations }}
     {{ range $location := $server.Locations }}
-    {{ $path := buildLocation $location }}
+    {{ $path := buildLocation $location $usesRewrite }}
 
     {{ if isLocationAllowed $location }}
     {{ if gt (len $location.Whitelist.CIDR) 0 }}
@@ -818,8 +819,9 @@ stream {
         {{ $server.ServerSnippet }}
         {{ end }}
 
+        {{ $usesRewrite := atLeastOneNeedsRewrite $server.Locations }}
         {{ range $location := $server.Locations }}
-        {{ $path := buildLocation $location }}
+        {{ $path := buildLocation $location $usesRewrite }}
         {{ $proxySetHeader := proxySetHeader $location }}
         {{ $authPath := buildAuthLocation $location }}
 

--- a/test/e2e/annotations/rewrite.go
+++ b/test/e2e/annotations/rewrite.go
@@ -121,13 +121,9 @@ var _ = framework.IngressNginxDescribe("Annotations - Rewrite", func() {
 	It("should use correct longest path match", func() {
 		host := "rewrite.bar.com"
 		expectBodyRequestURI := fmt.Sprintf("request_uri=http://%v:8080/.well-known/acme/challenge", host)
-		annotations := map[string]string{}
-		rewriteAnnotations := map[string]string{
-			"nginx.ingress.kubernetes.io/rewrite-target": "/new/backend",
-		}
 
 		By("creating a regular ingress definition")
-		ing := framework.NewSingleIngress("kube-lego", "/.well-known/acme/challenge", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
+		ing := framework.NewSingleIngress("kube-lego", "/.well-known/acme/challenge", host, f.IngressController.Namespace, "http-svc", 80, &map[string]string{})
 		_, err := f.EnsureIngress(ing)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ing).NotTo(BeNil())
@@ -149,7 +145,10 @@ var _ = framework.IngressNginxDescribe("Annotations - Rewrite", func() {
 		Expect(body).Should(ContainSubstring(expectBodyRequestURI))
 
 		By(`creating an ingress definition with the rewrite-target annotation set on the "/" location`)
-		rewriteIng := framework.NewSingleIngress("rewrite-index", "/", host, f.IngressController.Namespace, "http-svc", 80, &rewriteAnnotations)
+		annotations := map[string]string{
+			"nginx.ingress.kubernetes.io/rewrite-target": "/new/backend",
+		}
+		rewriteIng := framework.NewSingleIngress("rewrite-index", "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
 		_, err = f.EnsureIngress(rewriteIng)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(rewriteIng).NotTo(BeNil())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This PR fixes the edge case that currently breaks kube-lego. 

This issue causes requests to the path `/.well-known/acme/challenge` to be redirected to the `/` path when the rewrite-target annotation is set for the index route. This annotation enforces the use of the `~*` location modifier. In NGINX, regex paths take priority over regular prefixes unless the `=` or `^~` location modifiers are used. 

After this PR, when `nginx.ingress.kubernetes.io/rewrite-target` is set on ANY ingress, then the `^~` location modifier will be enforced on paths that do NOT use the `nginx.ingress.kubernetes.io/rewrite-target` annotation. Paths on the ingress with the annotation set will continue to use the `~*` location modifier. 

The only exception to the enforcement of the `^~` location modifier is for the `/` path. If the `^~` location modifier were to be used on the index route, then it would be turn into a catch-all and regex paths would never be checked.

**Which issue this PR fixes** : 
Partially fixes https://github.com/Shopify/edgescale/issues/659

**Special notes for your reviewer**:
Built off `Shopify:upstream-lego-e2e`: https://github.com/kubernetes/ingress-nginx/pull/3076 

**Relevant links:**
- [Ingress-Nginx Regex Support Project Brief](https://docs.google.com/document/d/1bb23mByl8TELMpcWLs_Cp30-ehKL-rblPO9weLch7NA/edit?ts=5b929287#heading=h.ypkmjgl9xesn)
- [Spreadsheet of regex support for ingress controllers](https://docs.google.com/spreadsheets/d/1-oS8CKD4MtdEMar7QMUibCb-TUJ5ZIglRl2cLvaQ5zs/edit#gid=0)
- [Discussion of standardizing regex support among ingress controllers](kubernetes/ingress-nginx#555)
- [Open issue on lack of regex support in ingress-nginx](https://github.com/kubernetes/ingress-nginx/pull/1415)
- [NGINX location modifiers](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/api/extensions/v1beta1/types.go#L703 )

@ElvinEfendi @sbfaulkner
