### PR TITLE
fix newlines location denied

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -1173,7 +1173,7 @@ stream {
             return 503;
             {{ end }}
             {{ else }}
-            # Location denied. Reason: {{ $location.Denied }}
+            # Location denied. Reason: {{ $location.Denied | printf "%q" }}
             return 503;
             {{ end }}
         }


### PR DESCRIPTION
**What this PR does / why we need it**:
Escape '\n' simbols when logging 'Location denied' error in nginx configuration. Without it, nginx completelly breaks and it's unable to generate new configurations affecting other possible tenants in the cluster.

**Which issue this PR fixes**
We create an ingress object with an incorrect ip-whitelisting annotation. For example:
```
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: cafe-ingress
  annotations:
    nginx.ingress.kubernetes.io/whitelist-source-range: |
       # This comment breaks ingress
       8.8.8.8/32,
       9.9.9.9/32
spec:
  rules:
  - host: cafe.example.com
    http:
      paths:
      - path: /tea
        backend:
          serviceName: tea-svc
          servicePort: 80
      - path: /coffee
        backend:
          serviceName: coffee-svc
          servicePort: 80
```
Ingress will start failing with an error:
```
E0921 09:40:26.453561       8 controller.go:183] Unexpected failure reloading the backend:-------------------------------------------------------------------------------
Error: exit status 1
2018/09/21 09:40:26 [emerg] 660#660: unknown directive "8.8.8.8/32" in /tmp/nginx-cfg534865713:414
nginx: [emerg] unknown directive "8.8.8.8/32" in /tmp/nginx-cfg534865713:414
nginx: configuration file /tmp/nginx-cfg534865713 test failed-------------------------------------------------------------------------------
W0921 09:40:26.453594       8 queue.go:130] requeuing default/cafe-ingress, err 
```

Because it's generating an incorrect location on nginx:
```
 location /tea {

                        set $namespace      "default";
                        set $ingress_name   "cafe-ingress";
                        set $service_name   "tea-svc";
                        set $service_port   "80";
                        set $location_path  "/tea";

                        rewrite_by_lua_block {

                                balancer.rewrite()

                        }

                        log_by_lua_block {

                                balancer.log()

                                monitor.call()
                        }

                        port_in_redirect off;

                        set $proxy_upstream_name "default-tea-svc-80";

                        # Location denied. Reason: the annotation does not contain a valid IP address or network: invalid CIDR address: # This should make it fail
                        8.8.8.8/32
                        return 503;

                }
```

