### PR TITLE
Document `$req_id` usage in upstream log format

### DIFF
--- a/docs/user-guide/nginx-configuration/log-format.md
+++ b/docs/user-guide/nginx-configuration/log-format.md
@@ -45,4 +45,5 @@ Additional available variables:
 Sources:
 
 - [Upstream variables](http://nginx.org/en/docs/http/ngx_http_upstream_module.html#variables)
-- [Embedded variables](http://nginx.org/en/docs/http/ngx_http_core_module.html#variables)
+- [Embedded variables](http://nginx.org/en/docs/http/ngx_http_core_module.html#variables
+)


### PR DESCRIPTION
By default, the upstream log format contains the `$req_id` parameter. This was added in changeset 51cf184c51, but overlooked in the documentation.

**What this PR does / why we need it**:

Simple documentation update. I found it because Fluent Bit was failing to parse nginx-ingress logs -- [I found an nginx-ingress regex](https://github.com/kubernetes/ingress-nginx/issues/1664) which matched the docs here and the default value of [`log-format-upstream`](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#log-format-upstream), but did not match against the actual logs.

This is the regex from the issue comments linked above:
```
(?<remote_addr>[^ ]*) - \[(?<proxy_protocol_addr>[^ ]*)\] - (?<remote_user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<request>[^\"]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*) "(?<referer>[^\"]*)" "(?<agent>[^\"]*)" (?<request_length>[^ ]*) (?<request_time>[^ ]*) \[(?<proxy_upstream_name>[^ ]*)\] (?<upstream_addr>[^ ]*) (?<upstream_response_length>[^ ]*) (?<upstream_response_time>[^ ]*) (?<upstream_status>[^ ]*)
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

Adds doc for changeset 51cf184c51

**Special notes for your reviewer**:

First time contributor here -- sorry in advance for the extra overhead :)


On a separate note, it would have been handy for me if there were a valid regex matcher documented here -- is that something you would like added?