### PR TITLE
Remove reloads when there is no endpoints

### DIFF
--- a/rootfs/etc/nginx/lua/balancer.lua
+++ b/rootfs/etc/nginx/lua/balancer.lua
@@ -68,6 +68,11 @@ local function format_ipv6_endpoints(endpoints)
 end
 
 local function sync_backend(backend)
+  if not backend.endpoints or #backend.endpoints == 0 then
+    ngx.log(ngx.INFO, string.format("there is no endpoint for backend %s. Skipping...", backend.name))
+    return
+  end
+
   local implementation = get_implementation(backend)
   local balancer = balancers[backend.name]
 


### PR DESCRIPTION
Which issue this PR fixes: fixes #3315

This PR removes the need to reload NGINX when there is a change in the number of endpoints (in particular 0).
Without this PR, when the replica count is 0 we had this
```
I1106 12:19:13.390606       6 nginx.go:629] NGINX configuration diff:
--- /etc/nginx/nginx.conf	2018-11-06 12:18:56.514692638 +0000
+++ /tmp/new-nginx-cfg561164329	2018-11-06 12:19:13.387865859 +0000
@@ -1,5 +1,5 @@
 
-# Configuration checksum: 14086898480532449296
+# Configuration checksum: 8624603592146078350
 
 # setup custom paths that do not require root access
 pid /tmp/nginx.pid;
@@ -533,7 +533,7 @@
 			
 			port_in_redirect off;
 			
-			set $proxy_upstream_name "default-http-svc-80";
+			set $proxy_upstream_name "";
 			
 			client_max_body_size                    1m;
```

which triggered the reload. With the introduced changes there is no difference in the configuration file