### PR TITLE
Update Certificate Generation Docs to not use MD5

### DIFF
--- a/docs/examples/auth/client-certs/README.md
+++ b/docs/examples/auth/client-certs/README.md
@@ -7,6 +7,20 @@ Before getting started you must have the following Certificates Setup:
 2. Server Certificate(Signed by CA) and Key (CN should be equal the hostname you will use)
 3. Client Certificate(Signed by CA) and Key
 
+For more details on the generation process, checkout the Prerequisite [docs](../../PREREQUISITES.md).
+
+You can have as many certificates as you want. If they're in the binary DER format, you can convert them as the following:
+```bash
+$ openssl x509 -in certificate.der -inform der -out certificate.crt -outform pem
+```
+Then, you can concatenate them all in only one file, named 'ca.crt' as the following:
+```bash
+$ cat certificate1.crt certificate2.crt certificate3.crt >> ca.crt
+```
+
+**Note:** Make sure that the Key Size is greater than 1024 and Hashing Algorithm(Digest) is something better than md5
+for each certificate generated. Otherwise you will receive an error.
+
 ## Creating Certificate Secrets
 
 There are many different ways of configuring your secrets to enable Client-Certificate


### PR DESCRIPTION
Updates the TLS and CA certificate sections to use algorithms better than md5. Using md5 as a digest causes nginx to fail to load because it is not accepted by open ssl.

Closes #3571