### PR TITLE
Fix yaml indentation in annotations server-snippet doc

### DIFF
--- a/docs/user-guide/nginx-configuration/annotations.md
+++ b/docs/user-guide/nginx-configuration/annotations.md
@@ -295,15 +295,15 @@ kind: Ingress
 metadata:
   annotations:
     nginx.ingress.kubernetes.io/server-snippet: |
-set $agentflag 0;
-
-if ($http_user_agent ~* "(Mobile)" ){
-  set $agentflag 1;
-}
-
-if ( $agentflag = 1 ) {
-  return 301 https://m.example.com;
-}
+        set $agentflag 0;
+        
+        if ($http_user_agent ~* "(Mobile)" ){
+          set $agentflag 1;
+        }
+        
+        if ( $agentflag = 1 ) {
+          return 301 https://m.example.com;
+        }
 ```
 
 !!! attention


### PR DESCRIPTION
Copy / Pasting the code made errors when injecting config in Kubernetes cluster. With this change, annotations now works in ingresses metadata.
