### PR TITLE
Fix ingress updating for session-cookie-* annotation changes

### DIFF
--- a/internal/ingress/types_equals.go
+++ b/internal/ingress/types_equals.go
@@ -230,6 +230,12 @@ func (csa1 *CookieSessionAffinity) Equal(csa2 *CookieSessionAffinity) bool {
 	if csa1.Path != csa2.Path {
 		return false
 	}
+	if csa1.Expires != csa2.Expires {
+		return false
+	}
+	if csa1.MaxAge != csa2.MaxAge {
+		return false
+	}
 
 	return true
 }

--- a/rootfs/etc/nginx/lua/test/balancer/sticky_test.lua
+++ b/rootfs/etc/nginx/lua/test/balancer/sticky_test.lua
@@ -55,7 +55,7 @@ describe("Sticky", function()
       it("returns an instance containing the corresponding cookie name", function()
         local sticky_balancer_instance = sticky:new(test_backend)
         local test_backend_cookie_name = test_backend.sessionAffinityConfig.cookieSessionAffinity.name
-        assert.equal(sticky_balancer_instance.cookie_name, test_backend_cookie_name)
+        assert.equal(sticky_balancer_instance:cookie_name(), test_backend_cookie_name)
       end)
     end)
 
@@ -65,7 +65,7 @@ describe("Sticky", function()
         temp_backend.sessionAffinityConfig.cookieSessionAffinity.name = nil
         local sticky_balancer_instance = sticky:new(temp_backend)
         local default_cookie_name = "route"
-        assert.equal(sticky_balancer_instance.cookie_name, default_cookie_name)
+        assert.equal(sticky_balancer_instance:cookie_name(), default_cookie_name)
       end)
     end)
 


### PR DESCRIPTION
**What this PR does / why we need it**: The `sticky` load balancer was ignoring changes in 
```yaml 
nginx.ingress.kubernetes.io/session-cookie-name
nginx.ingress.kubernetes.io/session-cookie-hash
nginx.ingress.kubernetes.io/session-cookie-expires
nginx.ingress.kubernetes.io/session-cookie-max-age
```
requiring the creation of a new pod before the annotations were applied.

**Which issue this PR fixes** : fixes #3725

**Special notes for your reviewer**: @ElvinEfendi let me know if this change is big enough to add an e2e test.
