### PR TITLE
Watch controller Pods and make then available in k8sStore

### DIFF
--- a/internal/ingress/controller/nginx.go
+++ b/internal/ingress/controller/nginx.go
@@ -56,6 +56,7 @@ import (
 	ngx_template "k8s.io/ingress-nginx/internal/ingress/controller/template"
 	"k8s.io/ingress-nginx/internal/ingress/metric"
 	"k8s.io/ingress-nginx/internal/ingress/status"
+	"k8s.io/ingress-nginx/internal/k8s"
 	ing_net "k8s.io/ingress-nginx/internal/net"
 	"k8s.io/ingress-nginx/internal/net/dns"
 	"k8s.io/ingress-nginx/internal/net/ssl"
@@ -110,6 +111,11 @@ func NewNGINXController(config *Configuration, mc metric.Collector, fs file.File
 		metricCollector: mc,
 	}
 
+	pod, err := k8s.GetPodDetails(config.Client)
+	if err != nil {
+		glog.Fatalf("unexpected error obtaining pod information: %v", err)
+	}
+
 	n.store = store.New(
 		config.EnableSSLChainCompletion,
 		config.Namespace,
@@ -121,7 +127,8 @@ func NewNGINXController(config *Configuration, mc metric.Collector, fs file.File
 		config.Client,
 		fs,
 		n.updateCh,
-		config.DynamicCertificatesEnabled)
+		config.DynamicCertificatesEnabled,
+		pod)
 
 	n.syncQueue = task.NewTaskQueue(n.syncIngress)
 

--- a/internal/ingress/controller/store/pod.go
+++ b/internal/ingress/controller/store/pod.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package store
+
+import (
+	"k8s.io/client-go/tools/cache"
+)
+
+// PodLister makes a Store that lists Pods.
+type PodLister struct {
+	cache.Store
+}

--- a/internal/ingress/controller/store/store_test.go
+++ b/internal/ingress/controller/store/store_test.go
@@ -18,6 +18,7 @@ package store
 
 import (
 	"fmt"
+	"os"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -38,10 +39,19 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/ingress-nginx/internal/file"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
+	"k8s.io/ingress-nginx/internal/k8s"
 	"k8s.io/ingress-nginx/test/e2e/framework"
 )
 
 func TestStore(t *testing.T) {
+	pod := &k8s.PodInfo{
+		Name:      "testpod",
+		Namespace: v1.NamespaceDefault,
+		Labels: map[string]string{
+			"pod-template-hash": "1234",
+		},
+	}
+
 	clientSet := fake.NewSimpleClientset()
 
 	t.Run("should return an error searching for non existing objects", func(t *testing.T) {
@@ -70,7 +80,8 @@ func TestStore(t *testing.T) {
 			clientSet,
 			fs,
 			updateCh,
-			false)
+			false,
+			pod)
 
 		storer.Run(stopCh)
 
@@ -158,7 +169,8 @@ func TestStore(t *testing.T) {
 			clientSet,
 			fs,
 			updateCh,
-			false)
+			false,
+			pod)
 
 		storer.Run(stopCh)
 
@@ -306,7 +318,8 @@ func TestStore(t *testing.T) {
 			clientSet,
 			fs,
 			updateCh,
-			false)
+			false,
+			pod)
 
 		storer.Run(stopCh)
 
@@ -395,7 +408,8 @@ func TestStore(t *testing.T) {
 			clientSet,
 			fs,
 			updateCh,
-			false)
+			false,
+			pod)
 
 		storer.Run(stopCh)
 
@@ -507,7 +521,8 @@ func TestStore(t *testing.T) {
 			clientSet,
 			fs,
 			updateCh,
-			false)
+			false,
+			pod)
 
 		storer.Run(stopCh)
 
@@ -727,17 +742,27 @@ func newStore(t *testing.T) *k8sStore {
 		t.Fatalf("error: %v", err)
 	}
 
+	pod := &k8s.PodInfo{
+		Name:      "ingress-1",
+		Namespace: v1.NamespaceDefault,
+		Labels: map[string]string{
+			"pod-template-hash": "1234",
+		},
+	}
+
 	return &k8sStore{
 		listers: &Lister{
 			// add more listers if needed
 			Ingress:           IngressLister{cache.NewStore(cache.MetaNamespaceKeyFunc)},
 			IngressAnnotation: IngressAnnotationsLister{cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)},
+			Pod:               PodLister{cache.NewStore(cache.MetaNamespaceKeyFunc)},
 		},
 		sslStore:         NewSSLCertTracker(),
 		filesystem:       fs,
 		updateCh:         channels.NewRingChannel(10),
 		mu:               new(sync.Mutex),
 		secretIngressMap: NewObjectRefMap(),
+		pod:              pod,
 	}
 }
 
@@ -941,5 +966,66 @@ func TestWriteSSLSessionTicketKey(t *testing.T) {
 		if test != encodedContent {
 			t.Fatalf("expected %v but returned %s", test, encodedContent)
 		}
+	}
+}
+
+func TestListControllerPods(t *testing.T) {
+	os.Setenv("POD_NAMESPACE", "testns")
+	os.Setenv("POD_NAME", "ingress-1")
+
+	s := newStore(t)
+	s.pod = &k8s.PodInfo{
+		Name:      "ingress-1",
+		Namespace: "testns",
+		Labels: map[string]string{
+			"pod-template-hash": "1234",
+		},
+	}
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ingress-1",
+			Namespace: "testns",
+			Labels: map[string]string{
+				"pod-template-hash": "1234",
+			},
+		},
+		Status: v1.PodStatus{
+			Phase: v1.PodRunning,
+		},
+	}
+	s.listers.Pod.Add(pod)
+
+	pod = &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ingress-2",
+			Namespace: "testns",
+			Labels: map[string]string{
+				"pod-template-hash": "1234",
+			},
+		},
+		Status: v1.PodStatus{
+			Phase: v1.PodRunning,
+		},
+	}
+	s.listers.Pod.Add(pod)
+
+	pod = &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ingress-3",
+			Namespace: "testns",
+			Labels: map[string]string{
+				"pod-template-hash": "1234",
+			},
+		},
+		Status: v1.PodStatus{
+			Phase: v1.PodFailed,
+		},
+	}
+	s.listers.Pod.Add(pod)
+
+	pods := s.ListControllerPods()
+	if s := len(pods); s != 2 {
+		t.Errorf("Expected 1 controller Pods but got %v", s)
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This add controller pod tracking for ingress-nginx. The list is available from the store `ListControllerPods()` function.

The purpose behind this is to track the number of running replicas.

A PR will follow to push this into a lua shared dict.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

