### PR TITLE
Convert isValidClientBodyBufferSize to something more generic

### DIFF
--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -151,7 +151,7 @@ var (
 		"serverConfig": func(all config.TemplateConfig, server *ingress.Server) interface{} {
 			return struct{ First, Second interface{} }{all, server}
 		},
-		"isValidClientBodyBufferSize":  isValidClientBodyBufferSize,
+		"isValidByteSize":              isValidByteSize,
 		"buildForwardedFor":            buildForwardedFor,
 		"buildAuthSignURL":             buildAuthSignURL,
 		"buildOpentracing":             buildOpentracing,
@@ -753,7 +753,7 @@ func buildNextUpstream(i, r interface{}) string {
 	return strings.Join(nextUpstreamCodes, " ")
 }
 
-func isValidClientBodyBufferSize(input interface{}) bool {
+func isValidByteSize(input interface{}) bool {
 	s, ok := input.(string)
 	if !ok {
 		glog.Errorf("expected an 'string' type but %T was returned", input)
@@ -761,6 +761,7 @@ func isValidClientBodyBufferSize(input interface{}) bool {
 	}
 
 	if s == "" {
+		glog.Errorf("empty byte size, hence it will not be set.")
 		return false
 	}
 
@@ -780,7 +781,7 @@ func isValidClientBodyBufferSize(input interface{}) bool {
 			return true
 		}
 
-		glog.Errorf("client-body-buffer-size '%v' was provided in an incorrect format, hence it will not be set.", s)
+		glog.Errorf("incorrect byte size format '%v', hence it will not be set.", s)
 		return false
 	}
 

--- a/internal/ingress/controller/template/template_test.go
+++ b/internal/ingress/controller/template/template_test.go
@@ -557,40 +557,40 @@ func TestBuildDenyVariable(t *testing.T) {
 	}
 }
 
-func TestBuildClientBodyBufferSize(t *testing.T) {
-	a := isValidClientBodyBufferSize("1000")
+func TestBuildByteSize(t *testing.T) {
+	a := isValidByteSize("1000")
 	if !a {
 		t.Errorf("Expected '%v' but returned '%v'", true, a)
 	}
-	b := isValidClientBodyBufferSize("1000k")
+	b := isValidByteSize("1000k")
 	if !b {
 		t.Errorf("Expected '%v' but returned '%v'", true, b)
 	}
-	c := isValidClientBodyBufferSize("1000m")
+	c := isValidByteSize("1000m")
 	if !c {
 		t.Errorf("Expected '%v' but returned '%v'", true, c)
 	}
-	d := isValidClientBodyBufferSize("1000km")
+	d := isValidByteSize("1000km")
 	if d {
 		t.Errorf("Expected '%v' but returned '%v'", false, d)
 	}
-	e := isValidClientBodyBufferSize("1000mk")
+	e := isValidByteSize("1000mk")
 	if e {
 		t.Errorf("Expected '%v' but returned '%v'", false, e)
 	}
-	f := isValidClientBodyBufferSize("1000kk")
+	f := isValidByteSize("1000kk")
 	if f {
 		t.Errorf("Expected '%v' but returned '%v'", false, f)
 	}
-	g := isValidClientBodyBufferSize("1000mm")
+	g := isValidByteSize("1000mm")
 	if g {
 		t.Errorf("Expected '%v' but returned '%v'", false, g)
 	}
-	h := isValidClientBodyBufferSize(nil)
+	h := isValidByteSize(nil)
 	if h {
 		t.Errorf("Expected '%v' but returned '%v'", false, h)
 	}
-	i := isValidClientBodyBufferSize("")
+	i := isValidByteSize("")
 	if i {
 		t.Errorf("Expected '%v' but returned '%v'", false, i)
 	}

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -874,8 +874,10 @@ stream {
             proxy_http_version          1.1;
             proxy_ssl_server_name       on;
             proxy_pass_request_headers  on;
+            {{ if isValidByteSize $location.Proxy.BodySize }}
             client_max_body_size        {{ $location.Proxy.BodySize }};
-            {{ if isValidClientBodyBufferSize $location.ClientBodyBufferSize }}
+            {{ end }}
+            {{ if isValidByteSize $location.ClientBodyBufferSize }}
             client_body_buffer_size     {{ $location.ClientBodyBufferSize }};
             {{ end }}
 
@@ -1084,8 +1086,10 @@ stream {
             }
             {{ end }}
 
+            {{ if isValidByteSize $location.Proxy.BodySize }}
             client_max_body_size                    {{ $location.Proxy.BodySize }};
-            {{ if isValidClientBodyBufferSize $location.ClientBodyBufferSize }}
+            {{ end }}
+            {{ if isValidByteSize $location.ClientBodyBufferSize }}
             client_body_buffer_size                 {{ $location.ClientBodyBufferSize }};
             {{ end }}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This re-use the isValidClientBodyBufferSize for client_max_body_size configuration.

I'm make isValidClientBodyBufferSize more generic for that.

Recently, we've had nginx configuration issue because of `client_max_body_size` being set to an empty value.

As mentioned in https://github.com/kubernetes/ingress-nginx/issues/2494 this is caused by a race condition somewhere, making https://github.com/kubernetes/ingress-nginx/blob/master/internal/ingress/controller/store/store.go#L675 return an empty `annotations.Ingress`.

**Which issue this PR fixes**

**Special notes for your reviewer**:

This does not solve the underlying race condition but fixes the reload issue it causes.
