### PR TITLE
Allow to disable NGINX metrics

### DIFF
--- a/cmd/nginx/flags.go
+++ b/cmd/nginx/flags.go
@@ -147,6 +147,9 @@ Requires the update-status parameter.`)
 			`Dynamically update SSL certificates instead of reloading NGINX.
 Feature backed by OpenResty Lua libraries. Requires that OCSP stapling is not enabled`)
 
+		enableMetrics = flags.Bool("enable-metrics", true,
+			`Enables the collection of NGINX metrics`)
+
 		httpPort      = flags.Int("http-port", 80, `Port to use for servicing HTTP traffic.`)
 		httpsPort     = flags.Int("https-port", 443, `Port to use for servicing HTTPS traffic.`)
 		statusPort    = flags.Int("status-port", 18080, `Port to use for exposing NGINX status pages.`)
@@ -223,6 +226,7 @@ Feature backed by OpenResty Lua libraries. Requires that OCSP stapling is not en
 		UpdateStatus:               *updateStatus,
 		ElectionID:                 *electionID,
 		EnableProfiling:            *profiling,
+		EnableMetrics:              *enableMetrics,
 		EnableSSLPassthrough:       *enableSSLPassthrough,
 		EnableSSLChainCompletion:   *enableSSLChainCompletion,
 		ResyncPeriod:               *resyncPeriod,

--- a/cmd/nginx/main.go
+++ b/cmd/nginx/main.go
@@ -128,9 +128,12 @@ func main() {
 		ReportErrors: true,
 	}))
 
-	mc, err := metric.NewCollector(conf.ListenPorts.Status, reg)
-	if err != nil {
-		glog.Fatalf("Error creating prometheus collector:  %v", err)
+	mc := metric.NewDummyCollector()
+	if conf.EnableMetrics {
+		mc, err = metric.NewCollector(conf.ListenPorts.Status, reg)
+		if err != nil {
+			glog.Fatalf("Error creating prometheus collector:  %v", err)
+		}
 	}
 	mc.Start()
 

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -715,6 +715,7 @@ type TemplateConfig struct {
 	ListenPorts                *ListenPorts
 	PublishService             *apiv1.Service
 	DynamicCertificatesEnabled bool
+	EnableMetrics              bool
 }
 
 // ListenPorts describe the ports required to run the

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -87,6 +87,8 @@ type Configuration struct {
 
 	EnableProfiling bool
 
+	EnableMetrics bool
+
 	EnableSSLChainCompletion bool
 
 	FakeCertificatePath string

--- a/internal/ingress/controller/nginx.go
+++ b/internal/ingress/controller/nginx.go
@@ -602,6 +602,7 @@ func (n *NGINXController) OnUpdate(ingressCfg ingress.Configuration) error {
 		ListenPorts:                n.cfg.ListenPorts,
 		PublishService:             n.GetPublishService(),
 		DynamicCertificatesEnabled: n.cfg.DynamicCertificatesEnabled,
+		EnableMetrics:              n.cfg.EnableMetrics,
 	}
 
 	tc.Cfg.Checksum = ingressCfg.ConfigurationChecksum

--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -914,13 +914,15 @@ func proxySetHeader(loc interface{}) string {
 
 // buildCustomErrorDeps is a utility function returning a struct wrapper with
 // the data required to build the 'CUSTOM_ERRORS' template
-func buildCustomErrorDeps(proxySetHeaders map[string]string, errorCodes []int) interface{} {
+func buildCustomErrorDeps(proxySetHeaders map[string]string, errorCodes []int, enableMetrics bool) interface{} {
 	return struct {
 		ProxySetHeaders map[string]string
 		ErrorCodes      []int
+		EnableMetrics   bool
 	}{
 		ProxySetHeaders: proxySetHeaders,
 		ErrorCodes:      errorCodes,
+		EnableMetrics:   enableMetrics,
 	}
 }
 

--- a/internal/ingress/controller/template/template_test.go
+++ b/internal/ingress/controller/template/template_test.go
@@ -826,7 +826,7 @@ func TestEscapeLiteralDollar(t *testing.T) {
 	}
 }
 
-func Test_opentracingPropagateContext(t *testing.T) {
+func TestOpentracingPropagateContext(t *testing.T) {
 	tests := map[interface{}]string{
 		&ingress.Location{BackendProtocol: "HTTP"}:  "opentracing_propagate_context",
 		&ingress.Location{BackendProtocol: "HTTPS"}: "opentracing_propagate_context",

--- a/internal/ingress/metric/dummy.go
+++ b/internal/ingress/metric/dummy.go
@@ -16,7 +16,15 @@ limitations under the License.
 
 package metric
 
-import "k8s.io/ingress-nginx/internal/ingress"
+import (
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/ingress-nginx/internal/ingress"
+)
+
+// NewDummyCollector returns a dummy metric collector
+func NewDummyCollector() Collector {
+	return &DummyCollector{}
+}
 
 // DummyCollector dummy implementation for mocks in tests
 type DummyCollector struct{}
@@ -41,3 +49,6 @@ func (dc DummyCollector) Stop() {}
 
 // SetSSLExpireTime ...
 func (dc DummyCollector) SetSSLExpireTime([]*ingress.Server) {}
+
+// SetHosts ...
+func (dc DummyCollector) SetHosts(hosts sets.String) {}

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -78,12 +78,14 @@ http {
           balancer = res
         end
 
+        {{ if $all.EnableMetrics }}
         ok, res = pcall(require, "monitor")
         if not ok then
           error("require failed: " .. tostring(res))
         else
           monitor = res
         end
+        {{ end }}
 
         {{ if $all.DynamicCertificatesEnabled }}
         ok, res = pcall(require, "certificate")
@@ -97,7 +99,9 @@ http {
 
     init_worker_by_lua_block {
         balancer.init_worker()
+        {{ if $all.EnableMetrics }}
         monitor.init_worker()
+        {{ end }}
     }
 
     {{/* Enable the real_ip module only if we use either X-Forwarded headers or Proxy Protocol. */}}
@@ -576,7 +580,7 @@ http {
         {{ $cfg.ServerSnippet }}
         {{ end }}
 
-        {{ template "CUSTOM_ERRORS" (buildCustomErrorDeps $all.ProxySetHeaders $cfg.CustomHTTPErrors) }}
+        {{ template "CUSTOM_ERRORS" (buildCustomErrorDeps $all.ProxySetHeaders $cfg.CustomHTTPErrors $all.EnableMetrics) }}
     }
     ## end server {{ $server.Hostname }}
 
@@ -679,7 +683,7 @@ http {
             proxy_pass          http://upstream_balancer;
         }
 
-        {{ template "CUSTOM_ERRORS" (buildCustomErrorDeps $all.ProxySetHeaders $cfg.CustomHTTPErrors) }}
+        {{ template "CUSTOM_ERRORS" (buildCustomErrorDeps $all.ProxySetHeaders $cfg.CustomHTTPErrors $all.EnableMetrics) }}
     }
 }
 
@@ -800,6 +804,7 @@ stream {
 {{/* definition of templates to avoid repetitions */}}
 {{ define "CUSTOM_ERRORS" }}
         {{ $proxySetHeaders := .ProxySetHeaders }}
+        {{ $enableMetrics := .EnableMetrics }}
         {{ range $errCode := .ErrorCodes }}
         location @custom_{{ $errCode }} {
             internal;
@@ -821,7 +826,9 @@ stream {
 
             proxy_pass            http://upstream_balancer;
             log_by_lua_block {
+                {{ if $enableMetrics }}
                 monitor.call()
+                {{ end }}
             }
         }
         {{ end }}
@@ -922,7 +929,7 @@ stream {
         {{ $server.ServerSnippet }}
         {{ end }}
 
-        {{ template "CUSTOM_ERRORS" (buildCustomErrorDeps $all.ProxySetHeaders (collectCustomErrorsPerServer $server)) }}
+        {{ template "CUSTOM_ERRORS" (buildCustomErrorDeps $all.ProxySetHeaders (collectCustomErrorsPerServer $server) $all.EnableMetrics) }}
 
         {{ $enforceRegex := enforceRegexModifier $server.Locations }}
         {{ range $location := $server.Locations }}
@@ -1087,7 +1094,9 @@ stream {
                 waf:exec()
                 {{ end }}
                 balancer.log()
+                {{ if $all.EnableMetrics }}
                 monitor.call()
+                {{ end }}
             }
 
             {{ if (and (not (empty $server.SSLCert.PemFileName)) $all.Cfg.HSTS) }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Allow disabling NGINX prometheus metrics