### PR TITLE
Fix modsecurity configuration file location

### DIFF
--- a/images/nginx/rootfs/build.sh
+++ b/images/nginx/rootfs/build.sh
@@ -407,9 +407,9 @@ sh build.sh
 make
 make install
 
-mkdir /etc/modsecurity
-cp modsecurity.conf-recommended /etc/modsecurity/modsecurity.conf
-cp unicode.mapping /etc/modsecurity/unicode.mapping
+mkdir -p /etc/nginx/modsecurity
+cp modsecurity.conf-recommended /etc/nginx/modsecurity/modsecurity.conf
+cp unicode.mapping /etc/nginx/modsecurity/unicode.mapping
 
 # Download owasp modsecurity crs
 cd /etc/nginx/


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix the location of modsecurity configuration files bug introduced in https://github.com/kubernetes/ingress-nginx/pull/3357/files#diff-4a5113d28634e29f2ab0bca34da7a3e5R425

This change is already present in nginx 0.69