### PR TITLE
Add support for redirect https to https (from-to-www-redirect)

### DIFF
--- a/docs/user-guide/nginx-configuration/annotations.md
+++ b/docs/user-guide/nginx-configuration/annotations.md
@@ -465,13 +465,16 @@ When using SSL offloading outside of cluster (e.g. AWS ELB) it may be useful to 
 even when there is no TLS certificate available.
 This can be achieved by using the `nginx.ingress.kubernetes.io/force-ssl-redirect: "true"` annotation in the particular resource.
 
-### Redirect from/to www.
+### Redirect from/to www
 
 In some scenarios is required to redirect from `www.domain.com` to `domain.com` or vice versa.
 To enable this feature use the annotation `nginx.ingress.kubernetes.io/from-to-www-redirect: "true"`
 
 !!! attention
     If at some point a new Ingress is created with a host equal to one of the options (like `domain.com`) the annotation will be omitted.
+
+!!! attention
+    For HTTPS to HTTPS redirects is mandatory the SSL Certificate defined in the Secret, located in the TLS section of Ingress, contains both FQDN in the common name of the certificate.
 
 ### Whitelist source range
 

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -721,7 +721,7 @@ type TemplateConfig struct {
 	IsSSLPassthroughEnabled    bool
 	NginxStatusIpv4Whitelist   []string
 	NginxStatusIpv6Whitelist   []string
-	RedirectServers            map[string]string
+	RedirectServers            interface{}
 	ListenPorts                *ListenPorts
 	PublishService             *apiv1.Service
 	DynamicCertificatesEnabled bool

--- a/internal/net/ssl/ssl.go
+++ b/internal/net/ssl/ssl.go
@@ -30,6 +30,7 @@ import (
 	"math/big"
 	"net"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/zakjan/cert-chain-resolver/certUtil"
@@ -507,4 +508,22 @@ func FullChainCert(in string, fs file.Filesystem) ([]byte, error) {
 	}
 
 	return certUtil.EncodeCertificates(certs), nil
+}
+
+// IsValidHostname checks if a hostname is valid in a list of common names
+func IsValidHostname(hostname string, commonNames []string) bool {
+	for _, cn := range commonNames {
+		if strings.EqualFold(hostname, cn) {
+			return true
+		}
+
+		labels := strings.Split(hostname, ".")
+		labels[0] = "*"
+		candidate := strings.Join(labels, ".")
+		if strings.EqualFold(candidate, cn) {
+			return true
+		}
+	}
+
+	return false
 }

--- a/internal/net/ssl/ssl_test.go
+++ b/internal/net/ssl/ssl_test.go
@@ -205,3 +205,39 @@ func newCA(name string) (*keyPair, error) {
 		Cert: cert,
 	}, nil
 }
+
+func TestIsValidHostname(t *testing.T) {
+	cases := map[string]struct {
+		Hostname string
+		CN       []string
+		Valid    bool
+	}{
+		"when there is no common names": {
+			"foo.bar",
+			[]string{},
+			false,
+		},
+		"when there is a match for foo.bar": {
+			"foo.bar",
+			[]string{"foo.bar"},
+			true,
+		},
+		"when there is a wildcard match for foo.bar": {
+			"foo.bar",
+			[]string{"*.bar"},
+			true,
+		},
+		"when there is a wrong wildcard for *.bar": {
+			"invalid.foo.bar",
+			[]string{"*.bar"},
+			false,
+		},
+	}
+
+	for k, tc := range cases {
+		valid := IsValidHostname(tc.Hostname, tc.CN)
+		if valid != tc.Valid {
+			t.Errorf("%s: expected '%v' but returned %v", k, tc.Valid, valid)
+		}
+	}
+}

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -520,7 +520,8 @@ http {
     {{ end }}
 
     {{/* Build server redirects (from/to www) */}}
-    {{ range $hostname, $to := .RedirectServers }}
+    {{ range $redirect := .RedirectServers }}
+    ## start server {{ $redirect.From }}
     server {
         {{ range $address := $all.Cfg.BindAddressIpv4 }}
         listen {{ $address }}:{{ $all.ListenPorts.HTTP }}{{ if $all.Cfg.UseProxyProtocol }} proxy_protocol{{ end }};
@@ -538,7 +539,25 @@ http {
         listen [::]:{{ if $all.IsSSLPassthroughEnabled }}{{ $all.ListenPorts.SSLProxy }} proxy_protocol{{ else }}{{ $all.ListenPorts.HTTPS }}{{ if $all.Cfg.UseProxyProtocol }} proxy_protocol{{ end }}{{ end }};
         {{ end }}
         {{ end }}
-        server_name {{ $hostname }};
+        server_name {{ $redirect.From }};
+
+        {{ if not (empty $redirect.SSLCert.PemFileName) }}
+        {{/* comment PEM sha is required to detect changes in the generated configuration and force a reload */}}
+        # PEM sha: {{ $redirect.SSLCert.PemSHA }}
+        ssl_certificate                         {{ $redirect.SSLCert.PemFileName }};
+        ssl_certificate_key                     {{ $redirect.SSLCert.PemFileName }};
+        {{ if not (empty $redirect.SSLCert.FullChainPemFileName)}}
+        ssl_trusted_certificate                 {{ $redirect.SSLCert.FullChainPemFileName }};
+        ssl_stapling                            on;
+        ssl_stapling_verify                     on;
+        {{ end }}
+
+        {{ if $all.DynamicCertificatesEnabled}}
+        ssl_certificate_by_lua_block {
+            certificate.call()
+        }
+        {{ end }}
+        {{ end }}
 
         {{ if gt (len $cfg.BlockUserAgents) 0 }}
         if ($block_ua) {
@@ -553,11 +572,12 @@ http {
 
         {{ if ne $all.ListenPorts.HTTPS 443 }}
         {{ $redirect_port := (printf ":%v" $all.ListenPorts.HTTPS) }}
-        return {{ $all.Cfg.HTTPRedirectCode }} $scheme://{{ $to }}{{ $redirect_port }}$request_uri;
+        return {{ $all.Cfg.HTTPRedirectCode }} $scheme://{{ $redirect.To }}{{ $redirect_port }}$request_uri;
         {{ else }}
-        return {{ $all.Cfg.HTTPRedirectCode }} $scheme://{{ $to }}$request_uri;
+        return {{ $all.Cfg.HTTPRedirectCode }} $scheme://{{ $redirect.To }}$request_uri;
         {{ end }}
     }
+    ## end server {{ $redirect.From }}
     {{ end }}
 
     {{ range $server := $servers }}

--- a/test/e2e/annotations/authtls.go
+++ b/test/e2e/annotations/authtls.go
@@ -53,8 +53,7 @@ var _ = framework.IngressNginxDescribe("Annotations - AuthTLS", func() {
 			"nginx.ingress.kubernetes.io/auth-tls-secret": nameSpace + "/" + host,
 		}
 
-		ing := framework.NewSingleIngressWithTLS(host, "/", host, nameSpace, "http-svc", 80, &annotations)
-		f.EnsureIngress(ing)
+		f.EnsureIngress(framework.NewSingleIngressWithTLS(host, "/", host, []string{host}, nameSpace, "http-svc", 80, &annotations))
 
 		// Since we can use the same certificate-chain for tls as well as mutual-auth, we will check all values
 		sslCertDirective := fmt.Sprintf("ssl_certificate /etc/ingress-controller/ssl/%s-%s.pem;", nameSpace, host)
@@ -111,8 +110,7 @@ var _ = framework.IngressNginxDescribe("Annotations - AuthTLS", func() {
 			"nginx.ingress.kubernetes.io/auth-tls-verify-depth":  "2",
 		}
 
-		ing := framework.NewSingleIngressWithTLS(host, "/", host, nameSpace, "http-svc", 80, &annotations)
-		f.EnsureIngress(ing)
+		f.EnsureIngress(framework.NewSingleIngressWithTLS(host, "/", host, []string{host}, nameSpace, "http-svc", 80, &annotations))
 
 		// Since we can use the same certificate-chain for tls as well as mutual-auth, we will check all values
 		sslCertDirective := fmt.Sprintf("ssl_certificate /etc/ingress-controller/ssl/%s-%s.pem;", nameSpace, host)
@@ -158,8 +156,7 @@ var _ = framework.IngressNginxDescribe("Annotations - AuthTLS", func() {
 			"nginx.ingress.kubernetes.io/auth-tls-pass-certificate-to-upstream": "true",
 		}
 
-		ing := framework.NewSingleIngressWithTLS(host, "/", host, nameSpace, "http-svc", 80, &annotations)
-		f.EnsureIngress(ing)
+		f.EnsureIngress(framework.NewSingleIngressWithTLS(host, "/", host, []string{host}, nameSpace, "http-svc", 80, &annotations))
 
 		// Since we can use the same certificate-chain for tls as well as mutual-auth, we will check all values
 		sslCertDirective := fmt.Sprintf("ssl_certificate /etc/ingress-controller/ssl/%s-%s.pem;", nameSpace, host)

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -20,7 +20,7 @@ import (
 	"time"
 
 	appsv1beta1 "k8s.io/api/apps/v1beta1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	extensions "k8s.io/api/extensions/v1beta1"
 	apiextcs "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -388,16 +388,16 @@ func UpdateIngress(kubeClientSet kubernetes.Interface, namespace string, name st
 }
 
 // NewSingleIngressWithTLS creates a simple ingress rule with TLS spec included
-func NewSingleIngressWithTLS(name, path, host, ns, service string, port int, annotations *map[string]string) *extensions.Ingress {
-	return newSingleIngressWithRules(name, path, host, ns, service, port, annotations, true)
+func NewSingleIngressWithTLS(name, path, host string, tlsHosts []string, ns, service string, port int, annotations *map[string]string) *extensions.Ingress {
+	return newSingleIngressWithRules(name, path, host, ns, service, port, annotations, tlsHosts)
 }
 
 // NewSingleIngress creates a simple ingress rule
 func NewSingleIngress(name, path, host, ns, service string, port int, annotations *map[string]string) *extensions.Ingress {
-	return newSingleIngressWithRules(name, path, host, ns, service, port, annotations, false)
+	return newSingleIngressWithRules(name, path, host, ns, service, port, annotations, nil)
 }
 
-func newSingleIngressWithRules(name, path, host, ns, service string, port int, annotations *map[string]string, withTLS bool) *extensions.Ingress {
+func newSingleIngressWithRules(name, path, host, ns, service string, port int, annotations *map[string]string, tlsHosts []string) *extensions.Ingress {
 
 	spec := extensions.IngressSpec{
 		Rules: []extensions.IngressRule{
@@ -420,10 +420,10 @@ func newSingleIngressWithRules(name, path, host, ns, service string, port int, a
 		},
 	}
 
-	if withTLS {
+	if len(tlsHosts) > 0 {
 		spec.TLS = []extensions.IngressTLS{
 			{
-				Hosts:      []string{host},
+				Hosts:      tlsHosts,
 				SecretName: host,
 			},
 		}

--- a/test/e2e/lua/dynamic_certificates.go
+++ b/test/e2e/lua/dynamic_certificates.go
@@ -80,7 +80,7 @@ var _ = framework.IngressNginxDescribe("Dynamic Certificate", func() {
 	})
 
 	It("picks up the previously missing secret for a given ingress without reloading", func() {
-		ing := framework.NewSingleIngressWithTLS(host, "/", host, f.IngressController.Namespace, "http-svc", 80, nil)
+		ing := framework.NewSingleIngressWithTLS(host, "/", host, []string{host}, f.IngressController.Namespace, "http-svc", 80, nil)
 		f.EnsureIngress(ing)
 
 		time.Sleep(waitForLuaSync)
@@ -120,7 +120,7 @@ var _ = framework.IngressNginxDescribe("Dynamic Certificate", func() {
 
 	Context("given an ingress with TLS correctly configured", func() {
 		BeforeEach(func() {
-			ing := f.EnsureIngress(framework.NewSingleIngressWithTLS(host, "/", host, f.IngressController.Namespace, "http-svc", 80, nil))
+			ing := f.EnsureIngress(framework.NewSingleIngressWithTLS(host, "/", host, []string{host}, f.IngressController.Namespace, "http-svc", 80, nil))
 
 			time.Sleep(waitForLuaSync)
 

--- a/test/e2e/ssl/secret_update.go
+++ b/test/e2e/ssl/secret_update.go
@@ -24,7 +24,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/ingress-nginx/test/e2e/framework"
 )
@@ -52,8 +52,7 @@ var _ = framework.IngressNginxDescribe("SSL", func() {
 			},
 		})
 
-		ing := f.EnsureIngress(framework.NewSingleIngressWithTLS(host, "/", host, f.IngressController.Namespace, "http-svc", 80, nil))
-
+		ing := f.EnsureIngress(framework.NewSingleIngressWithTLS(host, "/", host, []string{host}, f.IngressController.Namespace, "http-svc", 80, nil))
 		_, err := framework.CreateIngressTLSSecret(f.KubeClientSet,
 			ing.Spec.TLS[0].Hosts,
 			ing.Spec.TLS[0].SecretName,


### PR DESCRIPTION
**What this PR does / why we need it**:

Verifies the generated server contains an SSL Certificate and the list of common names contains both FQDN.
Also, this PR adds support for wildcard names in the CN of the SSL certificate

**Which issue this PR fixes**: 

fixes #2230
fixes #2043
