### PR TITLE
Add health-check-timeout as command line argument

### DIFF
--- a/cmd/nginx/flags.go
+++ b/cmd/nginx/flags.go
@@ -84,6 +84,8 @@ Takes the form "namespace/name".`)
 Configured inside the NGINX status server. All requests received on the port
 defined by the healthz-port parameter are forwarded internally to this path.`)
 
+		healthCheckTimeout = flags.Duration("health-check-timeout", 10, `Time limit, in seconds, for a probe to health-check-path to succeed.`)
+
 		updateStatus = flags.Bool("update-status", true,
 			`Update the load-balancer status of Ingress objects this controller satisfies.
 Requires setting the publish-service parameter to a valid Service reference.`)
@@ -217,6 +219,7 @@ Feature backed by OpenResty Lua libraries. Requires that OCSP stapling is not en
 		ConfigMapName:              *configMap,
 		DefaultSSLCertificate:      *defSSLCertificate,
 		DefaultHealthzURL:          *defHealthzURL,
+		HealthCheckTimeout:         *healthCheckTimeout,
 		PublishService:             *publishSvc,
 		PublishStatusAddress:       *publishStatusAddress,
 		ForceNamespaceIsolation:    *forceIsolation,

--- a/internal/ingress/controller/checker.go
+++ b/internal/ingress/controller/checker.go
@@ -38,7 +38,8 @@ func (n NGINXController) Name() string {
 func (n *NGINXController) Check(_ *http.Request) error {
 
 	url := fmt.Sprintf("http://127.0.0.1:%v%v", n.cfg.ListenPorts.Status, ngxHealthPath)
-	statusCode, err := simpleGet(url)
+	timeout := n.cfg.HealthCheckTimeout
+	statusCode, err := simpleGet(url, timeout)
 	if err != nil {
 		return err
 	}
@@ -48,7 +49,7 @@ func (n *NGINXController) Check(_ *http.Request) error {
 	}
 
 	url = fmt.Sprintf("http://127.0.0.1:%v/is-dynamic-lb-initialized", n.cfg.ListenPorts.Status)
-	statusCode, err = simpleGet(url)
+	statusCode, err = simpleGet(url, timeout)
 	if err != nil {
 		return err
 	}
@@ -75,9 +76,9 @@ func (n *NGINXController) Check(_ *http.Request) error {
 	return err
 }
 
-func simpleGet(url string) (int, error) {
+func simpleGet(url string, timeout time.Duration) (int, error) {
 	client := &http.Client{
-		Timeout:   10 * time.Second,
+		Timeout:   timeout * time.Second,
 		Transport: &http.Transport{DisableKeepAlives: true},
 	}
 

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -61,6 +61,7 @@ type Configuration struct {
 	ForceNamespaceIsolation bool
 
 	DefaultHealthzURL     string
+	HealthCheckTimeout    time.Duration
 	DefaultSSLCertificate string
 
 	// +optional


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This feature came up during this PR: https://github.com/kubernetes/ingress-nginx/pull/3247#issuecomment-430200955

This allows a user to define a timeout for the request to check if nginx healthz endpoint is returning ok.

