### PR TITLE
Ignore updates of ingresses with invalid class

### DIFF
--- a/internal/ingress/controller/store/backend_ssl.go
+++ b/internal/ingress/controller/store/backend_ssl.go
@@ -35,7 +35,7 @@ import (
 
 // syncSecret synchronizes the content of a TLS Secret (certificate(s), secret
 // key) with the filesystem. The resulting files can be used by NGINX.
-func (s k8sStore) syncSecret(key string) {
+func (s *k8sStore) syncSecret(key string) {
 	s.syncSecretMu.Lock()
 	defer s.syncSecretMu.Unlock()
 
@@ -74,7 +74,7 @@ func (s k8sStore) syncSecret(key string) {
 
 // getPemCertificate receives a secret, and creates a ingress.SSLCert as return.
 // It parses the secret and verifies if it's a keypair, or a 'ca.crt' secret only.
-func (s k8sStore) getPemCertificate(secretName string) (*ingress.SSLCert, error) {
+func (s *k8sStore) getPemCertificate(secretName string) (*ingress.SSLCert, error) {
 	secret, err := s.listers.Secret.ByKey(secretName)
 	if err != nil {
 		return nil, err
@@ -143,7 +143,7 @@ func (s k8sStore) getPemCertificate(secretName string) (*ingress.SSLCert, error)
 	return sslCert, nil
 }
 
-func (s k8sStore) checkSSLChainIssues() {
+func (s *k8sStore) checkSSLChainIssues() {
 	for _, item := range s.ListLocalSSLCerts() {
 		secrKey := k8s.MetaNamespaceKey(item)
 		secret, err := s.GetLocalSSLCert(secrKey)

--- a/internal/ingress/controller/store/backend_ssl.go
+++ b/internal/ingress/controller/store/backend_ssl.go
@@ -36,8 +36,8 @@ import (
 // syncSecret synchronizes the content of a TLS Secret (certificate(s), secret
 // key) with the filesystem. The resulting files can be used by NGINX.
 func (s k8sStore) syncSecret(key string) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.syncSecretMu.Lock()
+	defer s.syncSecretMu.Unlock()
 
 	klog.V(3).Infof("Syncing Secret %q", key)
 

--- a/internal/ingress/controller/store/store.go
+++ b/internal/ingress/controller/store/store.go
@@ -689,7 +689,7 @@ func objectRefAnnotationNsKey(ann string, ing *extensions.Ingress) (string, erro
 
 // syncSecrets synchronizes data from all Secrets referenced by the given
 // Ingress with the local store and file system.
-func (s k8sStore) syncSecrets(ing *extensions.Ingress) {
+func (s *k8sStore) syncSecrets(ing *extensions.Ingress) {
 	key := k8s.MetaNamespaceKey(ing)
 	for _, secrKey := range s.secretIngressMap.ReferencedBy(key) {
 		s.syncSecret(secrKey)
@@ -697,12 +697,12 @@ func (s k8sStore) syncSecrets(ing *extensions.Ingress) {
 }
 
 // GetSecret returns the Secret matching key.
-func (s k8sStore) GetSecret(key string) (*corev1.Secret, error) {
+func (s *k8sStore) GetSecret(key string) (*corev1.Secret, error) {
 	return s.listers.Secret.ByKey(key)
 }
 
 // ListLocalSSLCerts returns the list of local SSLCerts
-func (s k8sStore) ListLocalSSLCerts() []*ingress.SSLCert {
+func (s *k8sStore) ListLocalSSLCerts() []*ingress.SSLCert {
 	var certs []*ingress.SSLCert
 	for _, item := range s.sslStore.List() {
 		if s, ok := item.(*ingress.SSLCert); ok {
@@ -714,12 +714,12 @@ func (s k8sStore) ListLocalSSLCerts() []*ingress.SSLCert {
 }
 
 // GetService returns the Service matching key.
-func (s k8sStore) GetService(key string) (*corev1.Service, error) {
+func (s *k8sStore) GetService(key string) (*corev1.Service, error) {
 	return s.listers.Service.ByKey(key)
 }
 
 // getIngress returns the Ingress matching key.
-func (s k8sStore) getIngress(key string) (*extensions.Ingress, error) {
+func (s *k8sStore) getIngress(key string) (*extensions.Ingress, error) {
 	ing, err := s.listers.IngressWithAnnotation.ByKey(key)
 	if err != nil {
 		return nil, err
@@ -729,7 +729,7 @@ func (s k8sStore) getIngress(key string) (*extensions.Ingress, error) {
 }
 
 // ListIngresses returns the list of Ingresses
-func (s k8sStore) ListIngresses() []*ingress.Ingress {
+func (s *k8sStore) ListIngresses() []*ingress.Ingress {
 	// filter ingress rules
 	ingresses := make([]*ingress.Ingress, 0)
 	for _, item := range s.listers.IngressWithAnnotation.List() {
@@ -741,22 +741,22 @@ func (s k8sStore) ListIngresses() []*ingress.Ingress {
 }
 
 // GetLocalSSLCert returns the local copy of a SSLCert
-func (s k8sStore) GetLocalSSLCert(key string) (*ingress.SSLCert, error) {
+func (s *k8sStore) GetLocalSSLCert(key string) (*ingress.SSLCert, error) {
 	return s.sslStore.ByKey(key)
 }
 
 // GetConfigMap returns the ConfigMap matching key.
-func (s k8sStore) GetConfigMap(key string) (*corev1.ConfigMap, error) {
+func (s *k8sStore) GetConfigMap(key string) (*corev1.ConfigMap, error) {
 	return s.listers.ConfigMap.ByKey(key)
 }
 
 // GetServiceEndpoints returns the Endpoints of a Service matching key.
-func (s k8sStore) GetServiceEndpoints(key string) (*corev1.Endpoints, error) {
+func (s *k8sStore) GetServiceEndpoints(key string) (*corev1.Endpoints, error) {
 	return s.listers.Endpoint.ByKey(key)
 }
 
 // GetAuthCertificate is used by the auth-tls annotations to get a cert from a secret
-func (s k8sStore) GetAuthCertificate(name string) (*resolver.AuthSSLCert, error) {
+func (s *k8sStore) GetAuthCertificate(name string) (*resolver.AuthSSLCert, error) {
 	if _, err := s.GetLocalSSLCert(name); err != nil {
 		s.syncSecret(name)
 	}
@@ -773,7 +773,7 @@ func (s k8sStore) GetAuthCertificate(name string) (*resolver.AuthSSLCert, error)
 	}, nil
 }
 
-func (s k8sStore) writeSSLSessionTicketKey(cmap *corev1.ConfigMap, fileName string) {
+func (s *k8sStore) writeSSLSessionTicketKey(cmap *corev1.ConfigMap, fileName string) {
 	ticketString := ngx_template.ReadConfig(cmap.Data).SSLSessionTicketKey
 	s.backendConfig.SSLSessionTicketKey = ""
 
@@ -823,7 +823,7 @@ func (s *k8sStore) setConfig(cmap *corev1.ConfigMap) {
 
 // Run initiates the synchronization of the informers and the initial
 // synchronization of the secrets.
-func (s k8sStore) Run(stopCh chan struct{}) {
+func (s *k8sStore) Run(stopCh chan struct{}) {
 	// start informers
 	s.informers.Run(stopCh)
 
@@ -833,7 +833,7 @@ func (s k8sStore) Run(stopCh chan struct{}) {
 }
 
 // ListControllerPods returns a list of ingress-nginx controller Pods
-func (s k8sStore) ListControllerPods() []*corev1.Pod {
+func (s *k8sStore) ListControllerPods() []*corev1.Pod {
 	var pods []*corev1.Pod
 
 	for _, i := range s.listers.Pod.List() {

--- a/internal/ingress/controller/store/store.go
+++ b/internal/ingress/controller/store/store.go
@@ -363,6 +363,9 @@ func New(checkOCSP bool,
 				recorder.Eventf(curIng, corev1.EventTypeNormal, "DELETE", fmt.Sprintf("Ingress %s/%s", curIng.Namespace, curIng.Name))
 			} else if validCur && !reflect.DeepEqual(old, cur) {
 				recorder.Eventf(curIng, corev1.EventTypeNormal, "UPDATE", fmt.Sprintf("Ingress %s/%s", curIng.Namespace, curIng.Name))
+			} else {
+				klog.Infof("ignoring ingress %v based on annotation %v", curIng.Name, class.IngressKey)
+				return
 			}
 
 			store.syncIngress(curIng)

--- a/internal/ingress/controller/store/store_test.go
+++ b/internal/ingress/controller/store/store_test.go
@@ -865,7 +865,8 @@ func newStore(t *testing.T) *k8sStore {
 		sslStore:         NewSSLCertTracker(),
 		filesystem:       fs,
 		updateCh:         channels.NewRingChannel(10),
-		mu:               new(sync.Mutex),
+		syncSecretMu:     new(sync.Mutex),
+		backendConfigMu:  new(sync.RWMutex),
 		secretIngressMap: NewObjectRefMap(),
 		pod:              pod,
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Ignore updates of ingresses with invalid class. This avoids unnecessary nginx reload which can be really expensive in websocket scenario.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

When I run unit tests, the race detector reports some data races regarding `k8sStore.backendConfig`. I added a `RWMutex` to protect against simultaneous read/write of that. In addition, I also changed `k8sStore` member functions to receive a `k8sStore` pointer rather than a value to avoid copy, which implies read of `backendConfig`.