### PR TITLE
Set X-Forwarded-Port to 443 if X-Forwarded-Proto is https

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -345,8 +345,9 @@ http {
         default          $pass_server_port;
     }
     {{ else }}
-    map $pass_server_port $pass_port {
-        {{ $all.ListenPorts.HTTPS }}              443;
+    map "$pass_server_port:$pass_access_scheme" $pass_port {
+        "~^{{ $all.ListenPorts.HTTPS }}:.*"           443;
+        "~.*:https$"         443;
         default          $pass_server_port;
     }
     {{ end }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Set the `X-Forwarded-Port` header to `443` when `X-Forwarded-Proto` is `https`.

Fixes #3192.
