### PR TITLE
Use struct to pack Ingress and its annotations

### DIFF
--- a/internal/ingress/controller/controller_test.go
+++ b/internal/ingress/controller/controller_test.go
@@ -20,8 +20,9 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/asn1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	extensions "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,31 +31,33 @@ import (
 
 func TestMergeAlternativeBackends(t *testing.T) {
 	testCases := map[string]struct {
-		ingress                   *extensions.Ingress
+		ingress                   *ingress.Ingress
 		upstreams                 map[string]*ingress.Backend
 		servers                   map[string]*ingress.Server
 		expNumAlternativeBackends int
 		expNumLocations           int
 	}{
 		"alternative backend has no server and embeds into matching real backend": {
-			&extensions.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "example",
-				},
-				Spec: extensions.IngressSpec{
-					Rules: []extensions.IngressRule{
-						{
-							Host: "example.com",
-							IngressRuleValue: extensions.IngressRuleValue{
-								HTTP: &extensions.HTTPIngressRuleValue{
-									Paths: []extensions.HTTPIngressPath{
-										{
-											Path: "/",
-											Backend: extensions.IngressBackend{
-												ServiceName: "http-svc-canary",
-												ServicePort: intstr.IntOrString{
-													Type:   intstr.Int,
-													IntVal: 80,
+			&ingress.Ingress{
+				Ingress: extensions.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "example",
+					},
+					Spec: extensions.IngressSpec{
+						Rules: []extensions.IngressRule{
+							{
+								Host: "example.com",
+								IngressRuleValue: extensions.IngressRuleValue{
+									HTTP: &extensions.HTTPIngressRuleValue{
+										Paths: []extensions.HTTPIngressPath{
+											{
+												Path: "/",
+												Backend: extensions.IngressBackend{
+													ServiceName: "http-svc-canary",
+													ServicePort: intstr.IntOrString{
+														Type:   intstr.Int,
+														IntVal: 80,
+													},
 												},
 											},
 										},
@@ -93,43 +96,45 @@ func TestMergeAlternativeBackends(t *testing.T) {
 			1,
 		},
 		"merging a alternative backend matches with the correct host": {
-			&extensions.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "example",
-				},
-				Spec: extensions.IngressSpec{
-					Rules: []extensions.IngressRule{
-						{
-							Host: "foo.bar",
-							IngressRuleValue: extensions.IngressRuleValue{
-								HTTP: &extensions.HTTPIngressRuleValue{
-									Paths: []extensions.HTTPIngressPath{
-										{
-											Path: "/",
-											Backend: extensions.IngressBackend{
-												ServiceName: "foo-http-svc-canary",
-												ServicePort: intstr.IntOrString{
-													Type:   intstr.Int,
-													IntVal: 80,
+			&ingress.Ingress{
+				Ingress: extensions.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "example",
+					},
+					Spec: extensions.IngressSpec{
+						Rules: []extensions.IngressRule{
+							{
+								Host: "foo.bar",
+								IngressRuleValue: extensions.IngressRuleValue{
+									HTTP: &extensions.HTTPIngressRuleValue{
+										Paths: []extensions.HTTPIngressPath{
+											{
+												Path: "/",
+												Backend: extensions.IngressBackend{
+													ServiceName: "foo-http-svc-canary",
+													ServicePort: intstr.IntOrString{
+														Type:   intstr.Int,
+														IntVal: 80,
+													},
 												},
 											},
 										},
 									},
 								},
 							},
-						},
-						{
-							Host: "example.com",
-							IngressRuleValue: extensions.IngressRuleValue{
-								HTTP: &extensions.HTTPIngressRuleValue{
-									Paths: []extensions.HTTPIngressPath{
-										{
-											Path: "/",
-											Backend: extensions.IngressBackend{
-												ServiceName: "http-svc-canary",
-												ServicePort: intstr.IntOrString{
-													Type:   intstr.Int,
-													IntVal: 80,
+							{
+								Host: "example.com",
+								IngressRuleValue: extensions.IngressRuleValue{
+									HTTP: &extensions.HTTPIngressRuleValue{
+										Paths: []extensions.HTTPIngressPath{
+											{
+												Path: "/",
+												Backend: extensions.IngressBackend{
+													ServiceName: "http-svc-canary",
+													ServicePort: intstr.IntOrString{
+														Type:   intstr.Int,
+														IntVal: 80,
+													},
 												},
 											},
 										},
@@ -209,7 +214,7 @@ func TestMergeAlternativeBackends(t *testing.T) {
 func TestExtractTLSSecretName(t *testing.T) {
 	testCases := map[string]struct {
 		host    string
-		ingress *extensions.Ingress
+		ingress *ingress.Ingress
 		fn      func(string) (*ingress.SSLCert, error)
 		expName string
 	}{
@@ -223,7 +228,7 @@ func TestExtractTLSSecretName(t *testing.T) {
 		},
 		"empty ingress": {
 			"foo.bar",
-			&extensions.Ingress{},
+			&ingress.Ingress{},
 			func(string) (*ingress.SSLCert, error) {
 				return nil, nil
 			},
@@ -231,17 +236,19 @@ func TestExtractTLSSecretName(t *testing.T) {
 		},
 		"ingress tls, nil secret": {
 			"foo.bar",
-			&extensions.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test",
-				},
-				Spec: extensions.IngressSpec{
-					TLS: []extensions.IngressTLS{
-						{SecretName: "demo"},
+			&ingress.Ingress{
+				Ingress: extensions.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test",
 					},
-					Rules: []extensions.IngressRule{
-						{
-							Host: "foo.bar",
+					Spec: extensions.IngressSpec{
+						TLS: []extensions.IngressTLS{
+							{SecretName: "demo"},
+						},
+						Rules: []extensions.IngressRule{
+							{
+								Host: "foo.bar",
+							},
 						},
 					},
 				},
@@ -253,17 +260,19 @@ func TestExtractTLSSecretName(t *testing.T) {
 		},
 		"ingress tls, no host, matching cert cn": {
 			"foo.bar",
-			&extensions.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test",
-				},
-				Spec: extensions.IngressSpec{
-					TLS: []extensions.IngressTLS{
-						{SecretName: "demo"},
+			&ingress.Ingress{
+				Ingress: extensions.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test",
 					},
-					Rules: []extensions.IngressRule{
-						{
-							Host: "foo.bar",
+					Spec: extensions.IngressSpec{
+						TLS: []extensions.IngressTLS{
+							{SecretName: "demo"},
+						},
+						Rules: []extensions.IngressRule{
+							{
+								Host: "foo.bar",
+							},
 						},
 					},
 				},
@@ -277,19 +286,21 @@ func TestExtractTLSSecretName(t *testing.T) {
 		},
 		"ingress tls, no host, wildcard cert with matching cn": {
 			"foo.bar",
-			&extensions.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test",
-				},
-				Spec: extensions.IngressSpec{
-					TLS: []extensions.IngressTLS{
-						{
-							SecretName: "demo",
-						},
+			&ingress.Ingress{
+				Ingress: extensions.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test",
 					},
-					Rules: []extensions.IngressRule{
-						{
-							Host: "test.foo.bar",
+					Spec: extensions.IngressSpec{
+						TLS: []extensions.IngressTLS{
+							{
+								SecretName: "demo",
+							},
+						},
+						Rules: []extensions.IngressRule{
+							{
+								Host: "test.foo.bar",
+							},
 						},
 					},
 				},
@@ -303,20 +314,22 @@ func TestExtractTLSSecretName(t *testing.T) {
 		},
 		"ingress tls, hosts, matching cert cn": {
 			"foo.bar",
-			&extensions.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test",
-				},
-				Spec: extensions.IngressSpec{
-					TLS: []extensions.IngressTLS{
-						{
-							Hosts:      []string{"foo.bar", "example.com"},
-							SecretName: "demo",
-						},
+			&ingress.Ingress{
+				Ingress: extensions.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test",
 					},
-					Rules: []extensions.IngressRule{
-						{
-							Host: "foo.bar",
+					Spec: extensions.IngressSpec{
+						TLS: []extensions.IngressTLS{
+							{
+								Hosts:      []string{"foo.bar", "example.com"},
+								SecretName: "demo",
+							},
+						},
+						Rules: []extensions.IngressRule{
+							{
+								Host: "foo.bar",
+							},
 						},
 					},
 				},

--- a/internal/ingress/controller/store/store_test.go
+++ b/internal/ingress/controller/store/store_test.go
@@ -730,7 +730,8 @@ func newStore(t *testing.T) *k8sStore {
 	return &k8sStore{
 		listers: &Lister{
 			// add more listers if needed
-			Ingress: IngressLister{cache.NewStore(cache.MetaNamespaceKeyFunc)},
+			Ingress:           IngressLister{cache.NewStore(cache.MetaNamespaceKeyFunc)},
+			IngressAnnotation: IngressAnnotationsLister{cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)},
 		},
 		sslStore:         NewSSLCertTracker(),
 		filesystem:       fs,

--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -34,7 +34,6 @@ import (
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
 
-	extensions "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/ingress-nginx/internal/file"
 	"k8s.io/ingress-nginx/internal/ingress"
@@ -796,9 +795,9 @@ type ingressInformation struct {
 }
 
 func getIngressInformation(i, p interface{}) *ingressInformation {
-	ing, ok := i.(*extensions.Ingress)
+	ing, ok := i.(*ingress.Ingress)
 	if !ok {
-		glog.Errorf("expected an '*extensions.Ingress' type but %T was returned", i)
+		glog.Errorf("expected an '*ingress.Ingress' type but %T was returned", i)
 		return &ingressInformation{}
 	}
 

--- a/internal/ingress/status/status.go
+++ b/internal/ingress/status/status.go
@@ -30,7 +30,6 @@ import (
 
 	pool "gopkg.in/go-playground/pool.v3"
 	apiv1 "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -41,6 +40,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/kubernetes/pkg/kubelet/util/sliceutils"
 
+	"k8s.io/ingress-nginx/internal/ingress"
 	"k8s.io/ingress-nginx/internal/k8s"
 	"k8s.io/ingress-nginx/internal/task"
 )
@@ -57,7 +57,7 @@ type Sync interface {
 
 type ingressLister interface {
 	// ListIngresses returns the list of Ingresses
-	ListIngresses() []*extensions.Ingress
+	ListIngresses() []*ingress.Ingress
 }
 
 // Config ...
@@ -371,7 +371,7 @@ func (s *statusSync) updateStatus(newIngressPoint []apiv1.LoadBalancerIngress) {
 	batch.WaitAll()
 }
 
-func runUpdate(ing *extensions.Ingress, status []apiv1.LoadBalancerIngress,
+func runUpdate(ing *ingress.Ingress, status []apiv1.LoadBalancerIngress,
 	client clientset.Interface) pool.WorkFunc {
 	return func(wu pool.WorkUnit) (interface{}, error) {
 		if wu.IsCancelled() {

--- a/internal/ingress/status/status_test.go
+++ b/internal/ingress/status/status_test.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	testclient "k8s.io/client-go/kubernetes/fake"
 
+	"k8s.io/ingress-nginx/internal/ingress"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/class"
 	"k8s.io/ingress-nginx/internal/k8s"
 	"k8s.io/ingress-nginx/internal/task"
@@ -231,25 +232,27 @@ func buildExtensionsIngresses() []extensions.Ingress {
 type testIngressLister struct {
 }
 
-func (til *testIngressLister) ListIngresses() []*extensions.Ingress {
-	var ingresses []*extensions.Ingress
-	ingresses = append(ingresses, &extensions.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "foo_ingress_non_01",
-			Namespace: apiv1.NamespaceDefault,
-		}})
+func (til *testIngressLister) ListIngresses() []*ingress.Ingress {
+	var ingresses []*ingress.Ingress
+	ingresses = append(ingresses, &ingress.Ingress{
+		Ingress: extensions.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo_ingress_non_01",
+				Namespace: apiv1.NamespaceDefault,
+			}}})
 
-	ingresses = append(ingresses, &extensions.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "foo_ingress_1",
-			Namespace: apiv1.NamespaceDefault,
-		},
-		Status: extensions.IngressStatus{
-			LoadBalancer: apiv1.LoadBalancerStatus{
-				Ingress: buildLoadBalancerIngressByIP(),
+	ingresses = append(ingresses, &ingress.Ingress{
+		Ingress: extensions.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo_ingress_1",
+				Namespace: apiv1.NamespaceDefault,
 			},
-		},
-	})
+			Status: extensions.IngressStatus{
+				LoadBalancer: apiv1.LoadBalancerStatus{
+					Ingress: buildLoadBalancerIngressByIP(),
+				},
+			},
+		}})
 
 	return ingresses
 }

--- a/internal/ingress/types.go
+++ b/internal/ingress/types.go
@@ -20,6 +20,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	extensions "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/ingress-nginx/internal/ingress/annotations"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/modsecurity"
 
 	"k8s.io/ingress-nginx/internal/ingress/annotations/auth"
@@ -208,7 +209,7 @@ type Location struct {
 	// uses the default backend.
 	IsDefBackend bool `json:"isDefBackend"`
 	// Ingress returns the ingress from which this location was generated
-	Ingress *extensions.Ingress `json:"ingress"`
+	Ingress *Ingress `json:"ingress"`
 	// Backend describes the name of the backend to use.
 	Backend string `json:"backend"`
 	// Service describes the referenced services from the ingress
@@ -329,4 +330,10 @@ type L4Backend struct {
 type ProxyProtocol struct {
 	Decode bool `json:"decode"`
 	Encode bool `json:"encode"`
+}
+
+// Ingress holds the definition of an Ingress plus its annotations
+type Ingress struct {
+	extensions.Ingress
+	ParsedAnnotations *annotations.Ingress
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR pack `extensions.Ingress` and `annotations.Ingress` into one struct.
The purpose of this is to reduce the possible race condition we have with annotations.

See  https://github.com/kubernetes/ingress-nginx/issues/3411

**Which issue this PR fixes**
fixes https://github.com/kubernetes/ingress-nginx/issues/3411
