### PR TITLE
[1759] Ingress affinity session cookie with Secure flag for HTTPS

### DIFF
--- a/rootfs/etc/nginx/lua/balancer/sticky.lua
+++ b/rootfs/etc/nginx/lua/balancer/sticky.lua
@@ -54,6 +54,7 @@ local function set_cookie(self, value)
     path = cookie_path,
     domain = ngx.var.host,
     httponly = true,
+    secure = ngx.var.https == "on",
   }
 
   if self.cookie_expires and self.cookie_expires ~= "" then

--- a/rootfs/etc/nginx/lua/test/balancer/sticky_test.lua
+++ b/rootfs/etc/nginx/lua/test/balancer/sticky_test.lua
@@ -40,7 +40,7 @@ end
 
 describe("Sticky", function()
   before_each(function()
-    mock_ngx({ var = { location_path = "/", host = "test.com", https = "on" } })
+    mock_ngx({ var = { location_path = "/", host = "test.com" } })
   end)
 
   after_each(function()
@@ -121,7 +121,7 @@ describe("Sticky", function()
               assert.equal(payload.path, ngx.var.location_path)
               assert.equal(payload.domain, ngx.var.host)
               assert.equal(payload.httponly, true)
-              assert.equal(payload.secure, true)
+              assert.equal(payload.secure, false)
               return true, nil
             end,
             get = function(k) return false end,

--- a/rootfs/etc/nginx/lua/test/balancer/sticky_test.lua
+++ b/rootfs/etc/nginx/lua/test/balancer/sticky_test.lua
@@ -136,6 +136,35 @@ describe("Sticky", function()
         assert.has_no.errors(function() sticky_balancer_instance:balance() end)
         assert.spy(s).was_called()
       end)
+
+      it("sets a secure cookie on the client when being in ssl mode", function()
+        ngx.var.https = "on"
+        local s = {}
+        cookie.new = function(self)
+          local test_backend_hash_fn = test_backend.sessionAffinityConfig.cookieSessionAffinity.hash
+          local cookie_instance = {
+            set = function(self, payload)
+              assert.equal(payload.key, test_backend.sessionAffinityConfig.cookieSessionAffinity.name)
+              local expected_len = #util[test_backend_hash_fn .. "_digest"]("anything")
+              assert.equal(#payload.value, expected_len)
+              assert.equal(payload.path, ngx.var.location_path)
+              assert.equal(payload.domain, ngx.var.host)
+              assert.equal(payload.httponly, true)
+              assert.equal(payload.secure, true)
+              return true, nil
+            end,
+            get = function(k) return false end,
+          }
+          s = spy.on(cookie_instance, "set")
+          return cookie_instance, false
+        end
+        local b = get_test_backend()
+        b.sessionAffinityConfig.cookieSessionAffinity.locations = {}
+        b.sessionAffinityConfig.cookieSessionAffinity.locations["test.com"] = {"/"}
+        local sticky_balancer_instance = sticky:new(b)
+        assert.has_no.errors(function() sticky_balancer_instance:balance() end)
+        assert.spy(s).was_called()
+      end)
     end)
 
     context("when client doesn't have a cookie set and location not in cookie_locations", function()

--- a/rootfs/etc/nginx/lua/test/balancer/sticky_test.lua
+++ b/rootfs/etc/nginx/lua/test/balancer/sticky_test.lua
@@ -40,7 +40,7 @@ end
 
 describe("Sticky", function()
   before_each(function()
-    mock_ngx({ var = { location_path = "/", host = "test.com" } })
+    mock_ngx({ var = { location_path = "/", host = "test.com", https = "on" } })
   end)
 
   after_each(function()
@@ -102,7 +102,6 @@ describe("Sticky", function()
       cookie.new = mocked_cookie_new
     end)
 
-
     context("when client doesn't have a cookie set and location is in cookie_locations", function()
       it("picks an endpoint for the client", function()
         local sticky_balancer_instance = sticky:new(test_backend)
@@ -122,6 +121,7 @@ describe("Sticky", function()
               assert.equal(payload.path, ngx.var.location_path)
               assert.equal(payload.domain, ngx.var.host)
               assert.equal(payload.httponly, true)
+              assert.equal(payload.secure, true)
               return true, nil
             end,
             get = function(k) return false end,


### PR DESCRIPTION
Signed-off-by: Fabian Topfstedt <topfstedt@schneevonmorgen.com>

**What this PR does / why we need it**:
Ingress affinity session cookies did not set the `Secure` flag when the Ingress is called through HTTPS. The affinity cookie is therefore ignored by the client and every recurring request to the ingress will result in a new `Set-Cookie` header being send, preventing stickyness to work.
Since ingresses may be called both through both HTTP and HTTPS, setting the `Secure` flag depends on the context.

My proposal to solve it:

- nginx has a variable $https set to "on" in SSL mode 
(See http://nginx.org/en/docs/http/ngx_http_core_module.html#var_https).
- lua_resty_cookie has a boolean attribute `secure` 
(See https://github.com/cloudflare/lua-resty-cookie/blob/master/lib/resty/cookie.lua#L156)
- ingress-nginx has a `cookie_data` map that has no set a `secure` attribute yet. Adding the key `secure = ngx.var.https == "on"` should be sufficiant to set the `Secure` when (and only when) being in SSL mode. 
(See https://github.com/kubernetes/ingress-nginx/blob/master/rootfs/etc/nginx/lua/balancer/sticky.lua#L56)

**Which issue this PR fixes**: fixes #1759 

**Special notes for your reviewer**:
I managed to run and edit the Lua testsuite to unit test my assumptions. Being my first PR, I need someone experienced to review the integration though.