### PR TITLE
add more testing for mergeAlternativeBackends

### DIFF
--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -1122,6 +1122,28 @@ func (n *NGINXController) createServers(data []*extensions.Ingress,
 	return servers
 }
 
+func canMergeUpstreams(primary *ingress.Backend, alternative *ingress.Backend) bool {
+	if primary.Name != alternative.Name && !primary.NoServer {
+		return true
+	}
+
+	return false
+}
+
+// Performs the merge action and checks to ensure that one two alternative backends do not merge into each other
+func mergeAlternativeBackend(priUps *ingress.Backend, altUps *ingress.Backend) bool {
+	if priUps.NoServer {
+		glog.Warningf("unable to merge alternative backend %v into primary backend %v because %v is a primary backend",
+			altUps.Name, priUps.Name, priUps.Name)
+		return false
+	}
+
+	priUps.AlternativeBackends =
+		append(priUps.AlternativeBackends, altUps.Name)
+
+	return true
+}
+
 // Compares an Ingress of a potential alternative backend's rules with each existing server and finds matching host + path pairs.
 // If a match is found, we know that this server should back the alternative backend and add the alternative backend
 // to a backend's alternative list.
@@ -1133,16 +1155,24 @@ func mergeAlternativeBackends(ing *extensions.Ingress, upstreams map[string]*ing
 	if ing.Spec.Backend != nil {
 		upsName := upstreamName(ing.Namespace, ing.Spec.Backend.ServiceName, ing.Spec.Backend.ServicePort)
 
-		ups := upstreams[upsName]
+		altUps := upstreams[upsName]
 
-		for _, defLoc := range servers[defServerName].Locations {
-			if !upstreams[defLoc.Backend].NoServer {
+		merged := false
+
+		for _, loc := range servers[defServerName].Locations {
+			priUps := upstreams[loc.Backend]
+
+			if canMergeUpstreams(priUps, altUps) {
 				glog.Infof("matching backend %v found for alternative backend %v",
-					upstreams[defLoc.Backend].Name, ups.Name)
+					priUps.Name, altUps.Name)
 
-				upstreams[defLoc.Backend].AlternativeBackends =
-					append(upstreams[defLoc.Backend].AlternativeBackends, ups.Name)
+				merged = mergeAlternativeBackend(priUps, altUps)
 			}
+		}
+
+		if !merged {
+			glog.Warningf("unable to find real backend for alternative backend %v. Deleting.", altUps.Name)
+			delete(upstreams, altUps.Name)
 		}
 	}
 
@@ -1150,32 +1180,34 @@ func mergeAlternativeBackends(ing *extensions.Ingress, upstreams map[string]*ing
 		for _, path := range rule.HTTP.Paths {
 			upsName := upstreamName(ing.Namespace, path.Backend.ServiceName, path.Backend.ServicePort)
 
-			ups := upstreams[upsName]
+			altUps := upstreams[upsName]
 
 			merged := false
 
-			server := servers[rule.Host]
+			server, ok := servers[rule.Host]
+			if !ok {
+				glog.Errorf("cannot merge alternative backend %s into hostname %s that does not exist",
+					altUps.Name,
+					rule.Host)
+
+				continue
+			}
 
 			// find matching paths
-			for _, location := range server.Locations {
-				if location.Backend == defUpstreamName {
-					continue
-				}
+			for _, loc := range server.Locations {
+				priUps := upstreams[loc.Backend]
 
-				if location.Path == path.Path && !upstreams[location.Backend].NoServer {
+				if canMergeUpstreams(priUps, altUps) && loc.Path == path.Path {
 					glog.Infof("matching backend %v found for alternative backend %v",
-						upstreams[location.Backend].Name, ups.Name)
+						priUps.Name, altUps.Name)
 
-					upstreams[location.Backend].AlternativeBackends =
-						append(upstreams[location.Backend].AlternativeBackends, ups.Name)
-
-					merged = true
+					merged = mergeAlternativeBackend(priUps, altUps)
 				}
 			}
 
 			if !merged {
-				glog.Warningf("unable to find real backend for alternative backend %v. Deleting.", ups.Name)
-				delete(upstreams, ups.Name)
+				glog.Warningf("unable to find real backend for alternative backend %v. Deleting.", altUps.Name)
+				delete(upstreams, altUps.Name)
 			}
 		}
 	}

--- a/internal/ingress/controller/controller_test.go
+++ b/internal/ingress/controller/controller_test.go
@@ -20,21 +20,20 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/asn1"
-	"k8s.io/apimachinery/pkg/util/intstr"
-	"testing"
-
 	extensions "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/ingress-nginx/internal/ingress"
+	"testing"
 )
 
 func TestMergeAlternativeBackends(t *testing.T) {
 	testCases := map[string]struct {
-		ingress                   *extensions.Ingress
-		upstreams                 map[string]*ingress.Backend
-		servers                   map[string]*ingress.Server
-		expNumAlternativeBackends int
-		expNumLocations           int
+		ingress      *extensions.Ingress
+		upstreams    map[string]*ingress.Backend
+		servers      map[string]*ingress.Server
+		expUpstreams map[string]*ingress.Backend
+		expServers   map[string]*ingress.Server
 	}{
 		"alternative backend has no server and embeds into matching real backend": {
 			&extensions.Ingress{
@@ -89,10 +88,33 @@ func TestMergeAlternativeBackends(t *testing.T) {
 					},
 				},
 			},
-			1,
-			1,
+			map[string]*ingress.Backend{
+				"example-http-svc-80": {
+					Name:                "example-http-svc-80",
+					NoServer:            false,
+					AlternativeBackends: []string{"example-http-svc-canary-80"},
+				},
+				"example-http-svc-canary-80": {
+					Name:     "example-http-svc-canary-80",
+					NoServer: true,
+					TrafficShapingPolicy: ingress.TrafficShapingPolicy{
+						Weight: 20,
+					},
+				},
+			},
+			map[string]*ingress.Server{
+				"example.com": {
+					Hostname: "example.com",
+					Locations: []*ingress.Location{
+						{
+							Path:    "/",
+							Backend: "example-http-svc-80",
+						},
+					},
+				},
+			},
 		},
-		"merging a alternative backend matches with the correct host": {
+		"alternative backend merges with the correct real backend when multiple are present": {
 			&extensions.Ingress{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "example",
@@ -153,8 +175,9 @@ func TestMergeAlternativeBackends(t *testing.T) {
 					},
 				},
 				"example-http-svc-80": {
-					Name:     "example-http-svc-80",
-					NoServer: false,
+					Name:                "example-http-svc-80",
+					NoServer:            false,
+					AlternativeBackends: []string{"example-http-svc-canary-80"},
 				},
 				"example-http-svc-canary-80": {
 					Name:     "example-http-svc-canary-80",
@@ -184,8 +207,196 @@ func TestMergeAlternativeBackends(t *testing.T) {
 					},
 				},
 			},
-			1,
-			1,
+			map[string]*ingress.Backend{
+				"example-foo-http-svc-80": {
+					Name:                "example-foo-http-svc-80",
+					NoServer:            false,
+					AlternativeBackends: []string{"example-foo-http-svc-canary-80"},
+				},
+				"example-foo-http-svc-canary-80": {
+					Name:     "example-foo-http-svc-canary-80",
+					NoServer: true,
+					TrafficShapingPolicy: ingress.TrafficShapingPolicy{
+						Weight: 20,
+					},
+				},
+				"example-http-svc-80": {
+					Name:                "example-http-svc-80",
+					NoServer:            false,
+					AlternativeBackends: []string{"example-http-svc-canary-80"},
+				},
+				"example-http-svc-canary-80": {
+					Name:     "example-http-svc-canary-80",
+					NoServer: true,
+					TrafficShapingPolicy: ingress.TrafficShapingPolicy{
+						Weight: 20,
+					},
+				},
+			},
+			map[string]*ingress.Server{
+				"example.com": {
+					Hostname: "example.com",
+					Locations: []*ingress.Location{
+						{
+							Path:    "/",
+							Backend: "example-http-svc-80",
+						},
+					},
+				},
+			},
+		},
+		"alternative backend does not merge into itself": {
+			&extensions.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "example",
+				},
+				Spec: extensions.IngressSpec{
+					Rules: []extensions.IngressRule{
+						{
+							Host: "example.com",
+							IngressRuleValue: extensions.IngressRuleValue{
+								HTTP: &extensions.HTTPIngressRuleValue{
+									Paths: []extensions.HTTPIngressPath{
+										{
+											Path: "/",
+											Backend: extensions.IngressBackend{
+												ServiceName: "http-svc-canary",
+												ServicePort: intstr.IntOrString{
+													Type:   intstr.Int,
+													IntVal: 80,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			map[string]*ingress.Backend{
+				"example-http-svc-canary-80": {
+					Name:     "example-http-svc-canary-80",
+					NoServer: true,
+					TrafficShapingPolicy: ingress.TrafficShapingPolicy{
+						Weight: 20,
+					},
+				},
+			},
+			map[string]*ingress.Server{},
+			map[string]*ingress.Backend{},
+			map[string]*ingress.Server{},
+		},
+		"catch-all alternative backend has no server and embeds into matching real backend": {
+			&extensions.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "example",
+				},
+				Spec: extensions.IngressSpec{
+					Backend: &extensions.IngressBackend{
+						ServiceName: "http-svc-canary",
+						ServicePort: intstr.IntOrString{
+							IntVal: 80,
+						},
+					},
+				},
+			},
+			map[string]*ingress.Backend{
+				"example-http-svc-80": {
+					Name:     "example-http-svc-80",
+					NoServer: false,
+				},
+				"example-http-svc-canary-80": {
+					Name:     "example-http-svc-canary-80",
+					NoServer: true,
+					TrafficShapingPolicy: ingress.TrafficShapingPolicy{
+						Weight: 20,
+					},
+				},
+			},
+			map[string]*ingress.Server{
+				"_": {
+					Hostname: "_",
+					Locations: []*ingress.Location{
+						{
+							Path:    "/",
+							Backend: "example-http-svc-80",
+						},
+					},
+				},
+			},
+			map[string]*ingress.Backend{
+				"example-http-svc-80": {
+					Name:                "example-http-svc-80",
+					NoServer:            false,
+					AlternativeBackends: []string{"example-http-svc-canary-80"},
+				},
+				"example-http-svc-canary-80": {
+					Name:     "example-http-svc-canary-80",
+					NoServer: true,
+					TrafficShapingPolicy: ingress.TrafficShapingPolicy{
+						Weight: 20,
+					},
+				},
+			},
+			map[string]*ingress.Server{
+				"_": {
+					Hostname: "_",
+					Locations: []*ingress.Location{
+						{
+							Path:    "/",
+							Backend: "example-http-svc-80",
+						},
+					},
+				},
+			},
+		},
+		"catch-all alternative backend does not merge into itself": {
+			&extensions.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "example",
+				},
+				Spec: extensions.IngressSpec{
+					Backend: &extensions.IngressBackend{
+						ServiceName: "http-svc-canary",
+						ServicePort: intstr.IntOrString{
+							IntVal: 80,
+						},
+					},
+				},
+			},
+			map[string]*ingress.Backend{
+				"example-http-svc-canary-80": {
+					Name:     "example-http-svc-canary-80",
+					NoServer: true,
+					TrafficShapingPolicy: ingress.TrafficShapingPolicy{
+						Weight: 20,
+					},
+				},
+			},
+			map[string]*ingress.Server{
+				"_": {
+					Hostname: "_",
+					Locations: []*ingress.Location{
+						{
+							Path:    "/",
+							Backend: "example-http-svc-canary-80",
+						},
+					},
+				},
+			},
+			map[string]*ingress.Backend{},
+			map[string]*ingress.Server{
+				"_": {
+					Hostname: "_",
+					Locations: []*ingress.Location{
+						{
+							Path:    "/",
+							Backend: "example-http-svc-canary-80",
+						},
+					},
+				},
+			},
 		},
 	}
 
@@ -193,14 +404,28 @@ func TestMergeAlternativeBackends(t *testing.T) {
 		t.Run(title, func(t *testing.T) {
 			mergeAlternativeBackends(tc.ingress, tc.upstreams, tc.servers)
 
-			numAlternativeBackends := len(tc.upstreams["example-http-svc-80"].AlternativeBackends)
-			if numAlternativeBackends != tc.expNumAlternativeBackends {
-				t.Errorf("expected %d alternative backends (got %d)", tc.expNumAlternativeBackends, numAlternativeBackends)
+			for upsName, expUpstream := range tc.expUpstreams {
+				actualUpstream, ok := tc.upstreams[upsName]
+				if !ok {
+					t.Errorf("expected upstream %s to exist but it did not", upsName)
+				}
+
+				if !actualUpstream.Equal(expUpstream) {
+					t.Logf("actual upstream %s alternative backends: %s", actualUpstream.Name, actualUpstream.AlternativeBackends)
+					t.Logf("expected upstream %s alternative backends: %s", expUpstream.Name, expUpstream.AlternativeBackends)
+					t.Errorf("upstream %s was not equal to what was expected: ", upsName)
+				}
 			}
 
-			numLocations := len(tc.servers["example.com"].Locations)
-			if numLocations != tc.expNumLocations {
-				t.Errorf("expected %d locations (got %d)", tc.expNumLocations, numLocations)
+			for serverName, expServer := range tc.expServers {
+				actualServer, ok := tc.servers[serverName]
+				if !ok {
+					t.Errorf("expected server %s to exist but it did not", serverName)
+				}
+
+				if !actualServer.Equal(expServer) {
+					t.Errorf("server %s was not equal to what was expected", serverName)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

This adds more tests for the merge function when creating alternative backends. It also covers the scenarios where an alternative ingress merges with itself, which was fixed in https://github.com/kubernetes/ingress-nginx/pull/3417

I also fixed a few edge cases I found while adding the new tests. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
