### PR TITLE
Replace deprecated apiVersion in deploy folder

### DIFF
--- a/deploy/mandatory.yaml
+++ b/deploy/mandatory.yaml
@@ -185,7 +185,7 @@ subjects:
 
 ---
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx-ingress-controller

--- a/deploy/monitoring/grafana.yaml
+++ b/deploy/monitoring/grafana.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/deploy/with-rbac.yaml
+++ b/deploy/with-rbac.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx-ingress-controller


### PR DESCRIPTION
Removes old `extensions/v1beta1` apiVersion for all Deployments. 