### PR TITLE
enable use-forwarded-headers for L7 LB

### DIFF
--- a/deploy/provider/aws/patch-configmap-l7.yaml
+++ b/deploy/provider/aws/patch-configmap-l7.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/part-of: ingress-nginx
 data:
   use-proxy-protocol: "false"
-
+  use-forwarded-headers: "true"
+  proxy-real-ip-cidr: "0.0.0.0/0" # restrict this to the IP addresses of ELB
 ---
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Enable `use-forwarded-headers` in AWS L7 config since we disable it by default in https://github.com/kubernetes/ingress-nginx/pull/3333
