### PR TITLE
Remove initial log error during reconfiguration

### DIFF
--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -193,6 +193,16 @@ func (n *NGINXController) syncIngress(interface{}) error {
 		n.metricCollector.SetSSLExpireTime(servers)
 	}
 
+	isFirstSync := n.runningConfig.Equal(&ingress.Configuration{})
+	if isFirstSync {
+		// For the initial sync it always takes some time for NGINX to
+		//  start listening on the configured port (default 18080)
+		//  For large configurations it might take a while so we loop
+		//  and back off
+		glog.Info("Initial sync, sleeping for 1 second.")
+		time.Sleep(1 * time.Second)
+	}
+
 	retry := wait.Backoff{
 		Steps:    15,
 		Duration: 1 * time.Second,


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove confusing log during initial reload

```
I1120 17:59:31.940929       7 controller.go:190] Backend successfully reloaded.
W1120 17:59:31.942720       7 controller.go:210] Dynamic reconfiguration failed: Post http://localhost:18080/configuration/backends: dial tcp [::1]:18080: connect: connection refused
E1120 17:59:31.942792       7 controller.go:214] Unexpected failure reconfiguring NGINX:
Post http://localhost:18080/configuration/backends: dial tcp [::1]:18080: connect: connection refused
W1120 17:59:31.942826       7 queue.go:130] requeuing initial-sync, err Post http://localhost:18080/configuration/backends: dial tcp [::1]:18080: connect: connection refused

```
