### PR TITLE
Pass k8s `Service` data through to the TCP balancer script.

### DIFF
--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -343,6 +343,7 @@ func (n *NGINXController) getStreamServices(configmapName string, proto apiv1.Pr
 				ProxyProtocol: svcProxyProtocol,
 			},
 			Endpoints: endps,
+			Service:   svc,
 		})
 	}
 	// Keep upstream order sorted to reduce unnecessary nginx config reloads.

--- a/internal/ingress/controller/nginx.go
+++ b/internal/ingress/controller/nginx.go
@@ -816,21 +816,31 @@ func configureDynamically(pcfg *ingress.Configuration, port int, isDynamicCertif
 
 	streams := make([]ingress.Backend, 0)
 	for _, ep := range pcfg.TCPEndpoints {
+		var service *apiv1.Service
+		if ep.Service != nil {
+			service = &apiv1.Service{Spec: ep.Service.Spec}
+		}
+
 		key := fmt.Sprintf("tcp-%v-%v-%v", ep.Backend.Namespace, ep.Backend.Name, ep.Backend.Port.String())
 		streams = append(streams, ingress.Backend{
 			Name:      key,
 			Endpoints: ep.Endpoints,
 			Port:      intstr.FromInt(ep.Port),
-			Service:   ep.Service,
+			Service:   service,
 		})
 	}
 	for _, ep := range pcfg.UDPEndpoints {
+		var service *apiv1.Service
+		if ep.Service != nil {
+			service = &apiv1.Service{Spec: ep.Service.Spec}
+		}
+
 		key := fmt.Sprintf("udp-%v-%v-%v", ep.Backend.Namespace, ep.Backend.Name, ep.Backend.Port.String())
 		streams = append(streams, ingress.Backend{
 			Name:      key,
 			Endpoints: ep.Endpoints,
 			Port:      intstr.FromInt(ep.Port),
-			Service:   ep.Service,
+			Service:   service,
 		})
 	}
 

--- a/internal/ingress/controller/nginx.go
+++ b/internal/ingress/controller/nginx.go
@@ -821,6 +821,7 @@ func configureDynamically(pcfg *ingress.Configuration, port int, isDynamicCertif
 			Name:      key,
 			Endpoints: ep.Endpoints,
 			Port:      intstr.FromInt(ep.Port),
+			Service:   ep.Service,
 		})
 	}
 	for _, ep := range pcfg.UDPEndpoints {
@@ -829,6 +830,7 @@ func configureDynamically(pcfg *ingress.Configuration, port int, isDynamicCertif
 			Name:      key,
 			Endpoints: ep.Endpoints,
 			Port:      intstr.FromInt(ep.Port),
+			Service:   ep.Service,
 		})
 	}
 

--- a/internal/ingress/types.go
+++ b/internal/ingress/types.go
@@ -322,6 +322,8 @@ type L4Service struct {
 	Backend L4Backend `json:"backend"`
 	// Endpoints active endpoints of the service
 	Endpoints []Endpoint `json:"endpoints,omitempty"`
+	// k8s Service
+	Service *apiv1.Service `json:"service,omitempty"`
 }
 
 // L4Backend describes the kubernetes service behind L4 Ingress service


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes broken L4 ExternalName services.

The `tcp_udp_balancer.lua` script checks if the property
`backend.service.spec["type"]` equals `"ExternalName"`.  If so,
the script does a DNS lookup on the name in order to configure
the backend configuration.

However, before this commit, the k8s `Service` data was
_not_ set on the `Backend` struct passed into the `tcp_udp_balancer.lua`
script and therefore the `ExternalName` check always returned false.

This commit fixes the issue by setting the `Service` field on
the `Backend` struct. This also requires adding a new field to the
`L4Backend` struct, so that it's available to set on the `Backend`.
