### PR TITLE
Remove flag sort-backends

### DIFF
--- a/cmd/nginx/flags.go
+++ b/cmd/nginx/flags.go
@@ -114,9 +114,6 @@ different namespace than their own. May be used together with watch-namespace.`)
 			`Update the load-balancer status of Ingress objects when the controller shuts down.
 Requires the update-status parameter.`)
 
-		sortBackends = flags.Bool("sort-backends", false,
-			`Sort servers inside NGINX upstreams.`)
-
 		useNodeInternalIP = flags.Bool("report-node-internal-ip-address", false,
 			`Set the load-balancer status of Ingress objects to internal Node addresses instead of external.
 Requires the update-status parameter.`)
@@ -130,7 +127,7 @@ Requires the update-status parameter.`)
 		annotationsPrefix = flags.String("annotations-prefix", "nginx.ingress.kubernetes.io",
 			`Prefix of the Ingress annotations specific to the NGINX controller.`)
 
-		enableSSLChainCompletion = flags.Bool("enable-ssl-chain-completion", true,
+		enableSSLChainCompletion = flags.Bool("enable-ssl-chain-completion", false,
 			`Autocomplete SSL certificate chains with missing intermediate CA certificates.
 A valid certificate chain is required to enable OCSP stapling. Certificates
 uploaded to Kubernetes must have the "Authority Information Access" X.509 v3
@@ -162,6 +159,8 @@ Feature backed by OpenResty Lua libraries. Requires that OCSP stapling is not en
 		disableCatchAll = flags.Bool("disable-catch-all", false,
 			`Disable support for catch-all Ingresses`)
 	)
+
+	flags.MarkDeprecated("sort-backends", "Feature removed because of the lua load balancer that removed the need of reloads for change in endpoints")
 
 	flag.Set("logtostderr", "true")
 
@@ -248,7 +247,6 @@ Feature backed by OpenResty Lua libraries. Requires that OCSP stapling is not en
 		PublishStatusAddress:       *publishStatusAddress,
 		ForceNamespaceIsolation:    *forceIsolation,
 		UpdateStatusOnShutdown:     *updateStatusOnShutdown,
-		SortBackends:               *sortBackends,
 		UseNodeInternalIP:          *useNodeInternalIP,
 		SyncRateLimit:              *syncRateLimit,
 		DynamicCertificatesEnabled: *dynamicCertificatesEnabled,

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -18,7 +18,6 @@ package controller
 
 import (
 	"fmt"
-	"math/rand"
 	"sort"
 	"strconv"
 	"strings"
@@ -78,8 +77,6 @@ type Configuration struct {
 	UseNodeInternalIP      bool
 	ElectionID             string
 	UpdateStatusOnShutdown bool
-
-	SortBackends bool
 
 	ListenPorts *ngx_config.ListenPorts
 
@@ -845,17 +842,6 @@ func (n *NGINXController) serviceEndpoints(svcKey, backendPort string) ([]ingres
 				klog.Warningf("Service %q does not have any active Endpoint.", svcKey)
 			}
 
-			if n.cfg.SortBackends {
-				sort.SliceStable(endps, func(i, j int) bool {
-					iName := endps[i].Address
-					jName := endps[j].Address
-					if iName != jName {
-						return iName < jName
-					}
-
-					return endps[i].Port < endps[j].Port
-				})
-			}
 			upstreams = append(upstreams, endps...)
 			break
 		}
@@ -882,14 +868,6 @@ func (n *NGINXController) serviceEndpoints(svcKey, backendPort string) ([]ingres
 
 		upstreams = append(upstreams, endps...)
 		return upstreams, nil
-	}
-
-	if !n.cfg.SortBackends {
-		rand.Seed(time.Now().UnixNano())
-		for i := range upstreams {
-			j := rand.Intn(i + 1)
-			upstreams[i], upstreams[j] = upstreams[j], upstreams[i]
-		}
 	}
 
 	return upstreams, nil


### PR DESCRIPTION
**What this PR does / why we need it**:

The flag sort-backends was required to avoid reloads because of the change in the order of the upstream servers in the generated nginx.conf file. This is not an issue anymore since the use of lua.