### PR TITLE
Update static-ip-svc.yaml

### DIFF
--- a/docs/examples/static-ip/static-ip-svc.yaml
+++ b/docs/examples/static-ip/static-ip-svc.yaml
@@ -9,7 +9,6 @@ metadata:
 spec:
   externalTrafficPolicy: Local
   type: LoadBalancer
-  loadBalancerIP: 104.154.109.191
   ports:
   - port: 80
     name: http


### PR DESCRIPTION
Correct me if I'm wrong, but I believe the load balancer IP should be set by Kubernetes, not set manually.