### PR TITLE
Remove e2e boilerplate

### DIFF
--- a/test/e2e/annotations/alias.go
+++ b/test/e2e/annotations/alias.go
@@ -31,8 +31,7 @@ var _ = framework.IngressNginxDescribe("Annotations - Alias", func() {
 	f := framework.NewDefaultFramework("alias")
 
 	BeforeEach(func() {
-		err := f.NewEchoDeployment()
-		Expect(err).NotTo(HaveOccurred())
+		f.NewEchoDeployment()
 	})
 
 	AfterEach(func() {
@@ -43,17 +42,13 @@ var _ = framework.IngressNginxDescribe("Annotations - Alias", func() {
 		annotations := map[string]string{}
 
 		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
-		_, err := f.EnsureIngress(ing)
+		f.EnsureIngress(ing)
 
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ing).NotTo(BeNil())
-
-		err = f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return Expect(server).Should(ContainSubstring("server_name foo")) &&
 					Expect(server).ShouldNot(ContainSubstring("return 503"))
 			})
-		Expect(err).NotTo(HaveOccurred())
 
 		resp, body, errs := gorequest.New().
 			Get(f.IngressController.HTTPURL).
@@ -81,17 +76,13 @@ var _ = framework.IngressNginxDescribe("Annotations - Alias", func() {
 		}
 
 		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
-		_, err := f.EnsureIngress(ing)
+		f.EnsureIngress(ing)
 
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ing).NotTo(BeNil())
-
-		err = f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return Expect(server).Should(ContainSubstring("server_name foo")) &&
 					Expect(server).ShouldNot(ContainSubstring("return 503"))
 			})
-		Expect(err).NotTo(HaveOccurred())
 
 		hosts := []string{"foo", "bar"}
 		for _, host := range hosts {

--- a/test/e2e/annotations/approot.go
+++ b/test/e2e/annotations/approot.go
@@ -30,8 +30,7 @@ var _ = framework.IngressNginxDescribe("Annotations - Approot", func() {
 	f := framework.NewDefaultFramework("approot")
 
 	BeforeEach(func() {
-		err := f.NewEchoDeploymentWithReplicas(2)
-		Expect(err).NotTo(HaveOccurred())
+		f.NewEchoDeploymentWithReplicas(2)
 	})
 
 	AfterEach(func() {
@@ -45,17 +44,13 @@ var _ = framework.IngressNginxDescribe("Annotations - Approot", func() {
 		}
 
 		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
-		_, err := f.EnsureIngress(ing)
+		f.EnsureIngress(ing)
 
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ing).NotTo(BeNil())
-
-		err = f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return Expect(server).Should(ContainSubstring(`if ($uri = /) {`)) &&
 					Expect(server).Should(ContainSubstring(`return 302 /foo;`))
 			})
-		Expect(err).NotTo(HaveOccurred())
 
 		resp, _, errs := gorequest.New().
 			Get(f.IngressController.HTTPURL).

--- a/test/e2e/annotations/auth.go
+++ b/test/e2e/annotations/auth.go
@@ -25,6 +25,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	"github.com/parnurzeal/gorequest"
 
 	corev1 "k8s.io/api/core/v1"
@@ -39,8 +40,7 @@ var _ = framework.IngressNginxDescribe("Annotations - Auth", func() {
 	f := framework.NewDefaultFramework("auth")
 
 	BeforeEach(func() {
-		err := f.NewEchoDeployment()
-		Expect(err).NotTo(HaveOccurred())
+		f.NewEchoDeployment()
 	})
 
 	AfterEach(func() {
@@ -50,17 +50,13 @@ var _ = framework.IngressNginxDescribe("Annotations - Auth", func() {
 		host := "auth"
 
 		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, nil)
-		_, err := f.EnsureIngress(ing)
+		f.EnsureIngress(ing)
 
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ing).NotTo(BeNil())
-
-		err = f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return Expect(server).Should(ContainSubstring("server_name auth")) &&
 					Expect(server).ShouldNot(ContainSubstring("return 503"))
 			})
-		Expect(err).NotTo(HaveOccurred())
 
 		resp, body, errs := gorequest.New().
 			Get(f.IngressController.HTTPURL).
@@ -82,17 +78,13 @@ var _ = framework.IngressNginxDescribe("Annotations - Auth", func() {
 		}
 
 		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
-		_, err := f.EnsureIngress(ing)
+		f.EnsureIngress(ing)
 
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ing).NotTo(BeNil())
-
-		err = f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return Expect(server).Should(ContainSubstring("server_name auth")) &&
 					Expect(server).Should(ContainSubstring("return 503"))
 			})
-		Expect(err).NotTo(HaveOccurred())
 
 		resp, body, errs := gorequest.New().
 			Get(f.IngressController.HTTPURL).
@@ -108,10 +100,7 @@ var _ = framework.IngressNginxDescribe("Annotations - Auth", func() {
 	It("should return status code 401 when authentication is configured but Authorization header is not configured", func() {
 		host := "auth"
 
-		s, err := f.EnsureSecret(buildSecret("foo", "bar", "test", f.IngressController.Namespace))
-		Expect(err).NotTo(HaveOccurred())
-		Expect(s).NotTo(BeNil())
-		Expect(s.ObjectMeta).NotTo(BeNil())
+		s := f.EnsureSecret(buildSecret("foo", "bar", "test", f.IngressController.Namespace))
 
 		annotations := map[string]string{
 			"nginx.ingress.kubernetes.io/auth-type":   "basic",
@@ -120,17 +109,13 @@ var _ = framework.IngressNginxDescribe("Annotations - Auth", func() {
 		}
 
 		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
-		_, err = f.EnsureIngress(ing)
+		f.EnsureIngress(ing)
 
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ing).NotTo(BeNil())
-
-		err = f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return Expect(server).Should(ContainSubstring("server_name auth")) &&
 					Expect(server).ShouldNot(ContainSubstring("return 503"))
 			})
-		Expect(err).NotTo(HaveOccurred())
 
 		resp, body, errs := gorequest.New().
 			Get(f.IngressController.HTTPURL).
@@ -146,10 +131,7 @@ var _ = framework.IngressNginxDescribe("Annotations - Auth", func() {
 	It("should return status code 401 when authentication is configured and Authorization header is sent with invalid credentials", func() {
 		host := "auth"
 
-		s, err := f.EnsureSecret(buildSecret("foo", "bar", "test", f.IngressController.Namespace))
-		Expect(err).NotTo(HaveOccurred())
-		Expect(s).NotTo(BeNil())
-		Expect(s.ObjectMeta).NotTo(BeNil())
+		s := f.EnsureSecret(buildSecret("foo", "bar", "test", f.IngressController.Namespace))
 
 		annotations := map[string]string{
 			"nginx.ingress.kubernetes.io/auth-type":   "basic",
@@ -158,17 +140,13 @@ var _ = framework.IngressNginxDescribe("Annotations - Auth", func() {
 		}
 
 		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
-		_, err = f.EnsureIngress(ing)
+		f.EnsureIngress(ing)
 
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ing).NotTo(BeNil())
-
-		err = f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return Expect(server).Should(ContainSubstring("server_name auth")) &&
 					Expect(server).ShouldNot(ContainSubstring("return 503"))
 			})
-		Expect(err).NotTo(HaveOccurred())
 
 		resp, body, errs := gorequest.New().
 			Get(f.IngressController.HTTPURL).
@@ -185,10 +163,7 @@ var _ = framework.IngressNginxDescribe("Annotations - Auth", func() {
 	It("should return status code 200 when authentication is configured and Authorization header is sent", func() {
 		host := "auth"
 
-		s, err := f.EnsureSecret(buildSecret("foo", "bar", "test", f.IngressController.Namespace))
-		Expect(err).NotTo(HaveOccurred())
-		Expect(s).NotTo(BeNil())
-		Expect(s.ObjectMeta).NotTo(BeNil())
+		s := f.EnsureSecret(buildSecret("foo", "bar", "test", f.IngressController.Namespace))
 
 		annotations := map[string]string{
 			"nginx.ingress.kubernetes.io/auth-type":   "basic",
@@ -197,17 +172,13 @@ var _ = framework.IngressNginxDescribe("Annotations - Auth", func() {
 		}
 
 		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
-		_, err = f.EnsureIngress(ing)
+		f.EnsureIngress(ing)
 
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ing).NotTo(BeNil())
-
-		err = f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return Expect(server).Should(ContainSubstring("server_name auth")) &&
 					Expect(server).ShouldNot(ContainSubstring("return 503"))
 			})
-		Expect(err).NotTo(HaveOccurred())
 
 		resp, _, errs := gorequest.New().
 			Get(f.IngressController.HTTPURL).
@@ -223,7 +194,7 @@ var _ = framework.IngressNginxDescribe("Annotations - Auth", func() {
 	It("should return status code 500 when authentication is configured with invalid content and Authorization header is sent", func() {
 		host := "auth"
 
-		s, err := f.EnsureSecret(
+		s := f.EnsureSecret(
 			&corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test",
@@ -236,9 +207,6 @@ var _ = framework.IngressNginxDescribe("Annotations - Auth", func() {
 				Type: corev1.SecretTypeOpaque,
 			},
 		)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(s).NotTo(BeNil())
-		Expect(s.ObjectMeta).NotTo(BeNil())
 
 		annotations := map[string]string{
 			"nginx.ingress.kubernetes.io/auth-type":   "basic",
@@ -247,17 +215,13 @@ var _ = framework.IngressNginxDescribe("Annotations - Auth", func() {
 		}
 
 		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
-		_, err = f.EnsureIngress(ing)
+		f.EnsureIngress(ing)
 
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ing).NotTo(BeNil())
-
-		err = f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return Expect(server).Should(ContainSubstring("server_name auth")) &&
 					Expect(server).ShouldNot(ContainSubstring("return 503"))
 			})
-		Expect(err).NotTo(HaveOccurred())
 
 		resp, _, errs := gorequest.New().
 			Get(f.IngressController.HTTPURL).
@@ -274,11 +238,10 @@ var _ = framework.IngressNginxDescribe("Annotations - Auth", func() {
 		host := "auth"
 
 		BeforeEach(func() {
-			err := f.NewHttpbinDeployment()
-			Expect(err).NotTo(HaveOccurred())
+			f.NewHttpbinDeployment()
 
 			var httpbinIP string
-			err = wait.PollImmediate(time.Second, time.Minute, func() (bool, error) {
+			err := wait.PollImmediate(time.Second, time.Minute, func() (bool, error) {
 				e, err := f.KubeClientSet.CoreV1().Endpoints(f.IngressController.Namespace).Get("httpbin", metav1.GetOptions{})
 				if errors.IsNotFound(err) {
 					return false, nil
@@ -300,15 +263,11 @@ var _ = framework.IngressNginxDescribe("Annotations - Auth", func() {
 			}
 
 			ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
-			_, err = f.EnsureIngress(ing)
+			f.EnsureIngress(ing)
 
-			Expect(err).NotTo(HaveOccurred())
-			Expect(ing).NotTo(BeNil())
-
-			err = f.WaitForNginxServer(host, func(server string) bool {
+			f.WaitForNginxServer(host, func(server string) bool {
 				return Expect(server).ShouldNot(ContainSubstring("return 503"))
 			})
-			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("should return status code 200 when signed in", func() {

--- a/test/e2e/annotations/authtls.go
+++ b/test/e2e/annotations/authtls.go
@@ -19,20 +19,20 @@ package annotations
 import (
 	"crypto/tls"
 	"fmt"
+	"net/http"
+	"strings"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/parnurzeal/gorequest"
 	"k8s.io/ingress-nginx/test/e2e/framework"
-	"net/http"
-	"strings"
 )
 
 var _ = framework.IngressNginxDescribe("Annotations - AuthTLS", func() {
 	f := framework.NewDefaultFramework("authtls")
 
 	BeforeEach(func() {
-		err := f.NewEchoDeploymentWithReplicas(2)
-		Expect(err).NotTo(HaveOccurred())
+		f.NewEchoDeploymentWithReplicas(2)
 	})
 
 	AfterEach(func() {
@@ -54,10 +54,7 @@ var _ = framework.IngressNginxDescribe("Annotations - AuthTLS", func() {
 		}
 
 		ing := framework.NewSingleIngressWithTLS(host, "/", host, nameSpace, "http-svc", 80, &annotations)
-		_, err = f.EnsureIngress(ing)
-
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ing).NotTo(BeNil())
+		f.EnsureIngress(ing)
 
 		// Since we can use the same certificate-chain for tls as well as mutual-auth, we will check all values
 		sslCertDirective := fmt.Sprintf("ssl_certificate /etc/ingress-controller/ssl/%s-%s.pem;", nameSpace, host)
@@ -67,11 +64,14 @@ var _ = framework.IngressNginxDescribe("Annotations - AuthTLS", func() {
 		sslVerify := "ssl_verify_client on;"
 		sslVerifyDepth := "ssl_verify_depth 1;"
 
-		err = f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
-				return strings.Contains(server, sslCertDirective) && strings.Contains(server, sslKeyDirective) && strings.Contains(server, sslClientCertDirective) && strings.Contains(server, sslVerify) && strings.Contains(server, sslVerifyDepth)
+				return strings.Contains(server, sslCertDirective) &&
+					strings.Contains(server, sslKeyDirective) &&
+					strings.Contains(server, sslClientCertDirective) &&
+					strings.Contains(server, sslVerify) &&
+					strings.Contains(server, sslVerifyDepth)
 			})
-		Expect(err).NotTo(HaveOccurred())
 
 		// Send Request without Client Certs
 		req := gorequest.New()
@@ -112,10 +112,7 @@ var _ = framework.IngressNginxDescribe("Annotations - AuthTLS", func() {
 		}
 
 		ing := framework.NewSingleIngressWithTLS(host, "/", host, nameSpace, "http-svc", 80, &annotations)
-		_, err = f.EnsureIngress(ing)
-
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ing).NotTo(BeNil())
+		f.EnsureIngress(ing)
 
 		// Since we can use the same certificate-chain for tls as well as mutual-auth, we will check all values
 		sslCertDirective := fmt.Sprintf("ssl_certificate /etc/ingress-controller/ssl/%s-%s.pem;", nameSpace, host)
@@ -125,11 +122,10 @@ var _ = framework.IngressNginxDescribe("Annotations - AuthTLS", func() {
 		sslVerify := "ssl_verify_client off;"
 		sslVerifyDepth := "ssl_verify_depth 2;"
 
-		err = f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return strings.Contains(server, sslCertDirective) && strings.Contains(server, sslKeyDirective) && strings.Contains(server, sslClientCertDirective) && strings.Contains(server, sslVerify) && strings.Contains(server, sslVerifyDepth)
 			})
-		Expect(err).NotTo(HaveOccurred())
 
 		// Send Request without Client Certs
 		req := gorequest.New()
@@ -163,9 +159,7 @@ var _ = framework.IngressNginxDescribe("Annotations - AuthTLS", func() {
 		}
 
 		ing := framework.NewSingleIngressWithTLS(host, "/", host, nameSpace, "http-svc", 80, &annotations)
-		_, err = f.EnsureIngress(ing)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ing).NotTo(BeNil())
+		f.EnsureIngress(ing)
 
 		// Since we can use the same certificate-chain for tls as well as mutual-auth, we will check all values
 		sslCertDirective := fmt.Sprintf("ssl_certificate /etc/ingress-controller/ssl/%s-%s.pem;", nameSpace, host)
@@ -177,11 +171,16 @@ var _ = framework.IngressNginxDescribe("Annotations - AuthTLS", func() {
 		sslErrorPage := fmt.Sprintf("error_page 495 496 = %s;", f.IngressController.HTTPURL+errorPath)
 		sslUpstreamClientCert := "proxy_set_header ssl-client-cert $ssl_client_escaped_cert;"
 
-		err = f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
-				return strings.Contains(server, sslCertDirective) && strings.Contains(server, sslKeyDirective) && strings.Contains(server, sslClientCertDirective) && strings.Contains(server, sslVerify) && strings.Contains(server, sslVerifyDepth) && strings.Contains(server, sslErrorPage) && strings.Contains(server, sslUpstreamClientCert)
+				return strings.Contains(server, sslCertDirective) &&
+					strings.Contains(server, sslKeyDirective) &&
+					strings.Contains(server, sslClientCertDirective) &&
+					strings.Contains(server, sslVerify) &&
+					strings.Contains(server, sslVerifyDepth) &&
+					strings.Contains(server, sslErrorPage) &&
+					strings.Contains(server, sslUpstreamClientCert)
 			})
-		Expect(err).NotTo(HaveOccurred())
 
 		// Send Request without Client Certs
 		req := gorequest.New()

--- a/test/e2e/annotations/backendprotocol.go
+++ b/test/e2e/annotations/backendprotocol.go
@@ -26,8 +26,7 @@ var _ = framework.IngressNginxDescribe("Annotations - Backendprotocol", func() {
 	f := framework.NewDefaultFramework("backendprotocol")
 
 	BeforeEach(func() {
-		err := f.NewEchoDeploymentWithReplicas(2)
-		Expect(err).NotTo(HaveOccurred())
+		f.NewEchoDeploymentWithReplicas(2)
 	})
 
 	AfterEach(func() {
@@ -40,16 +39,12 @@ var _ = framework.IngressNginxDescribe("Annotations - Backendprotocol", func() {
 		}
 
 		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
-		_, err := f.EnsureIngress(ing)
+		f.EnsureIngress(ing)
 
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ing).NotTo(BeNil())
-
-		err = f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return Expect(server).Should(ContainSubstring("proxy_pass https://upstream_balancer;"))
 			})
-		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should set backend protocol to grpc://", func() {
@@ -59,16 +54,12 @@ var _ = framework.IngressNginxDescribe("Annotations - Backendprotocol", func() {
 		}
 
 		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
-		_, err := f.EnsureIngress(ing)
+		f.EnsureIngress(ing)
 
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ing).NotTo(BeNil())
-
-		err = f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return Expect(server).Should(ContainSubstring("grpc_pass grpc://upstream_balancer;"))
 			})
-		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should set backend protocol to grpcs://", func() {
@@ -78,16 +69,12 @@ var _ = framework.IngressNginxDescribe("Annotations - Backendprotocol", func() {
 		}
 
 		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
-		_, err := f.EnsureIngress(ing)
+		f.EnsureIngress(ing)
 
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ing).NotTo(BeNil())
-
-		err = f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return Expect(server).Should(ContainSubstring("grpc_pass grpcs://upstream_balancer;"))
 			})
-		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should set backend protocol to ''", func() {
@@ -97,15 +84,11 @@ var _ = framework.IngressNginxDescribe("Annotations - Backendprotocol", func() {
 		}
 
 		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
-		_, err := f.EnsureIngress(ing)
+		f.EnsureIngress(ing)
 
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ing).NotTo(BeNil())
-
-		err = f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return Expect(server).Should(ContainSubstring("ajp_pass upstream_balancer;"))
 			})
-		Expect(err).NotTo(HaveOccurred())
 	})
 })

--- a/test/e2e/annotations/clientbodybuffersize.go
+++ b/test/e2e/annotations/clientbodybuffersize.go
@@ -26,8 +26,7 @@ var _ = framework.IngressNginxDescribe("Annotations - Client-Body-Buffer-Size", 
 	f := framework.NewDefaultFramework("clientbodybuffersize")
 
 	BeforeEach(func() {
-		err := f.NewEchoDeploymentWithReplicas(2)
-		Expect(err).NotTo(HaveOccurred())
+		f.NewEchoDeploymentWithReplicas(2)
 	})
 
 	AfterEach(func() {
@@ -40,16 +39,12 @@ var _ = framework.IngressNginxDescribe("Annotations - Client-Body-Buffer-Size", 
 		}
 
 		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
-		_, err := f.EnsureIngress(ing)
+		f.EnsureIngress(ing)
 
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ing).NotTo(BeNil())
-
-		err = f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return Expect(server).Should(ContainSubstring("client_body_buffer_size 1000;"))
 			})
-		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should set client_body_buffer_size to 1K", func() {
@@ -59,16 +54,12 @@ var _ = framework.IngressNginxDescribe("Annotations - Client-Body-Buffer-Size", 
 		}
 
 		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
-		_, err := f.EnsureIngress(ing)
+		f.EnsureIngress(ing)
 
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ing).NotTo(BeNil())
-
-		err = f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return Expect(server).Should(ContainSubstring("client_body_buffer_size 1K;"))
 			})
-		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should set client_body_buffer_size to 1k", func() {
@@ -78,16 +69,12 @@ var _ = framework.IngressNginxDescribe("Annotations - Client-Body-Buffer-Size", 
 		}
 
 		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
-		_, err := f.EnsureIngress(ing)
+		f.EnsureIngress(ing)
 
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ing).NotTo(BeNil())
-
-		err = f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return Expect(server).Should(ContainSubstring("client_body_buffer_size 1k;"))
 			})
-		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should set client_body_buffer_size to 1m", func() {
@@ -97,16 +84,12 @@ var _ = framework.IngressNginxDescribe("Annotations - Client-Body-Buffer-Size", 
 		}
 
 		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
-		_, err := f.EnsureIngress(ing)
+		f.EnsureIngress(ing)
 
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ing).NotTo(BeNil())
-
-		err = f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return Expect(server).Should(ContainSubstring("client_body_buffer_size 1m;"))
 			})
-		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should set client_body_buffer_size to 1M", func() {
@@ -116,16 +99,12 @@ var _ = framework.IngressNginxDescribe("Annotations - Client-Body-Buffer-Size", 
 		}
 
 		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
-		_, err := f.EnsureIngress(ing)
+		f.EnsureIngress(ing)
 
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ing).NotTo(BeNil())
-
-		err = f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return Expect(server).Should(ContainSubstring("client_body_buffer_size 1M;"))
 			})
-		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should not set client_body_buffer_size to invalid 1b", func() {
@@ -135,15 +114,11 @@ var _ = framework.IngressNginxDescribe("Annotations - Client-Body-Buffer-Size", 
 		}
 
 		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
-		_, err := f.EnsureIngress(ing)
+		f.EnsureIngress(ing)
 
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ing).NotTo(BeNil())
-
-		err = f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return Expect(server).ShouldNot(ContainSubstring("client_body_buffer_size 1b;"))
 			})
-		Expect(err).NotTo(HaveOccurred())
 	})
 })

--- a/test/e2e/annotations/connection.go
+++ b/test/e2e/annotations/connection.go
@@ -31,8 +31,7 @@ var _ = framework.IngressNginxDescribe("Annotations - Connection", func() {
 	f := framework.NewDefaultFramework("connection")
 
 	BeforeEach(func() {
-		err := f.NewEchoDeploymentWithReplicas(2)
-		Expect(err).NotTo(HaveOccurred())
+		f.NewEchoDeploymentWithReplicas(2)
 	})
 
 	AfterEach(func() {
@@ -45,16 +44,12 @@ var _ = framework.IngressNginxDescribe("Annotations - Connection", func() {
 		}
 
 		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
-		_, err := f.EnsureIngress(ing)
+		f.EnsureIngress(ing)
 
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ing).NotTo(BeNil())
-
-		err = f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return Expect(server).Should(ContainSubstring(`proxy_set_header Connection keep-alive;`))
 			})
-		Expect(err).NotTo(HaveOccurred())
 
 		resp, body, errs := gorequest.New().
 			Get(f.IngressController.HTTPURL).

--- a/test/e2e/annotations/cors.go
+++ b/test/e2e/annotations/cors.go
@@ -17,10 +17,11 @@ limitations under the License.
 package annotations
 
 import (
+	"net/http"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/parnurzeal/gorequest"
-	"net/http"
 
 	"k8s.io/ingress-nginx/test/e2e/framework"
 )
@@ -29,8 +30,7 @@ var _ = framework.IngressNginxDescribe("Annotations - CORS", func() {
 	f := framework.NewDefaultFramework("cors")
 
 	BeforeEach(func() {
-		err := f.NewEchoDeploymentWithReplicas(2)
-		Expect(err).NotTo(HaveOccurred())
+		f.NewEchoDeploymentWithReplicas(2)
 	})
 
 	AfterEach(func() {
@@ -43,40 +43,32 @@ var _ = framework.IngressNginxDescribe("Annotations - CORS", func() {
 		}
 
 		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
-		_, err := f.EnsureIngress(ing)
+		f.EnsureIngress(ing)
 
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ing).NotTo(BeNil())
-
-		err = f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return Expect(server).Should(ContainSubstring("more_set_headers 'Access-Control-Allow-Methods: GET, PUT, POST, DELETE, PATCH, OPTIONS';"))
 			})
-		Expect(err).NotTo(HaveOccurred())
 
-		err = f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return Expect(server).Should(ContainSubstring("more_set_headers 'Access-Control-Allow-Origin: *';"))
 			})
-		Expect(err).NotTo(HaveOccurred())
 
-		err = f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return Expect(server).Should(ContainSubstring("more_set_headers 'Access-Control-Allow-Headers: DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization';"))
 			})
-		Expect(err).NotTo(HaveOccurred())
 
-		err = f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return Expect(server).Should(ContainSubstring("more_set_headers 'Access-Control-Max-Age: 1728000';"))
 			})
-		Expect(err).NotTo(HaveOccurred())
 
-		err = f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return Expect(server).Should(ContainSubstring("more_set_headers 'Access-Control-Allow-Credentials: true';"))
 			})
-		Expect(err).NotTo(HaveOccurred())
 
 		uri := "/"
 		resp, _, errs := gorequest.New().
@@ -95,16 +87,12 @@ var _ = framework.IngressNginxDescribe("Annotations - CORS", func() {
 		}
 
 		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
-		_, err := f.EnsureIngress(ing)
+		f.EnsureIngress(ing)
 
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ing).NotTo(BeNil())
-
-		err = f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return Expect(server).Should(ContainSubstring("more_set_headers 'Access-Control-Allow-Methods: POST, GET';"))
 			})
-		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should set cors max-age", func() {
@@ -115,16 +103,12 @@ var _ = framework.IngressNginxDescribe("Annotations - CORS", func() {
 		}
 
 		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
-		_, err := f.EnsureIngress(ing)
+		f.EnsureIngress(ing)
 
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ing).NotTo(BeNil())
-
-		err = f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return Expect(server).Should(ContainSubstring("more_set_headers 'Access-Control-Max-Age: 200';"))
 			})
-		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should disable cors allow credentials", func() {
@@ -135,16 +119,12 @@ var _ = framework.IngressNginxDescribe("Annotations - CORS", func() {
 		}
 
 		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
-		_, err := f.EnsureIngress(ing)
+		f.EnsureIngress(ing)
 
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ing).NotTo(BeNil())
-
-		err = f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return Expect(server).ShouldNot(ContainSubstring("more_set_headers 'Access-Control-Allow-Credentials: true';"))
 			})
-		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should allow origin for cors", func() {
@@ -155,16 +135,12 @@ var _ = framework.IngressNginxDescribe("Annotations - CORS", func() {
 		}
 
 		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
-		_, err := f.EnsureIngress(ing)
+		f.EnsureIngress(ing)
 
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ing).NotTo(BeNil())
-
-		err = f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return Expect(server).Should(ContainSubstring("more_set_headers 'Access-Control-Allow-Origin: https://origin.cors.com:8080';"))
 			})
-		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should allow headers for cors", func() {
@@ -175,15 +151,11 @@ var _ = framework.IngressNginxDescribe("Annotations - CORS", func() {
 		}
 
 		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
-		_, err := f.EnsureIngress(ing)
+		f.EnsureIngress(ing)
 
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ing).NotTo(BeNil())
-
-		err = f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return Expect(server).Should(ContainSubstring("more_set_headers 'Access-Control-Allow-Headers: DNT, User-Agent';"))
 			})
-		Expect(err).NotTo(HaveOccurred())
 	})
 })

--- a/test/e2e/annotations/default_backend.go
+++ b/test/e2e/annotations/default_backend.go
@@ -32,8 +32,7 @@ var _ = framework.IngressNginxDescribe("Annotations - custom default-backend", f
 	f := framework.NewDefaultFramework("default-backend")
 
 	BeforeEach(func() {
-		err := f.NewEchoDeployment()
-		Expect(err).NotTo(HaveOccurred())
+		f.NewEchoDeployment()
 	})
 
 	Context("when default backend annotation is enabled", func() {
@@ -44,18 +43,14 @@ var _ = framework.IngressNginxDescribe("Annotations - custom default-backend", f
 			}
 
 			ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "invalid", 80, &annotations)
-			_, err := f.EnsureIngress(ing)
-
-			Expect(err).NotTo(HaveOccurred())
-			Expect(ing).NotTo(BeNil())
+			f.EnsureIngress(ing)
 
 			time.Sleep(5 * time.Second)
 
-			err = f.WaitForNginxServer(host,
+			f.WaitForNginxServer(host,
 				func(server string) bool {
 					return Expect(server).Should(ContainSubstring(fmt.Sprintf("server_name %v", host)))
 				})
-			Expect(err).NotTo(HaveOccurred())
 
 			uri := "/alma/armud"
 			resp, body, errs := gorequest.New().

--- a/test/e2e/annotations/forcesslredirect.go
+++ b/test/e2e/annotations/forcesslredirect.go
@@ -30,8 +30,7 @@ var _ = framework.IngressNginxDescribe("Annotations - Forcesslredirect", func() 
 	f := framework.NewDefaultFramework("forcesslredirect")
 
 	BeforeEach(func() {
-		err := f.NewEchoDeploymentWithReplicas(2)
-		Expect(err).NotTo(HaveOccurred())
+		f.NewEchoDeploymentWithReplicas(2)
 	})
 
 	AfterEach(func() {
@@ -45,17 +44,13 @@ var _ = framework.IngressNginxDescribe("Annotations - Forcesslredirect", func() 
 		}
 
 		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
-		_, err := f.EnsureIngress(ing)
+		f.EnsureIngress(ing)
 
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ing).NotTo(BeNil())
-
-		err = f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return Expect(server).Should(ContainSubstring(`if ($redirect_to_https) {`)) &&
 					Expect(server).Should(ContainSubstring(`return 308 https://$best_http_host$request_uri;`))
 			})
-		Expect(err).NotTo(HaveOccurred())
 
 		resp, _, errs := gorequest.New().
 			Get(f.IngressController.HTTPURL).

--- a/test/e2e/annotations/fromtowwwredirect.go
+++ b/test/e2e/annotations/fromtowwwredirect.go
@@ -31,8 +31,7 @@ var _ = framework.IngressNginxDescribe("Annotations - Fromtowwwredirect", func()
 	f := framework.NewDefaultFramework("fromtowwwredirect")
 
 	BeforeEach(func() {
-		err := f.NewEchoDeploymentWithReplicas(2)
-		Expect(err).NotTo(HaveOccurred())
+		f.NewEchoDeploymentWithReplicas(2)
 	})
 
 	AfterEach(func() {
@@ -47,17 +46,13 @@ var _ = framework.IngressNginxDescribe("Annotations - Fromtowwwredirect", func()
 		}
 
 		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
-		_, err := f.EnsureIngress(ing)
+		f.EnsureIngress(ing)
 
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ing).NotTo(BeNil())
-
-		err = f.WaitForNginxConfiguration(
+		f.WaitForNginxConfiguration(
 			func(cfg string) bool {
 				return Expect(cfg).Should(ContainSubstring(`server_name www.fromtowwwredirect.bar.com;`)) &&
 					Expect(cfg).Should(ContainSubstring(`return 308 $scheme://fromtowwwredirect.bar.com$request_uri;`))
 			})
-		Expect(err).NotTo(HaveOccurred())
 
 		By("sending request to www.fromtowwwredirect.bar.com")
 

--- a/test/e2e/annotations/grpc.go
+++ b/test/e2e/annotations/grpc.go
@@ -29,8 +29,7 @@ var _ = framework.IngressNginxDescribe("Annotations - grpc", func() {
 	f := framework.NewDefaultFramework("grpc")
 
 	BeforeEach(func() {
-		err := f.NewGRPCFortuneTellerDeployment()
-		Expect(err).NotTo(HaveOccurred())
+		f.NewGRPCFortuneTellerDeployment()
 	})
 
 	Context("when grpc is enabled", func() {
@@ -42,25 +41,20 @@ var _ = framework.IngressNginxDescribe("Annotations - grpc", func() {
 			}
 
 			ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "fortune-teller", 50051, &annotations)
-			_, err := f.EnsureIngress(ing)
+			f.EnsureIngress(ing)
 
-			Expect(err).NotTo(HaveOccurred())
-			Expect(ing).NotTo(BeNil())
-
-			err = f.WaitForNginxServer(host,
+			f.WaitForNginxServer(host,
 				func(server string) bool {
 					return Expect(server).Should(ContainSubstring(fmt.Sprintf("server_name %v", host))) &&
 						Expect(server).ShouldNot(ContainSubstring("return 503"))
 				})
-			Expect(err).NotTo(HaveOccurred())
 
-			err = f.WaitForNginxServer(host,
+			f.WaitForNginxServer(host,
 				func(server string) bool {
 					return Expect(server).Should(ContainSubstring("grpc_pass")) &&
 						Expect(server).Should(ContainSubstring("grpc_set_header")) &&
 						Expect(server).ShouldNot(ContainSubstring("proxy_pass"))
 				})
-			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 })

--- a/test/e2e/annotations/influxdb.go
+++ b/test/e2e/annotations/influxdb.go
@@ -23,9 +23,10 @@ import (
 	"os/exec"
 	"time"
 
-	jsoniter "github.com/json-iterator/go"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	jsoniter "github.com/json-iterator/go"
 	"github.com/parnurzeal/gorequest"
 
 	corev1 "k8s.io/api/core/v1"
@@ -39,17 +40,13 @@ var _ = framework.IngressNginxDescribe("Annotations - influxdb", func() {
 	f := framework.NewDefaultFramework("influxdb")
 
 	BeforeEach(func() {
-		err := f.NewInfluxDBDeployment()
-		Expect(err).NotTo(HaveOccurred())
-		err = f.NewEchoDeployment()
-		Expect(err).NotTo(HaveOccurred())
+		f.NewInfluxDBDeployment()
+		f.NewEchoDeployment()
 	})
 
 	Context("when influxdb is enabled", func() {
 		It("should send the request metric to the influxdb server", func() {
-			ifs, err := createInfluxDBService(f)
-
-			Expect(err).NotTo(HaveOccurred())
+			ifs := createInfluxDBService(f)
 
 			// Ingress configured with InfluxDB annotations
 			host := "influxdb.e2e.local"
@@ -80,6 +77,8 @@ var _ = framework.IngressNginxDescribe("Annotations - influxdb", func() {
 			time.Sleep(5 * time.Second)
 
 			var measurements string
+			var err error
+
 			err = wait.PollImmediate(time.Second, time.Minute, func() (bool, error) {
 				measurements, err = extractInfluxDBMeasurements(f)
 				if err != nil {
@@ -100,7 +99,7 @@ var _ = framework.IngressNginxDescribe("Annotations - influxdb", func() {
 	})
 })
 
-func createInfluxDBService(f *framework.Framework) (*corev1.Service, error) {
+func createInfluxDBService(f *framework.Framework) *corev1.Service {
 	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "inflxudb-svc",
@@ -120,29 +119,18 @@ func createInfluxDBService(f *framework.Framework) (*corev1.Service, error) {
 		},
 	}
 
-	s, err := f.EnsureService(service)
-	if err != nil {
-		return nil, err
-	}
-
-	if s == nil {
-		return nil, fmt.Errorf("unexpected error creating service for influxdb deployment")
-	}
-
-	return s, nil
+	return f.EnsureService(service)
 }
 
 func createInfluxDBIngress(f *framework.Framework, host, service string, port int, annotations map[string]string) {
-	ing, err := f.EnsureIngress(framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, service, port, &annotations))
-	Expect(err).NotTo(HaveOccurred())
-	Expect(ing).NotTo(BeNil())
+	ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, service, port, &annotations)
+	f.EnsureIngress(ing)
 
-	err = f.WaitForNginxServer(host,
+	f.WaitForNginxServer(host,
 		func(server string) bool {
 			return Expect(server).Should(ContainSubstring(fmt.Sprintf("server_name %v", host))) &&
 				Expect(server).ShouldNot(ContainSubstring("return 503"))
 		})
-	Expect(err).NotTo(HaveOccurred())
 }
 
 func extractInfluxDBMeasurements(f *framework.Framework) (string, error) {

--- a/test/e2e/annotations/ipwhitelist.go
+++ b/test/e2e/annotations/ipwhitelist.go
@@ -17,19 +17,19 @@ limitations under the License.
 package annotations
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	"k8s.io/ingress-nginx/test/e2e/framework"
 	"regexp"
 	"strings"
+
+	. "github.com/onsi/ginkgo"
+
+	"k8s.io/ingress-nginx/test/e2e/framework"
 )
 
 var _ = framework.IngressNginxDescribe("Annotations - IPWhiteList", func() {
 	f := framework.NewDefaultFramework("ipwhitelist")
 
 	BeforeEach(func() {
-		err := f.NewEchoDeploymentWithReplicas(2)
-		Expect(err).NotTo(HaveOccurred())
+		f.NewEchoDeploymentWithReplicas(2)
 	})
 
 	AfterEach(func() {
@@ -44,15 +44,12 @@ var _ = framework.IngressNginxDescribe("Annotations - IPWhiteList", func() {
 		}
 
 		ing := framework.NewSingleIngress(host, "/", host, nameSpace, "http-svc", 80, &annotations)
-		_, err := f.EnsureIngress(ing)
-
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ing).NotTo(BeNil())
+		f.EnsureIngress(ing)
 
 		denyRegex := regexp.MustCompile("geo \\$the_real_ip \\$deny_[A-Za-z]{32}")
 		denyString := ""
 
-		err = f.WaitForNginxConfiguration(
+		f.WaitForNginxConfiguration(
 			func(conf string) bool {
 
 				match := denyRegex.FindStringSubmatch(conf)
@@ -64,22 +61,19 @@ var _ = framework.IngressNginxDescribe("Annotations - IPWhiteList", func() {
 				denyString = strings.Replace(match[0], "geo $the_real_ip ", "", -1)
 				return strings.Contains(conf, match[0])
 			})
-		Expect(err).NotTo(HaveOccurred())
 
 		ipOne := "18.0.0.0/8 0;"
 		ipTwo := "56.0.0.0/8 0;"
 
-		err = f.WaitForNginxConfiguration(
+		f.WaitForNginxConfiguration(
 			func(conf string) bool {
 				return strings.Contains(conf, ipOne) && strings.Contains(conf, ipTwo)
 			})
-		Expect(err).NotTo(HaveOccurred())
 
 		denyStatement := "if (" + denyString + ")"
-		err = f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return strings.Contains(server, denyStatement)
 			})
-		Expect(err).NotTo(HaveOccurred())
 	})
 })

--- a/test/e2e/annotations/log.go
+++ b/test/e2e/annotations/log.go
@@ -19,6 +19,7 @@ package annotations
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	"k8s.io/ingress-nginx/test/e2e/framework"
 )
 
@@ -26,8 +27,7 @@ var _ = framework.IngressNginxDescribe("Annotations - Log", func() {
 	f := framework.NewDefaultFramework("log")
 
 	BeforeEach(func() {
-		err := f.NewEchoDeploymentWithReplicas(2)
-		Expect(err).NotTo(HaveOccurred())
+		f.NewEchoDeploymentWithReplicas(2)
 	})
 
 	AfterEach(func() {
@@ -40,16 +40,12 @@ var _ = framework.IngressNginxDescribe("Annotations - Log", func() {
 		}
 
 		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
-		_, err := f.EnsureIngress(ing)
+		f.EnsureIngress(ing)
 
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ing).NotTo(BeNil())
-
-		err = f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return Expect(server).Should(ContainSubstring(`access_log off;`))
 			})
-		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("set rewrite_log on", func() {
@@ -59,15 +55,11 @@ var _ = framework.IngressNginxDescribe("Annotations - Log", func() {
 		}
 
 		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
-		_, err := f.EnsureIngress(ing)
+		f.EnsureIngress(ing)
 
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ing).NotTo(BeNil())
-
-		err = f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return Expect(server).Should(ContainSubstring(`rewrite_log on;`))
 			})
-		Expect(err).NotTo(HaveOccurred())
 	})
 })

--- a/test/e2e/annotations/luarestywaf.go
+++ b/test/e2e/annotations/luarestywaf.go
@@ -32,8 +32,7 @@ var _ = framework.IngressNginxDescribe("Annotations - lua-resty-waf", func() {
 	f := framework.NewDefaultFramework("luarestywaf")
 
 	BeforeEach(func() {
-		err := f.NewEchoDeployment()
-		Expect(err).NotTo(HaveOccurred())
+		f.NewEchoDeployment()
 	})
 
 	Context("when lua-resty-waf is enabled", func() {
@@ -204,16 +203,14 @@ var _ = framework.IngressNginxDescribe("Annotations - lua-resty-waf", func() {
 })
 
 func createIngress(f *framework.Framework, host, service string, port int, annotations map[string]string) {
-	ing, err := f.EnsureIngress(framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, service, port, &annotations))
-	Expect(err).NotTo(HaveOccurred())
-	Expect(ing).NotTo(BeNil())
+	ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, service, port, &annotations)
+	f.EnsureIngress(ing)
 
-	err = f.WaitForNginxServer(host,
+	f.WaitForNginxServer(host,
 		func(server string) bool {
 			return Expect(server).Should(ContainSubstring(fmt.Sprintf("server_name %v", host))) &&
 				Expect(server).ShouldNot(ContainSubstring("return 503"))
 		})
-	Expect(err).NotTo(HaveOccurred())
 
 	time.Sleep(1 * time.Second)
 

--- a/test/e2e/annotations/proxy.go
+++ b/test/e2e/annotations/proxy.go
@@ -17,9 +17,10 @@ limitations under the License.
 package annotations
 
 import (
+	"strings"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"strings"
 
 	"k8s.io/ingress-nginx/test/e2e/framework"
 )
@@ -28,8 +29,7 @@ var _ = framework.IngressNginxDescribe("Annotations - Proxy", func() {
 	f := framework.NewDefaultFramework("proxy")
 
 	BeforeEach(func() {
-		err := f.NewEchoDeploymentWithReplicas(2)
-		Expect(err).NotTo(HaveOccurred())
+		f.NewEchoDeploymentWithReplicas(2)
 	})
 
 	AfterEach(func() {
@@ -43,16 +43,12 @@ var _ = framework.IngressNginxDescribe("Annotations - Proxy", func() {
 		}
 
 		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
-		_, err := f.EnsureIngress(ing)
+		f.EnsureIngress(ing)
 
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ing).NotTo(BeNil())
-
-		err = f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return Expect(server).Should(ContainSubstring("proxy_redirect off;"))
 			})
-		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should set proxy_redirect to default", func() {
@@ -63,16 +59,12 @@ var _ = framework.IngressNginxDescribe("Annotations - Proxy", func() {
 		}
 
 		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
-		_, err := f.EnsureIngress(ing)
+		f.EnsureIngress(ing)
 
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ing).NotTo(BeNil())
-
-		err = f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return Expect(server).Should(ContainSubstring("proxy_redirect default;"))
 			})
-		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should set proxy_redirect to hello.com goodbye.com", func() {
@@ -83,16 +75,12 @@ var _ = framework.IngressNginxDescribe("Annotations - Proxy", func() {
 		}
 
 		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
-		_, err := f.EnsureIngress(ing)
+		f.EnsureIngress(ing)
 
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ing).NotTo(BeNil())
-
-		err = f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return Expect(server).Should(ContainSubstring("proxy_redirect hello.com goodbye.com;"))
 			})
-		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should set proxy client-max-body-size to 8m", func() {
@@ -102,16 +90,12 @@ var _ = framework.IngressNginxDescribe("Annotations - Proxy", func() {
 		}
 
 		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
-		_, err := f.EnsureIngress(ing)
+		f.EnsureIngress(ing)
 
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ing).NotTo(BeNil())
-
-		err = f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return Expect(server).Should(ContainSubstring("client_max_body_size 8m;"))
 			})
-		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should not set proxy client-max-body-size to incorrect value", func() {
@@ -121,16 +105,12 @@ var _ = framework.IngressNginxDescribe("Annotations - Proxy", func() {
 		}
 
 		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
-		_, err := f.EnsureIngress(ing)
+		f.EnsureIngress(ing)
 
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ing).NotTo(BeNil())
-
-		err = f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return Expect(server).ShouldNot(ContainSubstring("client_max_body_size 15r;"))
 			})
-		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should set valid proxy timeouts", func() {
@@ -142,16 +122,12 @@ var _ = framework.IngressNginxDescribe("Annotations - Proxy", func() {
 		}
 
 		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
-		_, err := f.EnsureIngress(ing)
+		f.EnsureIngress(ing)
 
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ing).NotTo(BeNil())
-
-		err = f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return strings.Contains(server, "proxy_connect_timeout 50s;") && strings.Contains(server, "proxy_send_timeout 20s;") && strings.Contains(server, "proxy_read_timeout 20s;")
 			})
-		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should not set invalid proxy timeouts", func() {
@@ -163,16 +139,12 @@ var _ = framework.IngressNginxDescribe("Annotations - Proxy", func() {
 		}
 
 		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
-		_, err := f.EnsureIngress(ing)
+		f.EnsureIngress(ing)
 
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ing).NotTo(BeNil())
-
-		err = f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return !strings.Contains(server, "proxy_connect_timeout 50ks;") && !strings.Contains(server, "proxy_send_timeout 20ks;") && !strings.Contains(server, "proxy_read_timeout 60s;")
 			})
-		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should turn on proxy-buffering", func() {
@@ -183,16 +155,12 @@ var _ = framework.IngressNginxDescribe("Annotations - Proxy", func() {
 		}
 
 		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
-		_, err := f.EnsureIngress(ing)
+		f.EnsureIngress(ing)
 
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ing).NotTo(BeNil())
-
-		err = f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return strings.Contains(server, "proxy_buffering on;") && strings.Contains(server, "proxy_buffer_size 8k;") && strings.Contains(server, "proxy_buffers 4 8k;") && strings.Contains(server, "proxy_request_buffering on;")
 			})
-		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should turn off proxy-request-buffering", func() {
@@ -202,16 +170,12 @@ var _ = framework.IngressNginxDescribe("Annotations - Proxy", func() {
 		}
 
 		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
-		_, err := f.EnsureIngress(ing)
+		f.EnsureIngress(ing)
 
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ing).NotTo(BeNil())
-
-		err = f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return Expect(server).Should(ContainSubstring("proxy_request_buffering off;"))
 			})
-		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should build proxy next upstream", func() {
@@ -222,16 +186,12 @@ var _ = framework.IngressNginxDescribe("Annotations - Proxy", func() {
 		}
 
 		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
-		_, err := f.EnsureIngress(ing)
+		f.EnsureIngress(ing)
 
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ing).NotTo(BeNil())
-
-		err = f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return strings.Contains(server, "proxy_next_upstream error timeout http_502;") && strings.Contains(server, "proxy_next_upstream_tries 5;")
 			})
-		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should setup proxy cookies", func() {
@@ -242,16 +202,11 @@ var _ = framework.IngressNginxDescribe("Annotations - Proxy", func() {
 		}
 
 		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
-		_, err := f.EnsureIngress(ing)
+		f.EnsureIngress(ing)
 
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ing).NotTo(BeNil())
-
-		err = f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return strings.Contains(server, "proxy_cookie_domain localhost example.org;") && strings.Contains(server, "proxy_cookie_path /one/ /;")
 			})
-		Expect(err).NotTo(HaveOccurred())
 	})
-
 })

--- a/test/e2e/annotations/redirect.go
+++ b/test/e2e/annotations/redirect.go
@@ -53,17 +53,13 @@ var _ = framework.IngressNginxDescribe("Annotations - Redirect", func() {
 		annotations := map[string]string{"nginx.ingress.kubernetes.io/permanent-redirect": redirectURL}
 
 		ing := framework.NewSingleIngress(host, redirectPath, host, f.IngressController.Namespace, "http-svc", 80, &annotations)
-		_, err := f.EnsureIngress(ing)
+		f.EnsureIngress(ing)
 
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ing).NotTo(BeNil())
-
-		err = f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return strings.Contains(server, fmt.Sprintf("if ($uri ~* %s) {", redirectPath)) &&
 					strings.Contains(server, fmt.Sprintf("return 301 %s;", redirectURL))
 			})
-		Expect(err).NotTo(HaveOccurred())
 
 		By("sending request to redirected URL path")
 
@@ -93,17 +89,13 @@ var _ = framework.IngressNginxDescribe("Annotations - Redirect", func() {
 		}
 
 		ing := framework.NewSingleIngress(host, redirectPath, host, f.IngressController.Namespace, "http-svc", 80, &annotations)
-		_, err := f.EnsureIngress(ing)
+		f.EnsureIngress(ing)
 
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ing).NotTo(BeNil())
-
-		err = f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return strings.Contains(server, fmt.Sprintf("if ($uri ~* %s) {", redirectPath)) &&
 					strings.Contains(server, fmt.Sprintf("return %d %s;", redirectCode, redirectURL))
 			})
-		Expect(err).NotTo(HaveOccurred())
 
 		By("sending request to redirected URL path")
 

--- a/test/e2e/annotations/serversnippet.go
+++ b/test/e2e/annotations/serversnippet.go
@@ -17,18 +17,18 @@ limitations under the License.
 package annotations
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	"k8s.io/ingress-nginx/test/e2e/framework"
 	"strings"
+
+	. "github.com/onsi/ginkgo"
+
+	"k8s.io/ingress-nginx/test/e2e/framework"
 )
 
 var _ = framework.IngressNginxDescribe("Annotations - ServerSnippet", func() {
 	f := framework.NewDefaultFramework("serversnippet")
 
 	BeforeEach(func() {
-		err := f.NewEchoDeploymentWithReplicas(2)
-		Expect(err).NotTo(HaveOccurred())
+		f.NewEchoDeploymentWithReplicas(2)
 	})
 
 	AfterEach(func() {
@@ -43,15 +43,11 @@ var _ = framework.IngressNginxDescribe("Annotations - ServerSnippet", func() {
 		}
 
 		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
-		_, err := f.EnsureIngress(ing)
+		f.EnsureIngress(ing)
 
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ing).NotTo(BeNil())
-
-		err = f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return strings.Contains(server, `more_set_headers "Content-Length: $content_length`) && strings.Contains(server, `more_set_headers "Content-Type: $content_type";`)
 			})
-		Expect(err).NotTo(HaveOccurred())
 	})
 })

--- a/test/e2e/annotations/snippet.go
+++ b/test/e2e/annotations/snippet.go
@@ -26,8 +26,7 @@ var _ = framework.IngressNginxDescribe("Annotations - Configurationsnippet", fun
 	f := framework.NewDefaultFramework("configurationsnippet")
 
 	BeforeEach(func() {
-		err := f.NewEchoDeploymentWithReplicas(2)
-		Expect(err).NotTo(HaveOccurred())
+		f.NewEchoDeploymentWithReplicas(2)
 	})
 
 	AfterEach(func() {
@@ -41,15 +40,11 @@ var _ = framework.IngressNginxDescribe("Annotations - Configurationsnippet", fun
 		}
 
 		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
-		_, err := f.EnsureIngress(ing)
+		f.EnsureIngress(ing)
 
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ing).NotTo(BeNil())
-
-		err = f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return Expect(server).Should(ContainSubstring(`more_set_headers "Request-Id: $req_id";`))
 			})
-		Expect(err).NotTo(HaveOccurred())
 	})
 })

--- a/test/e2e/annotations/sslciphers.go
+++ b/test/e2e/annotations/sslciphers.go
@@ -27,8 +27,7 @@ var _ = framework.IngressNginxDescribe("Annotations - SSL CIPHERS", func() {
 	f := framework.NewDefaultFramework("sslciphers")
 
 	BeforeEach(func() {
-		err := f.NewEchoDeploymentWithReplicas(2)
-		Expect(err).NotTo(HaveOccurred())
+		f.NewEchoDeploymentWithReplicas(2)
 	})
 
 	AfterEach(func() {
@@ -41,15 +40,11 @@ var _ = framework.IngressNginxDescribe("Annotations - SSL CIPHERS", func() {
 		}
 
 		ing := framework.NewSingleIngress(host, "/something", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
-		_, err := f.EnsureIngress(ing)
+		f.EnsureIngress(ing)
 
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ing).NotTo(BeNil())
-
-		err = f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return Expect(server).Should(ContainSubstring("ssl_ciphers ALL:!aNULL:!EXPORT56:RC4+RSA:+HIGH:+MEDIUM:+LOW:+SSLv2:+EXP;"))
 			})
-		Expect(err).NotTo(HaveOccurred())
 	})
 })

--- a/test/e2e/annotations/upstreamvhost.go
+++ b/test/e2e/annotations/upstreamvhost.go
@@ -26,8 +26,7 @@ var _ = framework.IngressNginxDescribe("Annotations - Upstreamvhost", func() {
 	f := framework.NewDefaultFramework("upstreamvhost")
 
 	BeforeEach(func() {
-		err := f.NewEchoDeploymentWithReplicas(2)
-		Expect(err).NotTo(HaveOccurred())
+		f.NewEchoDeploymentWithReplicas(2)
 	})
 
 	AfterEach(func() {
@@ -40,15 +39,11 @@ var _ = framework.IngressNginxDescribe("Annotations - Upstreamvhost", func() {
 		}
 
 		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
-		_, err := f.EnsureIngress(ing)
+		f.EnsureIngress(ing)
 
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ing).NotTo(BeNil())
-
-		err = f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return Expect(server).Should(ContainSubstring(`proxy_set_header Host "upstreamvhost.bar.com";`))
 			})
-		Expect(err).NotTo(HaveOccurred())
 	})
 })

--- a/test/e2e/defaultbackend/custom_default_backend.go
+++ b/test/e2e/defaultbackend/custom_default_backend.go
@@ -23,6 +23,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	"github.com/parnurzeal/gorequest"
 
 	appsv1beta1 "k8s.io/api/apps/v1beta1"
@@ -34,8 +35,7 @@ var _ = framework.IngressNginxDescribe("Dynamic Certificate", func() {
 	f := framework.NewDefaultFramework("custom-default-backend")
 
 	BeforeEach(func() {
-		err := f.NewEchoDeploymentWithReplicas(1)
-		Expect(err).NotTo(HaveOccurred())
+		f.NewEchoDeploymentWithReplicas(1)
 
 		framework.UpdateDeployment(f.KubeClientSet, f.IngressController.Namespace, "nginx-ingress-controller", 1,
 			func(deployment *appsv1beta1.Deployment) error {
@@ -47,11 +47,10 @@ var _ = framework.IngressNginxDescribe("Dynamic Certificate", func() {
 				return err
 			})
 
-		err = f.WaitForNginxServer("_",
+		f.WaitForNginxServer("_",
 			func(server string) bool {
 				return strings.Contains(server, "set $proxy_upstream_name \"upstream-default-backend\"")
 			})
-		Expect(err).ToNot(HaveOccurred())
 	})
 
 	It("uses custom default backend", func() {

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -117,14 +117,10 @@ func (f *Framework) BeforeEach() {
 	})
 	Expect(err).NotTo(HaveOccurred())
 
-	HTTPURL, err := f.GetNginxURL(HTTP)
-	Expect(err).NotTo(HaveOccurred())
-
+	HTTPURL := f.GetNginxURL(HTTP)
 	f.IngressController.HTTPURL = HTTPURL
 
-	HTTPSURL, err := f.GetNginxURL(HTTPS)
-	Expect(err).NotTo(HaveOccurred())
-
+	HTTPSURL := f.GetNginxURL(HTTPS)
 	f.IngressController.HTTPSURL = HTTPSURL
 
 	// we wait for any change in the informers and SSL certificate generation
@@ -154,8 +150,10 @@ func IngressNginxDescribe(text string, body func()) bool {
 
 // GetNginxIP returns the IP address of the minikube cluster
 // where the NGINX ingress controller is running
-func (f *Framework) GetNginxIP() (string, error) {
-	return os.Getenv("NODE_IP"), nil
+func (f *Framework) GetNginxIP() string {
+	nodeIP := os.Getenv("NODE_IP")
+	Expect(nodeIP).NotTo(BeEmpty(), "env variable NODE_IP is empty")
+	return nodeIP
 }
 
 // GetNginxPort returns the number of TCP port where NGINX is running
@@ -178,28 +176,24 @@ func (f *Framework) GetNginxPort(name string) (int, error) {
 }
 
 // GetNginxURL returns the URL should be used to make a request to NGINX
-func (f *Framework) GetNginxURL(scheme RequestScheme) (string, error) {
-	ip, err := f.GetNginxIP()
-	if err != nil {
-		return "", err
-	}
-
+func (f *Framework) GetNginxURL(scheme RequestScheme) string {
+	ip := f.GetNginxIP()
 	port, err := f.GetNginxPort(fmt.Sprintf("%v", scheme))
-	if err != nil {
-		return "", err
-	}
+	Expect(err).NotTo(HaveOccurred(), "unexpected error obtaning NGINX Port")
 
-	return fmt.Sprintf("%v://%v:%v", scheme, ip, port), nil
+	return fmt.Sprintf("%v://%v:%v", scheme, ip, port)
 }
 
 // WaitForNginxServer waits until the nginx configuration contains a particular server section
-func (f *Framework) WaitForNginxServer(name string, matcher func(cfg string) bool) error {
-	return wait.Poll(Poll, time.Minute*5, f.matchNginxConditions(name, matcher))
+func (f *Framework) WaitForNginxServer(name string, matcher func(cfg string) bool) {
+	err := wait.Poll(Poll, time.Minute*5, f.matchNginxConditions(name, matcher))
+	Expect(err).NotTo(HaveOccurred(), "unexpected error waiting for nginx server condition/s")
 }
 
 // WaitForNginxConfiguration waits until the nginx configuration contains a particular configuration
-func (f *Framework) WaitForNginxConfiguration(matcher func(cfg string) bool) error {
-	return wait.Poll(Poll, time.Minute*5, f.matchNginxConditions("", matcher))
+func (f *Framework) WaitForNginxConfiguration(matcher func(cfg string) bool) {
+	err := wait.Poll(Poll, time.Minute*5, f.matchNginxConditions("", matcher))
+	Expect(err).NotTo(HaveOccurred(), "unexpected error waiting for nginx server condition/s")
 }
 
 func nginxLogs(client kubernetes.Interface, namespace string) (string, error) {
@@ -320,16 +314,12 @@ func (f *Framework) GetNginxConfigMapData() (map[string]string, error) {
 }
 
 // SetNginxConfigMapData sets ingress-nginx's nginx-configuration configMap data
-func (f *Framework) SetNginxConfigMapData(cmData map[string]string) error {
+func (f *Framework) SetNginxConfigMapData(cmData map[string]string) {
 	// Needs to do a Get and Set, Update will not take just the Data field
 	// or a configMap that is not the very last revision
 	config, err := f.getNginxConfigMap()
-	if err != nil {
-		return err
-	}
-	if config == nil {
-		return fmt.Errorf("Unable to get nginx-configuration configMap")
-	}
+	Expect(err).NotTo(HaveOccurred())
+	Expect(config).NotTo(BeNil(), "expected a configmap but none returned")
 
 	config.Data = cmData
 
@@ -337,25 +327,19 @@ func (f *Framework) SetNginxConfigMapData(cmData map[string]string) error {
 		CoreV1().
 		ConfigMaps(f.IngressController.Namespace).
 		Update(config)
-	if err != nil {
-		return err
-	}
+	Expect(err).NotTo(HaveOccurred())
 
 	time.Sleep(5 * time.Second)
-
-	return err
 }
 
 // UpdateNginxConfigMapData updates single field in ingress-nginx's nginx-configuration map data
-func (f *Framework) UpdateNginxConfigMapData(key string, value string) error {
+func (f *Framework) UpdateNginxConfigMapData(key string, value string) {
 	config, err := f.GetNginxConfigMapData()
-	if err != nil {
-		return err
-	}
+	Expect(err).NotTo(HaveOccurred(), "unexpected error reading configmap")
 
 	config[key] = value
 
-	return f.SetNginxConfigMapData(config)
+	f.SetNginxConfigMapData(config)
 }
 
 // UpdateDeployment runs the given updateFunc on the deployment and waits for it to be updated
@@ -437,6 +421,7 @@ func newSingleIngress(name, path, host, ns, service string, port int, annotation
 			},
 		},
 	}
+
 	if withTLS {
 		ing.Spec.TLS = []extensions.IngressTLS{
 			{

--- a/test/e2e/framework/influxdb.go
+++ b/test/e2e/framework/influxdb.go
@@ -17,10 +17,9 @@ limitations under the License.
 package framework
 
 import (
-	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
+	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
 	extensions "k8s.io/api/extensions/v1beta1"
@@ -60,7 +59,7 @@ bind-address = "0.0.0.0:8088"
 
 // NewInfluxDBDeployment creates an InfluxDB server configured to reply
 // on 8086/tcp and 8089/udp
-func (f *Framework) NewInfluxDBDeployment() error {
+func (f *Framework) NewInfluxDBDeployment() {
 	configuration := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "influxdb-config",
@@ -72,13 +71,9 @@ func (f *Framework) NewInfluxDBDeployment() error {
 	}
 
 	cm, err := f.EnsureConfigMap(configuration)
-	if err != nil {
-		return err
-	}
+	Expect(err).NotTo(HaveOccurred(), "failed to create an Influxdb deployment")
 
-	if cm == nil {
-		return fmt.Errorf("unexpected error creating configmap for influxdb")
-	}
+	Expect(cm).NotTo(BeNil(), "expected a configmap but none returned")
 
 	deployment := &extensions.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -143,20 +138,12 @@ func (f *Framework) NewInfluxDBDeployment() error {
 	}
 
 	d, err := f.EnsureDeployment(deployment)
-	if err != nil {
-		return err
-	}
+	Expect(err).NotTo(HaveOccurred(), "failed to create an Influxdb deployment")
 
-	if d == nil {
-		return fmt.Errorf("unexpected error creating deployement for influxdb")
-	}
+	Expect(d).NotTo(BeNil(), "unexpected error creating deployement for influxdb")
 
 	err = WaitForPodsReady(f.KubeClientSet, 5*time.Minute, 1, f.IngressController.Namespace, metav1.ListOptions{
 		LabelSelector: fields.SelectorFromSet(fields.Set(d.Spec.Template.ObjectMeta.Labels)).String(),
 	})
-	if err != nil {
-		return errors.Wrap(err, "failed to wait for influxdb to become ready")
-	}
-
-	return nil
+	Expect(err).NotTo(HaveOccurred(), "failed to wait for influxdb to become ready")
 }

--- a/test/e2e/framework/k8s.go
+++ b/test/e2e/framework/k8s.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"time"
 
+	. "github.com/onsi/gomega"
+
 	api "k8s.io/api/core/v1"
 	core "k8s.io/api/core/v1"
 	extensions "k8s.io/api/extensions/v1beta1"
@@ -31,15 +33,23 @@ import (
 )
 
 // EnsureSecret creates a Secret object or returns it if it already exists.
-func (f *Framework) EnsureSecret(secret *api.Secret) (*api.Secret, error) {
+func (f *Framework) EnsureSecret(secret *api.Secret) *api.Secret {
 	s, err := f.KubeClientSet.CoreV1().Secrets(secret.Namespace).Create(secret)
 	if err != nil {
 		if k8sErrors.IsAlreadyExists(err) {
-			return f.KubeClientSet.CoreV1().Secrets(secret.Namespace).Update(secret)
+			s, err := f.KubeClientSet.CoreV1().Secrets(secret.Namespace).Update(secret)
+			Expect(err).NotTo(HaveOccurred(), "unexpected error updating secret")
+
+			return s
 		}
-		return nil, err
+
+		Expect(err).NotTo(HaveOccurred(), "unexpected error creating secret")
 	}
-	return s, nil
+
+	Expect(s).NotTo(BeNil())
+	Expect(s.ObjectMeta).NotTo(BeNil())
+
+	return s
 }
 
 // EnsureConfigMap creates a ConfigMap object or returns it if it already exists.
@@ -51,40 +61,49 @@ func (f *Framework) EnsureConfigMap(configMap *api.ConfigMap) (*api.ConfigMap, e
 		}
 		return nil, err
 	}
+
 	return cm, nil
 }
 
 // EnsureIngress creates an Ingress object or returns it if it already exists.
-func (f *Framework) EnsureIngress(ingress *extensions.Ingress) (*extensions.Ingress, error) {
-	s, err := f.KubeClientSet.ExtensionsV1beta1().Ingresses(ingress.Namespace).Update(ingress)
+func (f *Framework) EnsureIngress(ingress *extensions.Ingress) *extensions.Ingress {
+	ing, err := f.KubeClientSet.ExtensionsV1beta1().Ingresses(ingress.Namespace).Update(ingress)
 	if err != nil {
 		if k8sErrors.IsNotFound(err) {
-			s, err = f.KubeClientSet.ExtensionsV1beta1().Ingresses(ingress.Namespace).Create(ingress)
-			if err != nil {
-				return nil, err
-			}
-		} else {
-			return nil, err
+			ing, err = f.KubeClientSet.ExtensionsV1beta1().Ingresses(ingress.Namespace).Create(ingress)
+			Expect(err).NotTo(HaveOccurred(), "unexpected error creating ingress")
+			return ing
 		}
+
+		Expect(err).NotTo(HaveOccurred())
 	}
 
-	if s.Annotations == nil {
-		s.Annotations = make(map[string]string)
+	Expect(ing).NotTo(BeNil())
+
+	if ing.Annotations == nil {
+		ing.Annotations = make(map[string]string)
 	}
 
-	return s, nil
+	return ing
 }
 
 // EnsureService creates a Service object or returns it if it already exists.
-func (f *Framework) EnsureService(service *core.Service) (*core.Service, error) {
+func (f *Framework) EnsureService(service *core.Service) *core.Service {
 	s, err := f.KubeClientSet.CoreV1().Services(service.Namespace).Update(service)
 	if err != nil {
 		if k8sErrors.IsNotFound(err) {
-			return f.KubeClientSet.CoreV1().Services(service.Namespace).Create(service)
+			s, err := f.KubeClientSet.CoreV1().Services(service.Namespace).Create(service)
+			Expect(err).NotTo(HaveOccurred(), "unexpected error creating service")
+			return s
+
 		}
-		return nil, err
+
+		Expect(err).NotTo(HaveOccurred())
 	}
-	return s, nil
+
+	Expect(s).NotTo(BeNil(), "expected a service but none returned")
+
+	return s
 }
 
 // EnsureDeployment creates a Deployment object or returns it if it already exists.

--- a/test/e2e/framework/ssl.go
+++ b/test/e2e/framework/ssl.go
@@ -32,6 +32,8 @@ import (
 	"strings"
 	"time"
 
+	. "github.com/onsi/gomega"
+
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -140,8 +142,9 @@ func CreateIngressMASecret(client kubernetes.Interface, host string, secretName,
 }
 
 // WaitForTLS waits until the TLS handshake with a given server completes successfully.
-func WaitForTLS(url string, tlsConfig *tls.Config) error {
-	return wait.Poll(Poll, 30*time.Second, matchTLSServerName(url, tlsConfig))
+func WaitForTLS(url string, tlsConfig *tls.Config) {
+	err := wait.Poll(Poll, 30*time.Second, matchTLSServerName(url, tlsConfig))
+	Expect(err).NotTo(HaveOccurred(), "timeout waiting for TLS configuration in URL %s", url)
 }
 
 // generateRSACert generates a basic self signed certificate using a key length

--- a/test/e2e/lua/dynamic_certificates.go
+++ b/test/e2e/lua/dynamic_certificates.go
@@ -27,7 +27,6 @@ import (
 	appsv1beta1 "k8s.io/api/apps/v1beta1"
 	extensions "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 
 	"k8s.io/ingress-nginx/test/e2e/framework"
 )
@@ -37,17 +36,24 @@ var _ = framework.IngressNginxDescribe("Dynamic Certificate", func() {
 	host := "foo.com"
 
 	BeforeEach(func() {
-		err := enableDynamicCertificates(f.IngressController.Namespace, f.KubeClientSet)
-		Expect(err).NotTo(HaveOccurred())
+		err := framework.UpdateDeployment(f.KubeClientSet, f.IngressController.Namespace, "nginx-ingress-controller", 1,
+			func(deployment *appsv1beta1.Deployment) error {
+				args := deployment.Spec.Template.Spec.Containers[0].Args
+				args = append(args, "--enable-dynamic-certificates")
+				args = append(args, "--enable-ssl-chain-completion=false")
+				deployment.Spec.Template.Spec.Containers[0].Args = args
+				_, err := f.KubeClientSet.AppsV1beta1().Deployments(f.IngressController.Namespace).Update(deployment)
 
-		err = f.WaitForNginxConfiguration(
-			func(cfg string) bool {
-				return strings.Contains(cfg, "ok, res = pcall(require, \"certificate\")")
+				return err
 			})
 		Expect(err).NotTo(HaveOccurred())
 
-		err = f.NewEchoDeploymentWithReplicas(1)
-		Expect(err).NotTo(HaveOccurred())
+		f.WaitForNginxConfiguration(
+			func(cfg string) bool {
+				return strings.Contains(cfg, "ok, res = pcall(require, \"certificate\")")
+			})
+
+		f.NewEchoDeploymentWithReplicas(1)
 	})
 
 	It("picks up the certificate when we add TLS spec to existing ingress", func() {
@@ -74,27 +80,27 @@ var _ = framework.IngressNginxDescribe("Dynamic Certificate", func() {
 	})
 
 	It("picks up the previously missing secret for a given ingress without reloading", func() {
-		ing, err := f.EnsureIngress(framework.NewSingleIngressWithTLS(host, "/", host, f.IngressController.Namespace, "http-svc", 80, nil))
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ing).NotTo(BeNil())
+		ing := framework.NewSingleIngressWithTLS(host, "/", host, f.IngressController.Namespace, "http-svc", 80, nil)
+		f.EnsureIngress(ing)
+
 		time.Sleep(waitForLuaSync)
+
 		ensureHTTPSRequest(fmt.Sprintf("%s?id=dummy_log_splitter_foo_bar", f.IngressController.HTTPSURL), host, "ingress.local")
 
-		_, err = framework.CreateIngressTLSSecret(f.KubeClientSet,
+		_, err := framework.CreateIngressTLSSecret(f.KubeClientSet,
 			ing.Spec.TLS[0].Hosts,
 			ing.Spec.TLS[0].SecretName,
 			ing.Namespace)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("configuring certificate_by_lua and skipping Nginx configuration of the new certificate")
-		err = f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return strings.Contains(server, "ssl_certificate_by_lua_block") &&
 					!strings.Contains(server, fmt.Sprintf("ssl_certificate /etc/ingress-controller/ssl/%s-%s.pem;", ing.Namespace, host)) &&
 					!strings.Contains(server, fmt.Sprintf("ssl_certificate_key /etc/ingress-controller/ssl/%s-%s.pem;", ing.Namespace, host)) &&
 					strings.Contains(server, "listen 443")
 			})
-		Expect(err).ToNot(HaveOccurred())
 
 		time.Sleep(waitForLuaSync)
 
@@ -114,14 +120,13 @@ var _ = framework.IngressNginxDescribe("Dynamic Certificate", func() {
 
 	Context("given an ingress with TLS correctly configured", func() {
 		BeforeEach(func() {
-			ing, err := f.EnsureIngress(framework.NewSingleIngressWithTLS(host, "/", host, f.IngressController.Namespace, "http-svc", 80, nil))
-			Expect(err).NotTo(HaveOccurred())
-			Expect(ing).NotTo(BeNil())
+			ing := f.EnsureIngress(framework.NewSingleIngressWithTLS(host, "/", host, f.IngressController.Namespace, "http-svc", 80, nil))
+
 			time.Sleep(waitForLuaSync)
 
 			ensureHTTPSRequest(f.IngressController.HTTPSURL, host, "ingress.local")
 
-			_, err = framework.CreateIngressTLSSecret(f.KubeClientSet,
+			_, err := framework.CreateIngressTLSSecret(f.KubeClientSet,
 				ing.Spec.TLS[0].Hosts,
 				ing.Spec.TLS[0].SecretName,
 				ing.Namespace)
@@ -129,14 +134,13 @@ var _ = framework.IngressNginxDescribe("Dynamic Certificate", func() {
 			time.Sleep(waitForLuaSync)
 
 			By("configuring certificate_by_lua and skipping Nginx configuration of the new certificate")
-			err = f.WaitForNginxServer(ing.Spec.TLS[0].Hosts[0],
+			f.WaitForNginxServer(ing.Spec.TLS[0].Hosts[0],
 				func(server string) bool {
 					return strings.Contains(server, "ssl_certificate_by_lua_block") &&
 						!strings.Contains(server, fmt.Sprintf("ssl_certificate /etc/ingress-controller/ssl/%s-%s.pem;", ing.Namespace, host)) &&
 						!strings.Contains(server, fmt.Sprintf("ssl_certificate_key /etc/ingress-controller/ssl/%s-%s.pem;", ing.Namespace, host)) &&
 						strings.Contains(server, "listen 443")
 				})
-			Expect(err).ToNot(HaveOccurred())
 
 			time.Sleep(waitForLuaSync)
 
@@ -157,14 +161,13 @@ var _ = framework.IngressNginxDescribe("Dynamic Certificate", func() {
 			time.Sleep(waitForLuaSync)
 
 			By("configuring certificate_by_lua and skipping Nginx configuration of the new certificate")
-			err = f.WaitForNginxServer(ing.Spec.TLS[0].Hosts[0],
+			f.WaitForNginxServer(ing.Spec.TLS[0].Hosts[0],
 				func(server string) bool {
 					return strings.Contains(server, "ssl_certificate_by_lua_block") &&
 						!strings.Contains(server, fmt.Sprintf("ssl_certificate /etc/ingress-controller/ssl/%s-%s.pem;", ing.Namespace, host)) &&
 						!strings.Contains(server, fmt.Sprintf("ssl_certificate_key /etc/ingress-controller/ssl/%s-%s.pem;", ing.Namespace, host)) &&
 						strings.Contains(server, "listen 443")
 				})
-			Expect(err).ToNot(HaveOccurred())
 
 			time.Sleep(waitForLuaSync)
 
@@ -192,14 +195,13 @@ var _ = framework.IngressNginxDescribe("Dynamic Certificate", func() {
 			time.Sleep(waitForLuaSync)
 
 			By("configuring certificate_by_lua and skipping Nginx configuration of the new certificate")
-			err = f.WaitForNginxServer(ing.Spec.TLS[0].Hosts[0],
+			f.WaitForNginxServer(ing.Spec.TLS[0].Hosts[0],
 				func(server string) bool {
 					return strings.Contains(server, "ssl_certificate_by_lua_block") &&
 						strings.Contains(server, "ssl_certificate /etc/ingress-controller/ssl/default-fake-certificate.pem;") &&
 						strings.Contains(server, "ssl_certificate_key /etc/ingress-controller/ssl/default-fake-certificate.pem;") &&
 						strings.Contains(server, "listen 443")
 				})
-			Expect(err).ToNot(HaveOccurred())
 
 			time.Sleep(waitForLuaSync)
 
@@ -242,16 +244,3 @@ var _ = framework.IngressNginxDescribe("Dynamic Certificate", func() {
 		})
 	})
 })
-
-func enableDynamicCertificates(namespace string, kubeClientSet kubernetes.Interface) error {
-	return framework.UpdateDeployment(kubeClientSet, namespace, "nginx-ingress-controller", 1,
-		func(deployment *appsv1beta1.Deployment) error {
-			args := deployment.Spec.Template.Spec.Containers[0].Args
-			args = append(args, "--enable-dynamic-certificates")
-			args = append(args, "--enable-ssl-chain-completion=false")
-			deployment.Spec.Template.Spec.Containers[0].Args = args
-			_, err := kubeClientSet.AppsV1beta1().Deployments(namespace).Update(deployment)
-
-			return err
-		})
-}

--- a/test/e2e/servicebackend/service_backend.go
+++ b/test/e2e/servicebackend/service_backend.go
@@ -45,15 +45,12 @@ var _ = framework.IngressNginxDescribe("Service backend - 503", func() {
 		host := "nonexistent.svc.com"
 
 		bi := buildIngressWithNonexistentService(host, f.IngressController.Namespace, "/")
-		ing, err := f.EnsureIngress(bi)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ing).NotTo(BeNil())
+		f.EnsureIngress(bi)
 
-		err = f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return strings.Contains(server, "return 503;")
 			})
-		Expect(err).NotTo(HaveOccurred())
 
 		resp, _, errs := gorequest.New().
 			Get(f.IngressController.HTTPURL).
@@ -68,19 +65,15 @@ var _ = framework.IngressNginxDescribe("Service backend - 503", func() {
 
 		bi, bs := buildIngressWithUnavailableServiceEndpoints(host, f.IngressController.Namespace, "/")
 
-		svc, err := f.EnsureService(bs)
-		Expect(err).NotTo(HaveOccurred())
+		svc := f.EnsureService(bs)
 		Expect(svc).NotTo(BeNil())
 
-		ing, err := f.EnsureIngress(bi)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ing).NotTo(BeNil())
+		f.EnsureIngress(bi)
 
-		err = f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return strings.Contains(server, "return 503;")
 			})
-		Expect(err).NotTo(HaveOccurred())
 
 		resp, _, errs := gorequest.New().
 			Get(f.IngressController.HTTPURL).

--- a/test/e2e/settings/forwarded_headers.go
+++ b/test/e2e/settings/forwarded_headers.go
@@ -34,11 +34,8 @@ var _ = framework.IngressNginxDescribe("X-Forwarded headers", func() {
 	setting := "use-forwarded-headers"
 
 	BeforeEach(func() {
-		err := f.NewEchoDeployment()
-		Expect(err).NotTo(HaveOccurred())
-
-		err = f.UpdateNginxConfigMapData(setting, "false")
-		Expect(err).NotTo(HaveOccurred())
+		f.NewEchoDeployment()
+		f.UpdateNginxConfigMapData(setting, "false")
 	})
 
 	AfterEach(func() {
@@ -47,18 +44,15 @@ var _ = framework.IngressNginxDescribe("X-Forwarded headers", func() {
 	It("should trust X-Forwarded headers when setting is true", func() {
 		host := "forwarded-headers"
 
-		err := f.UpdateNginxConfigMapData(setting, "true")
-		Expect(err).NotTo(HaveOccurred())
+		f.UpdateNginxConfigMapData(setting, "true")
 
-		ing, err := f.EnsureIngress(framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, nil))
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ing).NotTo(BeNil())
+		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, nil)
+		f.EnsureIngress(ing)
 
-		err = f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return strings.Contains(server, "server_name forwarded-headers")
 			})
-		Expect(err).NotTo(HaveOccurred())
 
 		resp, body, errs := gorequest.New().
 			Get(f.IngressController.HTTPURL).
@@ -80,18 +74,14 @@ var _ = framework.IngressNginxDescribe("X-Forwarded headers", func() {
 	It("should not trust X-Forwarded headers when setting is false", func() {
 		host := "forwarded-headers"
 
-		err := f.UpdateNginxConfigMapData(setting, "false")
-		Expect(err).NotTo(HaveOccurred())
+		f.UpdateNginxConfigMapData(setting, "false")
 
-		ing, err := f.EnsureIngress(framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, nil))
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ing).NotTo(BeNil())
+		f.EnsureIngress(framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, nil))
 
-		err = f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return strings.Contains(server, "server_name forwarded-headers")
 			})
-		Expect(err).NotTo(HaveOccurred())
 
 		resp, body, errs := gorequest.New().
 			Get(f.IngressController.HTTPURL).

--- a/test/e2e/settings/main_snippet.go
+++ b/test/e2e/settings/main_snippet.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 
 	"k8s.io/ingress-nginx/test/e2e/framework"
 )
@@ -31,13 +30,11 @@ var _ = framework.IngressNginxDescribe("Main Snippet", func() {
 
 	It("should add value of main-snippet setting to nginx config", func() {
 		expectedComment := "# main snippet"
-		err := f.UpdateNginxConfigMapData(mainSnippet, expectedComment)
-		Expect(err).NotTo(HaveOccurred())
+		f.UpdateNginxConfigMapData(mainSnippet, expectedComment)
 
-		err = f.WaitForNginxConfiguration(
+		f.WaitForNginxConfiguration(
 			func(cfg string) bool {
 				return strings.Contains(cfg, expectedComment)
 			})
-		Expect(err).NotTo(HaveOccurred())
 	})
 })

--- a/test/e2e/settings/multi_accept.go
+++ b/test/e2e/settings/multi_accept.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 
 	"k8s.io/ingress-nginx/test/e2e/framework"
 )
@@ -31,34 +30,29 @@ var _ = framework.IngressNginxDescribe("Multi Accept", func() {
 
 	It("should be enabled by default", func() {
 		expectedDirective := "multi_accept on;"
-		err := f.WaitForNginxConfiguration(
+		f.WaitForNginxConfiguration(
 			func(cfg string) bool {
 				return strings.Contains(cfg, expectedDirective)
 			})
-		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should be enabled when set to true", func() {
 		expectedDirective := "multi_accept on;"
-		err := f.UpdateNginxConfigMapData(multiAccept, "true")
-		Expect(err).NotTo(HaveOccurred())
+		f.UpdateNginxConfigMapData(multiAccept, "true")
 
-		err = f.WaitForNginxConfiguration(
+		f.WaitForNginxConfiguration(
 			func(cfg string) bool {
 				return strings.Contains(cfg, expectedDirective)
 			})
-		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should be disabled when set to false", func() {
 		expectedDirective := "multi_accept off;"
-		err := f.UpdateNginxConfigMapData(multiAccept, "false")
-		Expect(err).NotTo(HaveOccurred())
+		f.UpdateNginxConfigMapData(multiAccept, "false")
 
-		err = f.WaitForNginxConfiguration(
+		f.WaitForNginxConfiguration(
 			func(cfg string) bool {
 				return strings.Contains(cfg, expectedDirective)
 			})
-		Expect(err).NotTo(HaveOccurred())
 	})
 })

--- a/test/e2e/settings/no_auth_locations.go
+++ b/test/e2e/settings/no_auth_locations.go
@@ -43,32 +43,24 @@ var _ = framework.IngressNginxDescribe("No Auth locations", func() {
 	noAuthPath := "/noauth"
 
 	BeforeEach(func() {
-		err := f.NewEchoDeployment()
-		Expect(err).NotTo(HaveOccurred())
+		f.NewEchoDeployment()
 
-		s, err := f.EnsureSecret(buildSecret(username, password, secretName, f.IngressController.Namespace))
-		Expect(err).NotTo(HaveOccurred())
-		Expect(s).NotTo(BeNil())
-		Expect(s.ObjectMeta).NotTo(BeNil())
+		s := f.EnsureSecret(buildSecret(username, password, secretName, f.IngressController.Namespace))
 
-		err = f.UpdateNginxConfigMapData(setting, noAuthPath)
-		Expect(err).NotTo(HaveOccurred())
+		f.UpdateNginxConfigMapData(setting, noAuthPath)
 
 		bi := buildBasicAuthIngressWithSecondPath(host, f.IngressController.Namespace, s.Name, noAuthPath)
-		ing, err := f.EnsureIngress(bi)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ing).NotTo(BeNil())
+		f.EnsureIngress(bi)
 	})
 
 	AfterEach(func() {
 	})
 
 	It("should return status code 401 when accessing '/' unauthentication", func() {
-		err := f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return Expect(server).Should(ContainSubstring("test auth"))
 			})
-		Expect(err).NotTo(HaveOccurred())
 
 		resp, body, errs := gorequest.New().
 			Get(f.IngressController.HTTPURL).
@@ -81,11 +73,10 @@ var _ = framework.IngressNginxDescribe("No Auth locations", func() {
 	})
 
 	It("should return status code 200 when accessing '/'  authentication", func() {
-		err := f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return Expect(server).Should(ContainSubstring("test auth"))
 			})
-		Expect(err).NotTo(HaveOccurred())
 
 		resp, _, errs := gorequest.New().
 			Get(f.IngressController.HTTPURL).
@@ -98,11 +89,10 @@ var _ = framework.IngressNginxDescribe("No Auth locations", func() {
 	})
 
 	It("should return status code 200 when accessing '/noauth' unauthenticated", func() {
-		err := f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return Expect(server).Should(ContainSubstring("test auth"))
 			})
-		Expect(err).NotTo(HaveOccurred())
 
 		resp, _, errs := gorequest.New().
 			Get(fmt.Sprintf("%s/noauth", f.IngressController.HTTPURL)).
@@ -156,8 +146,9 @@ func buildBasicAuthIngressWithSecondPath(host, namespace, secretName, pathName s
 
 func buildSecret(username, password, name, namespace string) *corev1.Secret {
 	out, err := exec.Command("openssl", "passwd", "-crypt", password).CombinedOutput()
+	Expect(err).NotTo(HaveOccurred(), "creating password")
+
 	encpass := fmt.Sprintf("%v:%s\n", username, out)
-	Expect(err).NotTo(HaveOccurred())
 
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/settings/proxy_protocol.go
+++ b/test/e2e/settings/proxy_protocol.go
@@ -35,11 +35,8 @@ var _ = framework.IngressNginxDescribe("Proxy Protocol", func() {
 	setting := "use-proxy-protocol"
 
 	BeforeEach(func() {
-		err := f.NewEchoDeployment()
-		Expect(err).NotTo(HaveOccurred())
-
-		err = f.UpdateNginxConfigMapData(setting, "false")
-		Expect(err).NotTo(HaveOccurred())
+		f.NewEchoDeployment()
+		f.UpdateNginxConfigMapData(setting, "false")
 	})
 
 	AfterEach(func() {
@@ -48,27 +45,22 @@ var _ = framework.IngressNginxDescribe("Proxy Protocol", func() {
 	It("should respect port passed by the PROXY Protocol", func() {
 		host := "proxy-protocol"
 
-		err := f.UpdateNginxConfigMapData(setting, "true")
-		Expect(err).NotTo(HaveOccurred())
+		f.UpdateNginxConfigMapData(setting, "true")
 
-		ing, err := f.EnsureIngress(framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, nil))
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ing).NotTo(BeNil())
+		f.EnsureIngress(framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, nil))
 
-		err = f.WaitForNginxServer(host,
+		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return strings.Contains(server, "server_name proxy-protocol") &&
 					strings.Contains(server, "listen 80 proxy_protocol")
 			})
-		Expect(err).NotTo(HaveOccurred())
 
-		ip, err := f.GetNginxIP()
-		Expect(err).NotTo(HaveOccurred())
+		ip := f.GetNginxIP()
 		port, err := f.GetNginxPort("http")
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred(), "unexpected error obtaning NGINX Port")
 
 		conn, err := net.Dial("tcp", net.JoinHostPort(ip, strconv.Itoa(port)))
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred(), "unexpected error creating connection to %s:%d", ip, port)
 		defer conn.Close()
 
 		header := "PROXY TCP4 192.168.0.1 192.168.0.11 56324 1234\r\n"
@@ -76,7 +68,7 @@ var _ = framework.IngressNginxDescribe("Proxy Protocol", func() {
 		conn.Write([]byte("GET / HTTP/1.1\r\nHost: proxy-protocol\r\n\r\n"))
 
 		data, err := ioutil.ReadAll(conn)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred(), "unexpected error reading connection data")
 		body := string(data)
 		Expect(body).Should(ContainSubstring(fmt.Sprintf("host=%v", "proxy-protocol")))
 		Expect(body).Should(ContainSubstring(fmt.Sprintf("x-forwarded-port=80")))

--- a/test/e2e/settings/server_tokens.go
+++ b/test/e2e/settings/server_tokens.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,34 +32,28 @@ var _ = framework.IngressNginxDescribe("Server Tokens", func() {
 	serverTokens := "server-tokens"
 
 	BeforeEach(func() {
-		err := f.NewEchoDeployment()
-		Expect(err).NotTo(HaveOccurred())
+		f.NewEchoDeployment()
 	})
 
 	AfterEach(func() {
 	})
 
 	It("should not exists Server header in the response", func() {
-		err := f.UpdateNginxConfigMapData(serverTokens, "false")
-		Expect(err).NotTo(HaveOccurred())
+		f.UpdateNginxConfigMapData(serverTokens, "false")
 
-		ing, err := f.EnsureIngress(framework.NewSingleIngress(serverTokens, "/", serverTokens, f.IngressController.Namespace, "http-svc", 80, nil))
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ing).NotTo(BeNil())
+		f.EnsureIngress(framework.NewSingleIngress(serverTokens, "/", serverTokens, f.IngressController.Namespace, "http-svc", 80, nil))
 
-		err = f.WaitForNginxConfiguration(
+		f.WaitForNginxConfiguration(
 			func(cfg string) bool {
 				return strings.Contains(cfg, "server_tokens off") &&
 					strings.Contains(cfg, "more_clear_headers Server;")
 			})
-		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should exists Server header in the response when is enabled", func() {
-		err := f.UpdateNginxConfigMapData(serverTokens, "true")
-		Expect(err).NotTo(HaveOccurred())
+		f.UpdateNginxConfigMapData(serverTokens, "true")
 
-		ing, err := f.EnsureIngress(&v1beta1.Ingress{
+		f.EnsureIngress(&v1beta1.Ingress{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        serverTokens,
 				Namespace:   f.IngressController.Namespace,
@@ -88,13 +81,9 @@ var _ = framework.IngressNginxDescribe("Server Tokens", func() {
 			},
 		})
 
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ing).NotTo(BeNil())
-
-		err = f.WaitForNginxConfiguration(
+		f.WaitForNginxConfiguration(
 			func(cfg string) bool {
 				return strings.Contains(cfg, "server_tokens on")
 			})
-		Expect(err).NotTo(HaveOccurred())
 	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR starts the process to remove `Expect(err).ToNot(HaveOccurred())` from the test and also avoid using methods from the framework package that return an error requiring an assert after the invocation.
