### PR TITLE
Empty access_by_lua_block breaks satisfy any

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -1032,8 +1032,10 @@ stream {
             rewrite_by_lua_block {
                 balancer.rewrite()
             }
+
+            {{ if shouldConfigureLuaRestyWAF $all.Cfg.DisableLuaRestyWAF $location.LuaRestyWAF.Mode }}
+
             access_by_lua_block {
-                {{ if shouldConfigureLuaRestyWAF $all.Cfg.DisableLuaRestyWAF $location.LuaRestyWAF.Mode }}
                 local lua_resty_waf = require("resty.waf")
                 local waf = lua_resty_waf:new()
 
@@ -1074,8 +1076,9 @@ stream {
                 {{ end }}
 
                 waf:exec()
-                {{ end }}
             }
+            {{ end }}
+
             header_filter_by_lua_block {
                 {{ if shouldConfigureLuaRestyWAF $all.Cfg.DisableLuaRestyWAF $location.LuaRestyWAF.Mode }}
                 local lua_resty_waf = require "resty.waf"


### PR DESCRIPTION
**What this PR does / why we need it**:

When `access_by_lua_block` is empty and `satisfy any` is specified in a snippet (or custom template), 
any restriction is broken due the fact an empty `access_by_lua_block` block means 'OK'

Example:
```
nginx.ingress.kubernetes.io/configuration-snippet: |-
  allow 127.0.0.0/8;
  allow 10.0.0.0/8;
  deny all;
  satisfy any;
```

This PR enables the `access_by_lua_block` only if the waf module is enabled

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #3480
