### PR TITLE
Adds CustomHTTPErrors ingress annotation and test

### DIFF
--- a/docs/user-guide/nginx-configuration/annotations.md
+++ b/docs/user-guide/nginx-configuration/annotations.md
@@ -31,6 +31,7 @@ You can add these Kubernetes annotations to specific Ingress objects to customiz
 |[nginx.ingress.kubernetes.io/base-url-scheme](#rewrite)|string|
 |[nginx.ingress.kubernetes.io/client-body-buffer-size](#client-body-buffer-size)|string|
 |[nginx.ingress.kubernetes.io/configuration-snippet](#configuration-snippet)|string|
+|[nginx.ingress.kubernetes.io/custom-http-errors](#custom-http-errors)|[]int|
 |[nginx.ingress.kubernetes.io/default-backend](#default-backend)|string|
 |[nginx.ingress.kubernetes.io/enable-cors](#enable-cors)|"true" or "false"|
 |[nginx.ingress.kubernetes.io/cors-allow-origin](#enable-cors)|string|
@@ -212,6 +213,17 @@ nginx.ingress.kubernetes.io/configuration-snippet: |
 The ingress controller requires a [default backend](../default-backend.md).
 This service handles the response when the service in the Ingress rule does not have endpoints.
 This is a global configuration for the ingress controller. In some cases could be required to return a custom content or format. In this scenario we can use the annotation `nginx.ingress.kubernetes.io/default-backend: <svc name>` to specify a custom default backend.
+
+### Custom HTTP Errors
+
+Like the [`custom-http-errors`](../configmap.md#custom-http-errors) value in the ConfigMap, this annotation will set NGINX `proxy-intercept-errors`, but only for the NGINX location associated with this ingress.
+Different ingresses can specify different sets of error codes. Even if multiple ingress objects share the same hostname, this annotation can be used to intercept different error codes for each ingress (for example, different error codes to be intercepted for different paths on the same hostname, if each path is on a different ingress).
+If `custom-http-errors` is also specified globally, the error values specified in this annotation will override the global value for the given ingress' hostname and path.
+
+Example usage:
+```
+custom-http-errors: "404,415"
+```
 
 ### Enable CORS
 

--- a/internal/ingress/annotations/annotations.go
+++ b/internal/ingress/annotations/annotations.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/ingress-nginx/internal/ingress/annotations/clientbodybuffersize"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/connection"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/cors"
+	"k8s.io/ingress-nginx/internal/ingress/annotations/customhttperrors"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/defaultbackend"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/influxdb"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/ipwhitelist"
@@ -72,6 +73,7 @@ type Ingress struct {
 	ConfigurationSnippet string
 	Connection           connection.Config
 	CorsConfig           cors.Config
+	CustomHTTPErrors     []int
 	DefaultBackend       *apiv1.Service
 	Denied               error
 	ExternalAuth         authreq.Config
@@ -112,6 +114,7 @@ func NewAnnotationExtractor(cfg resolver.Resolver) Extractor {
 			"ConfigurationSnippet": snippet.NewParser(cfg),
 			"Connection":           connection.NewParser(cfg),
 			"CorsConfig":           cors.NewParser(cfg),
+			"CustomHTTPErrors":     customhttperrors.NewParser(cfg),
 			"DefaultBackend":       defaultbackend.NewParser(cfg),
 			"ExternalAuth":         authreq.NewParser(cfg),
 			"Proxy":                proxy.NewParser(cfg),

--- a/internal/ingress/annotations/customhttperrors/main.go
+++ b/internal/ingress/annotations/customhttperrors/main.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package customhttperrors
+
+import (
+	"strconv"
+	"strings"
+
+	extensions "k8s.io/api/extensions/v1beta1"
+
+	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
+	"k8s.io/ingress-nginx/internal/ingress/resolver"
+)
+
+type customhttperrors struct {
+	r resolver.Resolver
+}
+
+// NewParser creates a new custom http errors annotation parser
+func NewParser(r resolver.Resolver) parser.IngressAnnotation {
+	return customhttperrors{r}
+}
+
+// Parse parses the annotations contained in the ingress to use
+// custom http errors
+func (e customhttperrors) Parse(ing *extensions.Ingress) (interface{}, error) {
+	c, err := parser.GetStringAnnotation("custom-http-errors", ing)
+	if err != nil {
+		return nil, err
+	}
+
+	cSplit := strings.Split(c, ",")
+	var codes []int
+	for _, i := range cSplit {
+		num, err := strconv.Atoi(i)
+		if err != nil {
+			return nil, err
+		}
+		codes = append(codes, num)
+	}
+
+	return codes, nil
+}

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -351,6 +351,7 @@ func (n *NGINXController) getBackendServers(ingresses []*extensions.Ingress) ([]
 						loc.InfluxDB = anns.InfluxDB
 						loc.DefaultBackend = anns.DefaultBackend
 						loc.BackendProtocol = anns.BackendProtocol
+						loc.CustomHTTPErrors = anns.CustomHTTPErrors
 
 						if loc.Redirect.FromToWWW {
 							server.RedirectFromToWWW = true
@@ -391,6 +392,7 @@ func (n *NGINXController) getBackendServers(ingresses []*extensions.Ingress) ([]
 						InfluxDB:             anns.InfluxDB,
 						DefaultBackend:       anns.DefaultBackend,
 						BackendProtocol:      anns.BackendProtocol,
+						CustomHTTPErrors:     anns.CustomHTTPErrors,
 					}
 
 					if loc.Redirect.FromToWWW {

--- a/internal/ingress/types.go
+++ b/internal/ingress/types.go
@@ -253,6 +253,9 @@ type Location struct {
 	// BackendProtocol indicates which protocol should be used to communicate with the service
 	// By default this is HTTP
 	BackendProtocol string `json:"backend-protocol"`
+	// CustomHTTPErrors specifies the error codes that should be intercepted.
+	// +optional
+	CustomHTTPErrors []int `json:"custom-http-errors"`
 }
 
 // SSLPassthroughBackend describes a SSL upstream server configured

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -575,7 +575,7 @@ http {
         {{ $cfg.ServerSnippet }}
         {{ end }}
 
-        {{ template "CUSTOM_ERRORS" $all }}
+        {{ template "CUSTOM_ERRORS" (buildCustomErrorDeps $all.ProxySetHeaders $cfg.CustomHTTPErrors) }}
     }
     ## end server {{ $server.Hostname }}
 
@@ -677,7 +677,7 @@ http {
             proxy_pass          http://upstream_balancer;
         }
 
-        {{ template "CUSTOM_ERRORS" $all }}
+        {{ template "CUSTOM_ERRORS" (buildCustomErrorDeps $all.ProxySetHeaders $cfg.CustomHTTPErrors) }}
     }
 }
 
@@ -696,7 +696,7 @@ stream {
 {{/* definition of templates to avoid repetitions */}}
 {{ define "CUSTOM_ERRORS" }}
         {{ $proxySetHeaders := .ProxySetHeaders }}
-        {{ range $errCode := .Cfg.CustomHTTPErrors }}
+        {{ range $errCode := .ErrorCodes }}
         location @custom_{{ $errCode }} {
             internal;
 
@@ -817,6 +817,8 @@ stream {
         {{ if not (empty $server.ServerSnippet) }}
         {{ $server.ServerSnippet }}
         {{ end }}
+
+        {{ template "CUSTOM_ERRORS" (buildCustomErrorDeps $all.ProxySetHeaders (collectCustomErrorsPerServer $server)) }}
 
         {{ $enforceRegex := enforceRegexModifier $server.Locations }}
         {{ range $location := $server.Locations }}
@@ -1172,6 +1174,16 @@ stream {
             proxy_set_header       X-Service-Name     $service_name;
             proxy_set_header       X-Service-Port     $service_port;
             {{ end }}
+
+            {{/* if a location-specific error override is set, add the proxy_intercept here */}}
+            {{ if $location.CustomHTTPErrors }}
+            # Custom error pages per ingress
+            proxy_intercept_errors on;
+            {{ end }}
+
+            {{ range $errCode := $location.CustomHTTPErrors }}
+            error_page {{ $errCode }} = @custom_{{ $errCode }};{{ end }}
+
 
             {{ buildProxyPass $server.Hostname $all.Backends $location }}
             {{ if (or (eq $location.Proxy.ProxyRedirectFrom "default") (eq $location.Proxy.ProxyRedirectFrom "off")) }}

--- a/test/e2e/annotations/customhttperrors.go
+++ b/test/e2e/annotations/customhttperrors.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package annotations
+
+import (
+	"fmt"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/ingress-nginx/test/e2e/framework"
+)
+
+var _ = framework.IngressNginxDescribe("Annotations - custom-http-errors", func() {
+	f := framework.NewDefaultFramework("custom-http-errors")
+
+	BeforeEach(func() {
+		f.NewEchoDeploymentWithReplicas(2)
+	})
+
+	AfterEach(func() {
+	})
+
+	It("should set proxy_intercept_errors", func() {
+		host := "customerrors.foo.com"
+
+		errorCodes := []string{"404", "500"}
+
+		annotations := map[string]string{
+			"nginx.ingress.kubernetes.io/custom-http-errors": strings.Join(errorCodes, ","),
+		}
+
+		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
+		f.EnsureIngress(ing)
+
+		f.WaitForNginxServer(host,
+			func(server string) bool {
+				return Expect(server).Should(ContainSubstring("proxy_intercept_errors on;"))
+			})
+	})
+
+	It("should create error routes", func() {
+		host := "customerrors.foo.com"
+		errorCodes := []string{"404", "500"}
+
+		annotations := map[string]string{
+			"nginx.ingress.kubernetes.io/custom-http-errors": strings.Join(errorCodes, ","),
+		}
+
+		ing := framework.NewSingleIngress(host, "/test", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
+		f.EnsureIngress(ing)
+
+		for _, code := range errorCodes {
+			f.WaitForNginxServer(host,
+				func(server string) bool {
+					return Expect(server).Should(ContainSubstring(fmt.Sprintf("@custom_%s", code)))
+				})
+		}
+	})
+
+	It("should set up error_page routing", func() {
+		host := "customerrors.foo.com"
+		errorCodes := []string{"404", "500"}
+
+		annotations := map[string]string{
+			"nginx.ingress.kubernetes.io/custom-http-errors": strings.Join(errorCodes, ","),
+		}
+
+		ing := framework.NewSingleIngress(host, "/test", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
+		f.EnsureIngress(ing)
+
+		for _, code := range errorCodes {
+			f.WaitForNginxServer(host,
+				func(server string) bool {
+					return Expect(server).Should(ContainSubstring(fmt.Sprintf("error_page %s = @custom_%s", code, code)))
+				})
+		}
+	})
+
+	It("should create only one of each error route", func() {
+		host := "customerrors.foo.com"
+		errorCodes := [][]string{{"404", "500"}, {"400", "404"}}
+
+		for i, codeSet := range errorCodes {
+			annotations := map[string]string{
+				"nginx.ingress.kubernetes.io/custom-http-errors": strings.Join(codeSet, ","),
+			}
+
+			ing := framework.NewSingleIngress(
+				fmt.Sprintf("%s-%d", host, i), fmt.Sprintf("/test-%d", i),
+				host, f.IngressController.Namespace, "http-svc", 80, &annotations)
+			f.EnsureIngress(ing)
+		}
+
+		for _, codeSet := range errorCodes {
+			for _, code := range codeSet {
+				f.WaitForNginxServer(host,
+					func(server string) bool {
+						count := strings.Count(server, fmt.Sprintf("location @custom_%s", code))
+						return Expect(count).Should(Equal(1))
+					})
+			}
+		}
+	})
+})


### PR DESCRIPTION
This is a reopen of https://github.com/kubernetes/ingress-nginx/pull/3340 (after some rebasing trouble)

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

This PR introduces a new annotation called `custom-http-errors`, which functions in a similar way to the config value `custom-http-errors`, but performs the proxy_intercept overriding on the location blocks specified by that Ingress only.

In our Kubernetes cluster, we have one single ingress controller which serves both frontend website services and APIs - and we want to send back 'pretty' error pages for the web services, but not the APIs.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

https://github.com/kubernetes/ingress-nginx/issues/2532
https://github.com/kubernetes/ingress-nginx/issues/3246 - when using this PR, it's possible to cancel out the global `custom-http-errors` setting by adding the Ingress annotation and setting an unused status code only, like `"nginx.ingress.kubernetes.io/custom-http-errors": "418"`.


**Special notes for your reviewer**:

We've been using this annotation in our development/test cluster for a while now and it's working well. I'm open to feedback on how to improve!