### PR TITLE
Fix --disable-catch-all

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -432,6 +432,36 @@ func newSingleIngressWithRules(name, path, host, ns, service string, port int, a
 	return newSingleIngress(name, ns, annotations, spec)
 }
 
+// NewSingleIngressWithBackendAndRules creates an ingress with both a default backend and a rule
+func NewSingleIngressWithBackendAndRules(name, path, host, ns, defaultService string, defaultPort int, service string, port int, annotations *map[string]string) *extensions.Ingress {
+	spec := extensions.IngressSpec{
+		Backend: &extensions.IngressBackend{
+			ServiceName: defaultService,
+			ServicePort: intstr.FromInt(defaultPort),
+		},
+		Rules: []extensions.IngressRule{
+			{
+				Host: host,
+				IngressRuleValue: extensions.IngressRuleValue{
+					HTTP: &extensions.HTTPIngressRuleValue{
+						Paths: []extensions.HTTPIngressPath{
+							{
+								Path: path,
+								Backend: extensions.IngressBackend{
+									ServiceName: service,
+									ServicePort: intstr.FromInt(port),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	return newSingleIngress(name, ns, annotations, spec)
+}
+
 // NewSingleCatchAllIngress creates a simple ingress with a catch-all backend
 func NewSingleCatchAllIngress(name, ns, service string, port int, annotations *map[string]string) *extensions.Ingress {
 	spec := extensions.IngressSpec{

--- a/test/e2e/settings/disable_catch_all.go
+++ b/test/e2e/settings/disable_catch_all.go
@@ -109,4 +109,24 @@ var _ = framework.IngressNginxDescribe("Disabled catch-all", func() {
 		Expect(errs).To(BeNil())
 		Expect(resp.StatusCode).Should(Equal(http.StatusNotFound))
 	})
+
+	It("should allow Ingress with both a default backend and rules", func() {
+		host := "foo"
+
+		ing := framework.NewSingleIngressWithBackendAndRules("not-catch-all", "/rulepath", host, f.IngressController.Namespace, "http-svc", 80, "http-svc", 80, nil)
+		f.EnsureIngress(ing)
+
+		f.WaitForNginxServer(host, func(cfg string) bool {
+			return strings.Contains(cfg, "server_name foo")
+		})
+
+		resp, _, errs := gorequest.New().
+			Get(f.IngressController.HTTPURL).
+			Set("Host", host).
+			End()
+
+		Expect(errs).To(BeNil())
+		Expect(resp.StatusCode).Should(Equal(http.StatusOK))
+
+	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
The `--disable-catch-all` flag that was recently added in https://github.com/kubernetes/ingress-nginx/pull/3586 is supposed to disallow ingresses that create a catch all server. Normally, a catch all server is created only if an ingress both defines a default backend **and** has no rules, however the flag disallows any ingress that just defines a default backend. The result is that ingresses like this are blocked by the flag:

```yaml
spec:
  backend:
    serviceName: echo-service
    servicePort: 8080
  rules:
  - host: example.com
    http:
      paths:
        - path: /testpath
          backend:
            serviceName: other-service
            servicePort: 5678
```

This PR tightens the circumstances under which the flag causes an ingress to be ignored from `spec.Backend != nil` to `spec.Backend != nil && len(spec.Rules) == 0`, as well as adding a test for the new behaviour.

cc: @ElvinEfendi 
