### PR TITLE
Match buffer

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -661,6 +661,7 @@ http {
 
             # this should be equals to configuration_data dict
             client_max_body_size                    10m;
+            client_body_buffer_size                 10m;
             proxy_buffering                         off;
 
             content_by_lua_block {


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes a warning while the ingress controller sends the configuration to nginx
```
I1120 17:53:21.359006       7 controller.go:190] Backend successfully reloaded.
2018/11/20 17:53:21 [warn] 58#58: *31 a client request body is buffered to a temporary file /tmp/client-body/0000000001, client: ::1, server: , request: "POST /configuration/backends HTTP/1.1", host: "localhost:18080"
```