### PR TITLE
Fix duplicate alternative backend merging

### DIFF
--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -1165,6 +1165,13 @@ func mergeAlternativeBackend(priUps *ingress.Backend, altUps *ingress.Backend) b
 		return false
 	}
 
+	for _, ab := range priUps.AlternativeBackends {
+		if ab == altUps.Name {
+			klog.V(2).Infof("skip merge alternative backend %v into %v, it's already present", altUps.Name, priUps.Name)
+			return true
+		}
+	}
+
 	priUps.AlternativeBackends =
 		append(priUps.AlternativeBackends, altUps.Name)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
When there are multiple locations per server, where each location is configured to point to the same server/backend, ingress-nginx will merge alternative backend into the main one repeatedly.

Ex:
```
  {
    "name": "web-app-80",
    "service": {
      "metadata": {
        "creationTimestamp": null
      },

...

    "noServer": false,
    "trafficShapingPolicy": {
      "weight": 0,
      "header": "",
      "cookie": ""
    },
    "alternativeBackends": [
      "web-canary-app-80",
      "web-canary-app-80",
      "web-canary-app-80"
    ]
  },
```

Here, `web-canary-app-80` gets merged 3 times while having 3 ingresses with different locations. All pointing to the same server `web-app`.

This causes no real issue for now but is definitely incorrect.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

Test in `controller_test.go` `TestMergeAlternativeBackends` for this are irrelevant because `ingress.Backend.Equal` does not check for a duplicate value https://github.com/kubernetes/ingress-nginx/blob/master/internal/ingress/types_equals.go#L182