### PR TITLE
Refactor e2e Tests to use common helper

### DIFF
--- a/test/e2e/annotations/affinity.go
+++ b/test/e2e/annotations/affinity.go
@@ -49,37 +49,14 @@ var _ = framework.IngressNginxDescribe("Annotations - Affinity", func() {
 
 	It("should set sticky cookie SERVERID", func() {
 		host := "sticky.foo.com"
+		annotations := map[string]string{
+			"nginx.ingress.kubernetes.io/affinity":            "cookie",
+			"nginx.ingress.kubernetes.io/session-cookie-name": "SERVERID",
+		}
 
-		ing, err := f.EnsureIngress(&v1beta1.Ingress{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      host,
-				Namespace: f.IngressController.Namespace,
-				Annotations: map[string]string{
-					"nginx.ingress.kubernetes.io/affinity":            "cookie",
-					"nginx.ingress.kubernetes.io/session-cookie-name": "SERVERID",
-				},
-			},
-			Spec: v1beta1.IngressSpec{
-				Rules: []v1beta1.IngressRule{
-					{
-						Host: host,
-						IngressRuleValue: v1beta1.IngressRuleValue{
-							HTTP: &v1beta1.HTTPIngressRuleValue{
-								Paths: []v1beta1.HTTPIngressPath{
-									{
-										Path: "/",
-										Backend: v1beta1.IngressBackend{
-											ServiceName: "http-svc",
-											ServicePort: intstr.FromInt(80),
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		})
+		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
+		_, err := f.EnsureIngress(ing)
+
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ing).NotTo(BeNil())
 
@@ -101,37 +78,13 @@ var _ = framework.IngressNginxDescribe("Annotations - Affinity", func() {
 
 	It("should redirect to '/something' with enabled affinity", func() {
 		host := "example.com"
+		annotations := map[string]string{
+			"nginx.ingress.kubernetes.io/affinity":            "cookie",
+			"nginx.ingress.kubernetes.io/session-cookie-name": "SERVERID",
+		}
 
-		ing, err := f.EnsureIngress(&v1beta1.Ingress{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      host,
-				Namespace: f.IngressController.Namespace,
-				Annotations: map[string]string{
-					"nginx.ingress.kubernetes.io/affinity":            "cookie",
-					"nginx.ingress.kubernetes.io/session-cookie-name": "SERVERID",
-				},
-			},
-			Spec: v1beta1.IngressSpec{
-				Rules: []v1beta1.IngressRule{
-					{
-						Host: host,
-						IngressRuleValue: v1beta1.IngressRuleValue{
-							HTTP: &v1beta1.HTTPIngressRuleValue{
-								Paths: []v1beta1.HTTPIngressPath{
-									{
-										Path: "/",
-										Backend: v1beta1.IngressBackend{
-											ServiceName: "http-svc",
-											ServicePort: intstr.FromInt(80),
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		})
+		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
+		_, err := f.EnsureIngress(ing)
 
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ing).NotTo(BeNil())
@@ -155,37 +108,13 @@ var _ = framework.IngressNginxDescribe("Annotations - Affinity", func() {
 
 	It("should set the path to /something on the generated cookie", func() {
 		host := "example.com"
+		annotations := map[string]string{
+			"nginx.ingress.kubernetes.io/affinity":            "cookie",
+			"nginx.ingress.kubernetes.io/session-cookie-name": "SERVERID",
+		}
 
-		ing, err := f.EnsureIngress(&v1beta1.Ingress{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      host,
-				Namespace: f.IngressController.Namespace,
-				Annotations: map[string]string{
-					"nginx.ingress.kubernetes.io/affinity":            "cookie",
-					"nginx.ingress.kubernetes.io/session-cookie-name": "SERVERID",
-				},
-			},
-			Spec: v1beta1.IngressSpec{
-				Rules: []v1beta1.IngressRule{
-					{
-						Host: host,
-						IngressRuleValue: v1beta1.IngressRuleValue{
-							HTTP: &v1beta1.HTTPIngressRuleValue{
-								Paths: []v1beta1.HTTPIngressPath{
-									{
-										Path: "/something",
-										Backend: v1beta1.IngressBackend{
-											ServiceName: "http-svc",
-											ServicePort: intstr.FromInt(80),
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		})
+		ing := framework.NewSingleIngress(host, "/something", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
+		_, err := f.EnsureIngress(ing)
 
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ing).NotTo(BeNil())
@@ -208,15 +137,16 @@ var _ = framework.IngressNginxDescribe("Annotations - Affinity", func() {
 
 	It("should set the path to / on the generated cookie if there's more than one rule referring to the same backend", func() {
 		host := "example.com"
+		annotations := map[string]string{
+			"nginx.ingress.kubernetes.io/affinity":            "cookie",
+			"nginx.ingress.kubernetes.io/session-cookie-name": "SERVERID",
+		}
 
 		ing, err := f.EnsureIngress(&v1beta1.Ingress{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      host,
-				Namespace: f.IngressController.Namespace,
-				Annotations: map[string]string{
-					"nginx.ingress.kubernetes.io/affinity":            "cookie",
-					"nginx.ingress.kubernetes.io/session-cookie-name": "SERVERID",
-				},
+				Name:        host,
+				Namespace:   f.IngressController.Namespace,
+				Annotations: annotations,
 			},
 			Spec: v1beta1.IngressSpec{
 				Rules: []v1beta1.IngressRule{

--- a/test/e2e/annotations/alias.go
+++ b/test/e2e/annotations/alias.go
@@ -24,10 +24,6 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/parnurzeal/gorequest"
 
-	v1beta1 "k8s.io/api/extensions/v1beta1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
-
 	"k8s.io/ingress-nginx/test/e2e/framework"
 )
 
@@ -44,33 +40,10 @@ var _ = framework.IngressNginxDescribe("Annotations - Alias", func() {
 
 	It("should return status code 200 for host 'foo' and 404 for 'bar'", func() {
 		host := "foo"
+		annotations := map[string]string{}
 
-		ing, err := f.EnsureIngress(&v1beta1.Ingress{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      host,
-				Namespace: f.IngressController.Namespace,
-			},
-			Spec: v1beta1.IngressSpec{
-				Rules: []v1beta1.IngressRule{
-					{
-						Host: host,
-						IngressRuleValue: v1beta1.IngressRuleValue{
-							HTTP: &v1beta1.HTTPIngressRuleValue{
-								Paths: []v1beta1.HTTPIngressPath{
-									{
-										Path: "/",
-										Backend: v1beta1.IngressBackend{
-											ServiceName: "http-svc",
-											ServicePort: intstr.FromInt(80),
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		})
+		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
+		_, err := f.EnsureIngress(ing)
 
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ing).NotTo(BeNil())
@@ -103,35 +76,12 @@ var _ = framework.IngressNginxDescribe("Annotations - Alias", func() {
 
 	It("should return status code 200 for host 'foo' and 'bar'", func() {
 		host := "foo"
-		ing, err := f.EnsureIngress(&v1beta1.Ingress{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      host,
-				Namespace: f.IngressController.Namespace,
-				Annotations: map[string]string{
-					"nginx.ingress.kubernetes.io/server-alias": "bar",
-				},
-			},
-			Spec: v1beta1.IngressSpec{
-				Rules: []v1beta1.IngressRule{
-					{
-						Host: host,
-						IngressRuleValue: v1beta1.IngressRuleValue{
-							HTTP: &v1beta1.HTTPIngressRuleValue{
-								Paths: []v1beta1.HTTPIngressPath{
-									{
-										Path: "/",
-										Backend: v1beta1.IngressBackend{
-											ServiceName: "http-svc",
-											ServicePort: intstr.FromInt(80),
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		})
+		annotations := map[string]string{
+			"nginx.ingress.kubernetes.io/server-alias": "bar",
+		}
+
+		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
+		_, err := f.EnsureIngress(ing)
 
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ing).NotTo(BeNil())

--- a/test/e2e/annotations/auth.go
+++ b/test/e2e/annotations/auth.go
@@ -49,9 +49,11 @@ var _ = framework.IngressNginxDescribe("Annotations - Auth", func() {
 	It("should return status code 200 when no authentication is configured", func() {
 		host := "auth"
 
-		bi, err := f.EnsureIngress(framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, nil))
+		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, nil)
+		_, err := f.EnsureIngress(ing)
+
 		Expect(err).NotTo(HaveOccurred())
-		Expect(bi).NotTo(BeNil())
+		Expect(ing).NotTo(BeNil())
 
 		err = f.WaitForNginxServer(host,
 			func(server string) bool {
@@ -73,16 +75,15 @@ var _ = framework.IngressNginxDescribe("Annotations - Auth", func() {
 
 	It("should return status code 503 when authentication is configured with an invalid secret", func() {
 		host := "auth"
+		annotations := map[string]string{
+			"nginx.ingress.kubernetes.io/auth-type":   "basic",
+			"nginx.ingress.kubernetes.io/auth-secret": "something",
+			"nginx.ingress.kubernetes.io/auth-realm":  "test auth",
+		}
 
-		bi, err := f.EnsureIngress(framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, nil))
-		Expect(err).NotTo(HaveOccurred())
-		Expect(bi).NotTo(BeNil())
+		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
+		_, err := f.EnsureIngress(ing)
 
-		bi.Annotations["nginx.ingress.kubernetes.io/auth-type"] = "basic"
-		bi.Annotations["nginx.ingress.kubernetes.io/auth-secret"] = "something"
-		bi.Annotations["nginx.ingress.kubernetes.io/auth-realm"] = "test auth"
-
-		ing, err := f.EnsureIngress(bi)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ing).NotTo(BeNil())
 
@@ -112,15 +113,15 @@ var _ = framework.IngressNginxDescribe("Annotations - Auth", func() {
 		Expect(s).NotTo(BeNil())
 		Expect(s.ObjectMeta).NotTo(BeNil())
 
-		bi, err := f.EnsureIngress(framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, nil))
-		Expect(err).NotTo(HaveOccurred())
-		Expect(bi).NotTo(BeNil())
+		annotations := map[string]string{
+			"nginx.ingress.kubernetes.io/auth-type":   "basic",
+			"nginx.ingress.kubernetes.io/auth-secret": s.Name,
+			"nginx.ingress.kubernetes.io/auth-realm":  "test auth",
+		}
 
-		bi.Annotations["nginx.ingress.kubernetes.io/auth-type"] = "basic"
-		bi.Annotations["nginx.ingress.kubernetes.io/auth-secret"] = s.Name
-		bi.Annotations["nginx.ingress.kubernetes.io/auth-realm"] = "test auth"
+		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
+		_, err = f.EnsureIngress(ing)
 
-		ing, err := f.EnsureIngress(bi)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ing).NotTo(BeNil())
 
@@ -150,15 +151,15 @@ var _ = framework.IngressNginxDescribe("Annotations - Auth", func() {
 		Expect(s).NotTo(BeNil())
 		Expect(s.ObjectMeta).NotTo(BeNil())
 
-		bi, err := f.EnsureIngress(framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, nil))
-		Expect(err).NotTo(HaveOccurred())
-		Expect(bi).NotTo(BeNil())
+		annotations := map[string]string{
+			"nginx.ingress.kubernetes.io/auth-type":   "basic",
+			"nginx.ingress.kubernetes.io/auth-secret": s.Name,
+			"nginx.ingress.kubernetes.io/auth-realm":  "test auth",
+		}
 
-		bi.Annotations["nginx.ingress.kubernetes.io/auth-type"] = "basic"
-		bi.Annotations["nginx.ingress.kubernetes.io/auth-secret"] = s.Name
-		bi.Annotations["nginx.ingress.kubernetes.io/auth-realm"] = "test auth"
+		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
+		_, err = f.EnsureIngress(ing)
 
-		ing, err := f.EnsureIngress(bi)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ing).NotTo(BeNil())
 
@@ -189,15 +190,15 @@ var _ = framework.IngressNginxDescribe("Annotations - Auth", func() {
 		Expect(s).NotTo(BeNil())
 		Expect(s.ObjectMeta).NotTo(BeNil())
 
-		bi, err := f.EnsureIngress(framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, nil))
-		Expect(err).NotTo(HaveOccurred())
-		Expect(bi).NotTo(BeNil())
+		annotations := map[string]string{
+			"nginx.ingress.kubernetes.io/auth-type":   "basic",
+			"nginx.ingress.kubernetes.io/auth-secret": s.Name,
+			"nginx.ingress.kubernetes.io/auth-realm":  "test auth",
+		}
 
-		bi.Annotations["nginx.ingress.kubernetes.io/auth-type"] = "basic"
-		bi.Annotations["nginx.ingress.kubernetes.io/auth-secret"] = s.Name
-		bi.Annotations["nginx.ingress.kubernetes.io/auth-realm"] = "test auth"
+		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
+		_, err = f.EnsureIngress(ing)
 
-		ing, err := f.EnsureIngress(bi)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ing).NotTo(BeNil())
 
@@ -239,15 +240,15 @@ var _ = framework.IngressNginxDescribe("Annotations - Auth", func() {
 		Expect(s).NotTo(BeNil())
 		Expect(s.ObjectMeta).NotTo(BeNil())
 
-		bi, err := f.EnsureIngress(framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, nil))
-		Expect(err).NotTo(HaveOccurred())
-		Expect(bi).NotTo(BeNil())
+		annotations := map[string]string{
+			"nginx.ingress.kubernetes.io/auth-type":   "basic",
+			"nginx.ingress.kubernetes.io/auth-secret": s.Name,
+			"nginx.ingress.kubernetes.io/auth-realm":  "test auth",
+		}
 
-		bi.Annotations["nginx.ingress.kubernetes.io/auth-type"] = "basic"
-		bi.Annotations["nginx.ingress.kubernetes.io/auth-secret"] = s.Name
-		bi.Annotations["nginx.ingress.kubernetes.io/auth-realm"] = "test auth"
+		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
+		_, err = f.EnsureIngress(ing)
 
-		ing, err := f.EnsureIngress(bi)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ing).NotTo(BeNil())
 
@@ -293,12 +294,16 @@ var _ = framework.IngressNginxDescribe("Annotations - Auth", func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			bi, err := f.EnsureIngress(framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &map[string]string{
+			annotations := map[string]string{
 				"nginx.ingress.kubernetes.io/auth-url":    fmt.Sprintf("http://%s/basic-auth/user/password", httpbinIP),
 				"nginx.ingress.kubernetes.io/auth-signin": "http://$host/auth/start",
-			}))
+			}
+
+			ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
+			_, err = f.EnsureIngress(ing)
+
 			Expect(err).NotTo(HaveOccurred())
-			Expect(bi).NotTo(BeNil())
+			Expect(ing).NotTo(BeNil())
 
 			err = f.WaitForNginxServer(host, func(server string) bool {
 				return Expect(server).ShouldNot(ContainSubstring("return 503"))

--- a/test/e2e/annotations/clientbodybuffersize.go
+++ b/test/e2e/annotations/clientbodybuffersize.go
@@ -19,11 +19,6 @@ package annotations
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	v1beta1 "k8s.io/api/extensions/v1beta1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
-
 	"k8s.io/ingress-nginx/test/e2e/framework"
 )
 
@@ -40,36 +35,13 @@ var _ = framework.IngressNginxDescribe("Annotations - Client-Body-Buffer-Size", 
 
 	It("should set client_body_buffer_size to 1000", func() {
 		host := "proxy.foo.com"
+		annotations := map[string]string{
+			"nginx.ingress.kubernetes.io/client-body-buffer-size": "1000",
+		}
 
-		ing, err := f.EnsureIngress(&v1beta1.Ingress{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      host,
-				Namespace: f.IngressController.Namespace,
-				Annotations: map[string]string{
-					"nginx.ingress.kubernetes.io/client-body-buffer-size": "1000",
-				},
-			},
-			Spec: v1beta1.IngressSpec{
-				Rules: []v1beta1.IngressRule{
-					{
-						Host: host,
-						IngressRuleValue: v1beta1.IngressRuleValue{
-							HTTP: &v1beta1.HTTPIngressRuleValue{
-								Paths: []v1beta1.HTTPIngressPath{
-									{
-										Path: "/",
-										Backend: v1beta1.IngressBackend{
-											ServiceName: "http-svc",
-											ServicePort: intstr.FromInt(80),
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		})
+		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
+		_, err := f.EnsureIngress(ing)
+
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ing).NotTo(BeNil())
 
@@ -82,36 +54,13 @@ var _ = framework.IngressNginxDescribe("Annotations - Client-Body-Buffer-Size", 
 
 	It("should set client_body_buffer_size to 1K", func() {
 		host := "proxy.foo.com"
+		annotations := map[string]string{
+			"nginx.ingress.kubernetes.io/client-body-buffer-size": "1K",
+		}
 
-		ing, err := f.EnsureIngress(&v1beta1.Ingress{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      host,
-				Namespace: f.IngressController.Namespace,
-				Annotations: map[string]string{
-					"nginx.ingress.kubernetes.io/client-body-buffer-size": "1K",
-				},
-			},
-			Spec: v1beta1.IngressSpec{
-				Rules: []v1beta1.IngressRule{
-					{
-						Host: host,
-						IngressRuleValue: v1beta1.IngressRuleValue{
-							HTTP: &v1beta1.HTTPIngressRuleValue{
-								Paths: []v1beta1.HTTPIngressPath{
-									{
-										Path: "/",
-										Backend: v1beta1.IngressBackend{
-											ServiceName: "http-svc",
-											ServicePort: intstr.FromInt(80),
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		})
+		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
+		_, err := f.EnsureIngress(ing)
+
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ing).NotTo(BeNil())
 
@@ -124,36 +73,13 @@ var _ = framework.IngressNginxDescribe("Annotations - Client-Body-Buffer-Size", 
 
 	It("should set client_body_buffer_size to 1k", func() {
 		host := "proxy.foo.com"
+		annotations := map[string]string{
+			"nginx.ingress.kubernetes.io/client-body-buffer-size": "1k",
+		}
 
-		ing, err := f.EnsureIngress(&v1beta1.Ingress{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      host,
-				Namespace: f.IngressController.Namespace,
-				Annotations: map[string]string{
-					"nginx.ingress.kubernetes.io/client-body-buffer-size": "1k",
-				},
-			},
-			Spec: v1beta1.IngressSpec{
-				Rules: []v1beta1.IngressRule{
-					{
-						Host: host,
-						IngressRuleValue: v1beta1.IngressRuleValue{
-							HTTP: &v1beta1.HTTPIngressRuleValue{
-								Paths: []v1beta1.HTTPIngressPath{
-									{
-										Path: "/",
-										Backend: v1beta1.IngressBackend{
-											ServiceName: "http-svc",
-											ServicePort: intstr.FromInt(80),
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		})
+		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
+		_, err := f.EnsureIngress(ing)
+
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ing).NotTo(BeNil())
 
@@ -164,80 +90,34 @@ var _ = framework.IngressNginxDescribe("Annotations - Client-Body-Buffer-Size", 
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	It("should set client_body_buffer_size to 1M", func() {
+	It("should set client_body_buffer_size to 1m", func() {
 		host := "proxy.foo.com"
+		annotations := map[string]string{
+			"nginx.ingress.kubernetes.io/client-body-buffer-size": "1m",
+		}
 
-		ing, err := f.EnsureIngress(&v1beta1.Ingress{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      host,
-				Namespace: f.IngressController.Namespace,
-				Annotations: map[string]string{
-					"nginx.ingress.kubernetes.io/client-body-buffer-size": "1M",
-				},
-			},
-			Spec: v1beta1.IngressSpec{
-				Rules: []v1beta1.IngressRule{
-					{
-						Host: host,
-						IngressRuleValue: v1beta1.IngressRuleValue{
-							HTTP: &v1beta1.HTTPIngressRuleValue{
-								Paths: []v1beta1.HTTPIngressPath{
-									{
-										Path: "/",
-										Backend: v1beta1.IngressBackend{
-											ServiceName: "http-svc",
-											ServicePort: intstr.FromInt(80),
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		})
+		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
+		_, err := f.EnsureIngress(ing)
+
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ing).NotTo(BeNil())
 
 		err = f.WaitForNginxServer(host,
 			func(server string) bool {
-				return Expect(server).Should(ContainSubstring("client_body_buffer_size 1M;"))
+				return Expect(server).Should(ContainSubstring("client_body_buffer_size 1m;"))
 			})
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should set client_body_buffer_size to 1M", func() {
 		host := "proxy.foo.com"
+		annotations := map[string]string{
+			"nginx.ingress.kubernetes.io/client-body-buffer-size": "1M",
+		}
 
-		ing, err := f.EnsureIngress(&v1beta1.Ingress{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      host,
-				Namespace: f.IngressController.Namespace,
-				Annotations: map[string]string{
-					"nginx.ingress.kubernetes.io/client-body-buffer-size": "1M",
-				},
-			},
-			Spec: v1beta1.IngressSpec{
-				Rules: []v1beta1.IngressRule{
-					{
-						Host: host,
-						IngressRuleValue: v1beta1.IngressRuleValue{
-							HTTP: &v1beta1.HTTPIngressRuleValue{
-								Paths: []v1beta1.HTTPIngressPath{
-									{
-										Path: "/",
-										Backend: v1beta1.IngressBackend{
-											ServiceName: "http-svc",
-											ServicePort: intstr.FromInt(80),
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		})
+		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
+		_, err := f.EnsureIngress(ing)
+
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ing).NotTo(BeNil())
 
@@ -250,36 +130,13 @@ var _ = framework.IngressNginxDescribe("Annotations - Client-Body-Buffer-Size", 
 
 	It("should not set client_body_buffer_size to invalid 1b", func() {
 		host := "proxy.foo.com"
+		annotations := map[string]string{
+			"nginx.ingress.kubernetes.io/client-body-buffer-size": "1b",
+		}
 
-		ing, err := f.EnsureIngress(&v1beta1.Ingress{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      host,
-				Namespace: f.IngressController.Namespace,
-				Annotations: map[string]string{
-					"nginx.ingress.kubernetes.io/client-body-buffer-size": "1b",
-				},
-			},
-			Spec: v1beta1.IngressSpec{
-				Rules: []v1beta1.IngressRule{
-					{
-						Host: host,
-						IngressRuleValue: v1beta1.IngressRuleValue{
-							HTTP: &v1beta1.HTTPIngressRuleValue{
-								Paths: []v1beta1.HTTPIngressPath{
-									{
-										Path: "/",
-										Backend: v1beta1.IngressBackend{
-											ServiceName: "http-svc",
-											ServicePort: intstr.FromInt(80),
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		})
+		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
+		_, err := f.EnsureIngress(ing)
+
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ing).NotTo(BeNil())
 

--- a/test/e2e/annotations/cors.go
+++ b/test/e2e/annotations/cors.go
@@ -22,10 +22,6 @@ import (
 	"github.com/parnurzeal/gorequest"
 	"net/http"
 
-	v1beta1 "k8s.io/api/extensions/v1beta1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
-
 	"k8s.io/ingress-nginx/test/e2e/framework"
 )
 
@@ -42,36 +38,13 @@ var _ = framework.IngressNginxDescribe("Annotations - CORS", func() {
 
 	It("should enable cors", func() {
 		host := "cors.foo.com"
+		annotations := map[string]string{
+			"nginx.ingress.kubernetes.io/enable-cors": "true",
+		}
 
-		ing, err := f.EnsureIngress(&v1beta1.Ingress{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      host,
-				Namespace: f.IngressController.Namespace,
-				Annotations: map[string]string{
-					"nginx.ingress.kubernetes.io/enable-cors": "true",
-				},
-			},
-			Spec: v1beta1.IngressSpec{
-				Rules: []v1beta1.IngressRule{
-					{
-						Host: host,
-						IngressRuleValue: v1beta1.IngressRuleValue{
-							HTTP: &v1beta1.HTTPIngressRuleValue{
-								Paths: []v1beta1.HTTPIngressPath{
-									{
-										Path: "/",
-										Backend: v1beta1.IngressBackend{
-											ServiceName: "http-svc",
-											ServicePort: intstr.FromInt(80),
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		})
+		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
+		_, err := f.EnsureIngress(ing)
+
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ing).NotTo(BeNil())
 
@@ -116,37 +89,14 @@ var _ = framework.IngressNginxDescribe("Annotations - CORS", func() {
 
 	It("should set cors methods to only allow POST, GET", func() {
 		host := "cors.foo.com"
+		annotations := map[string]string{
+			"nginx.ingress.kubernetes.io/enable-cors":        "true",
+			"nginx.ingress.kubernetes.io/cors-allow-methods": "POST, GET",
+		}
 
-		ing, err := f.EnsureIngress(&v1beta1.Ingress{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      host,
-				Namespace: f.IngressController.Namespace,
-				Annotations: map[string]string{
-					"nginx.ingress.kubernetes.io/enable-cors":        "true",
-					"nginx.ingress.kubernetes.io/cors-allow-methods": "POST, GET",
-				},
-			},
-			Spec: v1beta1.IngressSpec{
-				Rules: []v1beta1.IngressRule{
-					{
-						Host: host,
-						IngressRuleValue: v1beta1.IngressRuleValue{
-							HTTP: &v1beta1.HTTPIngressRuleValue{
-								Paths: []v1beta1.HTTPIngressPath{
-									{
-										Path: "/",
-										Backend: v1beta1.IngressBackend{
-											ServiceName: "http-svc",
-											ServicePort: intstr.FromInt(80),
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		})
+		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
+		_, err := f.EnsureIngress(ing)
+
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ing).NotTo(BeNil())
 
@@ -159,37 +109,14 @@ var _ = framework.IngressNginxDescribe("Annotations - CORS", func() {
 
 	It("should set cors max-age", func() {
 		host := "cors.foo.com"
+		annotations := map[string]string{
+			"nginx.ingress.kubernetes.io/enable-cors":  "true",
+			"nginx.ingress.kubernetes.io/cors-max-age": "200",
+		}
 
-		ing, err := f.EnsureIngress(&v1beta1.Ingress{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      host,
-				Namespace: f.IngressController.Namespace,
-				Annotations: map[string]string{
-					"nginx.ingress.kubernetes.io/enable-cors":  "true",
-					"nginx.ingress.kubernetes.io/cors-max-age": "200",
-				},
-			},
-			Spec: v1beta1.IngressSpec{
-				Rules: []v1beta1.IngressRule{
-					{
-						Host: host,
-						IngressRuleValue: v1beta1.IngressRuleValue{
-							HTTP: &v1beta1.HTTPIngressRuleValue{
-								Paths: []v1beta1.HTTPIngressPath{
-									{
-										Path: "/",
-										Backend: v1beta1.IngressBackend{
-											ServiceName: "http-svc",
-											ServicePort: intstr.FromInt(80),
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		})
+		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
+		_, err := f.EnsureIngress(ing)
+
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ing).NotTo(BeNil())
 
@@ -202,37 +129,14 @@ var _ = framework.IngressNginxDescribe("Annotations - CORS", func() {
 
 	It("should disable cors allow credentials", func() {
 		host := "cors.foo.com"
+		annotations := map[string]string{
+			"nginx.ingress.kubernetes.io/enable-cors":            "true",
+			"nginx.ingress.kubernetes.io/cors-allow-credentials": "false",
+		}
 
-		ing, err := f.EnsureIngress(&v1beta1.Ingress{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      host,
-				Namespace: f.IngressController.Namespace,
-				Annotations: map[string]string{
-					"nginx.ingress.kubernetes.io/enable-cors":            "true",
-					"nginx.ingress.kubernetes.io/cors-allow-credentials": "false",
-				},
-			},
-			Spec: v1beta1.IngressSpec{
-				Rules: []v1beta1.IngressRule{
-					{
-						Host: host,
-						IngressRuleValue: v1beta1.IngressRuleValue{
-							HTTP: &v1beta1.HTTPIngressRuleValue{
-								Paths: []v1beta1.HTTPIngressPath{
-									{
-										Path: "/",
-										Backend: v1beta1.IngressBackend{
-											ServiceName: "http-svc",
-											ServicePort: intstr.FromInt(80),
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		})
+		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
+		_, err := f.EnsureIngress(ing)
+
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ing).NotTo(BeNil())
 
@@ -245,37 +149,14 @@ var _ = framework.IngressNginxDescribe("Annotations - CORS", func() {
 
 	It("should allow origin for cors", func() {
 		host := "cors.foo.com"
+		annotations := map[string]string{
+			"nginx.ingress.kubernetes.io/enable-cors":       "true",
+			"nginx.ingress.kubernetes.io/cors-allow-origin": "https://origin.cors.com:8080",
+		}
 
-		ing, err := f.EnsureIngress(&v1beta1.Ingress{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      host,
-				Namespace: f.IngressController.Namespace,
-				Annotations: map[string]string{
-					"nginx.ingress.kubernetes.io/enable-cors":       "true",
-					"nginx.ingress.kubernetes.io/cors-allow-origin": "https://origin.cors.com:8080",
-				},
-			},
-			Spec: v1beta1.IngressSpec{
-				Rules: []v1beta1.IngressRule{
-					{
-						Host: host,
-						IngressRuleValue: v1beta1.IngressRuleValue{
-							HTTP: &v1beta1.HTTPIngressRuleValue{
-								Paths: []v1beta1.HTTPIngressPath{
-									{
-										Path: "/",
-										Backend: v1beta1.IngressBackend{
-											ServiceName: "http-svc",
-											ServicePort: intstr.FromInt(80),
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		})
+		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
+		_, err := f.EnsureIngress(ing)
+
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ing).NotTo(BeNil())
 
@@ -288,37 +169,14 @@ var _ = framework.IngressNginxDescribe("Annotations - CORS", func() {
 
 	It("should allow headers for cors", func() {
 		host := "cors.foo.com"
+		annotations := map[string]string{
+			"nginx.ingress.kubernetes.io/enable-cors":        "true",
+			"nginx.ingress.kubernetes.io/cors-allow-headers": "DNT, User-Agent",
+		}
 
-		ing, err := f.EnsureIngress(&v1beta1.Ingress{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      host,
-				Namespace: f.IngressController.Namespace,
-				Annotations: map[string]string{
-					"nginx.ingress.kubernetes.io/enable-cors":        "true",
-					"nginx.ingress.kubernetes.io/cors-allow-headers": "DNT, User-Agent",
-				},
-			},
-			Spec: v1beta1.IngressSpec{
-				Rules: []v1beta1.IngressRule{
-					{
-						Host: host,
-						IngressRuleValue: v1beta1.IngressRuleValue{
-							HTTP: &v1beta1.HTTPIngressRuleValue{
-								Paths: []v1beta1.HTTPIngressPath{
-									{
-										Path: "/",
-										Backend: v1beta1.IngressBackend{
-											ServiceName: "http-svc",
-											ServicePort: intstr.FromInt(80),
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		})
+		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
+		_, err := f.EnsureIngress(ing)
+
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ing).NotTo(BeNil())
 

--- a/test/e2e/annotations/default_backend.go
+++ b/test/e2e/annotations/default_backend.go
@@ -39,11 +39,13 @@ var _ = framework.IngressNginxDescribe("Annotations - custom default-backend", f
 	Context("when default backend annotation is enabled", func() {
 		It("should use a custom default backend as upstream", func() {
 			host := "default-backend"
-
 			annotations := map[string]string{
 				"nginx.ingress.kubernetes.io/default-backend": "http-svc",
 			}
-			ing, err := f.EnsureIngress(framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "invalid", 80, &annotations))
+
+			ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "invalid", 80, &annotations)
+			_, err := f.EnsureIngress(ing)
+
 			Expect(err).NotTo(HaveOccurred())
 			Expect(ing).NotTo(BeNil())
 

--- a/test/e2e/annotations/grpc.go
+++ b/test/e2e/annotations/grpc.go
@@ -40,7 +40,10 @@ var _ = framework.IngressNginxDescribe("Annotations - grpc", func() {
 			annotations := map[string]string{
 				"nginx.ingress.kubernetes.io/backend-protocol": "GRPC",
 			}
-			ing, err := f.EnsureIngress(framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "fortune-teller", 50051, &annotations))
+
+			ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "fortune-teller", 50051, &annotations)
+			_, err := f.EnsureIngress(ing)
+
 			Expect(err).NotTo(HaveOccurred())
 			Expect(ing).NotTo(BeNil())
 

--- a/test/e2e/annotations/proxy.go
+++ b/test/e2e/annotations/proxy.go
@@ -21,10 +21,6 @@ import (
 	. "github.com/onsi/gomega"
 	"strings"
 
-	"k8s.io/api/extensions/v1beta1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
-
 	"k8s.io/ingress-nginx/test/e2e/framework"
 )
 
@@ -46,7 +42,9 @@ var _ = framework.IngressNginxDescribe("Annotations - Proxy", func() {
 			"nginx.ingress.kubernetes.io/proxy-redirect-to":   "goodbye.com",
 		}
 
-		ing, err := ensureIngress(f, host, annotations)
+		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
+		_, err := f.EnsureIngress(ing)
+
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ing).NotTo(BeNil())
 
@@ -64,7 +62,9 @@ var _ = framework.IngressNginxDescribe("Annotations - Proxy", func() {
 			"nginx.ingress.kubernetes.io/proxy-redirect-to":   "goodbye.com",
 		}
 
-		ing, err := ensureIngress(f, host, annotations)
+		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
+		_, err := f.EnsureIngress(ing)
+
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ing).NotTo(BeNil())
 
@@ -82,7 +82,9 @@ var _ = framework.IngressNginxDescribe("Annotations - Proxy", func() {
 			"nginx.ingress.kubernetes.io/proxy-redirect-to":   "goodbye.com",
 		}
 
-		ing, err := ensureIngress(f, host, annotations)
+		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
+		_, err := f.EnsureIngress(ing)
+
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ing).NotTo(BeNil())
 
@@ -99,7 +101,9 @@ var _ = framework.IngressNginxDescribe("Annotations - Proxy", func() {
 			"nginx.ingress.kubernetes.io/proxy-body-size": "8m",
 		}
 
-		ing, err := ensureIngress(f, host, annotations)
+		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
+		_, err := f.EnsureIngress(ing)
+
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ing).NotTo(BeNil())
 
@@ -116,7 +120,9 @@ var _ = framework.IngressNginxDescribe("Annotations - Proxy", func() {
 			"nginx.ingress.kubernetes.io/proxy-body-size": "15r",
 		}
 
-		ing, err := ensureIngress(f, host, annotations)
+		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
+		_, err := f.EnsureIngress(ing)
+
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ing).NotTo(BeNil())
 
@@ -135,7 +141,9 @@ var _ = framework.IngressNginxDescribe("Annotations - Proxy", func() {
 			"nginx.ingress.kubernetes.io/proxy-read-timeout":    "20",
 		}
 
-		ing, err := ensureIngress(f, host, annotations)
+		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
+		_, err := f.EnsureIngress(ing)
+
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ing).NotTo(BeNil())
 
@@ -154,7 +162,9 @@ var _ = framework.IngressNginxDescribe("Annotations - Proxy", func() {
 			"nginx.ingress.kubernetes.io/proxy-read-timeout":    "20k",
 		}
 
-		ing, err := ensureIngress(f, host, annotations)
+		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
+		_, err := f.EnsureIngress(ing)
+
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ing).NotTo(BeNil())
 
@@ -172,7 +182,9 @@ var _ = framework.IngressNginxDescribe("Annotations - Proxy", func() {
 			"nginx.ingress.kubernetes.io/proxy-buffer-size": "8k",
 		}
 
-		ing, err := ensureIngress(f, host, annotations)
+		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
+		_, err := f.EnsureIngress(ing)
+
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ing).NotTo(BeNil())
 
@@ -189,7 +201,9 @@ var _ = framework.IngressNginxDescribe("Annotations - Proxy", func() {
 			"nginx.ingress.kubernetes.io/proxy-request-buffering": "off",
 		}
 
-		ing, err := ensureIngress(f, host, annotations)
+		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
+		_, err := f.EnsureIngress(ing)
+
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ing).NotTo(BeNil())
 
@@ -207,7 +221,9 @@ var _ = framework.IngressNginxDescribe("Annotations - Proxy", func() {
 			"nginx.ingress.kubernetes.io/proxy-next-upstream-tries": "5",
 		}
 
-		ing, err := ensureIngress(f, host, annotations)
+		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
+		_, err := f.EnsureIngress(ing)
+
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ing).NotTo(BeNil())
 
@@ -225,7 +241,9 @@ var _ = framework.IngressNginxDescribe("Annotations - Proxy", func() {
 			"nginx.ingress.kubernetes.io/proxy-cookie-path":   "/one/ /",
 		}
 
-		ing, err := ensureIngress(f, host, annotations)
+		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
+		_, err := f.EnsureIngress(ing)
+
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ing).NotTo(BeNil())
 
@@ -237,35 +255,3 @@ var _ = framework.IngressNginxDescribe("Annotations - Proxy", func() {
 	})
 
 })
-
-func ensureIngress(f *framework.Framework, host string, annotations map[string]string) (*v1beta1.Ingress, error) {
-	ing, err := f.EnsureIngress(&v1beta1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        host,
-			Namespace:   f.IngressController.Namespace,
-			Annotations: annotations,
-		},
-		Spec: v1beta1.IngressSpec{
-			Rules: []v1beta1.IngressRule{
-				{
-					Host: host,
-					IngressRuleValue: v1beta1.IngressRuleValue{
-						HTTP: &v1beta1.HTTPIngressRuleValue{
-							Paths: []v1beta1.HTTPIngressPath{
-								{
-									Path: "/",
-									Backend: v1beta1.IngressBackend{
-										ServiceName: "http-svc",
-										ServicePort: intstr.FromInt(80),
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	})
-
-	return ing, err
-}


### PR DESCRIPTION
Each e2e test is creating the same(or similar) Ingress Resource. This encapsulates the ingress resource creation into a common helper method, reducing code duplication.
