### PR TITLE
Add e2e test for session-cookie-hash

### DIFF
--- a/test/e2e/annotations/affinity.go
+++ b/test/e2e/annotations/affinity.go
@@ -19,6 +19,7 @@ package annotations
 import (
 	"fmt"
 	"net/http"
+	"regexp"
 	"strings"
 
 	. "github.com/onsi/ginkgo"
@@ -62,9 +63,42 @@ var _ = framework.IngressNginxDescribe("Annotations - Affinity/Sticky Sessions",
 			Set("Host", host).
 			End()
 
+		md5Regex := regexp.MustCompile("SERVERID=[0-9a-f]{32}")
+		match := md5Regex.FindStringSubmatch(resp.Header.Get("Set-Cookie"))
+		Expect(len(match)).Should(BeNumerically("==", 1))
+
 		Expect(len(errs)).Should(BeNumerically("==", 0))
 		Expect(resp.StatusCode).Should(Equal(http.StatusOK))
-		Expect(resp.Header.Get("Set-Cookie")).Should(ContainSubstring("SERVERID="))
+		Expect(resp.Header.Get("Set-Cookie")).Should(ContainSubstring(match[0]))
+	})
+
+	It("should set sticky cookie with sha1 hash", func() {
+		host := "sticky.foo.com"
+		annotations := map[string]string{
+			"nginx.ingress.kubernetes.io/affinity":            "cookie",
+			"nginx.ingress.kubernetes.io/session-cookie-hash": "sha1",
+		}
+
+		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
+		f.EnsureIngress(ing)
+
+		f.WaitForNginxServer(host,
+			func(server string) bool {
+				return strings.Contains(server, fmt.Sprintf("server_name %s ;", host))
+			})
+
+		resp, _, errs := gorequest.New().
+			Get(f.IngressController.HTTPURL).
+			Set("Host", host).
+			End()
+
+		sha1Regex := regexp.MustCompile("INGRESSCOOKIE=[0-9a-f]{40}")
+		match := sha1Regex.FindStringSubmatch(resp.Header.Get("Set-Cookie"))
+		Expect(len(match)).Should(BeNumerically("==", 1))
+
+		Expect(len(errs)).Should(BeNumerically("==", 0))
+		Expect(resp.StatusCode).Should(Equal(http.StatusOK))
+		Expect(resp.Header.Get("Set-Cookie")).Should(ContainSubstring(match[0]))
 	})
 
 	It("should set the path to /something on the generated cookie", func() {


### PR DESCRIPTION
Adds the e2e test for the session-cookie-hash annotation.
Part of the #3124 effort.