### PR TITLE
Ensure that entrypoint arguments remain properly quoted

### DIFF
--- a/images/nginx/rootfs/entrypoint.sh
+++ b/images/nginx/rootfs/entrypoint.sh
@@ -16,4 +16,4 @@
 
 set -e
 
-authbind --deep $@
+authbind --deep "$@"


### PR DESCRIPTION
**What this PR does / why we need it**:

Retaining quoted arguments when running nginx from the entrypoint is
important for things like `nginx -g "pid /tmp/nginx.pid;"` or any
similar quoted argument need.


**Which issue this PR fixes**

None.

**Special notes for your reviewer**:

This issue is trivially reproducible with a simple nginx.conf:

```
events {
    worker_connections 4096;
    multi_accept       on;
    use                epoll;
}

http {
    server {
        listen 8000 default_server;
    }
}
```

```
docker run  -p 8000:8000 -v  `pwd`/nginx.conf:/etc/nginx/nginx.conf quay.io/kubernetes-ingress-controller/nginx:0.69 
nginx: invalid option: "off;"
```

Mounting the updated entrypoint.sh at /entrypoint.sh fixes this issue, but would be good to fix it in the docker image