### PR TITLE
Fix a bug in Ingress update handler

### DIFF
--- a/test/e2e/settings/disable_catch_all.go
+++ b/test/e2e/settings/disable_catch_all.go
@@ -17,10 +17,16 @@ limitations under the License.
 package settings
 
 import (
+	"net/http"
 	"strings"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/parnurzeal/gorequest"
 	appsv1beta1 "k8s.io/api/apps/v1beta1"
+	extensions "k8s.io/api/extensions/v1beta1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"k8s.io/ingress-nginx/test/e2e/framework"
 )
@@ -64,46 +70,43 @@ var _ = framework.IngressNginxDescribe("Disabled catch-all", func() {
 		})
 	})
 
-	// FIXME: This test doesn't work because of a bug in Ingress update handle in store package.
-	// It("should delete Ingress updated to catch-all", func() {
-	// 	host := "foo"
+	It("should delete Ingress updated to catch-all", func() {
+		host := "foo"
 
-	// 	ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, nil)
-	// 	f.EnsureIngress(ing)
+		ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, nil)
+		f.EnsureIngress(ing)
 
-	// 	f.WaitForNginxServer(host,
-	// 		func(server string) bool {
-	// 			return strings.Contains(server, "server_name foo")
-	// 		})
+		f.WaitForNginxServer(host,
+			func(server string) bool {
+				return strings.Contains(server, "server_name foo")
+			})
 
-	// 	resp, _, errs := gorequest.New().
-	// 		Get(f.IngressController.HTTPURL).
-	// 		Set("Host", host).
-	// 		End()
-	// 	Expect(errs).To(BeNil())
-	// 	Expect(resp.StatusCode).Should(Equal(http.StatusOK))
+		resp, _, errs := gorequest.New().
+			Get(f.IngressController.HTTPURL).
+			Set("Host", host).
+			End()
+		Expect(errs).To(BeNil())
+		Expect(resp.StatusCode).Should(Equal(http.StatusOK))
 
-	// 	err := framework.UpdateIngress(f.KubeClientSet, f.IngressController.Namespace, host, func(ingress *extensions.Ingress) error {
-	// 		ingress.Spec.Rules = nil
-	// 		ingress.Spec.Backend = &extensions.IngressBackend{
-	// 			ServiceName: "http-svc",
-	// 			ServicePort: intstr.FromInt(80),
-	// 		}
-	// 		return nil
-	// 	})
-	// 	Expect(err).ToNot(HaveOccurred())
+		err := framework.UpdateIngress(f.KubeClientSet, f.IngressController.Namespace, host, func(ingress *extensions.Ingress) error {
+			ingress.Spec.Rules = nil
+			ingress.Spec.Backend = &extensions.IngressBackend{
+				ServiceName: "http-svc",
+				ServicePort: intstr.FromInt(80),
+			}
+			return nil
+		})
+		Expect(err).ToNot(HaveOccurred())
 
-	// 	f.WaitForNginxConfiguration(func(cfg string) bool {
-	// 		return !strings.Contains(cfg, "server_name foo") &&
-	// 			!strings.Contains(cfg, `set $ingress_name "foo"`) &&
-	// 			!strings.Contains(cfg, `set $service_name "http-svc"`)
-	// 	})
+		f.WaitForNginxConfiguration(func(cfg string) bool {
+			return !strings.Contains(cfg, "server_name foo")
+		})
 
-	// 	resp, _, errs = gorequest.New().
-	// 		Get(f.IngressController.HTTPURL).
-	// 		Set("Host", host).
-	// 		End()
-	// 	Expect(errs).To(BeNil())
-	// 	Expect(resp.StatusCode).Should(Equal(http.StatusNotFound))
-	// })
+		resp, _, errs = gorequest.New().
+			Get(f.IngressController.HTTPURL).
+			Set("Host", host).
+			End()
+		Expect(errs).To(BeNil())
+		Expect(resp.StatusCode).Should(Equal(http.StatusNotFound))
+	})
 })

--- a/test/e2e/settings/ingress_class.go
+++ b/test/e2e/settings/ingress_class.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package settings
+
+import (
+	"net/http"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/parnurzeal/gorequest"
+	appsv1beta1 "k8s.io/api/apps/v1beta1"
+
+	"k8s.io/ingress-nginx/test/e2e/framework"
+)
+
+var _ = framework.IngressNginxDescribe("Ingress class", func() {
+	f := framework.NewDefaultFramework("ingress-class")
+
+	BeforeEach(func() {
+		f.NewEchoDeploymentWithReplicas(1)
+	})
+
+	AfterEach(func() {
+	})
+
+	Context("Without a specific ingress-class", func() {
+
+		It("should ignore Ingress with class", func() {
+			invalidHost := "foo"
+			annotations := map[string]string{
+				"kubernetes.io/ingress.class": "testclass",
+			}
+			ing := framework.NewSingleIngress(invalidHost, "/", invalidHost, f.IngressController.Namespace, "http-svc", 80, &annotations)
+			f.EnsureIngress(ing)
+
+			validHost := "bar"
+			ing = framework.NewSingleIngress(validHost, "/", validHost, f.IngressController.Namespace, "http-svc", 80, nil)
+			f.EnsureIngress(ing)
+
+			f.WaitForNginxConfiguration(func(cfg string) bool {
+				return !strings.Contains(cfg, "server_name foo") &&
+					strings.Contains(cfg, "server_name bar")
+			})
+
+			resp, _, errs := gorequest.New().
+				Get(f.IngressController.HTTPURL).
+				Set("Host", invalidHost).
+				End()
+			Expect(errs).To(BeNil())
+			Expect(resp.StatusCode).Should(Equal(http.StatusNotFound))
+
+			resp, _, errs = gorequest.New().
+				Get(f.IngressController.HTTPURL).
+				Set("Host", validHost).
+				End()
+			Expect(errs).To(BeNil())
+			Expect(resp.StatusCode).Should(Equal(http.StatusOK))
+		})
+	})
+
+	Context("With a specific ingress-class", func() {
+		BeforeEach(func() {
+			framework.UpdateDeployment(f.KubeClientSet, f.IngressController.Namespace, "nginx-ingress-controller", 1,
+				func(deployment *appsv1beta1.Deployment) error {
+					args := deployment.Spec.Template.Spec.Containers[0].Args
+					args = append(args, "--ingress-class=testclass")
+					deployment.Spec.Template.Spec.Containers[0].Args = args
+					_, err := f.KubeClientSet.AppsV1beta1().Deployments(f.IngressController.Namespace).Update(deployment)
+
+					return err
+				})
+		})
+
+		It("should ignore Ingress with no class", func() {
+			invalidHost := "bar"
+
+			ing := framework.NewSingleIngress(invalidHost, "/", invalidHost, f.IngressController.Namespace, "http-svc", 80, nil)
+			f.EnsureIngress(ing)
+
+			validHost := "foo"
+			annotations := map[string]string{
+				"kubernetes.io/ingress.class": "testclass",
+			}
+			ing = framework.NewSingleIngress(validHost, "/", validHost, f.IngressController.Namespace, "http-svc", 80, &annotations)
+			f.EnsureIngress(ing)
+
+			f.WaitForNginxServer(validHost, func(cfg string) bool {
+				return strings.Contains(cfg, "server_name foo")
+			})
+
+			f.WaitForNginxConfiguration(func(cfg string) bool {
+				return !strings.Contains(cfg, "server_name bar")
+			})
+
+			resp, _, errs := gorequest.New().
+				Get(f.IngressController.HTTPURL).
+				Set("Host", validHost).
+				End()
+			Expect(errs).To(BeNil())
+			Expect(resp.StatusCode).Should(Equal(http.StatusOK))
+
+			resp, _, errs = gorequest.New().
+				Get(f.IngressController.HTTPURL).
+				Set("Host", invalidHost).
+				End()
+			Expect(errs).To(BeNil())
+			Expect(resp.StatusCode).Should(Equal(http.StatusNotFound))
+		})
+
+		It("should delete Ingress when class is removed", func() {
+			host := "foo"
+			annotations := map[string]string{
+				"kubernetes.io/ingress.class": "testclass",
+			}
+			ing := framework.NewSingleIngress(host, "/", host, f.IngressController.Namespace, "http-svc", 80, &annotations)
+			ing = f.EnsureIngress(ing)
+
+			f.WaitForNginxServer(host, func(cfg string) bool {
+				return strings.Contains(cfg, "server_name foo")
+			})
+
+			resp, _, errs := gorequest.New().
+				Get(f.IngressController.HTTPURL).
+				Set("Host", host).
+				End()
+			Expect(errs).To(BeNil())
+			Expect(resp.StatusCode).Should(Equal(http.StatusOK))
+
+			delete(ing.Annotations, "kubernetes.io/ingress.class")
+			ing = f.EnsureIngress(ing)
+
+			f.WaitForNginxConfiguration(func(cfg string) bool {
+				return !strings.Contains(cfg, "server_name foo")
+			})
+
+			resp, _, errs = gorequest.New().
+				Get(f.IngressController.HTTPURL).
+				Set("Host", host).
+				End()
+			Expect(errs).To(BeNil())
+			Expect(resp.StatusCode).Should(Equal(http.StatusNotFound))
+		})
+	})
+
+})


### PR DESCRIPTION
**What this PR does / why we need it**:
As discussed https://github.com/kubernetes/ingress-nginx/pull/3586#discussion_r245679117
Changes to annotation `kubernetes.io/ingress.class`and `.spec.rules` / `.spec.backend` were not correctly handled.

If the new value wasn't valid, the old Ingress was kept and updated instead of being deleted.

This was introduced in https://github.com/kubernetes/ingress-nginx/pull/3474 (@aledbf  can you confirm?).

New tests have been added to prevent future regression.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
