### PR TITLE
canary by cookie should support hypen in cookie name

### DIFF
--- a/rootfs/etc/nginx/lua/balancer.lua
+++ b/rootfs/etc/nginx/lua/balancer.lua
@@ -157,9 +157,8 @@ local function route_to_alternative_balancer(balancer)
     return false
   end
 
-  local clean_target_header = util.replace_special_char(traffic_shaping_policy.header, "-", "_")
-
-  local header = ngx.var["http_" .. clean_target_header]
+  local target_header = util.replace_special_char(traffic_shaping_policy.header, "-", "_")
+  local header = ngx.var["http_" .. target_header]
   if header then
     if header == "always" then
       return true
@@ -168,9 +167,8 @@ local function route_to_alternative_balancer(balancer)
     end
   end
 
-  local clean_target_cookie = util.replace_special_char(traffic_shaping_policy.cookie, "-", "_")
-
-  local cookie = ngx.var["cookie_" .. clean_target_cookie]
+  local target_cookie = traffic_shaping_policy.cookie
+  local cookie = ngx.var["cookie_" .. target_cookie]
   if cookie then
     if cookie == "always" then
       return true

--- a/test/e2e/annotations/canary.go
+++ b/test/e2e/annotations/canary.go
@@ -473,7 +473,7 @@ var _ = framework.IngressNginxDescribe("Annotations - canary", func() {
 
 			canaryAnnotations := map[string]string{
 				"nginx.ingress.kubernetes.io/canary":           "true",
-				"nginx.ingress.kubernetes.io/canary-by-cookie": "CanaryByCookie",
+				"nginx.ingress.kubernetes.io/canary-by-cookie": "Canary-By-Cookie",
 			}
 
 			canaryIngName := fmt.Sprintf("%v-canary", host)
@@ -488,7 +488,7 @@ var _ = framework.IngressNginxDescribe("Annotations - canary", func() {
 			resp, body, errs := gorequest.New().
 				Get(f.IngressController.HTTPURL).
 				Set("Host", host).
-				AddCookie(&http.Cookie{Name: "CanaryByCookie", Value: "always"}).
+				AddCookie(&http.Cookie{Name: "Canary-By-Cookie", Value: "always"}).
 				End()
 
 			Expect(errs).Should(BeEmpty())
@@ -500,7 +500,7 @@ var _ = framework.IngressNginxDescribe("Annotations - canary", func() {
 			resp, body, errs = gorequest.New().
 				Get(f.IngressController.HTTPURL).
 				Set("Host", host).
-				AddCookie(&http.Cookie{Name: "CanaryByCookie", Value: "never"}).
+				AddCookie(&http.Cookie{Name: "Canary-By-Cookie", Value: "never"}).
 				End()
 
 			Expect(errs).Should(BeEmpty())
@@ -513,7 +513,7 @@ var _ = framework.IngressNginxDescribe("Annotations - canary", func() {
 			resp, body, errs = gorequest.New().
 				Get(f.IngressController.HTTPURL).
 				Set("Host", host).
-				AddCookie(&http.Cookie{Name: "CanaryByCookie", Value: "badcookievalue"}).
+				AddCookie(&http.Cookie{Name: "Canary-By-Cookie", Value: "badcookievalue"}).
 				End()
 
 			Expect(errs).Should(BeEmpty())


### PR DESCRIPTION
**What this PR does / why we need it**:
The implementation assumed that cookie names are normalized as headers when exposed via `ngx.var` API and therefore replacing `-` with `_`, but this is not true. That meant `canary-by-cookie: <anything-with-hyphen>` did not work correctly. This PR fixes it.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
