### PR TITLE
Move mainSnippet before events to fix load_module issue.

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -35,15 +35,15 @@ worker_rlimit_nofile {{ .MaxOpenFiles }};
 {{/* avoid waiting too long during a reload */}}
 worker_shutdown_timeout {{ $cfg.WorkerShutdownTimeout }} ;
 
+{{ if not (empty $cfg.MainSnippet) }}
+{{ $cfg.MainSnippet }}
+{{ end }}
+
 events {
     multi_accept        {{ if $cfg.EnableMultiAccept }}on{{ else }}off{{ end }};
     worker_connections  {{ $cfg.MaxWorkerConnections }};
     use                 epoll;
 }
-
-{{ if not (empty $cfg.MainSnippet) }}
-{{ $cfg.MainSnippet }}
-{{ end }}
 
 http {
     {{ if not $all.DisableLua }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
I was trying to activate the dynamic geoip2 module added in 0.16 as follows:
```
main-snippet: |
    load_module /etc/nginx/modules/ngx_http_geoip2_module.so;
```

but then getting the error:
```
Error: exit status 1
nginx-ingress-controller 2018/10/02 13:24:16 [emerg] 21791#21791: "load_module" directive is specified too late in /tmp/nginx-cfg246481140:21
nginx-ingress-controller nginx: [emerg] "load_module" directive is specified too late in /tmp/nginx-cfg246481140:21
nginx-ingress-controller nginx: configuration file /tmp/nginx-cfg246481140 test failed
```

And turns out the `load_module` commands need to be listed before the `event` block.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
