### PR TITLE
 Fix OOM

### DIFF
--- a/internal/ingress/metric/collectors/socket.go
+++ b/internal/ingress/metric/collectors/socket.go
@@ -66,7 +66,7 @@ type SocketCollector struct {
 	responseTime   *prometheus.HistogramVec
 	responseLength *prometheus.HistogramVec
 
-	upstreamLatency *prometheus.SummaryVec
+	upstreamLatency *prometheus.HistogramVec
 
 	bytesSent *prometheus.HistogramVec
 
@@ -179,8 +179,8 @@ func NewSocketCollector(pod, namespace, class string) (*SocketCollector, error) 
 			requestTags,
 		),
 
-		upstreamLatency: prometheus.NewSummaryVec(
-			prometheus.SummaryOpts{
+		upstreamLatency: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
 				Name:        "ingress_upstream_latency_seconds",
 				Help:        "Upstream service latency per Ingress",
 				Namespace:   PrometheusNamespace,


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix memory leaks in high concurrent requests. 


In the case of higher QPS, the ingress-nginx-controller has serious memory leaks. After troubleshooting, the reason is that the stream_latency in `socket.go` uses the prometheus summary data type, the summary data type uses the global lock [#L277](https://github.com/kubernetes/ingress-nginx/blob/master/vendor/github.com/prometheus/client_golang/prometheus/summary.go#L277). the request volume is large, The global lock will cause a lot of gorontinue to wait, the memory cannot be released, and each gorontinue The variable allocation memory is large (variables contain up to 1w request information).

After upstream_latency is changed to use the prometheus Histogram data type, the CPU is reduced and there is no memory leak, because the Histogram logic is simple and no locks are used.

**Which issue this PR fixes** : 

fixes #3314 

