### PR TITLE
Update mandatory.yaml

### DIFF
--- a/deploy/mandatory.yaml
+++ b/deploy/mandatory.yaml
@@ -24,6 +24,7 @@ metadata:
     app.kubernetes.io/part-of: ingress-nginx
 
 ---
+kind: ConfigMap
 apiVersion: v1
 metadata:
   name: udp-services


### PR DESCRIPTION
**What this PR does / why we need it**: The Kind was not re-added to  udp-services when it's removal was reverted without the Kind being set the kubectl apply command fails.

**Which issue this PR fixes**: fixes #3514 

**Special notes for your reviewer**: n/a
