### PR TITLE
Revert removal of TCP and UDP support configmaps in mandatroy manifest

### DIFF
--- a/deploy/mandatory.yaml
+++ b/deploy/mandatory.yaml
@@ -14,6 +14,25 @@ metadata:
     app.kubernetes.io/part-of: ingress-nginx
 
 ---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: tcp-services
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+
+---
+apiVersion: v1
+metadata:
+  name: udp-services
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
TCP and UDP support has been removed and reverted with the following commits,
Remove: 10d3d48a6ccfac7109752cfc77cf9b44f65ccc73
Revert: 168f30d1ec47198d34ed50cd4adfc852ebb3c1ae
However the configmap parts have never been reverted yet.
https://github.com/kubernetes/ingress-nginx/commit/10d3d48a6ccfac7109752cfc77cf9b44f65ccc73#diff-b7d944663319ec93108dd9eb66df1d9d

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
No open issue related to this.

**Special notes for your reviewer**:
