### PR TITLE
Re-Enable Secure Upstream Annotation

### DIFF
--- a/docs/examples/auth/client-certs/README.md
+++ b/docs/examples/auth/client-certs/README.md
@@ -33,3 +33,5 @@ Note: The CA Certificate must contain the trusted certificate authority chain to
 2. Test by performing a curl against the Ingress Path without the Client Cert and expect a Status Code 400.
 3. Test by performing a curl against the Ingress Path with the Client Cert and expect a Status Code 200.
 
+Note: If you only want to pass the CA to the upstream, create an annotation with the CA cert as seen in [ingress2.yaml](ingress2.yaml).
+

--- a/docs/examples/auth/client-certs/ingress2.yaml
+++ b/docs/examples/auth/client-certs/ingress2.yaml
@@ -1,0 +1,24 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    # Create the secret containing the trusted ca certificates
+    nginx.ingress.kubernetes.io/secure-verify-ca-secret: "ca-secret"
+    # Setup the backend protocol, must be either "HTTPS" or "GRPC".
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+  name: nginx-test
+  namespace: default
+spec:
+  rules:
+  - host: ingress.test.com
+    http:
+      paths:
+      - backend:
+          serviceName: http-svc:80
+          servicePort: 80
+        path: /
+  tls:
+  - hosts:
+    - ingress.test.com
+    secretName: tls-secret
+

--- a/docs/user-guide/nginx-configuration/annotations.md
+++ b/docs/user-guide/nginx-configuration/annotations.md
@@ -64,7 +64,7 @@ You can add these Kubernetes annotations to specific Ingress objects to customiz
 |[nginx.ingress.kubernetes.io/proxy-redirect-to](#proxy-redirect)|string|
 |[nginx.ingress.kubernetes.io/enable-rewrite-log](#enable-rewrite-log)|"true" or "false"|
 |[nginx.ingress.kubernetes.io/rewrite-target](#rewrite)|URI|
-|[nginx.ingress.kubernetes.io/secure-verify-ca-secret](#secure-backends)|string|
+|[nginx.ingress.kubernetes.io/secure-verify-ca-secret](#backend-protocol)|string|
 |[nginx.ingress.kubernetes.io/server-alias](#server-alias)|string|
 |[nginx.ingress.kubernetes.io/server-snippet](#server-snippet)|string|
 |[nginx.ingress.kubernetes.io/service-upstream](#service-upstream)|"true" or "false"|
@@ -696,6 +696,18 @@ Example:
 ```yaml
 nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
 ```
+
+You can also specify a secret with a trusted CA certificate to [verify the certificate of the proxied HTTPS server](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_ssl_trusted_certificate) using:
+```yaml
+nginx.ingress.kubernetes.io/secure-verify-ca-secret: "my-ca-secret"
+```
+
+!!! example
+    Please check the [client-certs](../../examples/auth/client-certs/README.md) example.
+
+!!! Note: that the backend protocol must be set to either "HTTPS" or "GRPC". Also the `proxy_ssl_verify_depth` is set to 2 when
+    enabling is annotation.
+
 
 ### Use Regex
 

--- a/internal/ingress/annotations/annotations_test.go
+++ b/internal/ingress/annotations/annotations_test.go
@@ -133,6 +133,8 @@ func TestSecureVerifyCACert(t *testing.T) {
 		{5, map[string]string{backendProtocol: "HTTPS"}, false},
 		{6, map[string]string{}, false},
 		{7, nil, false},
+		{8, map[string]string{backendProtocol: "GRPCS", annotationSecureVerifyCACert: "not"}, false},
+		{9, map[string]string{backendProtocol: "GRPCS", annotationSecureVerifyCACert: "secure-verify-ca"}, true},
 	}
 
 	for _, ann := range anns {

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -356,6 +356,7 @@ func (n *NGINXController) getBackendServers(ingresses []*extensions.Ingress) ([]
 						loc.BackendProtocol = anns.BackendProtocol
 						loc.CustomHTTPErrors = anns.CustomHTTPErrors
 						loc.ModSecurity = anns.ModSecurity
+						loc.SecureVerifyCA = anns.SecureUpstream.CACert.CAFileName
 
 						if loc.Redirect.FromToWWW {
 							server.RedirectFromToWWW = true
@@ -398,6 +399,7 @@ func (n *NGINXController) getBackendServers(ingresses []*extensions.Ingress) ([]
 						BackendProtocol:      anns.BackendProtocol,
 						CustomHTTPErrors:     anns.CustomHTTPErrors,
 						ModSecurity:          anns.ModSecurity,
+						SecureVerifyCA:       anns.SecureUpstream.CACert.CAFileName,
 					}
 
 					if loc.Redirect.FromToWWW {
@@ -584,10 +586,6 @@ func (n *NGINXController) createUpstreams(data []*extensions.Ingress, du *ingres
 				glog.V(3).Infof("Creating upstream %q", name)
 				upstreams[name] = newUpstream(name)
 				upstreams[name].Port = path.Backend.ServicePort
-
-				if upstreams[name].SecureCACert.Secret == "" {
-					upstreams[name].SecureCACert = anns.SecureUpstream.CACert
-				}
 
 				if upstreams[name].UpstreamHashBy == "" {
 					upstreams[name].UpstreamHashBy = anns.UpstreamHashBy
@@ -851,6 +849,7 @@ func (n *NGINXController) createServers(data []*extensions.Ingress,
 					defLoc.InfluxDB = anns.InfluxDB
 					defLoc.BackendProtocol = anns.BackendProtocol
 					defLoc.ModSecurity = anns.ModSecurity
+					defLoc.SecureVerifyCA = anns.SecureUpstream.CACert.CAFileName
 				} else {
 					glog.V(3).Infof("Ingress %q defines both a backend and rules. Using its backend as default upstream for all its rules.",
 						ingKey)

--- a/internal/ingress/types.go
+++ b/internal/ingress/types.go
@@ -284,6 +284,10 @@ type Location struct {
 	// ModSecurity allows to enable and configure modsecurity
 	// +optional
 	ModSecurity modsecurity.Config `json:"modsecurity"`
+	// SecureVerifyCA indicates which secret containing ca.crt should be verified
+	// against the service. Note: If an invalid secret it given, it will be ignored.
+	// +optional
+	SecureVerifyCA string `json:"secure-verify-ca,omitempty"`
 }
 
 // SSLPassthroughBackend describes a SSL upstream server configured

--- a/internal/ingress/types_equals.go
+++ b/internal/ingress/types_equals.go
@@ -371,12 +371,13 @@ func (l1 *Location) Equal(l2 *Location) bool {
 	if !(&l1.LuaRestyWAF).Equal(&l2.LuaRestyWAF) {
 		return false
 	}
-
 	if !(&l1.InfluxDB).Equal(&l2.InfluxDB) {
 		return false
 	}
-
 	if l1.BackendProtocol != l2.BackendProtocol {
+		return false
+	}
+	if l1.SecureVerifyCA != l2.SecureVerifyCA {
 		return false
 	}
 

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -1195,6 +1195,11 @@ stream {
             {{ range $errCode := $location.CustomHTTPErrors }}
             error_page {{ $errCode }} = @custom_{{ $errCode }};{{ end }}
 
+            {{ if not (empty $location.SecureVerifyCA) }}
+            proxy_ssl_verify              on;
+            proxy_ssl_trusted_certificate {{ $location.SecureVerifyCA }};
+            proxy_ssl_verify_depth        2;
+            {{ end }}
 
             {{ buildProxyPass $server.Hostname $all.Backends $location }}
             {{ if (or (eq $location.Proxy.ProxyRedirectFrom "default") (eq $location.Proxy.ProxyRedirectFrom "off")) }}

--- a/test/e2e/annotations/authtls.go
+++ b/test/e2e/annotations/authtls.go
@@ -46,7 +46,8 @@ var _ = framework.IngressNginxDescribe("Annotations - AuthTLS", func() {
 			f.KubeClientSet,
 			host,
 			host,
-			nameSpace)
+			nameSpace,
+			false)
 		Expect(err).ToNot(HaveOccurred())
 
 		annotations := map[string]string{
@@ -102,7 +103,8 @@ var _ = framework.IngressNginxDescribe("Annotations - AuthTLS", func() {
 			f.KubeClientSet,
 			host,
 			host,
-			nameSpace)
+			nameSpace,
+			false)
 		Expect(err).ToNot(HaveOccurred())
 
 		annotations := map[string]string{
@@ -149,7 +151,8 @@ var _ = framework.IngressNginxDescribe("Annotations - AuthTLS", func() {
 			f.KubeClientSet,
 			host,
 			host,
-			nameSpace)
+			nameSpace,
+			false)
 		Expect(err).ToNot(HaveOccurred())
 
 		annotations := map[string]string{

--- a/test/e2e/annotations/secureupstream.go
+++ b/test/e2e/annotations/secureupstream.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package annotations
+
+import (
+	"fmt"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/ingress-nginx/test/e2e/framework"
+	"strings"
+)
+
+var _ = framework.IngressNginxDescribe("Annotations - SecureUpstream", func() {
+	f := framework.NewDefaultFramework("secureupstream")
+
+	BeforeEach(func() {
+		f.NewEchoDeployment()
+		f.NewGRPCFortuneTellerDeployment()
+	})
+
+	AfterEach(func() {
+	})
+
+	It("should set secure-verify-ca-secret with https backend", func() {
+		host := "secureupstream.foo.com"
+		nameSpace := f.IngressController.Namespace
+		ca := host + "-ca"
+
+		_, err := framework.CreateIngressMASecret(
+			f.KubeClientSet,
+			host,
+			ca,
+			nameSpace,
+			true)
+		Expect(err).ToNot(HaveOccurred())
+
+		_, err = framework.CreateIngressTLSSecret(
+			f.KubeClientSet,
+			[]string{host},
+			host,
+			nameSpace)
+		Expect(err).ToNot(HaveOccurred())
+
+		annotations := map[string]string{
+			"nginx.ingress.kubernetes.io/backend-protocol":        "HTTPS",
+			"nginx.ingress.kubernetes.io/secure-verify-ca-secret": ca,
+		}
+
+		ing := framework.NewSingleIngressWithTLS(host, "/", host, nameSpace, "http-svc", 80, &annotations)
+		f.EnsureIngress(ing)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ing).NotTo(BeNil())
+
+		proxySslVerify := "proxy_ssl_verify on;"
+		proxySslTrustedCertificate := fmt.Sprintf("proxy_ssl_trusted_certificate /etc/ingress-controller/ssl/ca-%s-%s.pem;", nameSpace, ca)
+		proxySslVerifyDepth := "proxy_ssl_verify_depth 2;"
+
+		f.WaitForNginxServer(host,
+			func(server string) bool {
+				return strings.Contains(server, proxySslTrustedCertificate) && strings.Contains(server, proxySslVerify) && strings.Contains(server, proxySslVerifyDepth)
+			})
+	})
+
+	It("should set secure-verify-ca-secret with grpcs backend", func() {
+		host := "secureupstream.foo.com"
+		nameSpace := f.IngressController.Namespace
+		ca := host + "-ca"
+
+		_, err := framework.CreateIngressMASecret(
+			f.KubeClientSet,
+			host,
+			ca,
+			nameSpace,
+			true)
+		Expect(err).ToNot(HaveOccurred())
+
+		_, err = framework.CreateIngressTLSSecret(
+			f.KubeClientSet,
+			[]string{host},
+			host,
+			nameSpace)
+		Expect(err).ToNot(HaveOccurred())
+
+		annotations := map[string]string{
+			"nginx.ingress.kubernetes.io/backend-protocol":        "GRPCS",
+			"nginx.ingress.kubernetes.io/secure-verify-ca-secret": ca,
+		}
+
+		ing := framework.NewSingleIngressWithTLS(host, "/", host, nameSpace, "fortune-teller", 80, &annotations)
+		f.EnsureIngress(ing)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ing).NotTo(BeNil())
+
+		proxySslVerify := "proxy_ssl_verify on;"
+		proxySslTrustedCertificate := fmt.Sprintf("proxy_ssl_trusted_certificate /etc/ingress-controller/ssl/ca-%s-%s.pem", nameSpace, ca)
+		proxySslVerifyDepth := "proxy_ssl_verify_depth 2;"
+
+		f.WaitForNginxServer(host,
+			func(server string) bool {
+				return strings.Contains(server, proxySslTrustedCertificate) && strings.Contains(server, proxySslVerify) && strings.Contains(server, proxySslVerifyDepth)
+			})
+	})
+})

--- a/test/e2e/framework/ssl.go
+++ b/test/e2e/framework/ssl.go
@@ -92,7 +92,7 @@ func CreateIngressTLSSecret(client kubernetes.Interface, hosts []string, secretN
 // CreateIngressMASecret creates or updates a Secret containing a Mutual Auth
 // certificate-chain for the given Ingress and returns a TLS configuration suitable
 // for HTTP clients to use against that particular Ingress.
-func CreateIngressMASecret(client kubernetes.Interface, host string, secretName, namespace string) (*tls.Config, error) {
+func CreateIngressMASecret(client kubernetes.Interface, host string, secretName, namespace string, onlyCA bool) (*tls.Config, error) {
 	if len(host) == 0 {
 		return nil, fmt.Errorf("requires a non-empty host")
 	}
@@ -108,6 +108,12 @@ func CreateIngressMASecret(client kubernetes.Interface, host string, secretName,
 		v1.TLSCertKey:       serverCert.Bytes(),
 		v1.TLSPrivateKeyKey: serverKey.Bytes(),
 		"ca.crt":            caCert.Bytes(),
+	}
+
+	if onlyCA {
+		data = map[string][]byte{
+			"ca.crt": caCert.Bytes(),
+		}
 	}
 
 	newSecret := &v1.Secret{


### PR DESCRIPTION
Renables the secure-verify-ca-secret annotation. This annotation allows a CA to be verified against a service. Also adds e2e tests.