### PR TITLE
Adjust probe timeouts

### DIFF
--- a/deploy/mandatory.yaml
+++ b/deploy/mandatory.yaml
@@ -251,7 +251,7 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
             successThreshold: 1
-            timeoutSeconds: 1
+            timeoutSeconds: 10
           readinessProbe:
             failureThreshold: 3
             httpGet:
@@ -260,6 +260,6 @@ spec:
               scheme: HTTP
             periodSeconds: 10
             successThreshold: 1
-            timeoutSeconds: 1
+            timeoutSeconds: 10
 
 ---

--- a/deploy/with-rbac.yaml
+++ b/deploy/with-rbac.yaml
@@ -64,7 +64,7 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
             successThreshold: 1
-            timeoutSeconds: 1
+            timeoutSeconds: 10
           readinessProbe:
             failureThreshold: 3
             httpGet:
@@ -73,7 +73,7 @@ spec:
               scheme: HTTP
             periodSeconds: 10
             successThreshold: 1
-            timeoutSeconds: 1
+            timeoutSeconds: 10
 
 ---
 


### PR DESCRIPTION
**What this PR does / why we need it**:

In https://github.com/kubernetes/ingress-nginx/issues/3457 some users reported timeouts in the probes when the node/pod is under heavy load https://github.com/kubernetes/ingress-nginx/issues/3457#issuecomment-455601331 Increasing the timeout should avoid potential restarts