### PR TITLE
Update lua configuration_data when number of controller pod change

### DIFF
--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -163,6 +163,7 @@ func (n *NGINXController) syncIngress(interface{}) error {
 		UDPEndpoints:          n.getStreamServices(n.cfg.UDPConfigMapName, apiv1.ProtocolUDP),
 		PassthroughBackends:   passUpstreams,
 		BackendConfigChecksum: n.store.GetBackendConfiguration().Checksum,
+		ControllerPodsCount:   n.store.GetRunningControllerPodsCount(),
 	}
 
 	if n.runningConfig.Equal(pcfg) {

--- a/internal/ingress/controller/nginx.go
+++ b/internal/ingress/controller/nginx.go
@@ -752,6 +752,8 @@ func (n *NGINXController) IsDynamicConfigurationEnough(pcfg *ingress.Configurati
 
 	copyOfRunningConfig.Backends = []*ingress.Backend{}
 	copyOfPcfg.Backends = []*ingress.Backend{}
+	copyOfRunningConfig.ControllerPodsCount = 0
+	copyOfPcfg.ControllerPodsCount = 0
 
 	if n.cfg.DynamicCertificatesEnabled {
 		clearCertificates(&copyOfRunningConfig)
@@ -821,6 +823,14 @@ func configureDynamically(pcfg *ingress.Configuration, port int, isDynamicCertif
 	}
 
 	err = updateStreamConfiguration(streams)
+	if err != nil {
+		return err
+	}
+
+	url = fmt.Sprintf("http://localhost:%d/configuration/general", port)
+	err = post(url, &ingress.GeneralConfig{
+		ControllerPodsCount: pcfg.ControllerPodsCount,
+	})
 	if err != nil {
 		return err
 	}

--- a/internal/ingress/controller/store/store.go
+++ b/internal/ingress/controller/store/store.go
@@ -76,8 +76,8 @@ type Storer interface {
 	// ListIngresses returns a list of all Ingresses in the store.
 	ListIngresses() []*ingress.Ingress
 
-	// ListControllerPods returns a list of ingress-nginx controller Pods.
-	ListControllerPods() []*corev1.Pod
+	// GetRunningControllerPodsCount returns the number of Running ingress-nginx controller Pods.
+	GetRunningControllerPodsCount() int
 
 	// GetLocalSSLCert returns the local copy of a SSLCert
 	GetLocalSSLCert(name string) (*ingress.SSLCert, error)
@@ -288,12 +288,10 @@ func New(checkOCSP bool,
 	store.informers.Pod = cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (k8sruntime.Object, error) {
-
 				options.LabelSelector = labelSelector.String()
 				return client.CoreV1().Pods(store.pod.Namespace).List(options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-
 				options.LabelSelector = labelSelector.String()
 				return client.CoreV1().Pods(store.pod.Namespace).Watch(options)
 			},
@@ -832,9 +830,9 @@ func (s *k8sStore) Run(stopCh chan struct{}) {
 	}
 }
 
-// ListControllerPods returns a list of ingress-nginx controller Pods
-func (s *k8sStore) ListControllerPods() []*corev1.Pod {
-	var pods []*corev1.Pod
+// GetRunningControllerPodsCount returns the number of Running ingress-nginx controller Pods
+func (s k8sStore) GetRunningControllerPodsCount() int {
+	count := 0
 
 	for _, i := range s.listers.Pod.List() {
 		pod := i.(*corev1.Pod)
@@ -843,8 +841,8 @@ func (s *k8sStore) ListControllerPods() []*corev1.Pod {
 			continue
 		}
 
-		pods = append(pods, pod)
+		count++
 	}
 
-	return pods
+	return count
 }

--- a/internal/ingress/controller/store/store_test.go
+++ b/internal/ingress/controller/store/store_test.go
@@ -1062,7 +1062,7 @@ func TestWriteSSLSessionTicketKey(t *testing.T) {
 	}
 }
 
-func TestListControllerPods(t *testing.T) {
+func TestGetRunningControllerPodsCount(t *testing.T) {
 	os.Setenv("POD_NAMESPACE", "testns")
 	os.Setenv("POD_NAME", "ingress-1")
 
@@ -1117,8 +1117,8 @@ func TestListControllerPods(t *testing.T) {
 	}
 	s.listers.Pod.Add(pod)
 
-	pods := s.ListControllerPods()
-	if s := len(pods); s != 2 {
+	podsCount := s.GetRunningControllerPodsCount()
+	if podsCount != 2 {
 		t.Errorf("Expected 1 controller Pods but got %v", s)
 	}
 }

--- a/internal/ingress/types.go
+++ b/internal/ingress/types.go
@@ -71,6 +71,9 @@ type Configuration struct {
 
 	// ConfigurationChecksum contains the particular checksum of a Configuration object
 	ConfigurationChecksum string `json:"configurationChecksum,omitempty"`
+
+	// ControllerPodsCount contains the list of running ingress controller Pod(s)
+	ControllerPodsCount int `json:"controllerPodsCount,omitempty"`
 }
 
 // Backend describes one or more remote server/s (endpoints) associated with a service
@@ -337,4 +340,9 @@ type ProxyProtocol struct {
 type Ingress struct {
 	extensions.Ingress
 	ParsedAnnotations *annotations.Ingress
+}
+
+// GeneralConfig holds the definition of lua general configuration data
+type GeneralConfig struct {
+	ControllerPodsCount int `json:"controllerPodsCount"`
 }

--- a/internal/ingress/types_equals.go
+++ b/internal/ingress/types_equals.go
@@ -105,6 +105,10 @@ func (c1 *Configuration) Equal(c2 *Configuration) bool {
 		return false
 	}
 
+	if c1.ControllerPodsCount != c2.ControllerPodsCount {
+		return false
+	}
+
 	return true
 }
 

--- a/test/e2e/framework/exec.go
+++ b/test/e2e/framework/exec.go
@@ -28,6 +28,16 @@ import (
 	"k8s.io/api/core/v1"
 )
 
+// ExecIngressPod executes a command inside the first container in ingress controller running pod
+func (f *Framework) ExecIngressPod(command string) (string, error) {
+	pod, err := getIngressNGINXPod(f.IngressController.Namespace, f.KubeClientSet)
+	if err != nil {
+		return "", err
+	}
+
+	return f.ExecCommand(pod, command)
+}
+
 // ExecCommand executes a command inside a the first container in a running pod
 func (f *Framework) ExecCommand(pod *v1.Pod, command string) (string, error) {
 	var (


### PR DESCRIPTION
**What this PR does / why we need it**:
Next to https://github.com/kubernetes/ingress-nginx/pull/3455
This introduces controller pods tracking inside the nginx configuration templating and lua configuration.

A change in the number of will be `POST` to lua configuration backend, inside a new `general` category.

The new configuration endpoint is `/configuration/general`, data can be `POST` or `GET`.

Example:
```
www-data@nginx-ingress-controller-545d76889-xgq6q:/etc/nginx$ curl 127.0.0.1:18080/configuration/general; echo
{"controllerPodsCount":3}
```

**Which issue this PR fixes**

**Special notes for your reviewer**:
