### PR TITLE
Added server alias to metrics

### DIFF
--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -130,6 +130,9 @@ func (n *NGINXController) syncIngress(interface{}) error {
 	for _, server := range servers {
 		if !hosts.Has(server.Hostname) {
 			hosts.Insert(server.Hostname)
+			if server.Alias != "" {
+				hosts.Insert(server.Alias)
+			}
 		}
 
 		if !server.SSLPassthrough {

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -130,9 +130,9 @@ func (n *NGINXController) syncIngress(interface{}) error {
 	for _, server := range servers {
 		if !hosts.Has(server.Hostname) {
 			hosts.Insert(server.Hostname)
-			if server.Alias != "" {
-				hosts.Insert(server.Alias)
-			}
+		}
+		if server.Alias != "" && !hosts.Has(server.Hostname) {
+			hosts.Insert(server.Alias)
 		}
 
 		if !server.SSLPassthrough {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Adds hosts specified via server alias to be added to them

**Which issue this PR fixes** fixes #3485

**Special notes for your reviewer**:
This PR is a resubmission of https://github.com/kubernetes/ingress-nginx/pull/3496.