### PR TITLE
fix two bugs with backend-protocol annotation

### DIFF
--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -824,6 +824,7 @@ func (n *NGINXController) createServers(data []*extensions.Ingress,
 					defLoc.Denied = anns.Denied
 					defLoc.LuaRestyWAF = anns.LuaRestyWAF
 					defLoc.InfluxDB = anns.InfluxDB
+					defLoc.BackendProtocol = anns.BackendProtocol
 				} else {
 					glog.V(3).Infof("Ingress %q defines both a backend and rules. Using its backend as default upstream for all its rules.",
 						ingKey)

--- a/internal/ingress/types_equals.go
+++ b/internal/ingress/types_equals.go
@@ -341,6 +341,10 @@ func (l1 *Location) Equal(l2 *Location) bool {
 		return false
 	}
 
+	if l1.BackendProtocol != l2.BackendProtocol {
+		return false
+	}
+
 	return true
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

There are two issues with backend-protocol annotations currently:
1. The annotation does not get applied to catch all server
2. Nginx configuration does not get regenerated when the annotation is changed

This PR fixes both of these.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
