### PR TITLE
Allows auth-tls-verify-client: "optional_no_ca" to be used without a CA

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -798,9 +798,11 @@ stream {
         return 403;
         {{ else }}
 
+        {{ if not (eq $server.CertificateAuth.VerifyClient "off") }}
         {{ if not (empty $server.CertificateAuth.CAFileName) }}
         # PEM sha: {{ $server.CertificateAuth.PemSHA }}
         ssl_client_certificate                  {{ $server.CertificateAuth.CAFileName }};
+        {{ end }}
         ssl_verify_client                       {{ $server.CertificateAuth.VerifyClient }};
         ssl_verify_depth                        {{ $server.CertificateAuth.ValidationDepth }};
         {{ if not (empty $server.CertificateAuth.ErrorPage)}}
@@ -879,7 +881,7 @@ stream {
             {{ end }}
 
             # Pass the extracted client certificate to the auth provider
-            {{ if not (empty $server.CertificateAuth.CAFileName) }}
+            {{ if not (eq $server.CertificateAuth.VerifyClient "off") }}
             {{ if $server.CertificateAuth.PassCertToUpstream }}
             proxy_set_header ssl-client-cert        $ssl_client_escaped_cert;
             {{ end }}
@@ -1096,7 +1098,7 @@ stream {
             {{ end }}
 
             # Pass the extracted client certificate to the backend
-            {{ if not (empty $server.CertificateAuth.CAFileName) }}
+            {{ if not (eq $server.CertificateAuth.VerifyClient "off") }}
             {{ if $server.CertificateAuth.PassCertToUpstream }}
             {{ $proxySetHeader }} ssl-client-cert        $ssl_client_escaped_cert;
             {{ end }}


### PR DESCRIPTION
**What this PR does / why we need it**: Allows [`auth-tls-verify-client`](https://kubernetes.github.io/ingress-nginx/examples/auth/client-certs/) annotation to be used without the need for `auth-tls-secret`. With `optional_no_ca`, a CA certificate is useless.

Current `nginx.tmpl` outputs `ssl_verify_client` only if `CertificateAuth.CAFileName` is provided. This assumption undermines the ability to use `optional_no_ca` without also specifying a CA certificate. [Per definition](http://nginx.org/en/docs/http/ngx_http_ssl_module.html), `optional_no_ca` should allow an empty CA in a valid nginx.conf.

This PR changes the template to output `ssl_verify_client` when `CertificateAuth.VerifyClient` is present and does not equal `off`. A few other portions of the template which made the same assumption are also adjusted to follow suit (related `proxy_set_header` directives).

**Which issue this PR fixes**: fixes #2922 

**Special notes for your reviewer**:
