### PR TITLE
be consistent with what Nginx supports

### DIFF
--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -727,11 +727,15 @@ func buildNextUpstream(i, r interface{}) string {
 	return strings.Join(nextUpstreamCodes, " ")
 }
 
-var sizeUnitRegex = regexp.MustCompile("^[0-9]+[kKmMgG]{0,1}$")
+// refer to http://nginx.org/en/docs/syntax.html
+// Nginx differentiates between size and offset
+// offset directives support gigabytes in addition
+var nginxSizeRegex = regexp.MustCompile("^[0-9]+[kKmM]{0,1}$")
+var nginxOffsetRegex = regexp.MustCompile("^[0-9]+[kKmMgG]{0,1}$")
 
 // isValidByteSize validates size units valid in nginx
 // http://nginx.org/en/docs/syntax.html
-func isValidByteSize(input interface{}) bool {
+func isValidByteSize(input interface{}, isOffset bool) bool {
 	s, ok := input.(string)
 	if !ok {
 		glog.Errorf("expected an 'string' type but %T was returned", input)
@@ -744,7 +748,11 @@ func isValidByteSize(input interface{}) bool {
 		return false
 	}
 
-	return sizeUnitRegex.MatchString(s)
+	if isOffset {
+		return nginxOffsetRegex.MatchString(s)
+	}
+
+	return nginxSizeRegex.MatchString(s)
 }
 
 type ingressInformation struct {

--- a/internal/ingress/controller/template/template_test.go
+++ b/internal/ingress/controller/template/template_test.go
@@ -559,24 +559,28 @@ func TestBuildDenyVariable(t *testing.T) {
 
 func TestBuildByteSize(t *testing.T) {
 	cases := []struct {
-		input    interface{}
+		value    interface{}
+		isOffset bool
 		expected bool
 	}{
-		{"1000", true},
-		{"1000k", true},
-		{"1m", true},
-		{"10g", true},
-		{" 1m ", true},
-		{"1000kk", false},
-		{"1000km", false},
-		{"1mm", false},
-		{nil, false},
-		{"", false},
-		{"    ", false},
+		{"1000", false, true},
+		{"1000k", false, true},
+		{"1m", false, true},
+		{"10g", false, false},
+		{" 1m ", false, true},
+		{"1000kk", false, false},
+		{"1000km", false, false},
+		{"1mm", false, false},
+		{nil, false, false},
+		{"", false, false},
+		{"    ", false, false},
+		{"1G", true, true},
+		{"1000kk", true, false},
+		{"", true, false},
 	}
 
 	for _, tc := range cases {
-		val := isValidByteSize(tc.input)
+		val := isValidByteSize(tc.value, tc.isOffset)
 		if tc.expected != val {
 			t.Errorf("Expected '%v' but returned '%v'", tc.expected, val)
 		}

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -980,10 +980,10 @@ stream {
             proxy_http_version          1.1;
             proxy_ssl_server_name       on;
             proxy_pass_request_headers  on;
-            {{ if isValidByteSize $location.Proxy.BodySize }}
+            {{ if isValidByteSize $location.Proxy.BodySize true }}
             client_max_body_size        {{ $location.Proxy.BodySize }};
             {{ end }}
-            {{ if isValidByteSize $location.ClientBodyBufferSize }}
+            {{ if isValidByteSize $location.ClientBodyBufferSize false }}
             client_body_buffer_size     {{ $location.ClientBodyBufferSize }};
             {{ end }}
 
@@ -1197,10 +1197,10 @@ stream {
             }
             {{ end }}
 
-            {{ if isValidByteSize $location.Proxy.BodySize }}
+            {{ if isValidByteSize $location.Proxy.BodySize true }}
             client_max_body_size                    {{ $location.Proxy.BodySize }};
             {{ end }}
-            {{ if isValidByteSize $location.ClientBodyBufferSize }}
+            {{ if isValidByteSize $location.ClientBodyBufferSize false }}
             client_body_buffer_size                 {{ $location.ClientBodyBufferSize }};
             {{ end }}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
In https://github.com/kubernetes/ingress-nginx/pull/3409/files we started to apply `client_body_buffer_size` validator to `client_max_body_size` directive's value as well. However it turns out `client_max_body_size` also supports gigabytes using `g` or `G`. This introduced and issue https://github.com/kubernetes/ingress-nginx/issues/3468 in 0.21.0. In https://github.com/kubernetes/ingress-nginx/pull/3492 @aledbf changed the validator to support gigabytes as well, but then it introduces another issue by supporting gigabytes for `client_body_buffer_size`.

This PR now adds a flag to apply a correct validator for `client_body_buffer_size` and `client_max_body_size` instead of applying the same one.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
