### PR TITLE
make canary ingresses independent of the order they were applied

### DIFF
--- a/test/e2e/annotations/canary.go
+++ b/test/e2e/annotations/canary.go
@@ -43,8 +43,8 @@ var _ = framework.IngressNginxDescribe("Annotations - canary", func() {
 		f.NewDeployment("http-svc-canary", "gcr.io/kubernetes-e2e-test-images/echoserver:2.2", 8080, 1)
 	})
 
-	Context("when canaried by header", func() {
-		It("should route requests to the canary pod if header is set to 'always'", func() {
+	Context("when canary is created", func() {
+		It("should response with a 200 status from the mainline upstream when requests are made to the mainline ingress", func() {
 			host := "foo"
 			annotations := map[string]string{}
 
@@ -72,15 +72,100 @@ var _ = framework.IngressNginxDescribe("Annotations - canary", func() {
 			resp, body, errs := gorequest.New().
 				Get(f.IngressController.HTTPURL).
 				Set("Host", host).
+				End()
+
+			Expect(errs).Should(BeEmpty())
+			Expect(resp.StatusCode).Should(Equal(http.StatusOK))
+			Expect(body).Should(ContainSubstring("http-svc"))
+			Expect(body).ShouldNot(ContainSubstring("http-svc-canary"))
+		})
+
+		It("should return 404 status for requests to the canary if no matching ingress is found", func() {
+			host := "foo"
+
+			canaryAnnotations := map[string]string{
+				"nginx.ingress.kubernetes.io/canary":           "true",
+				"nginx.ingress.kubernetes.io/canary-by-header": "CanaryByHeader",
+			}
+
+			canaryIngName := fmt.Sprintf("%v-canary", host)
+
+			canaryIng := framework.NewSingleIngress(canaryIngName, "/", host, f.IngressController.Namespace, "http-svc-canary",
+				80, &canaryAnnotations)
+
+			f.EnsureIngress(canaryIng)
+
+			time.Sleep(waitForLuaSync)
+
+			resp, _, errs := gorequest.New().
+				Get(f.IngressController.HTTPURL).
+				Set("Host", host).
 				Set("CanaryByHeader", "always").
 				End()
 
 			Expect(errs).Should(BeEmpty())
-			Expect(resp.StatusCode).ShouldNot(Equal(http.StatusNotFound))
-			Expect(body).Should(ContainSubstring("http-svc-canary"))
+			Expect(resp.StatusCode).Should(Equal(http.StatusNotFound))
 		})
 
-		It("should not route requests to the canary pod if header is set to 'never'", func() {
+		/*
+
+			TODO: This test needs improvements made to the e2e framework so that deployment updates work in order to successfully run
+
+			It("should return the correct status codes when endpoints are unavailable", func() {
+				host := "foo"
+				annotations := map[string]string{}
+
+				ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
+				f.EnsureIngress(ing)
+
+				f.WaitForNginxServer(host,
+					func(server string) bool {
+						return Expect(server).Should(ContainSubstring("server_name foo"))
+					})
+
+				canaryAnnotations := map[string]string{
+					"nginx.ingress.kubernetes.io/canary":           "true",
+					"nginx.ingress.kubernetes.io/canary-by-header": "CanaryByHeader",
+				}
+
+				canaryIngName := fmt.Sprintf("%v-canary", host)
+
+				canaryIng := framework.NewSingleIngress(canaryIngName, "/", host, f.IngressController.Namespace, "http-svc-canary",
+					80, &canaryAnnotations)
+				f.EnsureIngress(canaryIng)
+
+				time.Sleep(waitForLuaSync)
+
+				By("returning a 503 status when the mainline deployment has 0 replicas and a request is sent to the canary")
+
+				f.NewEchoDeploymentWithReplicas(0)
+
+				resp, _, errs := gorequest.New().
+					Get(f.IngressController.HTTPURL).
+					Set("Host", host).
+					Set("CanaryByHeader", "always").
+					End()
+
+				Expect(errs).Should(BeEmpty())
+				Expect(resp.StatusCode).Should(Equal(http.StatusServiceUnavailable))
+
+				By("returning a 200 status when the canary deployment has 0 replicas and a request is sent to the mainline ingress")
+
+				f.NewEchoDeploymentWithReplicas(1)
+				f.NewDeployment("http-svc-canary", "gcr.io/kubernetes-e2e-test-images/echoserver:2.2", 8080, 0)
+
+				resp, _, errs = gorequest.New().
+					Get(f.IngressController.HTTPURL).
+					Set("Host", host).
+					Set("CanaryByHeader", "never").
+					End()
+
+				Expect(errs).Should(BeEmpty())
+				Expect(resp.StatusCode).Should(Equal(http.StatusOK))
+			})
+		*/
+
+		It("should route requests to the correct upstream if mainline ingress is created before the canary ingress", func() {
 			host := "foo"
 			annotations := map[string]string{}
 
@@ -104,6 +189,122 @@ var _ = framework.IngressNginxDescribe("Annotations - canary", func() {
 			f.EnsureIngress(canaryIng)
 
 			time.Sleep(waitForLuaSync)
+
+			By("routing requests destined for the mainline ingress to the maineline upstream")
+			resp, body, errs := gorequest.New().
+				Get(f.IngressController.HTTPURL).
+				Set("Host", host).
+				Set("CanaryByHeader", "never").
+				End()
+
+			Expect(errs).Should(BeEmpty())
+			Expect(resp.StatusCode).Should(Equal(http.StatusOK))
+			Expect(body).Should(ContainSubstring("http-svc"))
+			Expect(body).ShouldNot(ContainSubstring("http-svc-canary"))
+
+			By("routing requests destined for the canary ingress to the canary upstream")
+
+			resp, body, errs = gorequest.New().
+				Get(f.IngressController.HTTPURL).
+				Set("Host", host).
+				Set("CanaryByHeader", "always").
+				End()
+
+			Expect(errs).Should(BeEmpty())
+			Expect(resp.StatusCode).Should(Equal(http.StatusOK))
+			Expect(body).Should(ContainSubstring("http-svc-canary"))
+		})
+
+		It("should route requests to the correct upstream if mainline ingress is created after the canary ingress", func() {
+			host := "foo"
+
+			canaryAnnotations := map[string]string{
+				"nginx.ingress.kubernetes.io/canary":           "true",
+				"nginx.ingress.kubernetes.io/canary-by-header": "CanaryByHeader",
+			}
+
+			canaryIngName := fmt.Sprintf("%v-canary", host)
+
+			canaryIng := framework.NewSingleIngress(canaryIngName, "/", host, f.IngressController.Namespace, "http-svc-canary",
+				80, &canaryAnnotations)
+			f.EnsureIngress(canaryIng)
+
+			time.Sleep(waitForLuaSync)
+
+			annotations := map[string]string{}
+
+			ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
+			f.EnsureIngress(ing)
+
+			f.WaitForNginxServer(host,
+				func(server string) bool {
+					return Expect(server).Should(ContainSubstring("server_name foo"))
+				})
+
+			By("routing requests destined for the mainline ingress to the mainelin upstream")
+			resp, body, errs := gorequest.New().
+				Get(f.IngressController.HTTPURL).
+				Set("Host", host).
+				Set("CanaryByHeader", "never").
+				End()
+
+			Expect(errs).Should(BeEmpty())
+			Expect(resp.StatusCode).Should(Equal(http.StatusOK))
+			Expect(body).Should(ContainSubstring("http-svc"))
+			Expect(body).ShouldNot(ContainSubstring("http-svc-canary"))
+
+			By("routing requests destined for the canary ingress to the canary upstream")
+
+			resp, body, errs = gorequest.New().
+				Get(f.IngressController.HTTPURL).
+				Set("Host", host).
+				Set("CanaryByHeader", "always").
+				End()
+
+			Expect(errs).Should(BeEmpty())
+			Expect(resp.StatusCode).Should(Equal(http.StatusOK))
+			Expect(body).Should(ContainSubstring("http-svc-canary"))
+		})
+
+		It("should route requests to the correct upstream if the mainline ingress is modified", func() {
+			host := "foo"
+			annotations := map[string]string{}
+
+			ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
+			f.EnsureIngress(ing)
+
+			f.WaitForNginxServer(host,
+				func(server string) bool {
+					return Expect(server).Should(ContainSubstring("server_name foo"))
+				})
+
+			canaryAnnotations := map[string]string{
+				"nginx.ingress.kubernetes.io/canary":           "true",
+				"nginx.ingress.kubernetes.io/canary-by-header": "CanaryByHeader",
+			}
+
+			canaryIngName := fmt.Sprintf("%v-canary", host)
+
+			canaryIng := framework.NewSingleIngress(canaryIngName, "/", host, f.IngressController.Namespace, "http-svc-canary",
+				80, &canaryAnnotations)
+			f.EnsureIngress(canaryIng)
+
+			time.Sleep(waitForLuaSync)
+
+			modAnnotations := map[string]string{
+				"foo": "bar",
+			}
+
+			modIng := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &modAnnotations)
+
+			f.EnsureIngress(modIng)
+
+			f.WaitForNginxServer(host,
+				func(server string) bool {
+					return Expect(server).Should(ContainSubstring("server_name foo"))
+				})
+
+			By("routing requests destined fro the mainline ingress to the mainline upstream")
 
 			resp, body, errs := gorequest.New().
 				Get(f.IngressController.HTTPURL).
@@ -112,13 +313,153 @@ var _ = framework.IngressNginxDescribe("Annotations - canary", func() {
 				End()
 
 			Expect(errs).Should(BeEmpty())
-			Expect(resp.StatusCode).ShouldNot(Equal(http.StatusNotFound))
+			Expect(resp.StatusCode).Should(Equal(http.StatusOK))
+			Expect(body).Should(ContainSubstring("http-svc"))
+			Expect(body).ShouldNot(ContainSubstring("http-svc-canary"))
+
+			By("routing requests destined for the canary ingress to the canary upstream")
+
+			resp, body, errs = gorequest.New().
+				Get(f.IngressController.HTTPURL).
+				Set("Host", host).
+				Set("CanaryByHeader", "always").
+				End()
+
+			Expect(errs).Should(BeEmpty())
+			Expect(resp.StatusCode).Should(Equal(http.StatusOK))
+			Expect(body).Should(ContainSubstring("http-svc-canary"))
+		})
+
+		It("should route requests to the correct upstream if the canary ingress is modified", func() {
+			host := "foo"
+			annotations := map[string]string{}
+
+			ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
+			f.EnsureIngress(ing)
+
+			f.WaitForNginxServer(host,
+				func(server string) bool {
+					return Expect(server).Should(ContainSubstring("server_name foo"))
+				})
+
+			canaryAnnotations := map[string]string{
+				"nginx.ingress.kubernetes.io/canary":           "true",
+				"nginx.ingress.kubernetes.io/canary-by-header": "CanaryByHeader",
+			}
+
+			canaryIngName := fmt.Sprintf("%v-canary", host)
+
+			canaryIng := framework.NewSingleIngress(canaryIngName, "/", host, f.IngressController.Namespace, "http-svc-canary",
+				80, &canaryAnnotations)
+			f.EnsureIngress(canaryIng)
+
+			time.Sleep(waitForLuaSync)
+
+			modCanaryAnnotations := map[string]string{
+				"nginx.ingress.kubernetes.io/canary":           "true",
+				"nginx.ingress.kubernetes.io/canary-by-header": "CanaryByHeader2",
+			}
+
+			modCanaryIng := framework.NewSingleIngress(canaryIngName, "/", host, f.IngressController.Namespace, "http-svc-canary", 80, &modCanaryAnnotations)
+			f.EnsureIngress(modCanaryIng)
+
+			time.Sleep(waitForLuaSync)
+
+			By("routing requests destined for the mainline ingress to the mainline upstream")
+
+			resp, body, errs := gorequest.New().
+				Get(f.IngressController.HTTPURL).
+				Set("Host", host).
+				Set("CanaryByHeader2", "never").
+				End()
+
+			Expect(errs).Should(BeEmpty())
+			Expect(resp.StatusCode).Should(Equal(http.StatusOK))
+			Expect(body).Should(ContainSubstring("http-svc"))
+			Expect(body).ShouldNot(ContainSubstring("http-svc-canary"))
+
+			By("routing requests destined for the canary ingress to the canary upstream")
+
+			resp, body, errs = gorequest.New().
+				Get(f.IngressController.HTTPURL).
+				Set("Host", host).
+				Set("CanaryByHeader2", "always").
+				End()
+
+			Expect(errs).Should(BeEmpty())
+			Expect(resp.StatusCode).Should(Equal(http.StatusOK))
+			Expect(body).Should(ContainSubstring("http-svc-canary"))
+		})
+	})
+
+	Context("when canaried by header", func() {
+		It("should route requests to the correct upstream", func() {
+			host := "foo"
+			annotations := map[string]string{}
+
+			ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
+			f.EnsureIngress(ing)
+
+			f.WaitForNginxServer(host,
+				func(server string) bool {
+					return Expect(server).Should(ContainSubstring("server_name foo"))
+				})
+
+			canaryAnnotations := map[string]string{
+				"nginx.ingress.kubernetes.io/canary":           "true",
+				"nginx.ingress.kubernetes.io/canary-by-header": "CanaryByHeader",
+			}
+
+			canaryIngName := fmt.Sprintf("%v-canary", host)
+
+			canaryIng := framework.NewSingleIngress(canaryIngName, "/", host, f.IngressController.Namespace, "http-svc-canary",
+				80, &canaryAnnotations)
+			f.EnsureIngress(canaryIng)
+
+			time.Sleep(waitForLuaSync)
+
+			By("routing requests to the canary upstream when header is set to 'always'")
+
+			resp, body, errs := gorequest.New().
+				Get(f.IngressController.HTTPURL).
+				Set("Host", host).
+				Set("CanaryByHeader", "always").
+				End()
+
+			Expect(errs).Should(BeEmpty())
+			Expect(resp.StatusCode).Should(Equal(http.StatusOK))
+			Expect(body).Should(ContainSubstring("http-svc-canary"))
+
+			By("routing requests to the mainline upstream when header is set to 'never'")
+
+			resp, body, errs = gorequest.New().
+				Get(f.IngressController.HTTPURL).
+				Set("Host", host).
+				Set("CanaryByHeader", "never").
+				End()
+
+			Expect(errs).Should(BeEmpty())
+			Expect(resp.StatusCode).Should(Equal(http.StatusOK))
+			Expect(body).Should(ContainSubstring("http-svc"))
+			Expect(body).ShouldNot(ContainSubstring("http-svc-canary"))
+
+			By("routing requests to the mainline upstream when header is set to anything else")
+
+			resp, body, errs = gorequest.New().
+				Get(f.IngressController.HTTPURL).
+				Set("Host", host).
+				Set("CanaryByHeader", "badheadervalue").
+				End()
+
+			Expect(errs).Should(BeEmpty())
+			Expect(resp.StatusCode).Should(Equal(http.StatusOK))
+			Expect(body).Should(ContainSubstring("http-svc"))
 			Expect(body).ShouldNot(ContainSubstring("http-svc-canary"))
 		})
 	})
 
 	Context("when canaried by cookie", func() {
-		It("should route requests to the canary pod if cookie is set to 'always'", func() {
+		It("should route requests to the correct upstream", func() {
 			host := "foo"
 			annotations := map[string]string{}
 
@@ -143,6 +484,7 @@ var _ = framework.IngressNginxDescribe("Annotations - canary", func() {
 
 			time.Sleep(waitForLuaSync)
 
+			By("routing requests to the canary upstream when cookie is set to 'always'")
 			resp, body, errs := gorequest.New().
 				Get(f.IngressController.HTTPURL).
 				Set("Host", host).
@@ -150,18 +492,45 @@ var _ = framework.IngressNginxDescribe("Annotations - canary", func() {
 				End()
 
 			Expect(errs).Should(BeEmpty())
-			Expect(resp.StatusCode).ShouldNot(Equal(http.StatusNotFound))
+			Expect(resp.StatusCode).Should(Equal(http.StatusOK))
 			Expect(body).Should(ContainSubstring("http-svc-canary"))
-		})
 
-		It("should not route requests to the canary pod if cookie is set to 'never'", func() {
+			By("routing requests to the mainline upstream when cookie is set to 'never'")
+
+			resp, body, errs = gorequest.New().
+				Get(f.IngressController.HTTPURL).
+				Set("Host", host).
+				AddCookie(&http.Cookie{Name: "CanaryByCookie", Value: "never"}).
+				End()
+
+			Expect(errs).Should(BeEmpty())
+			Expect(resp.StatusCode).Should(Equal(http.StatusOK))
+			Expect(body).Should(ContainSubstring("http-svc"))
+			Expect(body).ShouldNot(ContainSubstring("http-svc-canary"))
+
+			By("routing requests to the mainline upstream when cookie is set to anything else")
+
+			resp, body, errs = gorequest.New().
+				Get(f.IngressController.HTTPURL).
+				Set("Host", host).
+				AddCookie(&http.Cookie{Name: "CanaryByCookie", Value: "badcookievalue"}).
+				End()
+
+			Expect(errs).Should(BeEmpty())
+			Expect(resp.StatusCode).Should(Equal(http.StatusOK))
+			Expect(body).Should(ContainSubstring("http-svc"))
+			Expect(body).ShouldNot(ContainSubstring("http-svc-canary"))
+		})
+	})
+
+	// TODO: add testing for canary-weight 0 < weight < 100
+	Context("when canaried by weight", func() {
+		It("should route requests to the correct upstream", func() {
 			host := "foo"
 			annotations := map[string]string{}
 
 			ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
 			f.EnsureIngress(ing)
-
-			Expect(ing).NotTo(BeNil())
 
 			f.WaitForNginxServer(host,
 				func(server string) bool {
@@ -169,8 +538,8 @@ var _ = framework.IngressNginxDescribe("Annotations - canary", func() {
 				})
 
 			canaryAnnotations := map[string]string{
-				"nginx.ingress.kubernetes.io/canary":           "true",
-				"nginx.ingress.kubernetes.io/canary-by-header": "CanaryByHeader",
+				"nginx.ingress.kubernetes.io/canary":        "true",
+				"nginx.ingress.kubernetes.io/canary-weight": "0",
 			}
 
 			canaryIngName := fmt.Sprintf("%v-canary", host)
@@ -181,15 +550,40 @@ var _ = framework.IngressNginxDescribe("Annotations - canary", func() {
 
 			time.Sleep(waitForLuaSync)
 
+			By("returning requests from the mainline only when weight is equal to 0")
+
 			resp, body, errs := gorequest.New().
 				Get(f.IngressController.HTTPURL).
 				Set("Host", host).
-				AddCookie(&http.Cookie{Name: "CanaryByCookie", Value: "never"}).
 				End()
 
 			Expect(errs).Should(BeEmpty())
-			Expect(resp.StatusCode).ShouldNot(Equal(http.StatusNotFound))
+			Expect(resp.StatusCode).Should(Equal(http.StatusOK))
+			Expect(body).Should(ContainSubstring("http-svc"))
 			Expect(body).ShouldNot(ContainSubstring("http-svc-canary"))
+
+			By("returning requests from the canary only when weight is equal to 100")
+
+			modCanaryAnnotations := map[string]string{
+				"nginx.ingress.kubernetes.io/canary":        "true",
+				"nginx.ingress.kubernetes.io/canary-weight": "100",
+			}
+
+			modCanaryIng := framework.NewSingleIngress(canaryIngName, "/", host, f.IngressController.Namespace, "http-svc-canary", 80, &modCanaryAnnotations)
+
+			f.EnsureIngress(modCanaryIng)
+
+			time.Sleep(waitForLuaSync)
+
+			resp, body, errs = gorequest.New().
+				Get(f.IngressController.HTTPURL).
+				Set("Host", host).
+				End()
+
+			Expect(errs).Should(BeEmpty())
+			Expect(resp.StatusCode).Should(Equal(http.StatusOK))
+			Expect(body).Should(ContainSubstring("http-svc-canary"))
+
 		})
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a problem with the canary ingress feature where canary ingresses depend on the order of which they were applied. It also adds a check that a canary ingress cannot be merged into the default upstream when no other ingresses have been applied.

To make canary ingresses order independent, the `getBackendServers` function first sets aside canary ingresses as it iterates across them. Then, after servers are created for every real ingress, the a check is done to make sure merging is safe and canary ingresses are iterated over and merged. The current condition for knowing if it is safe to merge canary ingresses is whether the `length of ingresses - length of canary ingresses >  0` If true, we know that a real ingress must exist and there is a potential match which can be merged into. This is currently more of a sanity check than a condition for "safeness", but this function can be used to add more conditions for safeness if necessary. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
