### PR TITLE
Add some extra detail to the client cert auth example regarding potential gotcha

### DIFF
--- a/docs/examples/auth/client-certs/README.md
+++ b/docs/examples/auth/client-certs/README.md
@@ -1,11 +1,11 @@
 # Client Certificate Authentication
+It is possible to enable Client Certificate Authentication using additional annotations in Ingress resources, created by you.
 
-It is possible to enable Client Certificate Authentication using additional annotations in the Ingress.
+## Setup Instructions
+1. Create a file named `ca.crt` containing the trusted certificate authority chain to verify client certificates. All of the certificates must be in PEM format.  
+   *NB:* The file containing the trusted certificates must be named `ca.crt` exactly - this is expected to be found in the secret.
 
-## Setup instructions
-1. Create a file named `ca.crt` containing the trusted certificate authority chain (all ca certificates in PEM format) to verify client certificates. 
- 
-2. Create a secret from this file:
+2. Create a secret from this file:  
 `kubectl create secret generic auth-tls-chain --from-file=ca.crt --namespace=default`
 
-3. Add the annotations as provided in the [ingress.yaml](ingress.yaml) example to your ingress object.
+3. Add the annotations as provided in the [ingress.yaml](ingress.yaml) example to your own ingress resources as required.

--- a/docs/examples/auth/client-certs/ingress.yaml
+++ b/docs/examples/auth/client-certs/ingress.yaml
@@ -5,6 +5,7 @@ metadata:
     # Enable client certificate authentication
     nginx.ingress.kubernetes.io/auth-tls-verify-client: "on"
     # Create the secret containing the trusted ca certificates with `kubectl create secret generic auth-tls-chain --from-file=ca.crt --namespace=default`
+    # NB: The file _must_ be named "ca.crt" and nothing else. This filename is expected to be found in the secret.
     nginx.ingress.kubernetes.io/auth-tls-secret: "default/auth-tls-chain"
     # Specify the verification depth in the client certificates chain
     nginx.ingress.kubernetes.io/auth-tls-verify-depth: "1"


### PR DESCRIPTION
**What this PR does / why we need it**: I'm directly aware of at least two cases (one of them being myself!) where somebody was caught out by the fact that the trusted client cert issuers for an ingress resource _must_ be given in a file named `ca.crt` and that other filenames will fail to work entirely. Given that it's happened at least twice, I'm assuming it's something that could catch more people out and is worth mentioning in the client certificate example documentation.

This change makes it clear to those reading the documentation that this is a potential gotcha. Also, while I was at it, I improved some of the language in the example to be slightly clearer.

**Which issue this PR fixes**: N/a, documentation improvement only.

**Special notes for your reviewer**: N/a as far as I can tell. I just signed the CLA - I hope I did it correctly!
