### PR TITLE
Added ingress tls values.yaml example to documentation

### DIFF
--- a/docs/examples/tls-termination/README.md
+++ b/docs/examples/tls-termination/README.md
@@ -8,6 +8,31 @@ You need a [TLS cert](../PREREQUISITES.md#tls-certificates) and a [test HTTP ser
 
 ## Deployment
 
+Create a `values.yaml` file.
+
+```yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: nginx-test
+spec:
+  tls:
+    - hosts:
+      - foo.bar.com
+      # This assumes tls-secret exists and the SSL 
+      # certificate contains a CN for foo.bar.com
+      secretName: tls-secret
+  rules:
+    - host: foo.bar.com
+      http:
+        paths:
+        - path: /
+          backend:
+            # This assumes http-svc exists and routes to healthy endpoints
+            serviceName: http-svc
+            servicePort: 80
+```
+
 The following command instructs the controller to terminate traffic using the provided 
 TLS cert, and forward un-encrypted HTTP traffic to the test HTTP service.
 


### PR DESCRIPTION
Documentation fix


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

In the [live documentation (mkdocs)](https://kubernetes.github.io/ingress-nginx/examples/tls-termination/) the values.yaml file for tls is hidden. A link only would still hide the content, so adding the content to the docs itself.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*:  -

**Special notes for your reviewer**:
Browsing the live docs the example values.yaml was hidden and reader need to have the plan to browse the github repository to find the example. That's the reason to add it to the markdown directly.