### PR TITLE
Create backend service when there is no paths defined

### DIFF
--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -552,6 +552,11 @@ func (n *NGINXController) createUpstreams(data []*extensions.Ingress, du *ingres
 				}
 			}
 
+			s, err := n.store.GetService(svcKey)
+			if err != nil {
+				glog.Warningf("Error obtaining Service %q: %v", svcKey, err)
+			}
+			upstreams[defBackend].Service = s
 		}
 
 		for _, rule := range ing.Spec.Rules {


### PR DESCRIPTION
This is a special case when the Ingress does not contain rule paths and only a Backend

**Which issue this PR fixes**: fixes #3315
