### PR TITLE
Persist ewma stats through upstream changes

### DIFF
--- a/rootfs/etc/nginx/lua/balancer/ewma.lua
+++ b/rootfs/etc/nginx/lua/balancer/ewma.lua
@@ -113,9 +113,14 @@ function _M.sync(self, backend)
     local name = endpoint.address .. ":" .. endpoint.port
     old_ewma_average = old_ewma_average + (self.ewma[name] or 0)
   end
-  old_ewma_average = (old_ewma_average / #self.peers) or 0
 
-  -- Preserve the values for remaining endpoints and set the new ones to the average 
+  if #self.peers >= 1 then
+    old_ewma_average = old_ewma_average / #self.peers
+  else
+    old_ewma_average = 0
+  end
+
+  -- Preserve the values for remaining endpoints and set the new ones to the average
   local new_ewma = {}
   local new_ewma_last_touched_at = {}
   local now = ngx.now()
@@ -135,7 +140,6 @@ function _M.sync(self, backend)
   self.peers = backend.endpoints
   self.ewma = new_ewma
   self.ewma_last_touched_at = new_ewma_last_touched_at
-
 end
 
 function _M.new(self, backend)

--- a/rootfs/etc/nginx/lua/balancer/ewma.lua
+++ b/rootfs/etc/nginx/lua/balancer/ewma.lua
@@ -72,6 +72,24 @@ local function pick_and_score(self, peers, k)
   return peers[lowest_score_index]
 end
 
+-- Arithmetic mean of the EWMAs, or 0 if there are no entries
+local function get_average_ewma(peers, ewma)
+   -- Get the average for the ewma
+  local old_ewma_average = 0
+  for _, endpoint in ipairs(peers) do
+    local name = endpoint.address .. ":" .. endpoint.port
+    old_ewma_average = old_ewma_average + (ewma[name] or 0)
+  end
+
+  if #peers >= 1 then
+    old_ewma_average = old_ewma_average / #peers
+  else
+    old_ewma_average = 0
+  end
+
+  return old_ewma_average
+end
+
 function _M.balance(self)
   local peers = self.peers
   local endpoint = peers[1]
@@ -107,23 +125,12 @@ function _M.sync(self, backend)
     return
   end
 
-  -- Get the average for the ewma
-  local old_ewma_average = 0
-  for _, endpoint in ipairs(self.peers) do
-    local name = endpoint.address .. ":" .. endpoint.port
-    old_ewma_average = old_ewma_average + (self.ewma[name] or 0)
-  end
-
-  if #self.peers >= 1 then
-    old_ewma_average = old_ewma_average / #self.peers
-  else
-    old_ewma_average = 0
-  end
-
   -- Preserve the values for remaining endpoints and set the new ones to the average
   local new_ewma = {}
   local new_ewma_last_touched_at = {}
   local now = ngx.now()
+  local old_ewma_average = get_average_ewma(self.peers, self.ewma)
+
   for _, endpoint in ipairs(backend.endpoints) do
     local name = endpoint.address .. ":" .. endpoint.port
     if self.ewma[name] ~= nil then


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, whenever the list of upstreams changes, the EWMA load balancer forgets all of its information, even the information of upstreams that don't change. This PR makes two changes:

1. Persist the information for upstreams that don't change when the list changes
2. Set the EWMA for new upstreams to the average, to avoid starting at 0 and consequently flooding the new upstream with requests.

Example: If the EWMAs for the current upstreams are

| Upstream  | EWMA |
| ------------- | ------------- |
| 10.0.0.25:8080   | 50ms  |
| 10.0.0.26:8080 | 30ms  |

And upstream `10.0.0.27:8080` is added, the new EWMAs would be:

| Upstream  | EWMA |
| ------------- | ------------- |
| 10.0.0.25:8080   | 50ms  |
| 10.0.0.26:8080 | 30ms  |
| 10.0.0.27:8080 | 40ms |

instead of setting them all to zero.

cc: @ElvinEfendi 
