### PR TITLE
Remove manual content into installation guide

### DIFF
--- a/docs/deploy/index.md
+++ b/docs/deploy/index.md
@@ -1,20 +1,5 @@
 # Installation Guide
 
-## Contents
-
-- [Generic Deployment](#generic-deployment)
-  - [Mandatory command](#mandatory-command)
-  - [Provider Specific Steps](#provider-specific-steps)
-    - [Docker for Mac](#docker-for-mac)
-    - [minikube](#minikube)
-    - [AWS](#aws)
-    - [GCE - GKE](#gce-gke)
-    - [Azure](#azure)
-    - [Bare-metal](#bare-metal)
-  - [Verify installation](#verify-installation)
-  - [Detect installed version](#detect-installed-version)
-- [Using Helm](#using-helm)
-
 ## Prerequisite Generic Deployment Command
 
 The following **Mandatory Command** is required for all deployments.


### PR DESCRIPTION
Hi,

Documentation content is automatically generate on right side of documentation. It is not necessary to add one manually. Furthermore, the manual content is outdated.

You can find the issue here: https://kubernetes.github.io/ingress-nginx/deploy/; Content entry Generic Deployment is a dead link.

Regards,