### PR TITLE
Make literal $ character work in set $location_path

### DIFF
--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -120,7 +120,7 @@ var (
 			}
 			return true
 		},
-		"escapeLocationPathVar":      escapeLocationPathVar,
+		"escapeLiteralDollar":        escapeLiteralDollar,
 		"shouldConfigureLuaRestyWAF": shouldConfigureLuaRestyWAF,
 		"buildLuaSharedDictionaries": buildLuaSharedDictionaries,
 		"buildLocation":              buildLocation,
@@ -162,13 +162,13 @@ var (
 	}
 )
 
-// escapeLocationPathVar will replace the $ character with ${literal_dollar}
+// escapeLiteralDollar will replace the $ character with ${literal_dollar}
 // which is made to work via the following configuration in the http section of
 // the template:
 // geo $literal_dollar {
 //     default "$";
 // }
-func escapeLocationPathVar(input interface{}) string {
+func escapeLiteralDollar(input interface{}) string {
 	inputStr, ok := input.(string)
 	if !ok {
 		return ""

--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -120,6 +120,7 @@ var (
 			}
 			return true
 		},
+		"escapeLocationPathVar":      escapeLocationPathVar,
 		"shouldConfigureLuaRestyWAF": shouldConfigureLuaRestyWAF,
 		"buildLuaSharedDictionaries": buildLuaSharedDictionaries,
 		"buildLocation":              buildLocation,
@@ -160,6 +161,20 @@ var (
 		"stripLocationModifer":        stripLocationModifer,
 	}
 )
+
+// escapeLocationPathVar will replace the $ character with ${literal_dollar}
+// which is made to work via the following configuration in the http section of
+// the template:
+// geo $literal_dollar {
+//     default "$";
+// }
+func escapeLocationPathVar(input interface{}) string {
+	inputStr, ok := input.(string)
+	if !ok {
+		return ""
+	}
+	return strings.Replace(inputStr, `$`, `${literal_dollar}`, -1)
+}
 
 // formatIP will wrap IPv6 addresses in [] and return IPv4 addresses
 // without modification. If the input cannot be parsed as an IP address

--- a/internal/ingress/controller/template/template_test.go
+++ b/internal/ingress/controller/template/template_test.go
@@ -834,3 +834,16 @@ func TestBuildUpstreamName(t *testing.T) {
 		}
 	}
 }
+
+func TestEscapeLocationPathVar(t *testing.T) {
+	escapedPath := escapeLocationPathVar("/$")
+	expected := "/${literal_dollar}"
+	if escapedPath != expected {
+		t.Errorf("Expected %s but got %s", expected, escapedPath)
+	}
+	escapedPath = escapeLocationPathVar(false)
+	expected = ""
+	if escapedPath != expected {
+		t.Errorf("Expected %s but got %s", expected, escapedPath)
+	}
+}

--- a/internal/ingress/controller/template/template_test.go
+++ b/internal/ingress/controller/template/template_test.go
@@ -835,15 +835,28 @@ func TestBuildUpstreamName(t *testing.T) {
 	}
 }
 
-func TestEscapeLocationPathVar(t *testing.T) {
-	escapedPath := escapeLocationPathVar("/$")
+func TestEscapeLiteralDollar(t *testing.T) {
+	escapedPath := escapeLiteralDollar("/$")
 	expected := "/${literal_dollar}"
 	if escapedPath != expected {
-		t.Errorf("Expected %s but got %s", expected, escapedPath)
+		t.Errorf("Expected %v but returned %v", expected, escapedPath)
 	}
-	escapedPath = escapeLocationPathVar(false)
+
+	escapedPath = escapeLiteralDollar("/hello-$/world-$/")
+	expected = "/hello-${literal_dollar}/world-${literal_dollar}/"
+	if escapedPath != expected {
+		t.Errorf("Expected %v but returned %v", expected, escapedPath)
+	}
+
+	leaveUnchagned := "/leave-me/unchagned"
+	escapedPath = escapeLiteralDollar(leaveUnchagned)
+	if escapedPath != leaveUnchagned {
+		t.Errorf("Expected %v but returned %v", leaveUnchagned, escapedPath)
+	}
+
+	escapedPath = escapeLiteralDollar(false)
 	expected = ""
 	if escapedPath != expected {
-		t.Errorf("Expected %s but got %s", expected, escapedPath)
+		t.Errorf("Expected %v but returned %v", expected, escapedPath)
 	}
 }

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -976,7 +976,7 @@ stream {
             set $ingress_name   "{{ $ing.Rule }}";
             set $service_name   "{{ $ing.Service }}";
             set $service_port   "{{ $location.Port }}";
-            set $location_path  "{{ $location.Path | escapeLocationPathVar }}";
+            set $location_path  "{{ $location.Path | escapeLiteralDollar }}";
 
             {{ if $all.Cfg.EnableOpentracing }}
             opentracing_propagate_context;

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -347,6 +347,12 @@ http {
     }
     {{ end }}
 
+    # Create a variable that contains the literal $ character.
+    # This works because the geo module will not resolve variables.
+    geo $literal_dollar {
+        default "$";
+    }
+
     server_name_in_redirect off;
     port_in_redirect        off;
 
@@ -970,7 +976,7 @@ stream {
             set $ingress_name   "{{ $ing.Rule }}";
             set $service_name   "{{ $ing.Service }}";
             set $service_port   "{{ $location.Port }}";
-            set $location_path  "{{ $location.Path }}";
+            set $location_path  "{{ $location.Path | escapeLocationPathVar }}";
 
             {{ if $all.Cfg.EnableOpentracing }}
             opentracing_propagate_context;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

This is one option of making the template work when the literal `$` character is in a path. We ran into this testing the new regex functionality where we have paths using regexes that contain a `$`.

I had a hard time finding another way to get a literal `$` in a set variable in nginx. This idea was found in this thread - https://forum.nginx.org/read.php?2,218536,218559 .

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #3191 

**Special notes for your reviewer**:

Using the geo module definitely feels really strange. When we were using a custom template to facilitate regex, before testing the `use-regex` functionality that will come in 0.20.0, we just removed the `set $location_path` declaration as it didn't appear to be used by the template anywhere else that we could see and we didn't need to use it anywhere custom. We also considered a string replace with something like `%24` rather than this type of hack. There is possibly a better way to facilitate getting a `$` character in a set that I can't find.