### PR TITLE
Fix flaky test

### DIFF
--- a/internal/ingress/controller/store/store_test.go
+++ b/internal/ingress/controller/store/store_test.go
@@ -945,8 +945,6 @@ func TestUpdateSecretIngressMap(t *testing.T) {
 func TestListIngresses(t *testing.T) {
 	s := newStore(t)
 
-	sameTime := metav1.NewTime(time.Now())
-
 	ingressToIgnore := &ingress.Ingress{
 		Ingress: extensions.Ingress{
 			ObjectMeta: metav1.ObjectMeta{
@@ -955,7 +953,7 @@ func TestListIngresses(t *testing.T) {
 				Annotations: map[string]string{
 					"kubernetes.io/ingress.class": "something",
 				},
-				CreationTimestamp: sameTime,
+				CreationTimestamp: metav1.NewTime(time.Now()),
 			},
 			Spec: extensions.IngressSpec{
 				Backend: &extensions.IngressBackend{
@@ -972,7 +970,7 @@ func TestListIngresses(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "test-3",
 				Namespace:         "testns",
-				CreationTimestamp: sameTime,
+				CreationTimestamp: metav1.NewTime(time.Now()),
 			},
 			Spec: extensions.IngressSpec{
 				Rules: []extensions.IngressRule{


### PR DESCRIPTION
**What this PR does / why we need it**:
`TestListIngresses` was failing randomly in Travis because it depends on iterating over a map in a particular order. (see https://github.com/kubernetes/ingress-nginx/issues/3726)

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes https://github.com/kubernetes/ingress-nginx/issues/3726

**Special notes for your reviewer**:

@aledbf I fixed the issue just by removing the identical CreationTimestamp for the two ingresses. If there is supposed to be some other ordering guarantee, like order added, then the behavior of ListIngresses might need to be modified if this `map`-backed store is used outside of testing.
