### PR TITLE
Avoid reloads when endpoints are not available

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -1173,16 +1173,11 @@ stream {
             proxy_set_header       X-Service-Port     $service_port;
             {{ end }}
 
-            {{ if not (empty $location.Backend) }}
             {{ buildProxyPass $server.Hostname $all.Backends $location }}
             {{ if (or (eq $location.Proxy.ProxyRedirectFrom "default") (eq $location.Proxy.ProxyRedirectFrom "off")) }}
             proxy_redirect                          {{ $location.Proxy.ProxyRedirectFrom }};
             {{ else if not (eq $location.Proxy.ProxyRedirectTo "off") }}
             proxy_redirect                          {{ $location.Proxy.ProxyRedirectFrom }} {{ $location.Proxy.ProxyRedirectTo }};
-            {{ end }}
-            {{ else }}
-            # No endpoints available for the request
-            return 503;
             {{ end }}
             {{ else }}
             # Location denied. Reason: {{ $location.Denied | printf "%q" }}

--- a/test/e2e/servicebackend/service_backend.go
+++ b/test/e2e/servicebackend/service_backend.go
@@ -49,7 +49,7 @@ var _ = framework.IngressNginxDescribe("Service backend - 503", func() {
 
 		f.WaitForNginxServer(host,
 			func(server string) bool {
-				return strings.Contains(server, "return 503;")
+				return strings.Contains(server, "proxy_pass http://upstream_balancer;")
 			})
 
 		resp, _, errs := gorequest.New().
@@ -72,7 +72,7 @@ var _ = framework.IngressNginxDescribe("Service backend - 503", func() {
 
 		f.WaitForNginxServer(host,
 			func(server string) bool {
-				return strings.Contains(server, "return 503;")
+				return strings.Contains(server, "proxy_pass http://upstream_balancer;")
 			})
 
 		resp, _, errs := gorequest.New().


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR helps to avoid NGINX reloads when there are no endpoints available or changing too fast (pod restart, something normal in a dev cluster)

fixes #3314 (https://github.com/kubernetes/ingress-nginx/issues/3314#issuecomment-434690432)