### PR TITLE
Revert Kube-Lego Edge Case Fix and Enforce Regex on All Locations

### DIFF
--- a/docs/user-guide/ingress-path-matching.md
+++ b/docs/user-guide/ingress-path-matching.md
@@ -1,0 +1,142 @@
+# Ingress Path Matching
+
+## Regular Expression Support
+
+The ingress controller supports **case insensitive** regular expressions in the `spec.rules.http.paths.path` feild. 
+
+```
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: test-ingress
+spec:
+  host: test.com
+  rules:
+  - http:
+      paths:
+      - path: /testpath/.*
+        backend:
+          serviceName: test
+          servicePort: 80
+```
+
+The preceding ingress definition would translate to the following location block within the NGINX configuration for the `test.com` server:
+
+```
+location ~* ^/testpath/.* {
+  ...
+}
+```
+
+## Path Priority
+
+In NGINX, regular expressions follow a **first match** policy. In order to enable more acurate path matching, ingress-nginx first orders the paths by descending length before writing them to the NGINX template as location blocks. Therefore, longest path matching will be used in most cases. 
+
+### Example
+
+Let the following two ingress definitions be created:
+
+```
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: test-ingress-1
+spec:
+  host: test.com
+  rules:
+  - http:
+      paths:
+      - path: /foo/bar
+        backend:
+          serviceName: test
+          servicePort: 80
+      - path: /foo/bar/
+        backend:
+          serviceName: test
+          servicePort: 80
+```
+
+```
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: test-ingress-2
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  host: test.com
+  rules:
+  - http:
+      paths:
+      - path: /foo/bar/.+
+        backend:
+          serviceName: test
+          servicePort: 80
+```
+
+
+
+The ingress controller would define the following location blocks (in this order) within the NGINX template for the `test.com` server: 
+
+```
+location ~* ^/foo/bar/.+\/?(?<baseuri>.*) {
+  ...
+}
+
+location ~* ^/foo/bar/ {
+  ...
+}
+
+location ~* ^/foo/bar {
+  ...
+}
+```
+The following request URI's would match the corresponding location blocks:
+- `test.com/blog/topics/announcements` matches `~* ^/blog/topics/.+\/?(?<baseuri>.*)`
+- `test.com/blog/topics/` matches `^~ /blog/topics/`
+- `test.com/blog/topics` matches `^~ /blog/topics`
+
+_NOTE: paths created under the `rewrite-ingress` are sorted before `\/?(?<baseuri>.*)` is appended. For example if the path defined within `test-ingress-2` was `/foo/.+` then the location block for `^/foo/.+\/?(?<baseuri>.*)` would be the LAST block listed._
+
+
+## Path Priority Edge case
+The exception to this the longest match policy will occur when long regular expressions are used.
+
+### Example
+
+Let the following ingress be defined:
+
+```
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: test-ingress-1
+spec:
+  host: test.com
+  rules:
+  - http:
+      paths:
+      - path: /foo/bar/
+        backend:
+          serviceName: test
+          servicePort: 80
+      - path: /foo/bar/[A-Z0-9]{32}
+        backend:
+          serviceName: test
+          servicePort: 80
+```
+
+The ingress controller would define the following location blocks (in this order) within the NGINX template for the `test.com` server: 
+
+```
+location ~* ^/foo/bar/[A-Z0-9]{32} {
+  ...
+}
+
+location ~* ^/foo/bar/ {
+  ...
+}
+```
+
+A request to `test.com/foo/bar` would match the `^/foo/[A-Z0-9]{32}` location block. 
+

--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -26,7 +26,6 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
-	"sort"
 	"strconv"
 	"strings"
 	text_template "text/template"
@@ -156,7 +155,7 @@ var (
 		"buildOpentracing":            buildOpentracing,
 		"proxySetHeader":              proxySetHeader,
 		"buildInfluxDB":               buildInfluxDB,
-		"orderLocations":              orderLocations,
+		// "orderLocations":              orderLocations,
 	}
 )
 
@@ -287,24 +286,6 @@ func buildResolvers(res interface{}, disableIpv6 interface{}) string {
 	}
 
 	return strings.Join(r, " ") + ";"
-}
-
-// ByPath implements sort.Interface based on the path feild
-type ByPath []*ingress.Location
-
-func (p ByPath) Len() int           { return len(p) }
-func (p ByPath) Less(i, j int) bool { return len(p[i].Path) < len(p[j].Path) }
-func (p ByPath) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
-
-func orderLocations(input interface{}) []*ingress.Location {
-	locations, ok := input.([]*ingress.Location)
-	if !ok {
-		glog.Errorf("expected an '[]*ingress.Location' type but %T was returned", input)
-		return locations
-	}
-	// Go sort runs in O(nlogn)
-	sort.Sort(sort.Reverse(ByPath(locations)))
-	return locations
 }
 
 // buildLocation produces the location string, if the ingress has redirects

--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -155,7 +155,6 @@ var (
 		"buildOpentracing":            buildOpentracing,
 		"proxySetHeader":              proxySetHeader,
 		"buildInfluxDB":               buildInfluxDB,
-		// "orderLocations":              orderLocations,
 	}
 )
 

--- a/internal/ingress/controller/template/template_test.go
+++ b/internal/ingress/controller/template/template_test.go
@@ -803,23 +803,3 @@ func TestBuildUpstreamName(t *testing.T) {
 		}
 	}
 }
-
-func TestOrderLocations(t *testing.T) {
-	locations := []*ingress.Location{
-		{Path: "/"},
-		{Path: "/a"},
-		{Path: "/abc"},
-		{Path: "/abcd"},
-	}
-
-	ordered := orderLocations(locations)
-
-	prevLen := 6
-	for _, l := range ordered {
-		currLen := len(l.Path)
-		if prevLen < currLen {
-			t.Errorf("orderLocations did not sort location paths in descending order")
-		}
-		prevLen = currLen
-	}
-}

--- a/internal/ingress/controller/template/template_test.go
+++ b/internal/ingress/controller/template/template_test.go
@@ -50,76 +50,69 @@ var (
 		XForwardedPrefix            bool
 		DynamicConfigurationEnabled bool
 		SecureBackend               bool
-		atLeastOneNeedsRewrite      bool
 	}{
 		"when secure backend enabled": {
 			"/",
 			"/",
-			"/",
+			"~* ^/",
 			"proxy_pass https://upstream-name;",
 			false,
 			"",
 			false,
 			false,
 			false,
-			true,
-			false},
+			true},
 		"when secure backend and stickeness enabled": {
 			"/",
 			"/",
-			"/",
+			"~* ^/",
 			"proxy_pass https://sticky-upstream-name;",
 			false,
 			"",
 			true,
 			false,
 			false,
-			true,
-			false},
+			true},
 		"when secure backend and dynamic config enabled": {
 			"/",
 			"/",
-			"/",
+			"~* ^/",
 			"proxy_pass https://upstream_balancer;",
 			false,
 			"",
 			false,
 			false,
 			true,
-			true,
-			false},
+			true},
 		"when secure backend, stickeness and dynamic config enabled": {
 			"/",
 			"/",
-			"/",
+			"~* ^/",
 			"proxy_pass https://upstream_balancer;",
 			false,
 			"",
 			true,
 			false,
 			true,
-			true,
-			false},
+			true},
 		"invalid redirect / to / with dynamic config enabled": {
 			"/",
 			"/",
-			"/",
+			"~* ^/",
 			"proxy_pass http://upstream_balancer;",
 			false,
 			"",
 			false,
 			false,
 			true,
-			false,
 			false},
 		"invalid redirect / to /": {
 			"/",
 			"/",
-			"/",
+			"~* ^/",
 			"proxy_pass http://upstream-name;",
 			false,
 			"",
-			false,
 			false,
 			false,
 			false,
@@ -127,7 +120,7 @@ var (
 		"redirect / to /jenkins": {
 			"/",
 			"/jenkins",
-			"~* /",
+			"~* ^/",
 			`
 rewrite (?i)/(.*) /jenkins/$1 break;
 rewrite (?i)/$ /jenkins/ break;
@@ -138,8 +131,7 @@ proxy_pass http://upstream-name;
 			false,
 			false,
 			false,
-			false,
-			true},
+			false},
 		"redirect /something to /": {
 			"/something",
 			"/",
@@ -154,8 +146,7 @@ proxy_pass http://upstream-name;
 			false,
 			false,
 			false,
-			false,
-			true},
+			false},
 		"redirect /end-with-slash/ to /not-root": {
 			"/end-with-slash/",
 			"/not-root",
@@ -170,8 +161,7 @@ proxy_pass http://upstream-name;
 			false,
 			false,
 			false,
-			false,
-			true},
+			false},
 		"redirect /something-complex to /not-root": {
 			"/something-complex",
 			"/not-root",
@@ -186,12 +176,11 @@ proxy_pass http://upstream-name;
 			false,
 			false,
 			false,
-			false,
-			true},
+			false},
 		"redirect / to /jenkins and rewrite": {
 			"/",
 			"/jenkins",
-			"~* /",
+			"~* ^/",
 			`
 rewrite (?i)/(.*) /jenkins/$1 break;
 rewrite (?i)/$ /jenkins/ break;
@@ -205,8 +194,7 @@ subs_filter '(<(?:H|h)(?:E|e)(?:A|a)(?:D|d)(?:[^">]|"[^"]*")*>)' '$1<base href="
 			false,
 			false,
 			false,
-			false,
-			true},
+			false},
 		"redirect /something to / and rewrite": {
 			"/something",
 			"/",
@@ -224,8 +212,7 @@ subs_filter '(<(?:H|h)(?:E|e)(?:A|a)(?:D|d)(?:[^">]|"[^"]*")*>)' '$1<base href="
 			false,
 			false,
 			false,
-			false,
-			true},
+			false},
 		"redirect /end-with-slash/ to /not-root and rewrite": {
 			"/end-with-slash/",
 			"/not-root",
@@ -243,8 +230,7 @@ subs_filter '(<(?:H|h)(?:E|e)(?:A|a)(?:D|d)(?:[^">]|"[^"]*")*>)' '$1<base href="
 			false,
 			false,
 			false,
-			false,
-			true},
+			false},
 		"redirect /something-complex to /not-root and rewrite": {
 			"/something-complex",
 			"/not-root",
@@ -262,8 +248,7 @@ subs_filter '(<(?:H|h)(?:E|e)(?:A|a)(?:D|d)(?:[^">]|"[^"]*")*>)' '$1<base href="
 			false,
 			false,
 			false,
-			false,
-			true},
+			false},
 		"redirect /something to / and rewrite with specific scheme": {
 			"/something",
 			"/",
@@ -281,12 +266,11 @@ subs_filter '(<(?:H|h)(?:E|e)(?:A|a)(?:D|d)(?:[^">]|"[^"]*")*>)' '$1<base href="
 			false,
 			false,
 			false,
-			false,
-			true},
+			false},
 		"redirect / to /something with sticky enabled": {
 			"/",
 			"/something",
-			`~* /`,
+			`~* ^/`,
 			`
 rewrite (?i)/(.*) /something/$1 break;
 rewrite (?i)/$ /something/ break;
@@ -297,12 +281,11 @@ proxy_pass http://sticky-upstream-name;
 			true,
 			false,
 			false,
-			false,
-			true},
+			false},
 		"redirect / to /something with sticky and dynamic config enabled": {
 			"/",
 			"/something",
-			`~* /`,
+			`~* ^/`,
 			`
 rewrite (?i)/(.*) /something/$1 break;
 rewrite (?i)/$ /something/ break;
@@ -313,8 +296,7 @@ proxy_pass http://upstream_balancer;
 			true,
 			false,
 			true,
-			false,
-			true},
+			false},
 		"add the X-Forwarded-Prefix header": {
 			"/there",
 			"/something",
@@ -330,32 +312,7 @@ proxy_pass http://sticky-upstream-name;
 			true,
 			true,
 			false,
-			false,
-			true},
-		"do not use ^~ location modifier on index when ingress does not use rewrite target but at least one other ingress does": {
-			"/",
-			"/",
-			"/",
-			"proxy_pass http://upstream-name;",
-			false,
-			"",
-			false,
-			false,
-			false,
-			false,
-			true},
-		"use ^~ location modifier when ingress does not use rewrite target but at least one other ingress does": {
-			"/something",
-			"/something",
-			"^~ /something",
-			"proxy_pass http://upstream-name;",
-			false,
-			"",
-			false,
-			false,
-			false,
-			false,
-			true},
+			false},
 	}
 )
 
@@ -425,7 +382,7 @@ func TestBuildLocation(t *testing.T) {
 			Rewrite: rewrite.Config{Target: tc.Target, AddBaseURL: tc.AddBaseURL},
 		}
 
-		newLoc := buildLocation(loc, tc.atLeastOneNeedsRewrite)
+		newLoc := buildLocation(loc)
 		if tc.Location != newLoc {
 			t.Errorf("%s: expected '%v' but returned %v", k, tc.Location, newLoc)
 		}
@@ -844,5 +801,25 @@ func TestBuildUpstreamName(t *testing.T) {
 		if !strings.EqualFold(expected, pp) {
 			t.Errorf("%s: expected \n'%v'\nbut returned \n'%v'", k, expected, pp)
 		}
+	}
+}
+
+func TestOrderLocations(t *testing.T) {
+	locations := []*ingress.Location{
+		{Path: "/"},
+		{Path: "/a"},
+		{Path: "/abc"},
+		{Path: "/abcd"},
+	}
+
+	ordered := orderLocations(locations)
+
+	prevLen := 6
+	for _, l := range ordered {
+		currLen := len(l.Path)
+		if prevLen < currLen {
+			t.Errorf("orderLocations did not sort location paths in descending order")
+		}
+		prevLen = currLen
 	}
 }

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -451,9 +451,8 @@ http {
 
     {{/* build the maps that will be use to validate the Whitelist */}}
     {{ range $server := $servers }}
-    {{ $usesRewrite := atLeastOneNeedsRewrite $server.Locations }}
-    {{ range $location := $server.Locations }}
-    {{ $path := buildLocation $location $usesRewrite }}
+    {{ range $location := orderLocations $server.Locations }}
+    {{ $path := buildLocation $location }}
 
     {{ if isLocationAllowed $location }}
     {{ if gt (len $location.Whitelist.CIDR) 0 }}
@@ -818,9 +817,8 @@ stream {
         {{ $server.ServerSnippet }}
         {{ end }}
 
-        {{ $usesRewrite := atLeastOneNeedsRewrite $server.Locations }}
-        {{ range $location := $server.Locations }}
-        {{ $path := buildLocation $location $usesRewrite }}
+        {{ range $location := orderLocations $server.Locations }}
+        {{ $path := buildLocation $location }}
         {{ $proxySetHeader := proxySetHeader $location }}
         {{ $authPath := buildAuthLocation $location }}
 

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -1056,7 +1056,7 @@ stream {
             {{ buildInfluxDB $location.InfluxDB }}
 
             {{ if not (empty $location.Redirect.URL) }}
-            if ($uri ~* {{ $path }}) {
+            if ($uri {{ $path }}) {
                 return {{ $location.Redirect.Code }} {{ $location.Redirect.URL }};
             }
             {{ end }}

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -451,7 +451,7 @@ http {
 
     {{/* build the maps that will be use to validate the Whitelist */}}
     {{ range $server := $servers }}
-    {{ range $location := orderLocations $server.Locations }}
+    {{ range $location := $server.Locations }}
     {{ $path := buildLocation $location }}
 
     {{ if isLocationAllowed $location }}
@@ -817,7 +817,7 @@ stream {
         {{ $server.ServerSnippet }}
         {{ end }}
 
-        {{ range $location := orderLocations $server.Locations }}
+        {{ range $location := $server.Locations }}
         {{ $path := buildLocation $location }}
         {{ $proxySetHeader := proxySetHeader $location }}
         {{ $authPath := buildAuthLocation $location }}

--- a/test/e2e/annotations/redirect.go
+++ b/test/e2e/annotations/redirect.go
@@ -60,7 +60,7 @@ var _ = framework.IngressNginxDescribe("Annotations - Redirect", func() {
 
 		err = f.WaitForNginxServer(host,
 			func(server string) bool {
-				return strings.Contains(server, fmt.Sprintf("if ($uri ~* %s) {", redirectPath)) &&
+				return strings.Contains(server, fmt.Sprintf("if ($uri ~* ^%s) {", redirectPath)) &&
 					strings.Contains(server, fmt.Sprintf("return 301 %s;", redirectURL))
 			})
 		Expect(err).NotTo(HaveOccurred())
@@ -100,7 +100,7 @@ var _ = framework.IngressNginxDescribe("Annotations - Redirect", func() {
 
 		err = f.WaitForNginxServer(host,
 			func(server string) bool {
-				return strings.Contains(server, fmt.Sprintf("if ($uri ~* %s) {", redirectPath)) &&
+				return strings.Contains(server, fmt.Sprintf("if ($uri ~* ^%s) {", redirectPath)) &&
 					strings.Contains(server, fmt.Sprintf("return %d %s;", redirectCode, redirectURL))
 			})
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

### **What this PR does / why we need it**:

1. Reverts https://github.com/kubernetes/ingress-nginx/pull/3078
2. Sort the locations by path length in descending order in the NGINX template
3. Enforce the ~* location modifier on ALL paths

The goal of this is to allow for longest path matching without having to prioritize either regex or non-regex paths. In addition, this would allow a user to use regex on non-rewrite annotated paths.

### **How this works**: 
NGINX regex matching uses **first match** not **longest match**. Ordering by descending length will help resolve this problem.

### **Which issue this PR fixes** *: 
fixes https://github.com/kubernetes/ingress-nginx/pull/1415

### **Special notes for your reviewer**:
Due to the nature of how NGINX does regex matching, there will still be edge cases. However they are far less blocking than what currently exists:

#### Example edge case: long regex
Let two paths be defined on an ingress:
- `/foo/bar`
- `/foo/[A-Z0-9]{32}`

A request to `foo/bar` will hit `/foo/[A-Z0-9]{32}`

@ElvinEfendi @jmreid @sbfaulkner @Wayt

