### PR TITLE
Mount minikube volume to docker container

### DIFF
--- a/build/go-in-docker.sh
+++ b/build/go-in-docker.sh
@@ -64,6 +64,13 @@ NODE_IP=${NODE_IP:-127.0.0.1}
 SLOW_E2E_THRESHOLD=${SLOW_E2E_THRESHOLD:-40}
 EOF
 
+MINIKUBE_PATH=${HOME}/.minikube
+MINIKUBE_VOLUME="-v ${MINIKUBE_PATH}:${MINIKUBE_PATH}"
+if [ ! -d ${MINIKUBE_PATH} ]; then
+    echo "Minikube directory not found! Volume will be excluded from docker build."
+    MINIKUBE_VOLUME=""
+fi
+
 docker run                                       \
     --tty                                        \
     --rm                                         \
@@ -72,6 +79,7 @@ docker run                                       \
     -v ${PWD}:/go/src/${PKG}                     \
     -v ${PWD}/.gocache:${HOME}/.cache/go-build   \
     -v ${PWD}/bin/${ARCH}:/go/bin/linux_${ARCH}  \
+    ${MINIKUBE_VOLUME}                           \
     -w /go/src/${PKG}                            \
     --env-file .env                              \
     --entrypoint ${FLAGS}                        \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This was removed here: https://github.com/kubernetes/ingress-nginx/commit/f2bfc42b6502a2dd6c7347713c3dadec4916d9fc#diff-431621728cbbd3bf22d1c9ac24b0d761L72

However, mounting the minikube volume to the docker container is essential for e2e-tests to run properly. Failing to do so results in the following error:

```
Expected error:
      <clientcmd.errConfigurationInvalid | len:3, cap:4>: [
          {
              s: "unable to read client-cert $HOME/.minikube/client.crt for minikube due to open $HOME/.minikube/client.crt: no such file or directory",
          },
          {
              s: "unable to read client-key $HOME/.minikube/client.key for minikube due to open $HOME/.minikube/client.key: no such file or directory",
          },
          {
              s: "unable to read certificate-authority $HOME/.minikube/ca.crt for minikube due to open $HOME/.minikube/ca.crt: no such file or directory",
          },
      ]
      invalid configuration: [unable to read client-cert $HOME/.minikube/client.crt for minikube due to open $HOME/.minikube/client.crt: no such file or directory, unable to read client-key $HOME/.minikube/client.key for minikube due to open $HOME/.minikube/client.key: no such file or directory, unable to read certificate-authority $HOME/.minikube/ca.crt for minikube due to open $HOME/.minikube/ca.crt: no such file or directory]
  not to have occurred

```