### PR TITLE
Add mention of secure-backends to backend-protocol docs

### DIFF
--- a/docs/user-guide/nginx-configuration/annotations.md
+++ b/docs/user-guide/nginx-configuration/annotations.md
@@ -727,7 +727,7 @@ an ip address to `nginx.ingress.kubernetes.io/influxdb-host`. If you deploy Infl
 
 ### Backend Protocol
 
-Using `backend-protocol` annotations is possible to indicate how NGINX should communicate with the backend service.
+Using `backend-protocol` annotations is possible to indicate how NGINX should communicate with the backend service. (Replaces `secure-backends` in older versions)
 Valid Values: HTTP, HTTPS, GRPC, GRPCS and AJP
 
 By default NGINX uses `HTTP`.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This PR adds a mention of the deprecated `secure-backends` annotation to the new `backend-protocol` annotation. I spent all day trying to figure out how to connect to a secure backend and only finally figured it out because of #3416 .This PR adds a little note that makes it easy to Ctrl-F the old field and find the new one since many articles / SO answers reference the old `secure-backends`.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #3416 

**Special notes for your reviewer**:
