### PR TITLE
fix bug with balancer.lua configuration

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -884,8 +884,8 @@ stream {
             rewrite_by_lua_block {
                 balancer.rewrite()
             }
-            {{ if shouldConfigureLuaRestyWAF $all.Cfg.DisableLuaRestyWAF $location.LuaRestyWAF.Mode }}
             access_by_lua_block {
+                {{ if shouldConfigureLuaRestyWAF $all.Cfg.DisableLuaRestyWAF $location.LuaRestyWAF.Mode }}
                 local lua_resty_waf = require("resty.waf")
                 local waf = lua_resty_waf:new()
 
@@ -912,16 +912,21 @@ stream {
                 {{ end }}
 
                 waf:exec()
+                {{ end }}
             }
             header_filter_by_lua_block {
+                {{ if shouldConfigureLuaRestyWAF $all.Cfg.DisableLuaRestyWAF $location.LuaRestyWAF.Mode }}
                 local lua_resty_waf = require "resty.waf"
                 local waf = lua_resty_waf:new()
                 waf:exec()
+                {{ end }}
             }
             body_filter_by_lua_block {
+                {{ if shouldConfigureLuaRestyWAF $all.Cfg.DisableLuaRestyWAF $location.LuaRestyWAF.Mode }}
                 local lua_resty_waf = require "resty.waf"
                 local waf = lua_resty_waf:new()
                 waf:exec()
+                {{ end }}
             }
 
             log_by_lua_block {
@@ -933,7 +938,6 @@ stream {
                 balancer.log()
                 monitor.call()
             }
-            {{ end }}
 
             {{ if (and (not (empty $server.SSLCert.PemFileName)) $all.Cfg.HSTS) }}
             if ($scheme = https) {


### PR DESCRIPTION
A wrong `end` was removed at https://github.com/kubernetes/ingress-nginx/commit/3edf11b85f98a1f0b8ff2c4c456b2dc00b72a0cf#diff-980db9e4b88704f12338bd074839f94eL973 (https://github.com/kubernetes/ingress-nginx/commit/3edf11b85f98a1f0b8ff2c4c456b2dc00b72a0cf#diff-980db9e4b88704f12338bd074839f94eR933 should have been removed).

This PR fixes that regression.


**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
