### PR TITLE
[404-server] Conceal /metrics and /healthz behind port 10254

### DIFF
--- a/images/404-server/Makefile
+++ b/images/404-server/Makefile
@@ -20,7 +20,7 @@
 
 all: push
 
-TAG?=1.4
+TAG?=1.5
 PREFIX?=gcr.io/google_containers/defaultbackend
 ARCH?=amd64
 

--- a/images/404-server/cloudbuild.yaml
+++ b/images/404-server/cloudbuild.yaml
@@ -3,7 +3,7 @@ timeout: 10800s
 substitutions:
   { "_ARCH": "amd64",
     "_REGISTRY": "gcr.io/k8s-image-staging",
-    "_TAG": "1.4" }
+    "_TAG": "1.5" }
 
 steps:
 - name: gcr.io/cloud-builders/git


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

- Implements an HTTP multiplexer for the `/metrics` and `/healthz` endpoints and exposes a command line flag to change the port (default `10254`)
- Implements a timeout (default `5s`) for the graceful shutdown

**Which issue this PR fixes**:

Fixes https://github.com/kubernetes/ingress-nginx/issues/1733

**Special notes for your reviewer**:

~This PR is getting pretty big.. I don't know if we should cut a release yet, or wait until we bump the manifests?~ code has been updated to maintain existing functionality, so i don't think i'm that worried anymore

The 404-server is supposed to be small, but it's getting bigger, I don't know what we want to do here