### PR TITLE
Support Opentracing with Datadog - part 2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ IMAGE = $(REGISTRY)/$(IMGNAME)
 MULTI_ARCH_IMG = $(IMAGE)-$(ARCH)
 
 # Set default base image dynamically for each arch
-BASEIMAGE?=quay.io/kubernetes-ingress-controller/nginx-$(ARCH):0.76
+BASEIMAGE?=quay.io/kubernetes-ingress-controller/nginx-$(ARCH):0.77
 
 ifeq ($(ARCH),arm64)
 	QEMUARCH=aarch64

--- a/docs/user-guide/third-party-addons/opentracing.md
+++ b/docs/user-guide/third-party-addons/opentracing.md
@@ -18,11 +18,15 @@ We must also set the host to use when uploading traces:
 ```
 zipkin-collector-host: zipkin.default.svc.cluster.local
 jaeger-collector-host: jaeger-collector.default.svc.cluster.local
+datadog-collector-host: datadog-agent.default.svc.cluster.local
 ```
 NOTE: While the option is called `jaeger-collector-host`, you will need to point this to a `jaeger-agent`, and not the `jaeger-collector` component.  
 
-Next you will need to deploy a distributed tracing system which uses OpenTracing. Both [Zipkin](https://github.com/openzipkin/zipkin) and
-[Jaeger](https://github.com/jaegertracing/jaeger) have been tested.
+Next you will need to deploy a distributed tracing system which uses OpenTracing.
+[Zipkin](https://github.com/openzipkin/zipkin) and
+[Jaeger](https://github.com/jaegertracing/jaeger) and
+[Datadog](https://github.com/DataDog/dd-opentracing-cpp)
+have been tested.
 
 Other optional configuration options:
 ```
@@ -47,6 +51,15 @@ jaeger-sampler-type
 
 # specifies the argument to be passed to the sampler constructor, Default: 1
 jaeger-sampler-param
+
+# specifies the port to use when uploading traces, Default 8126
+datadog-collector-port
+
+# specifies the service name to use for any traces created, Default: nginx
+datadog-service-name
+
+# specifies the operation name to use for any traces collected, Default: nginx.handle
+datadog-operation-name-override
 ```
 
 All these options (including host) allow environment variables, such as `$HOSTNAME` or `$HOST_IP`. In the case of Jaeger, if you have a Jaeger agent running on each machine in your cluster, you can use something like `$HOST_IP` (which can be 'mounted' with the `status.hostIP` fieldpath, as described [here](https://kubernetes.io/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/#capabilities-of-the-downward-api)) to make sure traces will be sent to the local agent.

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -491,6 +491,21 @@ type Configuration struct {
 	// Default: 1
 	JaegerSamplerParam string `json:"jaeger-sampler-param"`
 
+	// DatadogCollectorHost specifies the datadog agent host to use when uploading traces
+	DatadogCollectorHost string `json:"datadog-collector-host"`
+
+	// DatadogCollectorPort specifies the port to use when uploading traces
+	// Default: 8126
+	DatadogCollectorPort int `json:"datadog-collector-port"`
+
+	// DatadogServiceName specifies the service name to use for any traces created
+	// Default: nginx
+	DatadogServiceName string `json:"datadog-service-name"`
+
+	// DatadogOperationNameOverride overrides the operation naem to use for any traces crated
+	// Default: nginx.handle
+	DatadogOperationNameOverride string `json:"datadog-operation-name-override"`
+
 	// MainSnippet adds custom configuration to the main section of the nginx configuration
 	MainSnippet string `json:"main-snippet"`
 
@@ -685,6 +700,9 @@ func NewDefault() Configuration {
 		JaegerServiceName:            "nginx",
 		JaegerSamplerType:            "const",
 		JaegerSamplerParam:           "1",
+		DatadogServiceName:           "nginx",
+		DatadogCollectorPort:         8126,
+		DatadogOperationNameOverride: "nginx.handle",
 		LimitReqStatusCode:           503,
 		LimitConnStatusCode:          503,
 		SyslogPort:                   514,

--- a/internal/ingress/controller/nginx.go
+++ b/internal/ingress/controller/nginx.go
@@ -943,6 +943,13 @@ const jaegerTmpl = `{
   }
 }`
 
+const datadogTmpl = `{
+  "service": "{{ .DatadogServiceName }}",
+  "agent_host": "{{ .DatadogCollectorHost }}",
+  "agent_port": {{ .DatadogCollectorPort }},
+  "operation_name_override": "{{ .DatadogOperationNameOverride }}"
+}`
+
 func createOpentracingCfg(cfg ngx_config.Configuration) error {
 	var tmpl *template.Template
 	var err error
@@ -954,6 +961,11 @@ func createOpentracingCfg(cfg ngx_config.Configuration) error {
 		}
 	} else if cfg.JaegerCollectorHost != "" {
 		tmpl, err = template.New("jaeger").Parse(jaegerTmpl)
+		if err != nil {
+			return err
+		}
+	} else if cfg.DatadogCollectorHost != "" {
+		tmpl, err = template.New("datadog").Parse(datadogTmpl)
 		if err != nil {
 			return err
 		}

--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -836,6 +836,8 @@ func buildOpentracing(input interface{}) string {
 		buf.WriteString("opentracing_load_tracer /usr/local/lib/libzipkin_opentracing.so /etc/nginx/opentracing.json;")
 	} else if cfg.JaegerCollectorHost != "" {
 		buf.WriteString("opentracing_load_tracer /usr/local/lib/libjaegertracing_plugin.so /etc/nginx/opentracing.json;")
+	} else if cfg.DatadogCollectorHost != "" {
+		buf.WriteString("opentracing_load_tracer /usr/local/lib/libdd_opentracing.so /etc/nginx/opentracing.json;")
 	}
 
 	buf.WriteString("\r\n")

--- a/internal/ingress/controller/template/template_test.go
+++ b/internal/ingress/controller/template/template_test.go
@@ -1002,6 +1002,17 @@ func TestBuildOpenTracing(t *testing.T) {
 		t.Errorf("Expected '%v' but returned '%v'", expected, actual)
 	}
 
+	cfgDatadog := config.Configuration{
+		EnableOpentracing:    true,
+		DatadogCollectorHost: "datadog-host.com",
+	}
+	expected = "opentracing_load_tracer /usr/local/lib/libdd_opentracing.so /etc/nginx/opentracing.json;\r\n"
+	actual = buildOpentracing(cfgDatadog)
+
+	if expected != actual {
+		t.Errorf("Expected '%v' but returned '%v'", expected, actual)
+	}
+
 }
 
 func TestEnforceRegexModifier(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Support Opentracing with Datadog, alongside Zipkin and Jaeger.

* Build `libdd_opentracing.so` from source, install it in the nginx container.
* Plumb configuration options from the ConfigMap down to the library via `/etc/nginx/opentracing.json` template.
* Add markdown documentation.

**Which issue this PR fixes**: fixes #3752

**Special notes for your reviewer**: I didn't sink a lot of time into this. I am open to alternative approaches/implementations, or improvement suggestions.