### PR TITLE
Download latest dep releases instead of fetching from HEAD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -226,7 +226,7 @@ check_dead_links:
 
 .PHONY: dep-ensure
 dep-ensure:
-	dep version || go get -u github.com/golang/dep/cmd/dep
+	dep version || curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
 	dep ensure -v
 	dep prune -v
 	find vendor -name '*_test.go' -delete


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Fetching dep from HEAD is not the best practice. We should instead download the latest binary release of dep.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
