### PR TITLE
fix: use correct order for trusted ips and real_ip_recursive

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -107,6 +107,10 @@ http {
     {{/* Enable the real_ip module only if we use either X-Forwarded headers or Proxy Protocol. */}}
     {{/* we use the value of the real IP for the geo_ip module */}}
     {{ if or $cfg.UseForwardedHeaders $cfg.UseProxyProtocol }}
+    {{ range $trusted_ip := $cfg.ProxyRealIPCIDR }}
+    set_real_ip_from    {{ $trusted_ip }};
+    {{ end }}
+    
     {{ if $cfg.UseProxyProtocol }}
     real_ip_header      proxy_protocol;
     {{ else }}
@@ -114,9 +118,6 @@ http {
     {{ end }}
 
     real_ip_recursive   on;
-    {{ range $trusted_ip := $cfg.ProxyRealIPCIDR }}
-    set_real_ip_from    {{ $trusted_ip }};
-    {{ end }}
     {{ end }}
 
     {{ if $cfg.UseGeoIP }}


### PR DESCRIPTION
**What this PR does / why we need it**:

The realip module requires the trusted ips to be set before enabling the module, as seen here in the example section: http://nginx.org/en/docs/http/ngx_http_realip_module.html

This fixes the order to be correct, as otherwise it might not work correctly.
