### PR TITLE
Remove payload from post log

### DIFF
--- a/internal/ingress/controller/nginx.go
+++ b/internal/ingress/controller/nginx.go
@@ -834,7 +834,7 @@ func post(url string, data interface{}) error {
 		return err
 	}
 
-	glog.V(2).Infof("Posting to %s: %s", url, buf)
+	glog.V(2).Infof("Posting to %s", url)
 
 	resp, err := http.Post(url, "application/json", bytes.NewReader(buf))
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

This function will log sensitive public and private certificate data when called from `configureCertificates`: https://github.com/kubernetes/ingress-nginx/blob/3f6314aa2f4b204f296d63840d3c37bfc65c3f2a/internal/ingress/controller/nginx.go#L813-L823 

Omitting the payload will prevent sensitive data from being leaked. 

@ElvinEfendi 
