### PR TITLE
Pass --shell to minikube docker-env

### DIFF
--- a/build/dev-env.sh
+++ b/build/dev-env.sh
@@ -33,13 +33,13 @@ if [ -z "${SKIP_MINIKUBE_START}" ]; then
         --extra-config=kubelet.sync-frequency=1s \
         --extra-config=apiserver.authorization-mode=RBAC
 
-    eval $(minikube docker-env)
+    eval $(minikube docker-env --shell bash)
 fi
 
 echo "[dev-env] building container"
 make build container
 
-docker save "${DEV_IMAGE}" | (eval $(minikube docker-env) && docker load) || true
+docker save "${DEV_IMAGE}" | (eval $(minikube docker-env --shell bash) && docker load) || true
 
 echo "[dev-env] installing kubectl"
 kubectl version || brew install kubectl


### PR DESCRIPTION
This fixes `make dev-env` for those developers who are using non-standard shell, for instance fish.

By default, `minikube docker-env` prints exports in the format of your shell. If your shell is fish and `minikube docker-env` is executed from a bash script, it will still print the export template in fish format. That makes the script break.

The solution is to pass `--shell bash` argument.

Side question: what minikube driver do you suggest use on Mac?