### PR TITLE
Add TLS metrics

### DIFF
--- a/internal/ingress/metric/collectors/socket.go
+++ b/internal/ingress/metric/collectors/socket.go
@@ -47,6 +47,9 @@ type socketData struct {
 	RequestLength float64 `json:"requestLength"`
 	RequestTime   float64 `json:"requestTime"`
 
+	TLSVersion string `json:"tlsVersion"`
+	TLSCipher  string `json:"tlsCipher"`
+
 	upstream
 
 	Namespace string `json:"namespace"`
@@ -169,7 +172,7 @@ func NewSocketCollector(pod, namespace, class string, metricsPerHost bool) (*Soc
 				Namespace:   PrometheusNamespace,
 				ConstLabels: constLabels,
 			},
-			[]string{"ingress", "namespace", "status"},
+			[]string{"ingress", "namespace", "status", "tls_version", "tls_cipher"},
 		),
 
 		bytesSent: prometheus.NewHistogramVec(
@@ -240,9 +243,11 @@ func (sc *SocketCollector) handleMessage(msg []byte) {
 		}
 
 		collectorLabels := prometheus.Labels{
-			"namespace": stats.Namespace,
-			"ingress":   stats.Ingress,
-			"status":    stats.Status,
+			"namespace":   stats.Namespace,
+			"ingress":     stats.Ingress,
+			"status":      stats.Status,
+			"tls_version": stats.TLSVersion,
+			"tls_cipher":  stats.TLSCipher,
 		}
 
 		latencyLabels := prometheus.Labels{

--- a/rootfs/etc/nginx/lua/monitor.lua
+++ b/rootfs/etc/nginx/lua/monitor.lua
@@ -30,6 +30,9 @@ local function metrics()
     requestTime = tonumber(ngx.var.request_time) or -1,
     responseLength = tonumber(ngx.var.bytes_sent) or -1,
 
+    tlsVersion = ngx.var.ssl_protocol or "-",
+    tlsCipher = ngx.var.ssl_cipher or "-",
+
     upstreamLatency = tonumber(ngx.var.upstream_connect_time) or -1,
     upstreamResponseTime = tonumber(ngx.var.upstream_response_time) or -1,
     upstreamResponseLength = tonumber(ngx.var.upstream_response_length) or -1,

--- a/rootfs/etc/nginx/lua/test/monitor_test.lua
+++ b/rootfs/etc/nginx/lua/test/monitor_test.lua
@@ -78,6 +78,8 @@ describe("Monitor", function()
         request_length = "256",
         request_time = "0.04",
         bytes_sent = "512",
+        ssl_protocol = "TLSv1.2",
+        ssl_cipher = "ECDHE-RSA-AES128-GCM-SHA256",
 
         upstream_addr = "10.10.0.1",
         upstream_connect_time = "0.01",

--- a/rootfs/etc/nginx/lua/test/monitor_test.lua
+++ b/rootfs/etc/nginx/lua/test/monitor_test.lua
@@ -98,7 +98,7 @@ describe("Monitor", function()
 
       monitor.flush()
 
-      local expected_payload = '[{"requestLength":256,"ingress":"example","status":"200","service":"http-svc","requestTime":0.04,"namespace":"default","host":"example.com","method":"GET","upstreamResponseTime":0.02,"upstreamResponseLength":456,"upstreamLatency":0.01,"path":"\\/","responseLength":512},{"requestLength":256,"ingress":"example","status":"201","service":"http-svc","requestTime":0.04,"namespace":"default","host":"example.com","method":"POST","upstreamResponseTime":0.02,"upstreamResponseLength":456,"upstreamLatency":0.01,"path":"\\/","responseLength":512}]'
+      local expected_payload = '[{"tlsVersion":"TLSv1.2","requestLength":256,"ingress":"example","status":"200","service":"http-svc","requestTime":0.04,"namespace":"default","host":"example.com","method":"GET","upstreamResponseTime":0.02,"upstreamResponseLength":456,"tlsCipher":"ECDHE-RSA-AES128-GCM-SHA256","upstreamLatency":0.01,"path":"\\/","responseLength":512},{"tlsVersion":"TLSv1.2","requestLength":256,"ingress":"example","status":"201","service":"http-svc","requestTime":0.04,"namespace":"default","host":"example.com","method":"POST","upstreamResponseTime":0.02,"upstreamResponseLength":456,"tlsCipher":"ECDHE-RSA-AES128-GCM-SHA256","upstreamLatency":0.01,"path":"\\/","responseLength":512}]'
 
       assert.stub(tcp_mock.connect).was_called_with(tcp_mock, "unix:/tmp/prometheus-nginx.socket")
       assert.stub(tcp_mock.send).was_called_with(tcp_mock, expected_payload)


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds metrics for TLS. Grants additional operational insight into clients and allows operators to make better decisions which TLS versions and ciphers to support.

**Special notes for your reviewer**: