### PR TITLE
bugfix: set canary attributes when initializing balancer

### DIFF
--- a/rootfs/etc/nginx/lua/balancer/chash.lua
+++ b/rootfs/etc/nginx/lua/balancer/chash.lua
@@ -9,6 +9,8 @@ function _M.new(self, backend)
   local o = {
     instance = self.factory:new(nodes),
     hash_by = backend["upstream-hash-by"],
+    traffic_shaping_policy = backend.trafficShapingPolicy,
+    alternative_backends = backend.alternativeBackends,
   }
   setmetatable(o, self)
   self.__index = self

--- a/rootfs/etc/nginx/lua/balancer/ewma.lua
+++ b/rootfs/etc/nginx/lua/balancer/ewma.lua
@@ -120,6 +120,8 @@ end
 function _M.new(self, backend)
   local o = {
     peers = backend.endpoints,
+    traffic_shaping_policy = backend.trafficShapingPolicy,
+    alternative_backends = backend.alternativeBackends,
   }
   setmetatable(o, self)
   self.__index = self

--- a/rootfs/etc/nginx/lua/balancer/round_robin.lua
+++ b/rootfs/etc/nginx/lua/balancer/round_robin.lua
@@ -8,6 +8,8 @@ function _M.new(self, backend)
   local nodes = util.get_nodes(backend.endpoints)
   local o = {
     instance = self.factory:new(nodes),
+    traffic_shaping_policy = backend.trafficShapingPolicy,
+    alternative_backends = backend.alternativeBackends,
   }
   setmetatable(o, self)
   self.__index = self

--- a/rootfs/etc/nginx/lua/balancer/sticky.lua
+++ b/rootfs/etc/nginx/lua/balancer/sticky.lua
@@ -18,6 +18,8 @@ function _M.new(self, backend)
     cookie_expires = backend["sessionAffinityConfig"]["cookieSessionAffinity"]["expires"],
     cookie_max_age = backend["sessionAffinityConfig"]["cookieSessionAffinity"]["maxage"],
     digest_func = digest_func,
+    traffic_shaping_policy = backend.trafficShapingPolicy,
+    alternative_backends = backend.alternativeBackends,
   }
   setmetatable(o, self)
   self.__index = self


### PR DESCRIPTION
**What this PR does / why we need it**:
These attributes currently are being set only when we sync balancers. But they should also be set when we initialize a balancer for the first time for given backend. Otherwise until the next sync we get errors such as:

```
2018/11/13 11:00:52 [error] 1434#1434: *14207402 failed to run log_by_lua*: /etc/nginx/lua/balancer.lua:138: attempt to index field 'traffic_shaping_policy' (a nil value)
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
