### PR TITLE
timeout documentation update

### DIFF
--- a/docs/user-guide/nginx-configuration/annotations.md
+++ b/docs/user-guide/nginx-configuration/annotations.md
@@ -47,9 +47,9 @@ You can add these Kubernetes annotations to specific Ingress objects to customiz
 |[nginx.ingress.kubernetes.io/proxy-body-size](#custom-max-body-size)|string|
 |[nginx.ingress.kubernetes.io/proxy-cookie-domain](#proxy-cookie-domain)|string|
 |[nginx.ingress.kubernetes.io/proxy-cookie-path](#proxy-cookie-path)|string|
-|[nginx.ingress.kubernetes.io/proxy-connect-timeout](#custom-timeouts)|number|
-|[nginx.ingress.kubernetes.io/proxy-send-timeout](#custom-timeouts)|number|
-|[nginx.ingress.kubernetes.io/proxy-read-timeout](#custom-timeouts)|number|
+|[nginx.ingress.kubernetes.io/proxy-connect-timeout](#custom-timeouts)|string|
+|[nginx.ingress.kubernetes.io/proxy-send-timeout](#custom-timeouts)|string|
+|[nginx.ingress.kubernetes.io/proxy-read-timeout](#custom-timeouts)|string|
 |[nginx.ingress.kubernetes.io/proxy-next-upstream](#custom-timeouts)|string|
 |[nginx.ingress.kubernetes.io/proxy-next-upstream-tries](#custom-timeouts)|number|
 |[nginx.ingress.kubernetes.io/proxy-request-buffering](#custom-timeouts)|string|


### PR DESCRIPTION
Timeouts are supposed to be set like this:
```
metadata:
  annotations:
    nginx.ingress.kubernetes.io/proxy-connect-timeout: "120s"
    nginx.ingress.kubernetes.io/proxy-read-timeout: "120s"
    nginx.ingress.kubernetes.io/proxy-send-timeout: "120s"
```

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Documentation about setting timout annotation is misleading.  It's not a `number` required but a `string` field. 

**Special notes for your reviewer**:
Documentation update only.