### PR TITLE
Set proxy_host variable to avoid using default value from proxy_pass

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -529,6 +529,9 @@ http {
         {{ end }}
         server_name {{ $hostname }};
 
+        {{/* default value of proxy_host is the name and port of a proxied server as specified in the proxy_pass directive */}}
+        set $proxy_host {{ $hostname }};
+
         {{ if gt (len $cfg.BlockUserAgents) 0 }}
         if ($block_ua) {
            return 403;


### PR DESCRIPTION
**What this PR does / why we need it**:

Avoid issues with default value of variable `$proxy_host`

```$proxy_host
name and port of a proxied server as specified in the proxy_pass directive;
```

http://nginx.org/en/docs/http/ngx_http_proxy_module.html

**Which issue this PR fixes**: fixes #3427
