### PR TITLE
Enable nginx proxy-buffering by default

### DIFF
--- a/docs/user-guide/nginx-configuration/configmap.md
+++ b/docs/user-guide/nginx-configuration/configmap.md
@@ -142,7 +142,7 @@ The following table shows a configuration option's name, type, and the default v
 |[limit-rate](#limit-rate)|int|0|
 |[limit-rate-after](#limit-rate-after)|int|0|
 |[http-redirect-code](#http-redirect-code)|int|308|
-|[proxy-buffering](#proxy-buffering)|string|"off"|
+|[proxy-buffering](#proxy-buffering)|string|"on"|
 |[limit-req-status-code](#limit-req-status-code)|int|503|
 |[no-tls-redirect-locations](#no-tls-redirect-locations)|string|"/.well-known/acme-challenge"|
 |[no-auth-locations](#no-auth-locations)|string|"/.well-known/acme-challenge"|

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -656,7 +656,7 @@ func NewDefault() Configuration {
 			SkipAccessLogURLs:      []string{},
 			LimitRate:              0,
 			LimitRateAfter:         0,
-			ProxyBuffering:         "off",
+			ProxyBuffering:         "on",
 		},
 		UpstreamKeepaliveConnections: 32,
 		UpstreamKeepaliveTimeout:     60,


### PR DESCRIPTION
**What this PR does / why we need it**:

This replicate nginx default configuration for `proxy-buffering`, which is enabled.
http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffering

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

Cc @ElvinEfendi 