### PR TITLE
Increase log level when there is an invalid size value

### DIFF
--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -761,7 +761,7 @@ func isValidByteSize(input interface{}) bool {
 	}
 
 	if s == "" {
-		glog.Errorf("empty byte size, hence it will not be set.")
+		glog.V(2).Info("empty byte size, hence it will not be set")
 		return false
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Increases the log level to avoid logs like 
```
E1120 17:59:35.050763       7 template.go:764] empty byte size, hence it will not be set.
E1120 17:59:35.051484       7 template.go:764] empty byte size, hence it will not be set.
E1120 17:59:35.051905       7 template.go:764] empty byte size, hence it will not be set.
```
in the default log level.
This will be partially fixed after https://github.com/kubernetes/ingress-nginx/pull/3437