### PR TITLE
add limit connection status code

### DIFF
--- a/docs/user-guide/nginx-configuration/configmap.md
+++ b/docs/user-guide/nginx-configuration/configmap.md
@@ -146,6 +146,7 @@ The following table shows a configuration option's name, type, and the default v
 |[http-redirect-code](#http-redirect-code)|int|308|
 |[proxy-buffering](#proxy-buffering)|string|"off"|
 |[limit-req-status-code](#limit-req-status-code)|int|503|
+|[limit-conn-status-code](#limit-conn-status-code)|int|503|
 |[no-tls-redirect-locations](#no-tls-redirect-locations)|string|"/.well-known/acme-challenge"|
 |[no-auth-locations](#no-auth-locations)|string|"/.well-known/acme-challenge"|
 |[block-cidrs](#block-cidrs)|[]string|""|
@@ -826,6 +827,10 @@ Enables or disables [buffering of responses from the proxied server](http://ngin
 ## limit-req-status-code
 
 Sets the [status code to return in response to rejected requests](http://nginx.org/en/docs/http/ngx_http_limit_req_module.html#limit_req_status). _**default:**_ 503
+
+## limit-conn-status-code
+
+Sets the [status code to return in response to rejected connections](http://nginx.org/en/docs/http/ngx_http_limit_conn_module.html#limit_conn_status). _**default:**_ 503
 
 ## no-tls-redirect-locations
 

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -519,6 +519,11 @@ type Configuration struct {
 	// Default: 503
 	LimitReqStatusCode int `json:"limit-req-status-code"`
 
+	// LimitConnStatusCode Sets the status code to return in response to rejected connections.
+	// http://nginx.org/en/docs/http/ngx_http_limit_conn_module.html#limit_conn_status
+	// Default: 503
+	LimitConnStatusCode int `json:"limit-conn-status-code"`
+
 	// EnableSyslog enables the configuration for remote logging in NGINX
 	EnableSyslog bool `json:"enable-syslog"`
 	// SyslogHost FQDN or IP address where the logs should be sent
@@ -675,6 +680,7 @@ func NewDefault() Configuration {
 		JaegerSamplerType:            "const",
 		JaegerSamplerParam:           "1",
 		LimitReqStatusCode:           503,
+		LimitConnStatusCode:          503,
 		SyslogPort:                   514,
 		NoTLSRedirectLocations:       "/.well-known/acme-challenge",
 		NoAuthLocations:              "/.well-known/acme-challenge",

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -198,6 +198,7 @@ http {
     ignore_invalid_headers          {{ if $cfg.IgnoreInvalidHeaders }}on{{ else }}off{{ end }};
 
     limit_req_status                {{ $cfg.LimitReqStatusCode }};
+    limit_conn_status               {{ $cfg.LimitConnStatusCode }};
 
     {{ if $cfg.EnableOpentracing }}
     opentracing on;


### PR DESCRIPTION
**What this PR does / why we need it**:
When settings `nginx.ingress.kubernetes.io/limit-connections: 'X'` there is currently no way to change the status code for requests that reached the connection limit.