### PR TITLE
[3485] ingress aliases metrics are not accounted for. This should fix…

### DIFF
--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -133,6 +133,7 @@ func (n *NGINXController) syncIngress(interface{}) error {
 	for _, server := range servers {
 		if !hosts.Has(server.Hostname) {
 			hosts.Insert(server.Hostname)
+			hosts.Insert(server.Alias)
 		}
 
 		if !server.SSLPassthrough {

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -133,7 +133,9 @@ func (n *NGINXController) syncIngress(interface{}) error {
 	for _, server := range servers {
 		if !hosts.Has(server.Hostname) {
 			hosts.Insert(server.Hostname)
-			hosts.Insert(server.Alias)
+                        if server.Alias != "" {
+				hosts.Insert(server.Alias)
+			}
 		}
 
 		if !server.SSLPassthrough {

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -133,7 +133,7 @@ func (n *NGINXController) syncIngress(interface{}) error {
 	for _, server := range servers {
 		if !hosts.Has(server.Hostname) {
 			hosts.Insert(server.Hostname)
-                        if server.Alias != "" {
+			if server.Alias != "" {
 				hosts.Insert(server.Alias)
 			}
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR should account for ingress aliases in the metrics

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #3485

**Special notes for your reviewer**:
