### PR TITLE
Add params for access log

### DIFF
--- a/docs/user-guide/nginx-configuration/configmap.md
+++ b/docs/user-guide/nginx-configuration/configmap.md
@@ -30,6 +30,7 @@ The following table shows a configuration option's name, type, and the default v
 |[add-headers](#add-headers)|string|""|
 |[allow-backend-server-header](#allow-backend-server-header)|bool|"false"|
 |[hide-headers](#hide-headers)|string array|empty|
+|[access-log-params](#access-log-params)|string|""|
 |[access-log-path](#access-log-path)|string|"/var/log/nginx/access.log"|
 |[error-log-path](#error-log-path)|string|"/var/log/nginx/error.log"|
 |[enable-dynamic-tls-records](#enable-dynamic-tls-records)|bool|"true"|
@@ -168,6 +169,13 @@ _**default:**_ empty
 
 _References:_
 [http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_hide_header](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_hide_header)
+
+## access-log-params
+
+Additional params for access_log. For example, buffer=16k, gzip, flush=1m
+
+_References:_
+[http://nginx.org/en/docs/http/ngx_http_log_module.html#access_log](http://nginx.org/en/docs/http/ngx_http_log_module.html#access_log)
 
 ## access-log-path
 

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -94,6 +94,11 @@ type Configuration struct {
 	// By default this is disabled
 	AllowBackendServerHeader bool `json:"allow-backend-server-header"`
 
+	// AccessLogParams sets additionals params for access_log
+	// http://nginx.org/en/docs/http/ngx_http_log_module.html#access_log
+	// By default it's empty
+	AccessLogParams string `json:"access-log-params,omitempty"`
+
 	// AccessLogPath sets the path of the access logs if enabled
 	// http://nginx.org/en/docs/http/ngx_http_log_module.html#access_log
 	// By default access logs go to /var/log/nginx/access.log
@@ -577,6 +582,7 @@ func NewDefault() Configuration {
 	cfg := Configuration{
 		AllowBackendServerHeader:   false,
 		AccessLogPath:              "/var/log/nginx/access.log",
+		AccessLogParams:            "",
 		WorkerCPUAffinity:          "",
 		ErrorLogPath:               "/var/log/nginx/error.log",
 		BlockCIDRs:                 defBlockEntity,

--- a/internal/ingress/controller/template/configmap_test.go
+++ b/internal/ingress/controller/template/configmap_test.go
@@ -59,6 +59,7 @@ func TestMergeConfigMapToStruct(t *testing.T) {
 		"skip-access-log-urls":          "/log,/demo,/test",
 		"use-proxy-protocol":            "true",
 		"disable-access-log":            "true",
+		"access-log-params":             "buffer=4k gzip",
 		"access-log-path":               "/var/log/test/access.log",
 		"error-log-path":                "/var/log/test/error.log",
 		"use-gzip":                      "true",
@@ -75,6 +76,7 @@ func TestMergeConfigMapToStruct(t *testing.T) {
 	def := config.NewDefault()
 	def.CustomHTTPErrors = []int{300, 400}
 	def.DisableAccessLog = true
+	def.AccessLogParams = "buffer=4k gzip"
 	def.AccessLogPath = "/var/log/test/access.log"
 	def.ErrorLogPath = "/var/log/test/error.log"
 	def.SkipAccessLogURLs = []string{"/log", "/demo", "/test"}

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -259,7 +259,7 @@ http {
     {{ if $cfg.EnableSyslog }}
     access_log syslog:server={{ $cfg.SyslogHost }}:{{ $cfg.SyslogPort }} upstreaminfo if=$loggable;
     {{ else }}
-    access_log {{ $cfg.AccessLogPath }} upstreaminfo if=$loggable;
+    access_log {{ $cfg.AccessLogPath }} upstreaminfo {{ $cfg.AccessLogParams }} if=$loggable;
     {{ end }}
     {{ end }}
 
@@ -751,7 +751,7 @@ stream {
     {{ if $cfg.DisableAccessLog }}
     access_log off;
     {{ else }}
-    access_log {{ $cfg.AccessLogPath }} log_stream;
+    access_log {{ $cfg.AccessLogPath }} log_stream {{ $cfg.AccessLogParams }};
     {{ end }}
 
     error_log  {{ $cfg.ErrorLogPath }};


### PR DESCRIPTION
**What this PR does / why we need it**:
Add additional params for access_log to improve performance while writing logs. For example, you may want to set **buffer=4k** or/and **gzip**

[nginx docs](http://nginx.org/en/docs/http/ngx_http_log_module.html#access_log)

