### PR TITLE
Add a flag to make per-host metrics optional

### DIFF
--- a/cmd/nginx/flags.go
+++ b/cmd/nginx/flags.go
@@ -149,6 +149,8 @@ Feature backed by OpenResty Lua libraries. Requires that OCSP stapling is not en
 
 		enableMetrics = flags.Bool("enable-metrics", true,
 			`Enables the collection of NGINX metrics`)
+		metricsPerHost = flags.Bool("metrics-per-host", true,
+			`Export metrics per-host`)
 
 		httpPort      = flags.Int("http-port", 80, `Port to use for servicing HTTP traffic.`)
 		httpsPort     = flags.Int("https-port", 443, `Port to use for servicing HTTPS traffic.`)
@@ -227,6 +229,7 @@ Feature backed by OpenResty Lua libraries. Requires that OCSP stapling is not en
 		ElectionID:                 *electionID,
 		EnableProfiling:            *profiling,
 		EnableMetrics:              *enableMetrics,
+		MetricsPerHost:             *metricsPerHost,
 		EnableSSLPassthrough:       *enableSSLPassthrough,
 		EnableSSLChainCompletion:   *enableSSLChainCompletion,
 		ResyncPeriod:               *resyncPeriod,

--- a/cmd/nginx/main.go
+++ b/cmd/nginx/main.go
@@ -131,7 +131,7 @@ func main() {
 
 	mc := metric.NewDummyCollector()
 	if conf.EnableMetrics {
-		mc, err = metric.NewCollector(conf.ListenPorts.Status, reg)
+		mc, err = metric.NewCollector(conf.ListenPorts.Status, conf.MetricsPerHost, reg)
 		if err != nil {
 			klog.Fatalf("Error creating prometheus collector:  %v", err)
 		}

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -87,7 +87,8 @@ type Configuration struct {
 
 	EnableProfiling bool
 
-	EnableMetrics bool
+	EnableMetrics  bool
+	MetricsPerHost bool
 
 	EnableSSLChainCompletion bool
 

--- a/internal/ingress/metric/collectors/socket_test.go
+++ b/internal/ingress/metric/collectors/socket_test.go
@@ -288,7 +288,7 @@ func TestCollector(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			registry := prometheus.NewPedanticRegistry()
 
-			sc, err := NewSocketCollector("pod", "default", "ingress")
+			sc, err := NewSocketCollector("pod", "default", "ingress", true)
 			if err != nil {
 				t.Errorf("%v: unexpected error creating new SocketCollector: %v", c.name, err)
 			}

--- a/internal/ingress/metric/main.go
+++ b/internal/ingress/metric/main.go
@@ -59,7 +59,7 @@ type collector struct {
 }
 
 // NewCollector creates a new metric collector the for ingress controller
-func NewCollector(statusPort int, registry *prometheus.Registry) (Collector, error) {
+func NewCollector(statusPort int, metricsPerHost bool, registry *prometheus.Registry) (Collector, error) {
 	podNamespace := os.Getenv("POD_NAMESPACE")
 	if podNamespace == "" {
 		podNamespace = "default"
@@ -77,7 +77,7 @@ func NewCollector(statusPort int, registry *prometheus.Registry) (Collector, err
 		return nil, err
 	}
 
-	s, err := collectors.NewSocketCollector(podName, podNamespace, class.IngressClass)
+	s, err := collectors.NewSocketCollector(podName, podNamespace, class.IngressClass, metricsPerHost)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

When serving many hosts from one nginx, the metrics may become too numerous for Prometheus.
Add a flag to disable the host label, so that metrics are totalled across all hosts.

This was raised at https://github.com/kubernetes/ingress-nginx/issues/2773#issuecomment-444485380
