### PR TITLE
Add documentation for spec.rules.host format

### DIFF
--- a/docs/user-guide/ingress-path-matching.md
+++ b/docs/user-guide/ingress-path-matching.md
@@ -2,6 +2,9 @@
 
 ## Regular Expression Support
 
+!!! important 
+    Regular expressions and wild cards are not supported in the `spec.rules.host` field. Full hostnames must be used. 
+
 The ingress controller supports **case insensitive** regular expressions in the `spec.rules.http.paths.path` field.
 
 See the [description](./nginx-configuration/annotations.md#use-regex) of the `use-regex` annotation for more details.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Wildcards/regex are not supported in the `spec.rules.host` field of an ingress definition. 

**Which issue this PR fixes** : fixes https://github.com/kubernetes/ingress-nginx/issues/3534

cc: @ElvinEfendi @aledbf 
