### PR TITLE
Deploy: Add missing `allowPrivilegeEscalation: true`

### DIFF
--- a/deploy/mandatory.yaml
+++ b/deploy/mandatory.yaml
@@ -220,6 +220,8 @@ spec:
             - --publish-service=$(POD_NAMESPACE)/ingress-nginx
             - --annotations-prefix=nginx.ingress.kubernetes.io
           securityContext:
+            # Required for authbind
+            allowPrivilegeEscalation: true
             capabilities:
               drop:
                 - ALL

--- a/deploy/with-rbac.yaml
+++ b/deploy/with-rbac.yaml
@@ -33,6 +33,8 @@ spec:
             - --publish-service=$(POD_NAMESPACE)/ingress-nginx
             - --annotations-prefix=nginx.ingress.kubernetes.io
           securityContext:
+            # Required for authbind
+            allowPrivilegeEscalation: true
             capabilities:
               drop:
                 - ALL

--- a/test/manifests/ingress-controller/mandatory.yaml
+++ b/test/manifests/ingress-controller/mandatory.yaml
@@ -210,6 +210,8 @@ spec:
             - --annotations-prefix=nginx.ingress.kubernetes.io
             - --watch-namespace=${NAMESPACE}
           securityContext:
+            # Required for authbind
+            allowPrivilegeEscalation: true
             capabilities:
               drop:
                 - ALL


### PR DESCRIPTION
**What this PR does / why we need it**:

authbind uses a setuid binary to bind a privileged port, so we need
to allow privilege escalation.

**Special notes for your reviewer**:

I'm wondering why no one noticed this before - I guess there are few
clusters configured with a pod security policy disabling privilege
escalation by default.

I'm also wondering whether `setcap` in the Dockerfile is still necessary
given that ingress-nginx now uses authbind, which acquires the
capability by running with uid 0 instead of having the capability
assigned explicitly (as far as I understand).
