### PR TITLE
Update nginx image

### DIFF
--- a/images/nginx/Makefile
+++ b/images/nginx/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # 0.0.0 shouldn't clobber any released builds
-TAG ?= 0.68
+TAG ?= 0.69
 REGISTRY ?= quay.io/kubernetes-ingress-controller
 ARCH ?= $(shell go env GOARCH)
 DOCKER ?= docker

--- a/images/nginx/rootfs/build.sh
+++ b/images/nginx/rootfs/build.sh
@@ -241,26 +241,6 @@ export HUNTER_JOBS_NUMBER=${CORES}
 export HUNTER_KEEP_PACKAGE_SOURCES=false
 export HUNTER_USE_CACHE_SERVERS=true
 
-OPENSSL_DIR="$BUILD_PATH/openssl"
-mkdir -p $OPENSSL_DIR
-cd $OPENSSL_DIR
-
-# Install Openssl 1.1.1 from source
-wget http://http.debian.net/debian/pool/main/o/openssl/openssl_1.1.1-1.dsc
-wget http://http.debian.net/debian/pool/main/o/openssl/openssl_1.1.1.orig.tar.gz
-wget http://http.debian.net/debian/pool/main/o/openssl/openssl_1.1.1.orig.tar.gz.asc
-wget http://http.debian.net/debian/pool/main/o/openssl/openssl_1.1.1-1.debian.tar.xz
-
-tar zxpvf openssl_1.1.1.orig.tar.gz
-cd openssl-1.1.1/
-tar xpvf ../openssl_1.1.1-1.debian.tar.xz
-
-DEB_BUILD_OPTIONS=nocheck dpkg-buildpackage -rfakeroot
-
-cd ..
-
-dpkg -i openssl_1.1.1-1_*.deb libssl1.1_1.1.1-1_*.deb libssl-dev_1.1.1-1_*.deb
-
 # Install luajit from openresty fork
 export LUAJIT_LIB=/usr/local/lib
 export LUA_LIB_DIR="$LUAJIT_LIB/lua"


### PR DESCRIPTION
**What this PR does / why we need it**:

OpenSSL 1.1.1 is now available as a debian package
