### PR TITLE
Fix SSL-Passthrough functionality

### DIFF
--- a/internal/ingress/controller/nginx.go
+++ b/internal/ingress/controller/nginx.go
@@ -714,7 +714,7 @@ func (n *NGINXController) setupSSLProxy() {
 			}
 
 			glog.V(3).Infof("Handling connection from remote address %s to local %s", conn.RemoteAddr(), conn.LocalAddr())
-			go n.Proxy.Handle(conn)
+			go n.Proxy.Handle(conn, n.runningConfig)
 		}
 	}()
 }

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -255,8 +255,10 @@ http {
     {{ if $cfg.UseProxyProtocol }}
         # Get IP address from Proxy Protocol
         default          $proxy_protocol_addr;
-    {{ else }}
+    {{ else if $all.IsSSLPassthroughEnabled }}
         https            $proxy_protocol_addr;
+        default          $remote_addr;
+    {{ else }}
         default          $remote_addr;
     {{ end }}
     }

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -251,11 +251,12 @@ http {
 
     # The following is a sneaky way to do "set $the_real_ip $remote_addr"
     # Needed because using set is not allowed outside server blocks.
-    map '' $the_real_ip {
+    map $scheme $the_real_ip {
     {{ if $cfg.UseProxyProtocol }}
         # Get IP address from Proxy Protocol
         default          $proxy_protocol_addr;
     {{ else }}
+        https            $proxy_protocol_addr;
         default          $remote_addr;
     {{ end }}
     }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the SSL-Passthrough functionality since whitelisting isn't working correctly.

**Which issue this PR fixes** :
 fixes #2096 

**Special notes for your reviewer**:
We did some tests regarding the functionality after each commit contained in that PR and the results are presented below.

* Current functionality:

| Scenario | HTTP | HTTPS with SSL-Offloading | HTTPS with SSL-Passthrough |
| :---: | :---: | :---: | :---: | 
| Proxy Protocol + SSL-Passthrough | :x: |   :white_check_mark: | :x: * |
| SSL-Passthrough | :white_check_mark: |  :x: ** | :x: * |
| - | :white_check_mark: | :white_check_mark: | :white_check_mark: *** |

*Notes*
\* Whitelisting isn't taken into account so anyone can access the service
\*\* If whitelisting is defined, then it blocks everyone except 127.0.0.1
\*\*\* Returns 404 which is correct.

___

* After commit acd5356:

| Scenario | HTTP | HTTPS with SSL-Offloading | HTTPS with SSL-Passthrough |
| :---: | :---: | :---: | :---: | 
| Proxy Protocol + SSL-Passthrough | :x: |   :white_check_mark: | :x: * |
| SSL-Passthrough | :white_check_mark: |  :white_check_mark: | :x: * |
| - | :white_check_mark: |  :x: | :white_check_mark: ** |

*Notes*
\* Whitelisting isn't taken into account so anyone can access the service
\*\* Returns 404 which is correct.

___

* After commit 5d22d27:

| Scenario | HTTP | HTTPS with SSL-Offloading | HTTPS with SSL-Passthrough |
| :---: | :---: | :---: | :---: | 
| Proxy Protocol + SSL-Passthrough | :x: |   :white_check_mark: | :x:  * |
| SSL-Passthrough | :white_check_mark: |   :white_check_mark: | :x: * |
| - | :white_check_mark: |  :white_check_mark: | :white_check_mark: ** |

*Notes*
\* Whitelisting isn't taken into account so anyone can access the service
\*\* Returns 404 which is correct.

___

* After commit 1f88c8e:

| Scenario | HTTP | HTTPS with SSL-Offloading | HTTPS with SSL-Passthrough |
| :---: | :---: | :---: | :---: | 
| Proxy Protocol + SSL-Passthrough | :x: |   :white_check_mark: | :white_check_mark: * |
| SSL-Passthrough | :white_check_mark: |   :white_check_mark: | :white_check_mark: * |
| - | :white_check_mark: |  :white_check_mark: | :white_check_mark: ** |

*Notes*
\* I cannot create a response with HTTP status code 403, so instead I send an empty reply. But in that case whitelisting is working correctly.
\*\* Returns 404 which is correct.

Additional contributors: @nrobert13 