### PR TITLE
the port range was too large

### DIFF
--- a/docs/examples/customization/sysctl/patch.json
+++ b/docs/examples/customization/sysctl/patch.json
@@ -8,7 +8,7 @@
 					"securityContext": {
 						"privileged": true
 					},
-					"command": ["sh", "-c", "sysctl -w net.core.somaxconn=32768; sysctl -w net.ipv4.ip_local_port_range=1024 65535"]
+					"command": ["sh", "-c", "sysctl -w net.core.somaxconn=32768; sysctl -w net.ipv4.ip_local_port_range=32767 65535"]
 				}]
 			}
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

the port range was too large which impact the kubelet data proxying like below:
```
Sep 19 03:39:00 hchenxa-1 hyperkube[12683]: E0919 03:39:00.856058   12683 upgradeaware.go:310] Error proxying data from client to backend: readfrom tcp 127.0.0.1:61590->127.0.0.1:1511: write tcp 127.0.0.1:61590->127.0.0.1:1511: write: broken pipe
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

/assign @aledbf 