### PR TITLE
Replace dockerfile entrypoint

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -49,4 +49,6 @@ RUN ln -sf /dev/stderr /var/log/nginx/error.log
 
 USER www-data
 
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+
 CMD ["/nginx-ingress-controller"]


### PR DESCRIPTION
This changes from https://github.com/kubernetes/ingress-nginx/pull/3535#issuecomment-445278474 to:
```
  PID TTY      STAT   TIME COMMAND
  116 pts/0    Rs+    0:00 ps axf
    1 ?        Ss     0:00 /usr/bin/dumb-init -- /nginx-ingress-controller --def
    6 ?        Ssl    0:00 /nginx-ingress-controller --default-backend-service=i
   30 ?        S      0:00  \_ nginx: master process /usr/sbin/nginx -c /etc/ngi
   50 ?        Sl     0:00      \_ nginx: worker process
   51 ?        Sl     0:00      \_ nginx: worker process
```

@breunigs `quay.io/kubernetes-ingress-controller/nginx-ingress-controller:dev` contains this PR

Before merging this change we need to run this PR several days (to make sure we don't introduce zombie processes). 
I am already doing this in several clusters. Will check on Monday if everything is working as expected