### PR TITLE
Don't sort IngressStatus from each Goroutine(update for each ingress)

### DIFF
--- a/internal/ingress/status/status.go
+++ b/internal/ingress/status/status.go
@@ -326,6 +326,7 @@ func (s *statusSync) updateStatus(newIngressPoint []apiv1.LoadBalancerIngress) {
 	defer p.Close()
 
 	batch := p.Batch()
+	sort.SliceStable(newIngressPoint, lessLoadBalancerIngress(newIngressPoint))
 
 	for _, ing := range ings {
 		batch.Queue(runUpdate(ing, newIngressPoint, s.Client))
@@ -341,8 +342,6 @@ func runUpdate(ing *extensions.Ingress, status []apiv1.LoadBalancerIngress,
 		if wu.IsCancelled() {
 			return nil, nil
 		}
-
-		sort.SliceStable(status, lessLoadBalancerIngress(status))
 
 		curIPs := ing.Status.LoadBalancer.Ingress
 		sort.SliceStable(curIPs, lessLoadBalancerIngress(curIPs))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Currently ingress controller try to update status for each ingress
resource in a parallel by using Goroutine, and inside this Goroutine we
are trying to sort same IngressStatus reference which is shared between
all Goroutine, this will break the original refrence if some Goroutine
tried to sort exact same time.
So we should have done sorting before passing reference to each
Goroutine to prevent from breaking original reference

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
fixes: #3269

**Special notes for your reviewer**:
