### PR TITLE
Fix X-Forwarded-Proto typo

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -841,7 +841,7 @@ stream {
 
             proxy_pass_request_body     off;
             proxy_set_header            Content-Length "";
-            proxy_set_header            X-Fowarded-Proto "";
+            proxy_set_header            X-Forwarded-Proto "";
 
             {{ if $location.ExternalAuth.Method }}
             proxy_method                {{ $location.ExternalAuth.Method }};


### PR DESCRIPTION
**What this PR does / why we need it**:

This fix a typo in `X-Forwarded-Proto` introduced in https://github.com/kubernetes/ingress-nginx/pull/3405

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

Thanks @ElvinEfendi for noticing