### PR TITLE
{tcp,udp}-services cm appear twice

### DIFF
--- a/test/manifests/ingress-controller/mandatory.yaml
+++ b/test/manifests/ingress-controller/mandatory.yaml
@@ -25,22 +25,6 @@ metadata:
     app.kubernetes.io/part-of: ingress-nginx
 
 ---
-kind: ConfigMap
-apiVersion: v1
-metadata:
-  name: tcp-services
-  labels:
-    app.kubernetes.io/name: ingress-nginx
-    app.kubernetes.io/part-of: ingress-nginx
----
-kind: ConfigMap
-apiVersion: v1
-metadata:
-  name: udp-services
-  labels:
-    app.kubernetes.io/name: ingress-nginx
-    app.kubernetes.io/part-of: ingress-nginx
----
 apiVersion: v1
 kind: ServiceAccount
 metadata:


### PR DESCRIPTION


**What this PR does / why we need it**:

The `{tcp,udp}-services` ConfigMaps appear twice, while idempotent, it's unnecessary. 

