### PR TITLE
Sort ingresses by creation timestamp

### DIFF
--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -120,13 +120,7 @@ func (n *NGINXController) syncIngress(interface{}) error {
 		return nil
 	}
 
-	// sort Ingresses using the ResourceVersion field
 	ings := n.store.ListIngresses()
-	sort.SliceStable(ings, func(i, j int) bool {
-		ir := ings[i].ResourceVersion
-		jr := ings[j].ResourceVersion
-		return ir < jr
-	})
 
 	upstreams, servers := n.getBackendServers(ings)
 	var passUpstreams []*ingress.SSLPassthroughBackend

--- a/internal/ingress/controller/store/store.go
+++ b/internal/ingress/controller/store/store.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"reflect"
+	"sort"
 	"sync"
 	"time"
 
@@ -735,6 +736,13 @@ func (s *k8sStore) ListIngresses() []*ingress.Ingress {
 		ing := item.(*ingress.Ingress)
 		ingresses = append(ingresses, ing)
 	}
+
+	// sort Ingresses using the CreationTimestamp field
+	sort.SliceStable(ingresses, func(i, j int) bool {
+		ir := ingresses[i].CreationTimestamp
+		jr := ingresses[j].CreationTimestamp
+		return ir.Before(&jr)
+	})
 
 	return ingresses
 }


### PR DESCRIPTION
**What this PR does / why we need it**: ResourceVersion is not immutable. It can change if the ingress is modified. Switching to CreationTimestamp to avoid edge cases.