### PR TITLE
[User guide] Fix link anchor for `from-to-www-redirect` annotation

### DIFF
--- a/docs/user-guide/nginx-configuration/annotations.md
+++ b/docs/user-guide/nginx-configuration/annotations.md
@@ -43,7 +43,7 @@ You can add these Kubernetes annotations to specific Ingress objects to customiz
 |[nginx.ingress.kubernetes.io/cors-allow-credentials](#enable-cors)|"true" or "false"|
 |[nginx.ingress.kubernetes.io/cors-max-age](#enable-cors)|number|
 |[nginx.ingress.kubernetes.io/force-ssl-redirect](#server-side-https-enforcement-through-redirect)|"true" or "false"|
-|[nginx.ingress.kubernetes.io/from-to-www-redirect](#redirect-from-to-www)|"true" or "false"|
+|[nginx.ingress.kubernetes.io/from-to-www-redirect](#redirect-fromto-www)|"true" or "false"|
 |[nginx.ingress.kubernetes.io/http2-push-preload](#http2-push-preload)|"true" or "false"|
 |[nginx.ingress.kubernetes.io/limit-connections](#rate-limiting)|number|
 |[nginx.ingress.kubernetes.io/limit-rps](#rate-limiting)|number|


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

This PR fixes the link anchor for the `nginx.ingress.kubernetes.io/from-to-www-redirect` annotation in the user guide.

**Which issue this PR fixes**

_None_

**Special notes for your reviewer**:

Try it:

* [docs/user-guide/nginx-configuration/annotations.md](https://github.com/kubernetes/ingress-nginx/blob/0e783b3/docs/user-guide/nginx-configuration/annotations.md) (before the fix)
* [docs/user-guide/nginx-configuration/annotations.md](https://github.com/janpieper/ingress-nginx/blob/4f5798eb1229ac546be875b8d566306bfbe9dee5/docs/user-guide/nginx-configuration/annotations.md) (after the fix)

Or try it on the official website:

https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/