### PR TITLE
Allow curly braces to be used in regex paths

### DIFF
--- a/docs/user-guide/ingress-path-matching.md
+++ b/docs/user-guide/ingress-path-matching.md
@@ -2,7 +2,7 @@
 
 ## Regular Expression Support
 
-The ingress controller supports **case insensitive** regular expressions in the `spec.rules.http.paths.path` field. __Currently curly braces `{}` cannot be used in regular expressions due to a [known issue](https://github.com/kubernetes/ingress-nginx/issues/3155).__
+The ingress controller supports **case insensitive** regular expressions in the `spec.rules.http.paths.path` field.
 
 
 See the [description](./nginx-configuration/annotations.md#use-regex) of the `use-regex` annotation for more details. 

--- a/internal/ingress/controller/template/template_test.go
+++ b/internal/ingress/controller/template/template_test.go
@@ -129,8 +129,8 @@ var (
 			"/jenkins",
 			"~* ^/",
 			`
-rewrite (?i)/(.*) /jenkins/$1 break;
-rewrite (?i)/$ /jenkins/ break;
+rewrite "(?i)/(.*)" /jenkins/$1 break;
+rewrite "(?i)/$" /jenkins/ break;
 proxy_pass http://upstream-name;
 `,
 			false,
@@ -143,10 +143,10 @@ proxy_pass http://upstream-name;
 		"redirect /something to /": {
 			"/something",
 			"/",
-			`~* ^/something\/?(?<baseuri>.*)`,
+			`~* "^/something\/?(?<baseuri>.*)"`,
 			`
-rewrite (?i)/something/(.*) /$1 break;
-rewrite (?i)/something$ / break;
+rewrite "(?i)/something/(.*)" /$1 break;
+rewrite "(?i)/something$" / break;
 proxy_pass http://upstream-name;
 `,
 			false,
@@ -159,10 +159,10 @@ proxy_pass http://upstream-name;
 		"redirect /end-with-slash/ to /not-root": {
 			"/end-with-slash/",
 			"/not-root",
-			"~* ^/end-with-slash/(?<baseuri>.*)",
+			`~* "^/end-with-slash/(?<baseuri>.*)"`,
 			`
-rewrite (?i)/end-with-slash/(.*) /not-root/$1 break;
-rewrite (?i)/end-with-slash/$ /not-root/ break;
+rewrite "(?i)/end-with-slash/(.*)" /not-root/$1 break;
+rewrite "(?i)/end-with-slash/$" /not-root/ break;
 proxy_pass http://upstream-name;
 `,
 			false,
@@ -175,10 +175,10 @@ proxy_pass http://upstream-name;
 		"redirect /something-complex to /not-root": {
 			"/something-complex",
 			"/not-root",
-			`~* ^/something-complex\/?(?<baseuri>.*)`,
+			`~* "^/something-complex\/?(?<baseuri>.*)"`,
 			`
-rewrite (?i)/something-complex/(.*) /not-root/$1 break;
-rewrite (?i)/something-complex$ /not-root/ break;
+rewrite "(?i)/something-complex/(.*)" /not-root/$1 break;
+rewrite "(?i)/something-complex$" /not-root/ break;
 proxy_pass http://upstream-name;
 `,
 			false,
@@ -193,8 +193,8 @@ proxy_pass http://upstream-name;
 			"/jenkins",
 			"~* ^/",
 			`
-rewrite (?i)/(.*) /jenkins/$1 break;
-rewrite (?i)/$ /jenkins/ break;
+rewrite "(?i)/(.*)" /jenkins/$1 break;
+rewrite "(?i)/$" /jenkins/ break;
 proxy_pass http://upstream-name;
 
 set_escape_uri $escaped_base_uri $baseuri;
@@ -210,10 +210,10 @@ subs_filter '(<(?:H|h)(?:E|e)(?:A|a)(?:D|d)(?:[^">]|"[^"]*")*>)' '$1<base href="
 		"redirect /something to / and rewrite": {
 			"/something",
 			"/",
-			`~* ^/something\/?(?<baseuri>.*)`,
+			`~* "^/something\/?(?<baseuri>.*)"`,
 			`
-rewrite (?i)/something/(.*) /$1 break;
-rewrite (?i)/something$ / break;
+rewrite "(?i)/something/(.*)" /$1 break;
+rewrite "(?i)/something$" / break;
 proxy_pass http://upstream-name;
 
 set_escape_uri $escaped_base_uri $baseuri;
@@ -229,10 +229,10 @@ subs_filter '(<(?:H|h)(?:E|e)(?:A|a)(?:D|d)(?:[^">]|"[^"]*")*>)' '$1<base href="
 		"redirect /end-with-slash/ to /not-root and rewrite": {
 			"/end-with-slash/",
 			"/not-root",
-			`~* ^/end-with-slash/(?<baseuri>.*)`,
+			`~* "^/end-with-slash/(?<baseuri>.*)"`,
 			`
-rewrite (?i)/end-with-slash/(.*) /not-root/$1 break;
-rewrite (?i)/end-with-slash/$ /not-root/ break;
+rewrite "(?i)/end-with-slash/(.*)" /not-root/$1 break;
+rewrite "(?i)/end-with-slash/$" /not-root/ break;
 proxy_pass http://upstream-name;
 
 set_escape_uri $escaped_base_uri $baseuri;
@@ -248,10 +248,10 @@ subs_filter '(<(?:H|h)(?:E|e)(?:A|a)(?:D|d)(?:[^">]|"[^"]*")*>)' '$1<base href="
 		"redirect /something-complex to /not-root and rewrite": {
 			"/something-complex",
 			"/not-root",
-			`~* ^/something-complex\/?(?<baseuri>.*)`,
+			`~* "^/something-complex\/?(?<baseuri>.*)"`,
 			`
-rewrite (?i)/something-complex/(.*) /not-root/$1 break;
-rewrite (?i)/something-complex$ /not-root/ break;
+rewrite "(?i)/something-complex/(.*)" /not-root/$1 break;
+rewrite "(?i)/something-complex$" /not-root/ break;
 proxy_pass http://upstream-name;
 
 set_escape_uri $escaped_base_uri $baseuri;
@@ -267,10 +267,10 @@ subs_filter '(<(?:H|h)(?:E|e)(?:A|a)(?:D|d)(?:[^">]|"[^"]*")*>)' '$1<base href="
 		"redirect /something to / and rewrite with specific scheme": {
 			"/something",
 			"/",
-			`~* ^/something\/?(?<baseuri>.*)`,
+			`~* "^/something\/?(?<baseuri>.*)"`,
 			`
-rewrite (?i)/something/(.*) /$1 break;
-rewrite (?i)/something$ / break;
+rewrite "(?i)/something/(.*)" /$1 break;
+rewrite "(?i)/something$" / break;
 proxy_pass http://upstream-name;
 
 set_escape_uri $escaped_base_uri $baseuri;
@@ -288,8 +288,8 @@ subs_filter '(<(?:H|h)(?:E|e)(?:A|a)(?:D|d)(?:[^">]|"[^"]*")*>)' '$1<base href="
 			"/something",
 			`~* ^/`,
 			`
-rewrite (?i)/(.*) /something/$1 break;
-rewrite (?i)/$ /something/ break;
+rewrite "(?i)/(.*)" /something/$1 break;
+rewrite "(?i)/$" /something/ break;
 proxy_pass http://sticky-upstream-name;
 `,
 			false,
@@ -304,8 +304,8 @@ proxy_pass http://sticky-upstream-name;
 			"/something",
 			`~* ^/`,
 			`
-rewrite (?i)/(.*) /something/$1 break;
-rewrite (?i)/$ /something/ break;
+rewrite "(?i)/(.*)" /something/$1 break;
+rewrite "(?i)/$" /something/ break;
 proxy_pass http://upstream_balancer;
 `,
 			false,
@@ -318,10 +318,10 @@ proxy_pass http://upstream_balancer;
 		"add the X-Forwarded-Prefix header": {
 			"/there",
 			"/something",
-			`~* ^/there\/?(?<baseuri>.*)`,
+			`~* "^/there\/?(?<baseuri>.*)"`,
 			`
-rewrite (?i)/there/(.*) /something/$1 break;
-rewrite (?i)/there$ /something/ break;
+rewrite "(?i)/there/(.*)" /something/$1 break;
+rewrite "(?i)/there$" /something/ break;
 proxy_set_header X-Forwarded-Prefix "/there/";
 proxy_pass http://sticky-upstream-name;
 `,
@@ -335,7 +335,7 @@ proxy_pass http://sticky-upstream-name;
 		"use ~* location modifier when ingress does not use rewrite/regex target but at least one other ingress does": {
 			"/something",
 			"/something",
-			"~* ^/something",
+			`~* "^/something"`,
 			"proxy_pass http://upstream-name;",
 			false,
 			"",

--- a/test/e2e/annotations/rewrite.go
+++ b/test/e2e/annotations/rewrite.go
@@ -55,8 +55,8 @@ var _ = framework.IngressNginxDescribe("Annotations - Rewrite", func() {
 
 		err = f.WaitForNginxServer(host,
 			func(server string) bool {
-				return strings.Contains(server, "rewrite (?i)/something/(.*) /$1 break;") &&
-					strings.Contains(server, "rewrite (?i)/something$ / break;")
+				return strings.Contains(server, `rewrite "(?i)/something/(.*)" /$1 break;`) &&
+					strings.Contains(server, `rewrite "(?i)/something$" / break;`)
 			})
 		Expect(err).NotTo(HaveOccurred())
 
@@ -154,7 +154,7 @@ var _ = framework.IngressNginxDescribe("Annotations - Rewrite", func() {
 
 		err = f.WaitForNginxServer(host,
 			func(server string) bool {
-				return strings.Contains(server, "location ~* ^/ {") && strings.Contains(server, "location ~* ^/.well-known/acme/challenge {")
+				return strings.Contains(server, "location ~* ^/ {") && strings.Contains(server, `location ~* "^/.well-known/acme/challenge" {`)
 			})
 		Expect(err).NotTo(HaveOccurred())
 
@@ -195,7 +195,7 @@ var _ = framework.IngressNginxDescribe("Annotations - Rewrite", func() {
 
 		err = f.WaitForNginxServer(host,
 			func(server string) bool {
-				return strings.Contains(server, "location ~* ^/foo {") && strings.Contains(server, `location ~* ^/foo.+\/?(?<baseuri>.*) {`)
+				return strings.Contains(server, `location ~* "^/foo" {`) && strings.Contains(server, `location ~* "^/foo.+\/?(?<baseuri>.*)" {`)
 			})
 		Expect(err).NotTo(HaveOccurred())
 
@@ -234,14 +234,14 @@ var _ = framework.IngressNginxDescribe("Annotations - Rewrite", func() {
 			"nginx.ingress.kubernetes.io/use-regex":      "true",
 			"nginx.ingress.kubernetes.io/rewrite-target": "/new/backend",
 		}
-		ing = framework.NewSingleIngress("regex", "/foo/bar/[a-z][a-z][a-z]", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
+		ing = framework.NewSingleIngress("regex", "/foo/bar/[a-z]{3}", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
 		_, err = f.EnsureIngress(ing)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ing).NotTo(BeNil())
 
 		err = f.WaitForNginxServer(host,
 			func(server string) bool {
-				return strings.Contains(server, "location ~* ^/foo/bar/bar {") && strings.Contains(server, `location ~* ^/foo/bar/[a-z][a-z][a-z]\/?(?<baseuri>.*) {`)
+				return strings.Contains(server, `location ~* "^/foo/bar/bar" {`) && strings.Contains(server, `location ~* "^/foo/bar/[a-z]{3}\/?(?<baseuri>.*)" {`)
 			})
 		Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: 

This fixes the issue where the nginx template breaks if curly braces are used in a regular expression ingress path. 

**Which issue this PR fixes**: fixes https://github.com/kubernetes/ingress-nginx/issues/3155
