### PR TITLE
Correct the password file creation permissions

### DIFF
--- a/internal/file/filesystem.go
+++ b/internal/file/filesystem.go
@@ -31,6 +31,9 @@ const ReadWriteByUser = 0660
 // ReadByUserGroup defines linux permission to read files by the user and group owner/s
 const ReadByUserGroup = 0640
 
+//ReadByAny defines linux permission to anyone read the file
+const ReadByAny = 0644
+
 // Filesystem is an interface that we can use to mock various filesystem operations
 type Filesystem interface {
 	filesystem.Filesystem

--- a/internal/ingress/annotations/auth/main.go
+++ b/internal/ingress/annotations/auth/main.go
@@ -144,7 +144,7 @@ func dumpSecret(filename string, secret *api.Secret) error {
 		}
 	}
 
-	err := ioutil.WriteFile(filename, val, file.ReadWriteByUser)
+	err := ioutil.WriteFile(filename, val, file.ReadByAny)
 	if err != nil {
 		return ing_errors.LocationDenied{
 			Reason: errors.Wrap(err, "unexpected error creating password file"),


### PR DESCRIPTION
Signed-off-by: Ricardo Pchevuzinske Katz <ricardo.katz@serpro.gov.br>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: This PR corrects the file permission when creating ".passwd" files for basic authentication

When using the unprivileged ``www-data`` user, ingress-controller creates the files inside ``/etc/ingress-controller/auth`` with permission 0660. As the ingress-controller runs as root, this leads to creating files without permission to NGINX process, and giving log errors as:

```
*15 open() "/etc/ingress-controller/auth/namespace-ingress.passwd" failed (13: Permission denied), client: 10.10.10.10, server: test.lab, request: "GET / HTTP/2.0", host: "test.lab"
```


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
