### PR TITLE
make upstream keepalive work for http

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -244,16 +244,15 @@ http {
 
     {{ buildResolvers $cfg.Resolver $cfg.DisableIpv6DNS }}
 
-    {{/* Whenever nginx proxies a request without a "Connection" header, the "Connection" header is set to "close" */}}
-    {{/* when making the target request.  This means that you cannot simply use */}}
-    {{/* "proxy_set_header Connection $http_connection" for WebSocket support because in this case, the */}}
-    {{/* "Connection" header would be set to "" whenever the original request did not have a "Connection" header, */}}
-    {{/* which would mean no "Connection" header would be in the target request.  Since this would deviate from */}}
-    {{/* normal nginx behavior we have to use this approach. */}}
-    # Retain the default nginx handling of requests without a "Connection" header
+    # See https://www.nginx.com/blog/websocket-nginx
     map $http_upgrade $connection_upgrade {
         default          upgrade;
+        {{ if (gt $cfg.UpstreamKeepaliveConnections 0) }}
+        # See http://nginx.org/en/docs/http/ngx_http_upstream_module.html#keepalive
+        ''               '';
+        {{ else }}
         ''               close;
+        {{ end }}
     }
 
     # The following is a sneaky way to do "set $the_real_ip $remote_addr"


### PR DESCRIPTION
**What this PR does / why we need it**:
When `upstream-keepalive-connections` is used we don't configure Nginx properly to actually make keepalive effective. Excerpt from docs: http://nginx.org/en/docs/http/ngx_http_upstream_module.html#keepalive
```
For HTTP, the proxy_http_version directive should be set to “1.1” and the “Connection” header field should be cleared:
```

We do set `proxy_http_version`, but don't clear `Connection` header. This PR makes sure the `Connection` header is cleared when the client is not websocket client (a.k.a it is not setting HTTP `Upgrade` header).

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
