### PR TITLE
Fix --enable-dynamic-certificates for nested subdomain

### DIFF
--- a/rootfs/etc/nginx/lua/certificate.lua
+++ b/rootfs/etc/nginx/lua/certificate.lua
@@ -32,7 +32,7 @@ local function get_pem_cert_key(hostname)
     return pem_cert_key
   end
 
-  local wildcard_hosatname, _, err = re_sub(hostname, "^.+\\.", "*.", "jo")
+  local wildcard_hosatname, _, err = re_sub(hostname, "^[^\\.]+\\.", "*.", "jo")
   if err then
     ngx.log(ngx.ERR, "error: ", err)
     return pem_cert_key

--- a/rootfs/etc/nginx/lua/test/certificate_test.lua
+++ b/rootfs/etc/nginx/lua/test/certificate_test.lua
@@ -78,6 +78,20 @@ describe("Certificate", function()
       assert.spy(ssl.set_der_priv_key).was_called_with(ssl.priv_key_pem_to_der(PEM_CERT_KEY))
     end)
 
+    it("successfully sets SSL certificate and key for nested wildcard cert", function()
+      ssl.server_name = function() return "sub.nested.hostname", nil end
+      ngx.shared.certificate_data:set("*.nested.hostname", PEM_CERT_KEY)
+
+      spy.on(ngx, "log")
+      spy.on(ssl, "set_der_cert")
+      spy.on(ssl, "set_der_priv_key")
+
+      assert.has_no.errors(certificate.call)
+      assert.spy(ngx.log).was_not_called_with(ngx.ERR, _)
+      assert.spy(ssl.set_der_cert).was_called_with(ssl.cert_pem_to_der(PEM_CERT_KEY))
+      assert.spy(ssl.set_der_priv_key).was_called_with(ssl.priv_key_pem_to_der(PEM_CERT_KEY))
+    end)
+
     it("logs error message when certificate in dictionary is invalid", function()
       ngx.shared.certificate_data:set("hostname", "something invalid")
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This fixes Lua dynamic certificate with nested subdomain.

Previous regexp `^.+\\.` is matching until the last `.`.
So it replaces `www.example.com` by `*.com` instead of `*.example.com`.

The new regexp matches until the first `.`.
So `www.sub.example.com` is replaced by `*.sub.example.com`.

**Which issue this PR fixes**:

**Special notes for your reviewer**:
