### PR TITLE
Clarify mandatory script doc

### DIFF
--- a/docs/deploy/index.md
+++ b/docs/deploy/index.md
@@ -15,9 +15,9 @@
   - [Detect installed version](#detect-installed-version)
 - [Using Helm](#using-helm)
 
-## Prerequisite Generic Deployment Script 
+## Prerequisite Generic Deployment Command
 
-The following **Mandatory command** is required for all deployments.
+The following **Mandatory Command** is required for all deployments.
 
 !!! attention
     The default configuration watches Ingress object from all the namespaces.

--- a/docs/deploy/index.md
+++ b/docs/deploy/index.md
@@ -15,15 +15,9 @@
   - [Detect installed version](#detect-installed-version)
 - [Using Helm](#using-helm)
 
-## Generic Deployment 
+## Prerequisite Generic Deployment Script 
 
-The following resources are required for a generic deployment.
-
-### Mandatory command
-
-```console
-kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/mandatory.yaml
-```
+The following **Mandatory command** is required for all deployments.
 
 !!! attention
     The default configuration watches Ingress object from all the namespaces.
@@ -35,6 +29,10 @@ kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/mast
 !!! attention
     If you're using GKE you need to initialize your user as a cluster-admin with the following command: 
     ```kubectl create clusterrolebinding cluster-admin-binding   --clusterrole cluster-admin   --user $(gcloud config get-value account)```
+
+```console
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/mandatory.yaml
+```
 
 ### Provider Specific Steps
 


### PR DESCRIPTION
The warnings should probably be above the script, not below, especially in the ever popular GKE, where they are prerequisites. Generic Deployment sounds like it's a deployment that should work on all vanilla Kubernetes installations. It sounds like an OR logic operator, when it should be an AND.

**What this PR does / why we need it**: Clarifies installation doc... the most popular doc relevant to everyone who uses this wonderful program

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #3248
