### PR TITLE
Parse environment variables in OpenTracing configuration

### DIFF
--- a/docs/user-guide/third-party-addons/opentracing.md
+++ b/docs/user-guide/third-party-addons/opentracing.md
@@ -1,13 +1,13 @@
 # OpenTracing
 
-Enables requests served by nginx for distributed tracing via The OpenTracing Project.
+Enables requests served by NGINX for distributed tracing via The OpenTracing Project.
 
 Using the third party module [opentracing-contrib/nginx-opentracing](https://github.com/opentracing-contrib/nginx-opentracing) the NGINX ingress controller can configure NGINX to enable [OpenTracing](http://opentracing.io) instrumentation.
 By default this feature is disabled.
 
 ## Usage
 
-To enable the instrumentation we must enable opentracing in the configuration configmap:
+To enable the instrumentation we must enable OpenTracing in the configuration ConfigMap:
 ```
 data:
   enable-opentracing: "true"
@@ -19,6 +19,7 @@ We must also set the host to use when uploading traces:
 zipkin-collector-host: zipkin.default.svc.cluster.local
 jaeger-collector-host: jaeger-collector.default.svc.cluster.local
 ```
+NOTE: While the option is called `jaeger-collector-host`, you will need to point this to a `jaeger-agent`, and not the `jaeger-collector` component.
 
 Next you will need to deploy a distributed tracing system which uses OpenTracing. Both [Zipkin](https://github.com/openzipkin/zipkin) and
 [Jaeger](https://github.com/jaegertracing/jaeger) have been tested.
@@ -48,6 +49,8 @@ jaeger-sampler-type
 jaeger-sampler-param
 ```
 
+All these options (including host) allow environment variables, such as `$HOSTNAME` or `$HOST_IP`. In the case of Jaeger, if you have a Jaeger agent running on each machine in your cluster, you can use something like `$HOST_IP` (which can be 'mounted' with the `status.hostIP` fieldpath) to make sure traces will be sent to the local agent.
+
 ## Examples
 
 The following examples show how to deploy and test different distributed tracing systems. These example can be performed
@@ -56,14 +59,14 @@ using Minikube.
 ### Zipkin
 
 In the [rnburn/zipkin-date-server](https://github.com/rnburn/zipkin-date-server)
-github repository is an example of a dockerized date service. To install the example and zipkin collector run:
+GitHub repository is an example of a dockerized date service. To install the example and Zipkin collector run:
 
 ```
 kubectl create -f https://raw.githubusercontent.com/rnburn/zipkin-date-server/master/kubernetes/zipkin.yaml
 kubectl create -f https://raw.githubusercontent.com/rnburn/zipkin-date-server/master/kubernetes/deployment.yaml
 ```
 
-Also we need to configure the NGINX controller configmap with the required values:
+Also we need to configure the NGINX controller ConfigMap with the required values:
 
 ```
 $ echo '
@@ -78,22 +81,22 @@ metadata:
 ' | kubectl replace -f -
 ```
 
-In the zipkin interface we can see the details:
+In the Zipkin interface we can see the details:
 ![zipkin screenshot](../../images/zipkin-demo.png "zipkin collector screenshot")
 
 ### Jaeger
 
-1. Enable Ingress addon in minikube:
+1. Enable Ingress addon in Minikube:
     ```
     $ minikube addons enable ingress
     ```
 
-2. Add minikube IP to /etc/hosts:
+2. Add Minikube IP to /etc/hosts:
     ```
     $ echo "$(minikube ip) example.com" | sudo tee -a /etc/hosts
     ```
 
-3. Apply a Basic Service and Ingress Resource:
+3. Apply a basic Service and Ingress Resource:
     ```
     # Create Echoheaders Deployment
     $ kubectl run echoheaders --image=k8s.gcr.io/echoserver:1.4 --replicas=1 --port=8080
@@ -178,5 +181,5 @@ In the zipkin interface we can see the details:
     http://192.168.99.100:30183
     ```
 
-    In the jaeger interface we can see the details:
+    In the Jaeger interface we can see the details:
     ![jaeger screenshot](../../images/jaeger-demo.png "jaeger collector screenshot")

--- a/docs/user-guide/third-party-addons/opentracing.md
+++ b/docs/user-guide/third-party-addons/opentracing.md
@@ -19,7 +19,7 @@ We must also set the host to use when uploading traces:
 zipkin-collector-host: zipkin.default.svc.cluster.local
 jaeger-collector-host: jaeger-collector.default.svc.cluster.local
 ```
-NOTE: While the option is called `jaeger-collector-host`, you will need to point this to a `jaeger-agent`, and not the `jaeger-collector` component.
+NOTE: While the option is called `jaeger-collector-host`, you will need to point this to a `jaeger-agent`, and not the `jaeger-collector` component.  
 
 Next you will need to deploy a distributed tracing system which uses OpenTracing. Both [Zipkin](https://github.com/openzipkin/zipkin) and
 [Jaeger](https://github.com/jaegertracing/jaeger) have been tested.
@@ -49,7 +49,7 @@ jaeger-sampler-type
 jaeger-sampler-param
 ```
 
-All these options (including host) allow environment variables, such as `$HOSTNAME` or `$HOST_IP`. In the case of Jaeger, if you have a Jaeger agent running on each machine in your cluster, you can use something like `$HOST_IP` (which can be 'mounted' with the `status.hostIP` fieldpath) to make sure traces will be sent to the local agent.
+All these options (including host) allow environment variables, such as `$HOSTNAME` or `$HOST_IP`. In the case of Jaeger, if you have a Jaeger agent running on each machine in your cluster, you can use something like `$HOST_IP` (which can be 'mounted' with the `status.hostIP` fieldpath, as described [here](https://kubernetes.io/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/#capabilities-of-the-downward-api)) to make sure traces will be sent to the local agent.
 
 ## Examples
 

--- a/internal/ingress/controller/nginx.go
+++ b/internal/ingress/controller/nginx.go
@@ -954,7 +954,7 @@ func createOpentracingCfg(cfg ngx_config.Configuration) error {
 			return err
 		}
 	} else if cfg.JaegerCollectorHost != "" {
-		tmpl, err = template.New("jarger").Parse(jaegerTmpl)
+		tmpl, err = template.New("jaeger").Parse(jaegerTmpl)
 		if err != nil {
 			return err
 		}
@@ -968,7 +968,10 @@ func createOpentracingCfg(cfg ngx_config.Configuration) error {
 		return err
 	}
 
-	return ioutil.WriteFile("/etc/nginx/opentracing.json", tmplBuf.Bytes(), file.ReadWriteByUser)
+	// Expand possible environment variables before writing the configuration to file.
+	expanded := os.ExpandEnv(string(tmplBuf.Bytes()))
+
+	return ioutil.WriteFile("/etc/nginx/opentracing.json", []byte(expanded), file.ReadWriteByUser)
 }
 
 func cleanTempNginxCfg() error {


### PR DESCRIPTION
**What this PR does / why we need it**: Gives users the opportunity to use environment variables in the OpenTracing configuration.

**Which issue this PR fixes**: fixes #3224

**Special notes for your reviewer**: I took the liberty of cleaning up the documentation on OpenTracing a little bit as well. Tested and verified the feature (with $HOST_IP example) locally.
