### PR TITLE
[3461] adding the edge case handling for when weight is 0

### DIFF
--- a/rootfs/etc/nginx/lua/balancer.lua
+++ b/rootfs/etc/nginx/lua/balancer.lua
@@ -173,6 +173,10 @@ local function route_to_alternative_balancer(balancer)
     end
   end
 
+  if traffic_shaping_policy.weight == 0 then
+    return false
+  end
+
   if math.random(100) <= traffic_shaping_policy.weight then
     return true
   end


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding edge case handling for canary. When weight is 0 we don't want ANY traffic to be sent to canary. So we do special handling because setting the comparison operator to < will not work for the other special case when weight is 100.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #3461

**Special notes for your reviewer**:
