### PR TITLE
Fix DNS lookup failures in L4 services

### DIFF
--- a/rootfs/etc/nginx/lua/tcp_udp_configuration.lua
+++ b/rootfs/etc/nginx/lua/tcp_udp_configuration.lua
@@ -1,9 +1,7 @@
 -- this is the Lua representation of TCP/UDP Configuration
 local tcp_udp_configuration_data = ngx.shared.tcp_udp_configuration_data
 
-local _M = {
-  nameservers = {}
-}
+local _M = {}
 
 function _M.get_backends_data()
   return tcp_udp_configuration_data:get("backends")

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -689,12 +689,19 @@ stream {
         -- init modules
         local ok, res
 
+        ok, res = pcall(require, "configuration")
+        if not ok then
+          error("require failed: " .. tostring(res))
+        else
+          configuration = res
+          configuration.nameservers = { {{ buildResolversForLua $cfg.Resolver $cfg.DisableIpv6DNS }} }
+        end
+
         ok, res = pcall(require, "tcp_udp_configuration")
         if not ok then
           error("require failed: " .. tostring(res))
         else
           tcp_udp_configuration = res
-          tcp_udp_configuration.nameservers = { {{ buildResolversForLua $cfg.Resolver $cfg.DisableIpv6DNS }} }
         end
 
         ok, res = pcall(require, "tcp_udp_balancer")

--- a/test/e2e/tcpudp/tcp.go
+++ b/test/e2e/tcpudp/tcp.go
@@ -22,6 +22,7 @@ import (
 	"github.com/parnurzeal/gorequest"
 	"net"
 	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,6 +32,10 @@ import (
 	. "github.com/onsi/gomega"
 
 	"k8s.io/ingress-nginx/test/e2e/framework"
+)
+
+const (
+	waitForLuaSync = 5 * time.Second
 )
 
 var _ = framework.IngressNginxDescribe("TCP Feature", func() {
@@ -164,6 +169,8 @@ var _ = framework.IngressNginxDescribe("TCP Feature", func() {
 			Update(config)
 		Expect(err).NotTo(HaveOccurred(), "unexpected error updating configmap")
 
+		time.Sleep(waitForLuaSync)
+
 		// Validate that the generated nginx config contains the expected `proxy_upstream_name` value
 		f.WaitForNginxConfiguration(
 			func(cfg string) bool {
@@ -183,6 +190,7 @@ var _ = framework.IngressNginxDescribe("TCP Feature", func() {
 			},
 		}
 		ips, err := resolver.LookupHost(context.Background(), "google-public-dns-b.google.com")
+		Expect(err).NotTo(HaveOccurred(), "unexpected error from DNS resolver")
 		Expect(ips).Should(ContainElement("8.8.4.4"))
 
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:

While adding an e2e test for https://github.com/kubernetes/ingress-nginx/pull/3615#issuecomment-451166094 I ran into DNS lookup failures when resolving DNS for external name TCP & UDP services.  Any external name TCP & UDP services defined with a hostname (vs raw IP address) do not work due to the failing DNS lookups.

This PR fixes these DNS failures.

**Details**

Before this change, `nginx.tmpl` set the `nameservers` variable on `tcp_udp_configuration.lua`. However, no code references this variable.  Instead, both `balancer.lua` and `tcp_udp_balancer.lua` load `dns.lua`, and `dns.lua` always references `configuration.nameservers`.

This PR removes the `nameservers` variable from `tcp_udp_configuration`, updates the nginx  template's `stream` config to initialize the `nameservers` variable on `configuration.lua`, and adds an e2e test to validate a L4 TCP external name service by performing a DNS lookup on google's nameservers.