### PR TITLE
worker_connections should be less (3/4th) than worker_rlimit_nofile

### DIFF
--- a/internal/ingress/controller/nginx.go
+++ b/internal/ingress/controller/nginx.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"math"
 	"net"
 	"net/http"
 	"os"
@@ -538,8 +539,9 @@ func (n *NGINXController) OnUpdate(ingressCfg ingress.Configuration) error {
 	}
 
 	if cfg.MaxWorkerConnections == 0 {
-		klog.V(3).Infof("Adjusting MaxWorkerConnections variable to %d", cfg.MaxWorkerOpenFiles)
-		cfg.MaxWorkerConnections = cfg.MaxWorkerOpenFiles
+		maxWorkerConnections := int(math.Ceil(float64(cfg.MaxWorkerOpenFiles * 3.0 / 4)))
+		klog.V(3).Infof("Adjusting MaxWorkerConnections variable to %d", maxWorkerConnections)
+		cfg.MaxWorkerConnections = maxWorkerConnections
 	}
 
 	setHeaders := map[string]string{}


### PR DESCRIPTION
**What this PR does / why we need it**:
When calculated automatically we set `worker_rlimit_nofile` and `worker_connections` to the same value. This can be problematic because connections are not the only things using file descriptors. Nginx can be using file descriptors to open temporary files it uses to store cached data, or for serving static asset, or serving compressed data from disk etc.

This PR suggest to set the `worker_connections` to 75% of `worker_rlimit_nofile`, but I'm not yet convinced this is the best option. Open for discussion.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
