### PR TITLE
bugfix: do not merge catch-all canary backends with itself

### DIFF
--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -1008,13 +1008,15 @@ func mergeAlternativeBackends(ing *extensions.Ingress, upstreams map[string]*ing
 
 		ups := upstreams[upsName]
 
-		defLoc := servers[defServerName].Locations[0]
+		for _, defLoc := range servers[defServerName].Locations {
+			if !upstreams[defLoc.Backend].NoServer {
+				glog.Infof("matching backend %v found for alternative backend %v",
+					upstreams[defLoc.Backend].Name, ups.Name)
 
-		glog.Infof("matching backend %v found for alternative backend %v",
-			upstreams[defLoc.Backend].Name, ups.Name)
-
-		upstreams[defLoc.Backend].AlternativeBackends =
-			append(upstreams[defLoc.Backend].AlternativeBackends, ups.Name)
+				upstreams[defLoc.Backend].AlternativeBackends =
+					append(upstreams[defLoc.Backend].AlternativeBackends, ups.Name)
+			}
+		}
 	}
 
 	for _, rule := range ing.Spec.Rules {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**don't merge yet, I plan on adding a test for this case**

**What this PR does / why we need it**:
If a canary backend is created at the catch all level of the ingress spec, it can merge with itself in some situations. If this happens, then the real backend won't know it exists. 

This fixes the problem by iterating over each location at `defServerName` and merges with the first backend which has a server rather than the backend at location 0.
