### PR TITLE
Generalize Rewrite Block Creation and Deprecate AddBaseUrl (not backwards compatible) 

### DIFF
--- a/docs/examples/rewrite/README.md
+++ b/docs/examples/rewrite/README.md
@@ -15,16 +15,20 @@ Rewriting can be controlled using the following annotations:
 |Name|Description|Values|
 | --- | --- | --- |
 |nginx.ingress.kubernetes.io/rewrite-target|Target URI where the traffic must be redirected|string|
-|nginx.ingress.kubernetes.io/add-base-url|indicates if is required to add a base tag in the head of the responses from the upstream servers|bool|
-|nginx.ingress.kubernetes.io/base-url-scheme|Override for the scheme passed to the base tag|string|
 |nginx.ingress.kubernetes.io/ssl-redirect|Indicates if the location section is accessible SSL only (defaults to True when Ingress contains a Certificate)|bool|
 |nginx.ingress.kubernetes.io/force-ssl-redirect|Forces the redirection to HTTPS even if the Ingress is not TLS Enabled|bool|
 |nginx.ingress.kubernetes.io/app-root|Defines the Application Root that the Controller must redirect if it's in '/' context|string|
 |nginx.ingress.kubernetes.io/use-regex|Indicates if the paths defined on an Ingress use regular expressions|bool|
 
-## Validation
+## Examples
 
 ### Rewrite Target
+
+!!! attention
+    Starting in Version 0.2.2, ingress definitions using the annotation `nginx.ingress.kubernetes.io/rewrite-target` are not backwards compatible with previous versions. In Version 0.2.2 and beyond, any substrings within the request URI that need to be passed to the rewritten path must explicitly be defined in a [capture group](https://www.regular-expressions.info/refcapture.html).
+    
+!!! note
+    [Captured groups](https://www.regular-expressions.info/refcapture.html) are saved in numbered placeholders, chronologically, in the form `$1`, `$2` ... `$n`. These placeholders can be used as parameters in the `rewrite-target` annotation. 
 
 Create an Ingress rule with a rewrite annotation:
 
@@ -34,7 +38,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   annotations:
-    nginx.ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
   name: rewrite
   namespace: default
 spec:
@@ -45,53 +49,16 @@ spec:
       - backend:
           serviceName: http-svc
           servicePort: 80
-        path: /something
+        path: /something/?(.*)
 " | kubectl create -f -
 ```
 
-Check the rewrite is working
+In this ingress definition, any characters captured by `(.*)` will be assigned to the placeholder `$1`, which is then used as a parameter in the `rewrite-target` annotation. 
 
-```
-$ curl -v http://172.17.4.99/something -H 'Host: rewrite.bar.com'
-*   Trying 172.17.4.99...
-* Connected to 172.17.4.99 (172.17.4.99) port 80 (#0)
-> GET /something HTTP/1.1
-> Host: rewrite.bar.com
-> User-Agent: curl/7.43.0
-> Accept: */*
->
-< HTTP/1.1 200 OK
-< Server: nginx/1.11.0
-< Date: Tue, 31 May 2016 16:07:31 GMT
-< Content-Type: text/plain
-< Transfer-Encoding: chunked
-< Connection: keep-alive
-<
-CLIENT VALUES:
-client_address=10.2.56.9
-command=GET
-real path=/
-query=nil
-request_version=1.1
-request_uri=http://rewrite.bar.com:8080/
-
-SERVER VALUES:
-server_version=nginx: 1.9.11 - lua: 10001
-
-HEADERS RECEIVED:
-accept=*/*
-connection=close
-host=rewrite.bar.com
-user-agent=curl/7.43.0
-x-forwarded-for=10.2.56.1
-x-forwarded-host=rewrite.bar.com
-x-forwarded-port=80
-x-forwarded-proto=http
-x-real-ip=10.2.56.1
-BODY:
-* Connection #0 to host 172.17.4.99 left intact
--no body in request-
-```
+For example, the ingress definition above will result in the following rewrites:
+- `rewrite.bar.com/something` rewrites to `rewrite.bar.com/`
+- `rewrite.bar.com/something/` rewrites to `rewrite.bar.com/`
+- `rewrite.bar.com/something/new` rewrites to `rewrite.bar.com/new`
 
 ### App Root
 

--- a/docs/user-guide/ingress-path-matching.md
+++ b/docs/user-guide/ingress-path-matching.md
@@ -54,11 +54,11 @@ spec:
       paths:
       - path: /foo/bar
         backend:
-          serviceName: test
+          serviceName: service1
           servicePort: 80
       - path: /foo/bar/
         backend:
-          serviceName: test
+          serviceName: service2
           servicePort: 80
 ```
 
@@ -76,14 +76,14 @@ spec:
       paths:
       - path: /foo/bar/.+
         backend:
-          serviceName: test
+          serviceName: service3
           servicePort: 80
 ```
 
 The ingress controller would define the following location blocks, in order of descending length, within the NGINX template for the `test.com` server:
 
 ```txt
-location ~* "^/foo/bar/.+\/?(?<baseuri>.*)" {
+location ~* ^/foo/bar/.+ {
   ...
 }
 
@@ -98,13 +98,12 @@ location ~* "^/foo/bar" {
 
 The following request URI's would match the corresponding location blocks:
 
-- `test.com/foo/bar/1` matches `~* "^/foo/bar/.+\/?(?<baseuri>.*)"`
-- `test.com/foo/bar/` matches `~* "^/foo/bar/"`
-- `test.com/foo/bar` matches `~* "^/foo/bar"`
+- `test.com/foo/bar/1` matches `~* ^/foo/bar/.+` and will go to service 3.
+- `test.com/foo/bar/` matches `~* ^/foo/bar/` and will go to service 2.
+- `test.com/foo/bar` matches `~* ^/foo/bar` and will go to service 1.
 
 **IMPORTANT NOTES**:
 
-- paths created under the `rewrite-ingress` are sorted before `\/?(?<baseuri>.*)` is appended. For example if the path defined within `test-ingress-2` was `/foo/.+` then the location block for `^/foo/.+\/?(?<baseuri>.*)` would be the LAST block listed.
 - If the `use-regex` OR `rewrite-target` annotation is used on any Ingress for a given host, then the case insensitive regular expression [location modifier](https://nginx.org/en/docs/http/ngx_http_core_module.html#location) will be enforced on ALL paths for a given host regardless of what Ingress they are defined on.
 
 ## Warning

--- a/docs/user-guide/nginx-configuration/annotations.md
+++ b/docs/user-guide/nginx-configuration/annotations.md
@@ -15,7 +15,6 @@ You can add these Kubernetes annotations to specific Ingress objects to customiz
 
 |Name                       | type |
 |---------------------------|------|
-|[nginx.ingress.kubernetes.io/add-base-url](#rewrite)|"true" or "false"|
 |[nginx.ingress.kubernetes.io/app-root](#rewrite)|string|
 |[nginx.ingress.kubernetes.io/affinity](#session-affinity)|cookie|
 |[nginx.ingress.kubernetes.io/auth-realm](#authentication)|string|
@@ -29,7 +28,6 @@ You can add these Kubernetes annotations to specific Ingress objects to customiz
 |[nginx.ingress.kubernetes.io/auth-url](#external-authentication)|string|
 |[nginx.ingress.kubernetes.io/auth-snippet](#external-authentication)|string|
 |[nginx.ingress.kubernetes.io/backend-protocol](#backend-protocol)|string|HTTP,HTTPS,GRPC,GRPCS,AJP|
-|[nginx.ingress.kubernetes.io/base-url-scheme](#rewrite)|string|
 |[nginx.ingress.kubernetes.io/canary](#canary)|"true" or "false"|
 |[nginx.ingress.kubernetes.io/canary-by-header](#canary)|string|
 |[nginx.ingress.kubernetes.io/canary-by-cookie](#canary)|string|
@@ -124,10 +122,6 @@ Currently a maximum of one canary ingress can be applied per Ingress rule.
 
 In some scenarios the exposed URL in the backend service differs from the specified path in the Ingress rule. Without a rewrite any request will return 404.
 Set the annotation `nginx.ingress.kubernetes.io/rewrite-target` to the path expected by the service.
-
-If the application contains relative links it is possible to add an additional annotation `nginx.ingress.kubernetes.io/add-base-url` that will prepend a [`base` tag](https://developer.mozilla.org/en/docs/Web/HTML/Element/base) in the header of the returned HTML from the backend.
-
-If the scheme of [`base` tag](https://developer.mozilla.org/en/docs/Web/HTML/Element/base) need to be specific, set the annotation `nginx.ingress.kubernetes.io/base-url-scheme` to the scheme such as `http` and `https`.
 
 If the Application Root is exposed in a different path and needs to be redirected, set the annotation `nginx.ingress.kubernetes.io/app-root` to redirect requests for `/`.
 

--- a/internal/ingress/annotations/rewrite/main.go
+++ b/internal/ingress/annotations/rewrite/main.go
@@ -27,11 +27,6 @@ import (
 type Config struct {
 	// Target URI where the traffic must be redirected
 	Target string `json:"target"`
-	// AddBaseURL indicates if is required to add a base tag in the head
-	// of the responses from the upstream servers
-	AddBaseURL bool `json:"addBaseUrl"`
-	// BaseURLScheme override for the scheme passed to the base tag
-	BaseURLScheme string `json:"baseUrlScheme"`
 	// SSLRedirect indicates if the location section is accessible SSL only
 	SSLRedirect bool `json:"sslRedirect"`
 	// ForceSSLRedirect indicates if the location section is accessible SSL only
@@ -51,12 +46,6 @@ func (r1 *Config) Equal(r2 *Config) bool {
 		return false
 	}
 	if r1.Target != r2.Target {
-		return false
-	}
-	if r1.AddBaseURL != r2.AddBaseURL {
-		return false
-	}
-	if r1.BaseURLScheme != r2.BaseURLScheme {
 		return false
 	}
 	if r1.SSLRedirect != r2.SSLRedirect {
@@ -101,8 +90,6 @@ func (a rewrite) Parse(ing *extensions.Ingress) (interface{}, error) {
 		config.ForceSSLRedirect = a.r.GetDefaultBackend().ForceSSLRedirect
 	}
 
-	config.AddBaseURL, _ = parser.GetBoolAnnotation("add-base-url", ing)
-	config.BaseURLScheme, _ = parser.GetStringAnnotation("base-url-scheme", ing)
 	config.AppRoot, _ = parser.GetStringAnnotation("app-root", ing)
 	config.UseRegex, _ = parser.GetBoolAnnotation("use-regex", ing)
 

--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -338,19 +338,6 @@ func buildLocation(input interface{}, enforceRegex bool) string {
 	}
 
 	path := location.Path
-	if needsRewrite(location) {
-		if path == slash {
-			return fmt.Sprintf("~* ^%s", path)
-		}
-		// baseuri regex will parse basename from the given location
-		baseuri := `(?<baseuri>.*)`
-		if !strings.HasSuffix(path, slash) {
-			// Not treat the slash after "location path" as a part of baseuri
-			baseuri = fmt.Sprintf(`\/?%s`, baseuri)
-		}
-		return fmt.Sprintf(`~* "^%s%s"`, path, baseuri)
-	}
-
 	if enforceRegex {
 		return fmt.Sprintf(`~* "^%s"`, path)
 	}
@@ -465,48 +452,16 @@ func buildProxyPass(host string, b interface{}, loc interface{}) string {
 		return defProxyPass
 	}
 
-	if !strings.HasSuffix(path, slash) {
-		path = fmt.Sprintf("%s/", path)
-	}
-
 	if len(location.Rewrite.Target) > 0 {
-		var abu string
 		var xForwardedPrefix string
-
-		if location.Rewrite.AddBaseURL {
-			bPath := fmt.Sprintf("%s$escaped_base_uri", path)
-			regex := `(<(?:H|h)(?:E|e)(?:A|a)(?:D|d)(?:[^">]|"[^"]*")*>)`
-			scheme := "$scheme"
-
-			if len(location.Rewrite.BaseURLScheme) > 0 {
-				scheme = location.Rewrite.BaseURLScheme
-			}
-
-			abu = fmt.Sprintf(`
-set_escape_uri $escaped_base_uri $baseuri;
-subs_filter '%v' '$1<base href="%v://$http_host%v">' ro;
-`, regex, scheme, bPath)
-		}
 
 		if location.XForwardedPrefix {
 			xForwardedPrefix = fmt.Sprintf("proxy_set_header X-Forwarded-Prefix \"%s\";\n", path)
 		}
 
-		if location.Rewrite.Target == slash {
-			// special case redirect to /
-			// ie /something to /
-			return fmt.Sprintf(`
-rewrite "(?i)%s(.*)" /$1 break;
-rewrite "(?i)%s$" / break;
-%v%v %s%s;
-%v`, path, location.Path, xForwardedPrefix, proxyPass, proto, upstreamName, abu)
-		}
-
 		return fmt.Sprintf(`
-rewrite "(?i)%s(.*)" %s/$1 break;
-rewrite "(?i)%s$" %s/ break;
-%v%v %s%s;
-%v`, path, location.Rewrite.Target, location.Path, location.Rewrite.Target, xForwardedPrefix, proxyPass, proto, upstreamName, abu)
+rewrite "(?i)%s" %s break;
+%v%v %s%s;`, path, location.Rewrite.Target, xForwardedPrefix, proxyPass, proto, upstreamName)
 	}
 
 	// default proxy_pass

--- a/internal/ingress/controller/template/template_test.go
+++ b/internal/ingress/controller/template/template_test.go
@@ -44,8 +44,6 @@ var (
 		Target           string
 		Location         string
 		ProxyPass        string
-		AddBaseURL       bool
-		BaseURLScheme    string
 		Sticky           bool
 		XForwardedPrefix bool
 		SecureBackend    bool
@@ -57,8 +55,6 @@ var (
 			"/",
 			"proxy_pass https://upstream_balancer;",
 			false,
-			"",
-			false,
 			false,
 			true,
 			false,
@@ -69,8 +65,6 @@ var (
 			"/",
 			"proxy_pass https://upstream_balancer;",
 			false,
-			"",
-			false,
 			false,
 			true,
 			false,
@@ -80,8 +74,6 @@ var (
 			"/",
 			"/",
 			"proxy_pass https://upstream_balancer;",
-			false,
-			"",
 			true,
 			false,
 			true,
@@ -93,8 +85,6 @@ var (
 			"/",
 			"proxy_pass http://upstream_balancer;",
 			false,
-			"",
-			false,
 			false,
 			false,
 			false,
@@ -105,8 +95,6 @@ var (
 			"/",
 			"proxy_pass http://upstream_balancer;",
 			false,
-			"",
-			false,
 			false,
 			false,
 			false,
@@ -114,157 +102,10 @@ var (
 		"redirect / to /jenkins": {
 			"/",
 			"/jenkins",
-			"~* ^/",
+			`~* "^/"`,
 			`
-rewrite "(?i)/(.*)" /jenkins/$1 break;
-rewrite "(?i)/$" /jenkins/ break;
-proxy_pass http://upstream_balancer;
-`,
-			false,
-			"",
-			false,
-			false,
-			false,
-			true,
-		},
-		"redirect /something to /": {
-			"/something",
-			"/",
-			`~* "^/something\/?(?<baseuri>.*)"`,
-			`
-rewrite "(?i)/something/(.*)" /$1 break;
-rewrite "(?i)/something$" / break;
-proxy_pass http://upstream_balancer;
-`,
-			false,
-			"",
-			false,
-			false,
-			false,
-			true,
-		},
-		"redirect /end-with-slash/ to /not-root": {
-			"/end-with-slash/",
-			"/not-root",
-			`~* "^/end-with-slash/(?<baseuri>.*)"`,
-			`
-rewrite "(?i)/end-with-slash/(.*)" /not-root/$1 break;
-rewrite "(?i)/end-with-slash/$" /not-root/ break;
-proxy_pass http://upstream_balancer;
-`,
-			false,
-			"",
-			false,
-			false,
-			false,
-			true,
-		},
-		"redirect /something-complex to /not-root": {
-			"/something-complex",
-			"/not-root",
-			`~* "^/something-complex\/?(?<baseuri>.*)"`,
-			`
-rewrite "(?i)/something-complex/(.*)" /not-root/$1 break;
-rewrite "(?i)/something-complex$" /not-root/ break;
-proxy_pass http://upstream_balancer;
-`,
-			false,
-			"",
-			false,
-			false,
-			false,
-			true,
-		},
-		"redirect / to /jenkins and rewrite": {
-			"/",
-			"/jenkins",
-			"~* ^/",
-			`
-rewrite "(?i)/(.*)" /jenkins/$1 break;
-rewrite "(?i)/$" /jenkins/ break;
-proxy_pass http://upstream_balancer;
-
-set_escape_uri $escaped_base_uri $baseuri;
-subs_filter '(<(?:H|h)(?:E|e)(?:A|a)(?:D|d)(?:[^">]|"[^"]*")*>)' '$1<base href="$scheme://$http_host/$escaped_base_uri">' ro;
-`,
-			true,
-			"",
-			false,
-			false,
-			false,
-			true,
-		},
-		"redirect /something to / and rewrite": {
-			"/something",
-			"/",
-			`~* "^/something\/?(?<baseuri>.*)"`,
-			`
-rewrite "(?i)/something/(.*)" /$1 break;
-rewrite "(?i)/something$" / break;
-proxy_pass http://upstream_balancer;
-
-set_escape_uri $escaped_base_uri $baseuri;
-subs_filter '(<(?:H|h)(?:E|e)(?:A|a)(?:D|d)(?:[^">]|"[^"]*")*>)' '$1<base href="$scheme://$http_host/something/$escaped_base_uri">' ro;
-`,
-			true,
-			"",
-			false,
-			false,
-			false,
-			true,
-		},
-		"redirect /end-with-slash/ to /not-root and rewrite": {
-			"/end-with-slash/",
-			"/not-root",
-			`~* "^/end-with-slash/(?<baseuri>.*)"`,
-			`
-rewrite "(?i)/end-with-slash/(.*)" /not-root/$1 break;
-rewrite "(?i)/end-with-slash/$" /not-root/ break;
-proxy_pass http://upstream_balancer;
-
-set_escape_uri $escaped_base_uri $baseuri;
-subs_filter '(<(?:H|h)(?:E|e)(?:A|a)(?:D|d)(?:[^">]|"[^"]*")*>)' '$1<base href="$scheme://$http_host/end-with-slash/$escaped_base_uri">' ro;
-`,
-			true,
-			"",
-			false,
-			false,
-			false,
-			true,
-		},
-		"redirect /something-complex to /not-root and rewrite": {
-			"/something-complex",
-			"/not-root",
-			`~* "^/something-complex\/?(?<baseuri>.*)"`,
-			`
-rewrite "(?i)/something-complex/(.*)" /not-root/$1 break;
-rewrite "(?i)/something-complex$" /not-root/ break;
-proxy_pass http://upstream_balancer;
-
-set_escape_uri $escaped_base_uri $baseuri;
-subs_filter '(<(?:H|h)(?:E|e)(?:A|a)(?:D|d)(?:[^">]|"[^"]*")*>)' '$1<base href="$scheme://$http_host/something-complex/$escaped_base_uri">' ro;
-`,
-			true,
-			"",
-			false,
-			false,
-			false,
-			true,
-		},
-		"redirect /something to / and rewrite with specific scheme": {
-			"/something",
-			"/",
-			`~* "^/something\/?(?<baseuri>.*)"`,
-			`
-rewrite "(?i)/something/(.*)" /$1 break;
-rewrite "(?i)/something$" / break;
-proxy_pass http://upstream_balancer;
-
-set_escape_uri $escaped_base_uri $baseuri;
-subs_filter '(<(?:H|h)(?:E|e)(?:A|a)(?:D|d)(?:[^">]|"[^"]*")*>)' '$1<base href="http://$http_host/something/$escaped_base_uri">' ro;
-`,
-			true,
-			"http",
+rewrite "(?i)/" /jenkins break;
+proxy_pass http://upstream_balancer;`,
 			false,
 			false,
 			false,
@@ -273,14 +114,10 @@ subs_filter '(<(?:H|h)(?:E|e)(?:A|a)(?:D|d)(?:[^">]|"[^"]*")*>)' '$1<base href="
 		"redirect / to /something with sticky enabled": {
 			"/",
 			"/something",
-			`~* ^/`,
+			`~* "^/"`,
 			`
-rewrite "(?i)/(.*)" /something/$1 break;
-rewrite "(?i)/$" /something/ break;
-proxy_pass http://upstream_balancer;
-`,
-			false,
-			"http",
+rewrite "(?i)/" /something break;
+proxy_pass http://upstream_balancer;`,
 			true,
 			false,
 			false,
@@ -289,14 +126,10 @@ proxy_pass http://upstream_balancer;
 		"redirect / to /something with sticky and dynamic config enabled": {
 			"/",
 			"/something",
-			`~* ^/`,
+			`~* "^/"`,
 			`
-rewrite "(?i)/(.*)" /something/$1 break;
-rewrite "(?i)/$" /something/ break;
-proxy_pass http://upstream_balancer;
-`,
-			false,
-			"http",
+rewrite "(?i)/" /something break;
+proxy_pass http://upstream_balancer;`,
 			true,
 			false,
 			false,
@@ -305,15 +138,11 @@ proxy_pass http://upstream_balancer;
 		"add the X-Forwarded-Prefix header": {
 			"/there",
 			"/something",
-			`~* "^/there\/?(?<baseuri>.*)"`,
+			`~* "^/there"`,
 			`
-rewrite "(?i)/there/(.*)" /something/$1 break;
-rewrite "(?i)/there$" /something/ break;
-proxy_set_header X-Forwarded-Prefix "/there/";
-proxy_pass http://upstream_balancer;
-`,
-			false,
-			"http",
+rewrite "(?i)/there" /something break;
+proxy_set_header X-Forwarded-Prefix "/there";
+proxy_pass http://upstream_balancer;`,
 			true,
 			true,
 			false,
@@ -324,8 +153,6 @@ proxy_pass http://upstream_balancer;
 			"/something",
 			`~* "^/something"`,
 			"proxy_pass http://upstream_balancer;",
-			false,
-			"",
 			false,
 			false,
 			false,
@@ -384,7 +211,7 @@ func TestBuildLocation(t *testing.T) {
 	for k, tc := range tmplFuncTestcases {
 		loc := &ingress.Location{
 			Path:    tc.Path,
-			Rewrite: rewrite.Config{Target: tc.Target, AddBaseURL: tc.AddBaseURL},
+			Rewrite: rewrite.Config{Target: tc.Target},
 		}
 
 		newLoc := buildLocation(loc, tc.enforceRegex)
@@ -401,7 +228,7 @@ func TestBuildProxyPass(t *testing.T) {
 	for k, tc := range tmplFuncTestcases {
 		loc := &ingress.Location{
 			Path:             tc.Path,
-			Rewrite:          rewrite.Config{Target: tc.Target, AddBaseURL: tc.AddBaseURL, BaseURLScheme: tc.BaseURLScheme},
+			Rewrite:          rewrite.Config{Target: tc.Target},
 			Backend:          defaultBackend,
 			XForwardedPrefix: tc.XForwardedPrefix,
 		}
@@ -767,7 +594,7 @@ func TestBuildUpstreamName(t *testing.T) {
 	for k, tc := range tmplFuncTestcases {
 		loc := &ingress.Location{
 			Path:             tc.Path,
-			Rewrite:          rewrite.Config{Target: tc.Target, AddBaseURL: tc.AddBaseURL, BaseURLScheme: tc.BaseURLScheme},
+			Rewrite:          rewrite.Config{Target: tc.Target},
 			Backend:          defaultBackend,
 			XForwardedPrefix: tc.XForwardedPrefix,
 		}

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -1283,11 +1283,6 @@ stream {
             proxy_next_upstream                     {{ buildNextUpstream $location.Proxy.NextUpstream $all.Cfg.RetryNonIdempotent }};
             proxy_next_upstream_tries               {{ $location.Proxy.NextUpstreamTries }};
 
-            {{/* rewrite only works if the content is not compressed */}}
-            {{ if $location.Rewrite.AddBaseURL }}
-            {{ $proxySetHeader }}                        Accept-Encoding     "";
-            {{ end }}
-
             {{/* Add any additional configuration defined */}}
             {{ $location.ConfigurationSnippet }}
 

--- a/test/manifests/configuration-a.json
+++ b/test/manifests/configuration-a.json
@@ -276,7 +276,6 @@
 			},
 			"redirect": {
 				"target": "",
-				"addBaseUrl": false,
 				"sslRedirect": false,
 				"forceSSLRedirect": false,
 				"appRoot": ""
@@ -384,7 +383,6 @@
 			},
 			"redirect": {
 				"target": "",
-				"addBaseUrl": false,
 				"sslRedirect": true,
 				"forceSSLRedirect": false,
 				"appRoot": ""
@@ -463,7 +461,6 @@
 			},
 			"redirect": {
 				"target": "",
-				"addBaseUrl": false,
 				"sslRedirect": false,
 				"forceSSLRedirect": false,
 				"appRoot": ""
@@ -576,7 +573,6 @@
 			},
 			"redirect": {
 				"target": "/",
-				"addBaseUrl": false,
 				"sslRedirect": true,
 				"forceSSLRedirect": false,
 				"appRoot": ""
@@ -655,7 +651,6 @@
 			},
 			"redirect": {
 				"target": "",
-				"addBaseUrl": false,
 				"sslRedirect": false,
 				"forceSSLRedirect": false,
 				"appRoot": ""

--- a/test/manifests/configuration-b.json
+++ b/test/manifests/configuration-b.json
@@ -276,7 +276,6 @@
 			},
 			"redirect": {
 				"target": "",
-				"addBaseUrl": false,
 				"sslRedirect": false,
 				"forceSSLRedirect": false,
 				"appRoot": ""
@@ -384,7 +383,6 @@
 			},
 			"redirect": {
 				"target": "",
-				"addBaseUrl": false,
 				"sslRedirect": true,
 				"forceSSLRedirect": false,
 				"appRoot": ""
@@ -463,7 +461,6 @@
 			},
 			"redirect": {
 				"target": "",
-				"addBaseUrl": false,
 				"sslRedirect": false,
 				"forceSSLRedirect": false,
 				"appRoot": ""
@@ -576,7 +573,6 @@
 			},
 			"redirect": {
 				"target": "/",
-				"addBaseUrl": false,
 				"sslRedirect": true,
 				"forceSSLRedirect": false,
 				"appRoot": ""
@@ -675,7 +671,6 @@
 			},
 			"redirect": {
 				"target": "",
-				"addBaseUrl": false,
 				"sslRedirect": false,
 				"forceSSLRedirect": false,
 				"appRoot": ""

--- a/test/manifests/configuration-c.json
+++ b/test/manifests/configuration-c.json
@@ -128,7 +128,6 @@
 			},
 			"redirect": {
 				"target": "",
-				"addBaseUrl": false,
 				"sslRedirect": false,
 				"forceSSLRedirect": false,
 				"appRoot": ""
@@ -229,7 +228,6 @@
 			},
 			"redirect": {
 				"target": "",
-				"addBaseUrl": false,
 				"sslRedirect": true,
 				"forceSSLRedirect": false,
 				"appRoot": ""


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

When the `rewrite-target` annotation is used and the written path uses regex and does not end in `/` (ex. `foo/bar/.+`), rewrite does not work as expected. This provides a regex check in `BuildProxyPass` and uses a custom rewrite block if the `use-regex` annotation is true for a location.

_UPDATE_
In addition to the above, this PR deprecates the `AddBaseUrl` annotation. 

**Problem**

An ingress is created with `use-regex="true"` and `rewrite-target="/new"` and the path `/foo/bar/.+`.

This results in the following rewrite blocks for that location:
```
rewrite (?i)/foo/bar/.+/(.*) /new/$1 break;
rewrite (?i)/foo/bar/.+$ /new break;
...
```

Therefore a request to `/foo/bar/bar` will go to `/new` instead of `/new/bar` as a user may expect.

**Solution**

Check if a use-regex is true for a location when building the proxy pass. 

An ingress is created with `use-regex="true"` and `rewrite-target="/new/$1"` and the path `/foo/bar/(.+)`.

This results in the following rewrite blocks for that location:
```
rewrite (?i)/foo/bar/(.+) /new/$1 break;
...
```

Now a request to `/foo/bar/bar` will go to `/new/bar`.
