### PR TITLE
breaking change: by default do not trust any client

### DIFF
--- a/docs/user-guide/nginx-configuration/configmap.md
+++ b/docs/user-guide/nginx-configuration/configmap.md
@@ -106,7 +106,7 @@ The following table shows a configuration option's name, type, and the default v
 |[proxy-stream-timeout](#proxy-stream-timeout)|string|"600s"|
 |[proxy-stream-responses](#proxy-stream-responses)|int|1|
 |[bind-address](#bind-address)|[]string|""|
-|[use-forwarded-headers](#use-forwarded-headers)|bool|"true"|
+|[use-forwarded-headers](#use-forwarded-headers)|bool|"false"|
 |[forwarded-for-header](#forwarded-for-header)|string|"X-Forwarded-For"|
 |[compute-full-forwarded-for](#compute-full-forwarded-for)|bool|"false"|
 |[proxy-add-original-uri-header](#proxy-add-original-uri-header)|bool|"true"|

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -588,7 +588,7 @@ func NewDefault() Configuration {
 		EnableDynamicTLSRecords:    true,
 		EnableUnderscoresInHeaders: false,
 		ErrorLogLevel:              errorLevel,
-		UseForwardedHeaders:        true,
+		UseForwardedHeaders:        false,
 		ForwardedForHeader:         "X-Forwarded-For",
 		ComputeFullForwardedFor:    false,
 		ProxyAddOriginalURIHeader:  true,

--- a/test/e2e/settings/geoip2.go
+++ b/test/e2e/settings/geoip2.go
@@ -45,6 +45,7 @@ var _ = framework.IngressNginxDescribe("Geoip2", func() {
   AU 0;
 }`
 		f.UpdateNginxConfigMapData("http-snippet", httpSnippetAllowingOnlyAustralia)
+		f.UpdateNginxConfigMapData("use-forwarded-headers", "true")
 
 		f.WaitForNginxConfiguration(
 			func(cfg string) bool {


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently we configure Nginx in a way that it trusts any client to extract true client IP address from X-Forwarded-For header using realip module. This PR makes it so that by default it does not trust any client at all.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
