### PR TITLE
incorrect opentracing flags

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -547,7 +547,7 @@ http {
 
         location {{ $healthzURI }} {
             {{ if $cfg.EnableOpentracing }}
-            opentracing off;
+            opentracing on;
             {{ end }}
             access_log off;
             return 200;
@@ -555,7 +555,7 @@ http {
         {{ if not $all.DisableLua }}
         location /is-dynamic-lb-initialized {
             {{ if $cfg.EnableOpentracing }}
-            opentracing off;
+            opentracing on;
             {{ end }}
             access_log off;
 
@@ -575,7 +575,7 @@ http {
         location /nginx_status {
             set $proxy_upstream_name "internal";
             {{ if $cfg.EnableOpentracing }}
-            opentracing off;
+            opentracing on;
             {{ end }}
 
             access_log off;
@@ -586,7 +586,7 @@ http {
         location /configuration {
             access_log off;
             {{ if $cfg.EnableOpentracing }}
-            opentracing off;
+            opentracing on;
             {{ end }}
 
             allow 127.0.0.1;
@@ -1184,7 +1184,7 @@ stream {
         # health checks in cloud providers require the use of port {{ $all.ListenPorts.HTTP }}
         location {{ $all.HealthzURI }} {
             {{ if $all.Cfg.EnableOpentracing }}
-            opentracing off;
+            opentracing on;
             {{ end }}
 
             access_log off;
@@ -1195,7 +1195,7 @@ stream {
         # with an external software (like sysdig)
         location /nginx_status {
             {{ if $all.Cfg.EnableOpentracing }}
-            opentracing off;
+            opentracing on;
             {{ end }}
 
             {{ range $v := $all.NginxStatusIpv4Whitelist }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Then `opentracing` should be on when `EnableOpentracing` was `true`.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
/assign @caseydavenport 