### PR TITLE
add header-value annotation

### DIFF
--- a/docs/user-guide/nginx-configuration/annotations.md
+++ b/docs/user-guide/nginx-configuration/annotations.md
@@ -30,6 +30,7 @@ You can add these Kubernetes annotations to specific Ingress objects to customiz
 |[nginx.ingress.kubernetes.io/backend-protocol](#backend-protocol)|string|HTTP,HTTPS,GRPC,GRPCS,AJP|
 |[nginx.ingress.kubernetes.io/canary](#canary)|"true" or "false"|
 |[nginx.ingress.kubernetes.io/canary-by-header](#canary)|string|
+|[nginx.ingress.kubernetes.io/canary-by-header-value](#canary)|string
 |[nginx.ingress.kubernetes.io/canary-by-cookie](#canary)|string|
 |[nginx.ingress.kubernetes.io/canary-weight](#canary)|number|
 |[nginx.ingress.kubernetes.io/client-body-buffer-size](#client-body-buffer-size)|string|
@@ -105,6 +106,8 @@ You can add these Kubernetes annotations to specific Ingress objects to customiz
 In some cases, you may want to "canary" a new set of changes by sending a small number of requests to a different service than the production service. The canary annotation enables the Ingress spec to act as an alternative service for requests to route to depending on the rules applied. The following annotations to configure canary can be enabled after `nginx.ingress.kubernetes.io/canary: "true"` is set:
 
 * `nginx.ingress.kubernetes.io/canary-by-header`: The header to use for notifying the Ingress to route the request to the service specified in the Canary Ingress. When the request header is set to `always`, it will be routed to the canary. When the header is set to `never`, it will never be routed to the canary. For any other value, the header will be ignored and the request compared against the other canary rules by precedence.
+
+* `nginx.ingress.kubernetes.io/canary-by-header-value`: The header value to match for notifying the Ingress to route the request to the service specified in the Canary Ingress. When the request header is set to this value, it will be routed to the canary. For any other header value, the header will be ignored and the request compared against the other canary rules by precedence. This annotation has to be used together with . The annotation is an extension of the `nginx.ingress.kubernetes.io/canary-by-header` to allow customizing the header value instead of using hardcoded values. It doesn't have any effect if the `nginx.ingress.kubernetes.io/canary-by-header` annotation is not defined.
 
 * `nginx.ingress.kubernetes.io/canary-by-cookie`: The cookie to use for notifying the Ingress to route the request to the service specified in the Canary Ingress. When the cookie value is set to `always`, it will be routed to the canary. When the cookie is set to `never`, it will never be routed to the canary. For any other value, the cookie will be ingored and the request compared against the other canary rules by precedence. 
 

--- a/internal/ingress/annotations/canary/main.go
+++ b/internal/ingress/annotations/canary/main.go
@@ -30,10 +30,11 @@ type canary struct {
 
 // Config returns the configuration rules for setting up the Canary
 type Config struct {
-	Enabled bool
-	Weight  int
-	Header  string
-	Cookie  string
+	Enabled     bool
+	Weight      int
+	Header      string
+	HeaderValue string
+	Cookie      string
 }
 
 // NewParser parses the ingress for canary related annotations
@@ -62,12 +63,17 @@ func (c canary) Parse(ing *extensions.Ingress) (interface{}, error) {
 		config.Header = ""
 	}
 
+	config.HeaderValue, err = parser.GetStringAnnotation("canary-by-header-value", ing)
+	if err != nil {
+		config.HeaderValue = ""
+	}
+
 	config.Cookie, err = parser.GetStringAnnotation("canary-by-cookie", ing)
 	if err != nil {
 		config.Cookie = ""
 	}
 
-	if !config.Enabled && (config.Weight > 0 || len(config.Header) > 0 || len(config.Cookie) > 0) {
+	if !config.Enabled && (config.Weight > 0 || len(config.Header) > 0 || len(config.HeaderValue) > 0 || len(config.Cookie) > 0) {
 		return nil, errors.NewInvalidAnnotationConfiguration("canary", "configured but not enabled")
 	}
 

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -690,9 +690,10 @@ func (n *NGINXController) createUpstreams(data []*ingress.Ingress, du *ingress.B
 			if anns.Canary.Enabled {
 				upstreams[defBackend].NoServer = true
 				upstreams[defBackend].TrafficShapingPolicy = ingress.TrafficShapingPolicy{
-					Weight: anns.Canary.Weight,
-					Header: anns.Canary.Header,
-					Cookie: anns.Canary.Cookie,
+					Weight:      anns.Canary.Weight,
+					Header:      anns.Canary.Header,
+					HeaderValue: anns.Canary.HeaderValue,
+					Cookie:      anns.Canary.Cookie,
 				}
 			}
 
@@ -757,9 +758,10 @@ func (n *NGINXController) createUpstreams(data []*ingress.Ingress, du *ingress.B
 				if anns.Canary.Enabled {
 					upstreams[name].NoServer = true
 					upstreams[name].TrafficShapingPolicy = ingress.TrafficShapingPolicy{
-						Weight: anns.Canary.Weight,
-						Header: anns.Canary.Header,
-						Cookie: anns.Canary.Cookie,
+						Weight:      anns.Canary.Weight,
+						Header:      anns.Canary.Header,
+						HeaderValue: anns.Canary.HeaderValue,
+						Cookie:      anns.Canary.Cookie,
 					}
 				}
 

--- a/internal/ingress/types.go
+++ b/internal/ingress/types.go
@@ -118,6 +118,8 @@ type TrafficShapingPolicy struct {
 	Weight int `json:"weight"`
 	// Header on which to redirect requests to this backend
 	Header string `json:"header"`
+	// HeaderValue on which to redirect requests to this backend
+	HeaderValue string `json:"headerValue"`
 	// Cookie on which to redirect requests to this backend
 	Cookie string `json:"cookie"`
 }

--- a/internal/ingress/types_equals.go
+++ b/internal/ingress/types_equals.go
@@ -293,6 +293,9 @@ func (tsp1 TrafficShapingPolicy) Equal(tsp2 TrafficShapingPolicy) bool {
 	if tsp1.Header != tsp2.Header {
 		return false
 	}
+	if tsp1.HeaderValue != tsp2.HeaderValue {
+		return false
+	}
 	if tsp1.Cookie != tsp2.Cookie {
 		return false
 	}

--- a/rootfs/etc/nginx/lua/balancer.lua
+++ b/rootfs/etc/nginx/lua/balancer.lua
@@ -160,7 +160,11 @@ local function route_to_alternative_balancer(balancer)
   local target_header = util.replace_special_char(traffic_shaping_policy.header, "-", "_")
   local header = ngx.var["http_" .. target_header]
   if header then
-    if header == "always" then
+    if traffic_shaping_policy.headerValue then
+      if traffic_shaping_policy.headerValue == header then
+        return true
+      end
+    elseif header == "always" then
       return true
     elseif header == "never" then
       return false

--- a/rootfs/etc/nginx/lua/balancer.lua
+++ b/rootfs/etc/nginx/lua/balancer.lua
@@ -160,7 +160,7 @@ local function route_to_alternative_balancer(balancer)
   local target_header = util.replace_special_char(traffic_shaping_policy.header, "-", "_")
   local header = ngx.var["http_" .. target_header]
   if header then
-    if traffic_shaping_policy.headerValue then
+    if traffic_shaping_policy.headerValue and #traffic_shaping_policy.headerValue > 0 then
       if traffic_shaping_policy.headerValue == header then
         return true
       end


### PR DESCRIPTION
This PR extends the existing `canary-by-header` [annotation](https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md#canary).

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This PR introduce more flexibility into the existing definition of the canary routing rules. The current implementation requires sending a header with a fixed value in order to trigger a canary routing which requires dedicated changes in the code of the application. This is less convenient when the application already has a header which can be used given its value represents a partition of users applicable to the canary testing (e.g. tenant id in the multi-tenant application).

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
This subject was already discussed in [this message thread](https://mail.google.com/mail/u/0/#inbox/WhctKJVJZlQvrXZpvpphsKScFxldkZKVmzvbHJcFCpmVJHJZjXtPTJVTgHcHqcRtWrbhlgQ). Given we agree on implementation, I am going to add tests to the new annotation.