### PR TITLE
Add standard labels to namespace specs

### DIFF
--- a/deploy/mandatory.yaml
+++ b/deploy/mandatory.yaml
@@ -2,6 +2,9 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
 
 ---
 

--- a/deploy/namespace.yaml
+++ b/deploy/namespace.yaml
@@ -2,6 +2,9 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
 
 ---
 


### PR DESCRIPTION
Add standard app resource metadata labels to the namespaces specs
created when deploying nginx-ingress.

Closes kubernetes/ingress-nginx#3576

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

This would make it possible to include the nginx-ingress controller in network policy rules, which rely on label selectors for both namespaces and pods, without further manual configuration.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes kubernetes/ingress-nginx#3576

**Special notes for your reviewer**:
