### PR TITLE
lua randomseed per worker

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -3,3 +3,8 @@ globals = {
   '_TEST'
 }
 exclude_files = {'./rootfs/etc/nginx/lua/test/**/*.lua'}
+files["rootfs/etc/nginx/lua/lua_ingress.lua"] = {
+  ignore = { "122" },
+  -- TODO(elvinefendi) figure out why this does not work
+  --read_globals = {"math.randomseed"},
+}

--- a/build/static-check.sh
+++ b/build/static-check.sh
@@ -25,4 +25,4 @@ fi
 
 hack/verify-all.sh
 
-luacheck -q rootfs/etc/nginx/lua/
+luacheck --codes -q rootfs/etc/nginx/lua/

--- a/rootfs/etc/nginx/lua/lua_ingress.lua
+++ b/rootfs/etc/nginx/lua/lua_ingress.lua
@@ -1,0 +1,26 @@
+local _M = {}
+
+local seeds = {}
+local original_randomseed = math.randomseed
+math.randomseed = function(seed)
+  local pid = ngx.worker.pid()
+
+  if seeds[pid] then
+    ngx.log(ngx.WARN,
+      string.format("ignoring math.randomseed(%d) since PRNG is already seeded for worker %d", seed, pid))
+    return
+  end
+
+  original_randomseed(seed)
+  seeds[pid] = seed
+end
+
+local function randomseed()
+  math.randomseed(ngx.time() + ngx.worker.pid())
+end
+
+function _M.init_worker()
+  randomseed()
+end
+
+return _M

--- a/rootfs/etc/nginx/lua/test/lua_ingress_test.lua
+++ b/rootfs/etc/nginx/lua/test/lua_ingress_test.lua
@@ -1,0 +1,9 @@
+describe("lua_ingress", function()
+  it("patches math.randomseed to not be called more than once per worker", function()
+    local s = spy.on(ngx, "log")
+
+    math.randomseed(100)
+    assert.spy(s).was_called_with(ngx.WARN,
+      string.format("ignoring math.randomseed(%d) since PRNG is already seeded for worker %d", 100, ngx.worker.pid()))
+  end)
+end)

--- a/rootfs/etc/nginx/lua/test/run.lua
+++ b/rootfs/etc/nginx/lua/test/run.lua
@@ -1,4 +1,5 @@
 local ffi = require("ffi")
+local lua_ingress = require("lua_ingress")
 
 -- without this we get errors such as "attempt to redefine XXX"
 local old_cdef = ffi.cdef
@@ -32,7 +33,6 @@ end
 ngx.log = function(...) end
 ngx.print = function(...) end
 
--- TODO(elvinefendi) once this is implemented for production (should be!), share the same code
-math.randomseed(ngx.time() + ngx.worker.pid())
+lua_ingress.init_worker()
 
 require "busted.runner"({ standalone = false })

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -63,6 +63,13 @@ http {
         -- init modules
         local ok, res
 
+        ok, res = pcall(require, "lua_ingress")
+        if not ok then
+          error("require failed: " .. tostring(res))
+        else
+          lua_ingress = res
+        end
+
         ok, res = pcall(require, "configuration")
         if not ok then
           error("require failed: " .. tostring(res))
@@ -98,6 +105,7 @@ http {
     }
 
     init_worker_by_lua_block {
+        lua_ingress.init_worker()
         balancer.init_worker()
         {{ if $all.EnableMetrics }}
         monitor.init_worker()


### PR DESCRIPTION
**What this PR does / why we need it**:
Previously we have switched to explicitly seeding PRNG for tests and this PR does it for production code. I've also patched `math.randomseed` so that individual modules can not re-seed PRNG since that can potentially affect randomness. And the reason why I'm seeding per worker rather than in `init_by_lua` is because otherwise every worker would be seeded with the same seed.

`lua_ingress.lua` will be used for general things such as this. And eventually I'd like it to be the only entry point to Lua code that executes everything else.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
