### PR TITLE
fix removing endpoints from balancing if there is no endpoints

### DIFF
--- a/rootfs/etc/nginx/lua/balancer.lua
+++ b/rootfs/etc/nginx/lua/balancer.lua
@@ -75,6 +75,10 @@ end
 
 local function sync_backend(backend)
   if not backend.endpoints or #backend.endpoints == 0 then
+    if balancers[backend.name] then
+      balancers[backend.name] = nil
+    end
+
     ngx.log(ngx.INFO, string.format("there is no endpoint for backend %s. Skipping...", backend.name))
     return
   end


### PR DESCRIPTION
**What this PR does / why we need it**:
Balancer don't remove current endpoints for service even it's have no endpoint for now


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #3523

**Special notes for your reviewer**:
