### PR TITLE
Add kubectl plugin

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -896,7 +896,7 @@
   revision = "kubernetes-1.13.3"
 
 [[projects]]
-  digest = "1:04f210e4055be6dd920fbc52e6c3548ae34cdf9249cd666ad2cec41da149c7b5"
+  digest = "1:8e9cf9f8e6ced4caf9abcf7191f46d81d0ce7cbdb1ce78a17944abe0020edc50"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/errors",
@@ -905,6 +905,7 @@
     "pkg/apis/meta/internalversion",
     "pkg/apis/meta/v1",
     "pkg/apis/meta/v1/unstructured",
+    "pkg/apis/meta/v1/unstructured/unstructuredscheme",
     "pkg/apis/meta/v1beta1",
     "pkg/conversion",
     "pkg/conversion/queryparams",
@@ -961,7 +962,18 @@
   revision = "kubernetes-1.13.3"
 
 [[projects]]
-  digest = "1:65bb1c16431d6a811dbe6d68a7a7b566c1ae57ada86c3735127ee492c76dc3e3"
+  digest = "1:63793246976569a95e534c731e79cc555dabee6f8efa29a0b28ca33f23b7e28b"
+  name = "k8s.io/cli-runtime"
+  packages = [
+    "pkg/genericclioptions",
+    "pkg/genericclioptions/printers",
+    "pkg/genericclioptions/resource",
+  ]
+  pruneopts = "NUT"
+  revision = "kubernetes-1.13.3"
+
+[[projects]]
+  digest = "1:8ed4701154a41791914e89f9aad23ec76c8826824af285c5606dd4afd9ac2f25"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -1119,6 +1131,7 @@
     "plugin/pkg/client/auth/openstack",
     "rest",
     "rest/watch",
+    "restmapper",
     "testing",
     "third_party/forked/golang/template",
     "tools/auth",
@@ -1279,11 +1292,13 @@
     "k8s.io/apimachinery/pkg/watch",
     "k8s.io/apiserver/pkg/server/healthz",
     "k8s.io/apiserver/pkg/util/logs",
+    "k8s.io/cli-runtime/pkg/genericclioptions",
     "k8s.io/client-go/informers",
     "k8s.io/client-go/kubernetes",
     "k8s.io/client-go/kubernetes/fake",
     "k8s.io/client-go/kubernetes/scheme",
     "k8s.io/client-go/kubernetes/typed/core/v1",
+    "k8s.io/client-go/kubernetes/typed/extensions/v1beta1",
     "k8s.io/client-go/plugin/pkg/client/auth",
     "k8s.io/client-go/rest",
     "k8s.io/client-go/tools/cache",
@@ -1292,6 +1307,7 @@
     "k8s.io/client-go/tools/leaderelection",
     "k8s.io/client-go/tools/leaderelection/resourcelock",
     "k8s.io/client-go/tools/record",
+    "k8s.io/client-go/tools/remotecommand",
     "k8s.io/client-go/util/cert",
     "k8s.io/client-go/util/flowcontrol",
     "k8s.io/client-go/util/workqueue",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -118,3 +118,7 @@
 [[constraint]]
   name = "k8s.io/apiserver"
   revision = "kubernetes-1.13.3"
+
+[[constraint]]
+  name = "k8s.io/cli-runtime"
+  revision = "kubernetes-1.13.3"

--- a/Makefile
+++ b/Makefile
@@ -153,6 +153,12 @@ build:
 	GOBUILD_FLAGS="$(GOBUILD_FLAGS)" \
 	build/go-in-docker.sh build/build.sh
 
+.PHONY: build-plugin
+build-plugin:
+	@$(DEF_VARS) \
+	GOBUILD_FLAGS="$(GOBUILD_FLAGS)" \
+	build/go-in-docker.sh build/build-plugin.sh
+
 .PHONY: clean
 clean:
 	rm -rf bin/ .gocache/ .env

--- a/build/build-plugin.sh
+++ b/build/build-plugin.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+declare -a mandatory
+mandatory=(
+  PKG
+  ARCH
+  GIT_COMMIT
+  REPO_INFO
+  TAG
+)
+
+missing=false
+for var in "${mandatory[@]}"; do
+  if [[ -z "${!var:-}" ]]; then
+    echo "Environment variable $var must be set"
+    missing=true
+  fi
+done
+
+if [ "$missing" = true ]; then
+  exit 1
+fi
+
+export CGO_ENABLED=0
+
+release=cmd/plugin/release
+
+function build_for_arch(){
+  os=$1
+  arch=$2
+
+  env GOOS=${os} GOARCH=${arch} go build \
+    ${GOBUILD_FLAGS} \
+    -ldflags "-s -w \
+        -X ${PKG}/version.RELEASE=${TAG} \
+        -X ${PKG}/version.COMMIT=${GIT_COMMIT} \
+        -X ${PKG}/version.REPO=${REPO_INFO}" \
+    -o ${release}/kubectl-ingress_nginx ${PKG}/cmd/plugin
+
+    tar -C ${release} -zcvf ${release}/kubectl-ingress_nginx-${os}-${arch}.tar.gz kubectl-ingress_nginx
+    rm ${release}/kubectl-ingress_nginx
+    hash=`sha256sum ${release}/kubectl-ingress_nginx-${os}-${arch}.tar.gz | awk '{ print $1 }'`
+    sed -i "s/%%%shasum_${os}_${arch}%%%/${hash}/g" ${release}/ingress-nginx.yaml
+}
+
+rm -rf ${release}
+mkdir ${release}
+
+cp cmd/plugin/ingress-nginx.yaml.tmpl ${release}/ingress-nginx.yaml
+
+sed -i "s/%%%tag%%%/${TAG}/g" ${release}/ingress-nginx.yaml
+
+build_for_arch darwin amd64
+build_for_arch linux amd64
+build_for_arch windows amd64

--- a/cmd/plugin/ingress-nginx.yaml.tmpl
+++ b/cmd/plugin/ingress-nginx.yaml.tmpl
@@ -1,0 +1,40 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: ingress-nginx
+spec:
+  shortDescription: Interact with ingress-nginx
+  description: |
+    The official kubectl plugin for ingress-nginx.
+  version: %%%tag%%%
+  platforms:
+  - uri: https://github.com/kubernetes/ingress-nginx/releases/download/nginx-%%%tag%%%/kubectl-ingress_nginx-darwin-amd64.tar.gz
+    sha256: %%%shasum_darwin_amd64%%%
+    files:
+    - from: "*"
+      to: "."
+    bin: "./kubectl-ingress_nginx"
+    selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+  - uri: https://github.com/kubernetes/ingress-nginx/releases/download/nginx-%%%tag%%%/kubectl-ingress_nginx-linux-amd64.tar.gz
+    sha256: %%%shasum_linux_amd64%%%
+    files:
+    - from: "*"
+      to: "."
+    bin: "./kubectl-ingress_nginx"
+    selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+  - uri: https://github.com/kubernetes/ingress-nginx/releases/download/nginx-%%%tag%%%/kubectl-ingress_nginx-windows-amd64.tar.gz
+    sha256: %%%shasum_windows_amd64%%%
+    files:
+    - from: "*"
+      to: "."
+    bin: "./kubectl-ingress_nginx"
+    selector:
+      matchLabels:
+        os: windows
+        arch: amd64

--- a/cmd/plugin/main.go
+++ b/cmd/plugin/main.go
@@ -1,0 +1,416 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	//Just importing this is supposed to allow cloud authentication
+	// eg GCP, AWS, Azure ...
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	"k8s.io/ingress-nginx/cmd/plugin/request"
+	"k8s.io/ingress-nginx/cmd/plugin/util"
+	"k8s.io/ingress-nginx/internal/nginx"
+)
+
+func main() {
+	rootCmd := &cobra.Command{
+		Use:   "ingress-nginx",
+		Short: "A kubectl plugin for inspecting your ingress-nginx deployments",
+	}
+
+	// Respect some basic kubectl flags like --namespace
+	flags := genericclioptions.NewConfigFlags()
+	flags.AddFlags(rootCmd.PersistentFlags())
+
+	ingCmd := &cobra.Command{
+		Use:     "ingresses",
+		Aliases: []string{"ingress", "ing"},
+		Short:   "Provide a short summary of all of the ingress definitions",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			host, err := cmd.Flags().GetString("host")
+			if err != nil {
+				return err
+			}
+
+			allNamespaces, err := cmd.Flags().GetBool("all-namespaces")
+			if err != nil {
+				return err
+			}
+
+			util.PrintError(ingresses(flags, host, allNamespaces))
+			return nil
+		},
+	}
+	ingCmd.Flags().String("host", "", "Show just the ingress definitions for this hostname")
+	ingCmd.Flags().Bool("all-namespaces", false, "Find ingress definitions from all namespaces")
+	rootCmd.AddCommand(ingCmd)
+
+	confCmd := &cobra.Command{
+		Use:   "conf",
+		Short: "Inspect the generated nginx.conf",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			host, err := cmd.Flags().GetString("host")
+			if err != nil {
+				return err
+			}
+
+			pod, err := cmd.Flags().GetString("pod")
+			if err != nil {
+				return err
+			}
+
+			util.PrintError(conf(flags, host, pod))
+			return nil
+		},
+	}
+	confCmd.Flags().String("host", "", "Print just the server block with this hostname")
+	confCmd.Flags().String("pod", "", "Query a particular ingress-nginx pod")
+	rootCmd.AddCommand(confCmd)
+
+	generalCmd := &cobra.Command{
+		Use:   "general",
+		Short: "Inspect the other dynamic ingress-nginx information",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			pod, err := cmd.Flags().GetString("pod")
+			if err != nil {
+				return err
+			}
+
+			util.PrintError(general(flags, pod))
+			return nil
+		},
+	}
+	generalCmd.Flags().String("pod", "", "Query a particular ingress-nginx pod")
+	rootCmd.AddCommand(generalCmd)
+
+	infoCmd := &cobra.Command{
+		Use:   "info",
+		Short: "Show information about the ingress-nginx service",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			util.PrintError(info(flags))
+			return nil
+		},
+	}
+	rootCmd.AddCommand(infoCmd)
+
+	backendsCmd := &cobra.Command{
+		Use:   "backends",
+		Short: "Inspect the dynamic backend information of an ingress-nginx instance",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			pod, err := cmd.Flags().GetString("pod")
+			if err != nil {
+				return err
+			}
+			backend, err := cmd.Flags().GetString("backend")
+			if err != nil {
+				return err
+			}
+			onlyList, err := cmd.Flags().GetBool("list")
+			if err != nil {
+				return err
+			}
+			if onlyList && backend != "" {
+				return fmt.Errorf("--list and --backend cannot both be specified")
+			}
+
+			util.PrintError(backends(flags, pod, backend, onlyList))
+			return nil
+		},
+	}
+	backendsCmd.Flags().String("pod", "", "Query a particular ingress-nginx pod")
+	backendsCmd.Flags().String("backend", "", "Output only the information for the given backend")
+	backendsCmd.Flags().Bool("list", false, "Output a newline-separated list of backend names")
+	rootCmd.AddCommand(backendsCmd)
+
+	certsCmd := &cobra.Command{
+		Use:   "certs",
+		Short: "Output the certificate data stored in an ingress-nginx pod",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			pod, err := cmd.Flags().GetString("pod")
+			if err != nil {
+				return err
+			}
+			host, err := cmd.Flags().GetString("host")
+			if err != nil {
+				return err
+			}
+
+			util.PrintError(certs(flags, pod, host))
+			return nil
+		},
+	}
+	certsCmd.Flags().String("host", "", "Get the cert for this hostname")
+	certsCmd.Flags().String("pod", "", "Query a particular ingress-nginx pod")
+	cobra.MarkFlagRequired(certsCmd.Flags(), "host")
+	rootCmd.AddCommand(certsCmd)
+
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}
+
+func certs(flags *genericclioptions.ConfigFlags, pod string, host string) error {
+	command := []string{"/dbg", "certs", "get", host}
+	var out string
+	var err error
+	if pod != "" {
+		out, err = request.NamedPodExec(flags, pod, command)
+	} else {
+		out, err = request.IngressPodExec(flags, command)
+	}
+	if err != nil {
+		return err
+	}
+
+	fmt.Print(out)
+	return nil
+}
+
+func info(flags *genericclioptions.ConfigFlags) error {
+	service, err := request.GetIngressService(flags)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Service cluster IP address: %v\n", service.Spec.ClusterIP)
+	fmt.Printf("LoadBalancer IP|CNAME: %v\n", service.Spec.LoadBalancerIP)
+	return nil
+}
+
+func backends(flags *genericclioptions.ConfigFlags, pod string, backend string, onlyList bool) error {
+	var command []string
+	if onlyList {
+		command = []string{"/dbg", "backends", "list"}
+	} else if backend != "" {
+		command = []string{"/dbg", "backends", "get", backend}
+	} else {
+		command = []string{"/dbg", "backends", "all"}
+	}
+
+	var out string
+	var err error
+	if pod != "" {
+		out, err = request.NamedPodExec(flags, pod, command)
+	} else {
+		out, err = request.IngressPodExec(flags, command)
+	}
+	if err != nil {
+		return err
+	}
+
+	fmt.Print(out)
+	return nil
+}
+
+func general(flags *genericclioptions.ConfigFlags, pod string) error {
+	var general string
+	var err error
+	if pod != "" {
+		general, err = request.NamedPodExec(flags, pod, []string{"/dbg", "general"})
+	} else {
+		general, err = request.IngressPodExec(flags, []string{"/dbg", "general"})
+	}
+	if err != nil {
+		return err
+	}
+
+	fmt.Print(general)
+	return nil
+}
+
+func ingresses(flags *genericclioptions.ConfigFlags, host string, allNamespaces bool) error {
+	var namespace string
+	if allNamespaces {
+		namespace = ""
+	} else {
+		namespace = util.GetNamespace(flags)
+	}
+
+	ingresses, err := request.GetIngressDefinitions(flags, namespace)
+	if err != nil {
+		return err
+	}
+
+	rows := getIngressRows(&ingresses)
+
+	if host != "" {
+		rowsWithHost := make([]ingressRow, 0)
+		for _, row := range rows {
+			if row.Host == host {
+				rowsWithHost = append(rowsWithHost, row)
+			}
+		}
+		rows = rowsWithHost
+	}
+
+	printer := tabwriter.NewWriter(os.Stdout, 6, 4, 3, ' ', 0)
+	defer printer.Flush()
+
+	if allNamespaces {
+		fmt.Fprintln(printer, "NAMESPACE\tINGRESS NAME\tHOST+PATH\tADDRESSES\tTLS\tSERVICE\tSERVICE PORT")
+	} else {
+		fmt.Fprintln(printer, "INGRESS NAME\tHOST+PATH\tADDRESSES\tTLS\tSERVICE\tSERVICE PORT")
+	}
+
+	for _, row := range rows {
+		var tlsMsg string
+		if row.TLS {
+			tlsMsg = "YES"
+		} else {
+			tlsMsg = "NO"
+		}
+		if allNamespaces {
+			fmt.Fprintf(printer, "%v\t%v\t%v\t%v\t%v\t%v\t%v\t\n", row.Namespace, row.IngressName, row.Host+row.Path, row.Address, tlsMsg, row.ServiceName, row.ServicePort)
+		} else {
+			fmt.Fprintf(printer, "%v\t%v\t%v\t%v\t%v\t%v\t\n", row.IngressName, row.Host+row.Path, row.Address, tlsMsg, row.ServiceName, row.ServicePort)
+		}
+	}
+
+	return nil
+}
+
+func conf(flags *genericclioptions.ConfigFlags, host string, pod string) error {
+	var nginxConf string
+	var err error
+	if pod != "" {
+		nginxConf, err = request.NamedPodExec(flags, pod, []string{"/dbg", "conf"})
+	} else {
+		nginxConf, err = request.IngressPodExec(flags, []string{"/dbg", "conf"})
+	}
+	if err != nil {
+		return err
+	}
+
+	if host != "" {
+		block, err := nginx.GetServerBlock(nginxConf, host)
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(strings.TrimRight(strings.Trim(block, " \n"), " \n\t"))
+	} else {
+		fmt.Print(nginxConf)
+	}
+
+	return nil
+}
+
+type ingressRow struct {
+	Namespace   string
+	IngressName string
+	Host        string
+	Path        string
+	TLS         bool
+	ServiceName string
+	ServicePort string
+	Address     string
+}
+
+func getIngressRows(ingresses *[]v1beta1.Ingress) []ingressRow {
+	rows := make([]ingressRow, 0)
+
+	for _, ing := range *ingresses {
+
+		address := ""
+		for _, lbIng := range ing.Status.LoadBalancer.Ingress {
+			if len(lbIng.IP) > 0 {
+				address = address + lbIng.IP + ","
+			}
+			if len(lbIng.Hostname) > 0 {
+				address = address + lbIng.Hostname + ","
+			}
+		}
+		if len(address) > 0 {
+			address = address[:len(address)-1]
+		}
+
+		tlsHosts := make(map[string]struct{})
+		for _, tls := range ing.Spec.TLS {
+			for _, host := range tls.Hosts {
+				tlsHosts[host] = struct{}{}
+			}
+		}
+
+		defaultBackendService := ""
+		defaultBackendPort := ""
+		if ing.Spec.Backend != nil {
+			defaultBackendService = ing.Spec.Backend.ServiceName
+			defaultBackendPort = ing.Spec.Backend.ServicePort.String()
+		}
+
+		// Handle catch-all ingress
+		if len(ing.Spec.Rules) == 0 && len(defaultBackendService) > 0 {
+			row := ingressRow{
+				Namespace:   ing.Namespace,
+				IngressName: ing.Name,
+				Host:        "*",
+				ServiceName: defaultBackendService,
+				ServicePort: defaultBackendPort,
+				Address:     address,
+			}
+
+			rows = append(rows, row)
+			continue
+		}
+
+		for _, rule := range ing.Spec.Rules {
+			_, hasTLS := tlsHosts[rule.Host]
+
+			//Handle ingress with no paths
+			if rule.HTTP == nil {
+				row := ingressRow{
+					Namespace:   ing.Namespace,
+					IngressName: ing.Name,
+					Host:        rule.Host,
+					Path:        "",
+					TLS:         hasTLS,
+					ServiceName: defaultBackendService,
+					ServicePort: defaultBackendPort,
+					Address:     address,
+				}
+				rows = append(rows, row)
+				continue
+			}
+
+			for _, path := range rule.HTTP.Paths {
+				row := ingressRow{
+					Namespace:   ing.Namespace,
+					IngressName: ing.Name,
+					Host:        rule.Host,
+					Path:        path.Path,
+					TLS:         hasTLS,
+					ServiceName: path.Backend.ServiceName,
+					ServicePort: path.Backend.ServicePort.String(),
+					Address:     address,
+				}
+
+				rows = append(rows, row)
+			}
+		}
+	}
+
+	return rows
+}

--- a/cmd/plugin/request/request.go
+++ b/cmd/plugin/request/request.go
@@ -1,0 +1,209 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package request
+
+import (
+	"bytes"
+	"fmt"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/kubernetes/scheme"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	extensions "k8s.io/client-go/kubernetes/typed/extensions/v1beta1"
+	"k8s.io/client-go/tools/remotecommand"
+	"k8s.io/ingress-nginx/cmd/plugin/util"
+)
+
+const (
+	ingressPodName     = "nginx-ingress-controller"
+	ingressServiceName = "ingress-nginx"
+)
+
+// NamedPodExec finds a pod with the given name, executes a command inside it, and returns stdout
+func NamedPodExec(flags *genericclioptions.ConfigFlags, podName string, cmd []string) (string, error) {
+	allPods, err := getPods(flags)
+	if err != nil {
+		return "", err
+	}
+
+	for _, pod := range allPods {
+		if pod.Name == podName {
+			return podExec(flags, &pod, cmd)
+		}
+	}
+
+	return "", fmt.Errorf("Pod %v not found in namespace %v", podName, util.GetNamespace(flags))
+}
+
+// IngressPodExec finds an ingress-nginx pod in the given namespace, executes a command inside it, and returns stdout
+func IngressPodExec(flags *genericclioptions.ConfigFlags, cmd []string) (string, error) {
+	ings, err := getIngressPods(flags)
+	if err != nil {
+		return "", err
+	}
+
+	if len(ings) == 0 {
+		return "", fmt.Errorf("No ingress-nginx pods found in namespace %v", util.GetNamespace(flags))
+	}
+
+	return podExec(flags, &ings[0], cmd)
+}
+
+func podExec(flags *genericclioptions.ConfigFlags, pod *apiv1.Pod, cmd []string) (string, error) {
+	config, err := flags.ToRESTConfig()
+	if err != nil {
+		return "", err
+	}
+
+	client, err := corev1.NewForConfig(config)
+	if err != nil {
+		return "", err
+	}
+
+	namespace, _, err := flags.ToRawKubeConfigLoader().Namespace()
+	if err != nil {
+		return "", err
+	}
+
+	restClient := client.RESTClient()
+
+	req := restClient.Post().
+		Resource("pods").
+		Name(pod.Name).
+		Namespace(namespace).
+		SubResource("exec").
+		Param("container", ingressPodName)
+
+	req.VersionedParams(&apiv1.PodExecOptions{
+		Container: ingressPodName,
+		Command:   cmd,
+		Stdin:     false,
+		Stdout:    true,
+		Stderr:    false,
+		TTY:       false,
+	}, scheme.ParameterCodec)
+
+	exec, err := remotecommand.NewSPDYExecutor(config, "POST", req.URL())
+
+	if err != nil {
+		return "", err
+	}
+
+	stdout := bytes.NewBuffer(make([]byte, 0))
+	err = exec.Stream(remotecommand.StreamOptions{
+		Stdout: stdout,
+	})
+
+	return stdout.String(), err
+}
+
+func getIngressPods(flags *genericclioptions.ConfigFlags) ([]apiv1.Pod, error) {
+	pods, err := getPods(flags)
+	if err != nil {
+		return make([]apiv1.Pod, 0), err
+	}
+
+	ingressPods := make([]apiv1.Pod, 0)
+	for _, pod := range pods {
+		if pod.Spec.Containers[0].Name == ingressPodName {
+			ingressPods = append(ingressPods, pod)
+		}
+	}
+
+	return ingressPods, nil
+}
+
+func getPods(flags *genericclioptions.ConfigFlags) ([]apiv1.Pod, error) {
+	namespace := util.GetNamespace(flags)
+
+	rawConfig, err := flags.ToRESTConfig()
+	if err != nil {
+		return make([]apiv1.Pod, 0), err
+	}
+
+	api, err := corev1.NewForConfig(rawConfig)
+	if err != nil {
+		return make([]apiv1.Pod, 0), err
+	}
+
+	pods, err := api.Pods(namespace).List(metav1.ListOptions{})
+	if err != nil {
+		return make([]apiv1.Pod, 0), err
+	}
+
+	return pods.Items, nil
+}
+
+// GetIngressDefinitions returns an array of Ingress resource definitions
+func GetIngressDefinitions(flags *genericclioptions.ConfigFlags, namespace string) ([]v1beta1.Ingress, error) {
+	rawConfig, err := flags.ToRESTConfig()
+	if err != nil {
+		return make([]v1beta1.Ingress, 0), err
+	}
+
+	api, err := extensions.NewForConfig(rawConfig)
+	if err != nil {
+		return make([]v1beta1.Ingress, 0), err
+	}
+
+	pods, err := api.Ingresses(namespace).List(metav1.ListOptions{})
+	if err != nil {
+		return make([]v1beta1.Ingress, 0), err
+	}
+
+	return pods.Items, nil
+}
+
+// GetIngressService finds and returns the ingress-nginx service definition
+func GetIngressService(flags *genericclioptions.ConfigFlags) (apiv1.Service, error) {
+	services, err := getServices(flags)
+	if err != nil {
+		return apiv1.Service{}, err
+	}
+
+	for _, svc := range services {
+		if svc.Name == ingressServiceName {
+			return svc, nil
+		}
+	}
+
+	return apiv1.Service{}, fmt.Errorf("Could not find service %v in namespace %v", ingressServiceName, util.GetNamespace(flags))
+}
+
+func getServices(flags *genericclioptions.ConfigFlags) ([]apiv1.Service, error) {
+	namespace := util.GetNamespace(flags)
+
+	rawConfig, err := flags.ToRESTConfig()
+	if err != nil {
+		return make([]apiv1.Service, 0), err
+	}
+
+	api, err := corev1.NewForConfig(rawConfig)
+	if err != nil {
+		return make([]apiv1.Service, 0), err
+	}
+
+	services, err := api.Services(namespace).List(metav1.ListOptions{})
+	if err != nil {
+		return make([]apiv1.Service, 0), err
+	}
+
+	return services.Items, nil
+
+}

--- a/cmd/plugin/util/util.go
+++ b/cmd/plugin/util/util.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+// PrintError receives an error value and prints it if it exists
+func PrintError(e error) {
+	if e != nil {
+		fmt.Println(e)
+	}
+}
+
+func printWithError(s string, e error) {
+	if e != nil {
+		fmt.Println(e)
+	}
+	fmt.Print(s)
+}
+
+func printOrError(s string, e error) error {
+	if e != nil {
+		return e
+	}
+	fmt.Print(s)
+	return nil
+}
+
+// GetNamespace takes a set of kubectl flag values and returns the namespace we should be operating in
+func GetNamespace(flags *genericclioptions.ConfigFlags) string {
+	namespace, _, err := flags.ToRawKubeConfigLoader().Namespace()
+	if err != nil || len(namespace) == 0 {
+		namespace = apiv1.NamespaceDefault
+	}
+	return namespace
+}

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -93,6 +93,18 @@ kube-system   kube-dns               ClusterIP   10.96.0.10       <none>        
 kube-system   kubernetes-dashboard   NodePort    10.103.128.17    <none>        80:30000/TCP    30m
 ```
 
+Use the `ingress-nginx` kubectl plugin
+
+Install [krew](https://github.com/GoogleContainerTools/krew), then run
+```console
+$ kubectl krew install --manifest https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/cmd/plugin/release/ingress-nginx.yaml
+```
+to install the plugin. Then run
+```console
+$ kubectl ingress-nginx --help
+```
+to make sure the plugin is properly installed and to get a list of commands. The plugin includes all of the commands present in the `/dbg` tool, plus a more detailed version of `kubectl get ingresses` available by runnning `kubectl ingress-nginx ingresses`.
+
 Use the `/dbg` Tool to Check Dynamic Configuration
 
 ```console

--- a/vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructuredscheme/scheme.go
+++ b/vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructuredscheme/scheme.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unstructuredscheme
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"k8s.io/apimachinery/pkg/runtime/serializer/versioning"
+)
+
+var (
+	scheme = runtime.NewScheme()
+	codecs = serializer.NewCodecFactory(scheme)
+)
+
+// NewUnstructuredNegotiatedSerializer returns a simple, negotiated serializer
+func NewUnstructuredNegotiatedSerializer() runtime.NegotiatedSerializer {
+	return unstructuredNegotiatedSerializer{
+		scheme:  scheme,
+		typer:   NewUnstructuredObjectTyper(),
+		creator: NewUnstructuredCreator(),
+	}
+}
+
+type unstructuredNegotiatedSerializer struct {
+	scheme  *runtime.Scheme
+	typer   runtime.ObjectTyper
+	creator runtime.ObjectCreater
+}
+
+func (s unstructuredNegotiatedSerializer) SupportedMediaTypes() []runtime.SerializerInfo {
+	return []runtime.SerializerInfo{
+		{
+			MediaType:        "application/json",
+			EncodesAsText:    true,
+			Serializer:       json.NewSerializer(json.DefaultMetaFactory, s.creator, s.typer, false),
+			PrettySerializer: json.NewSerializer(json.DefaultMetaFactory, s.creator, s.typer, true),
+			StreamSerializer: &runtime.StreamSerializerInfo{
+				EncodesAsText: true,
+				Serializer:    json.NewSerializer(json.DefaultMetaFactory, s.creator, s.typer, false),
+				Framer:        json.Framer,
+			},
+		},
+		{
+			MediaType:     "application/yaml",
+			EncodesAsText: true,
+			Serializer:    json.NewYAMLSerializer(json.DefaultMetaFactory, s.creator, s.typer),
+		},
+	}
+}
+
+func (s unstructuredNegotiatedSerializer) EncoderForVersion(encoder runtime.Encoder, gv runtime.GroupVersioner) runtime.Encoder {
+	return versioning.NewDefaultingCodecForScheme(s.scheme, encoder, nil, gv, nil)
+}
+
+func (s unstructuredNegotiatedSerializer) DecoderToVersion(decoder runtime.Decoder, gv runtime.GroupVersioner) runtime.Decoder {
+	return versioning.NewDefaultingCodecForScheme(s.scheme, nil, decoder, nil, gv)
+}
+
+type unstructuredObjectTyper struct {
+}
+
+// NewUnstructuredObjectTyper returns an object typer that can deal with unstructured things
+func NewUnstructuredObjectTyper() runtime.ObjectTyper {
+	return unstructuredObjectTyper{}
+}
+
+func (t unstructuredObjectTyper) ObjectKinds(obj runtime.Object) ([]schema.GroupVersionKind, bool, error) {
+	// Delegate for things other than Unstructured.
+	if _, ok := obj.(runtime.Unstructured); !ok {
+		return nil, false, fmt.Errorf("cannot type %T", obj)
+	}
+	gvk := obj.GetObjectKind().GroupVersionKind()
+	if len(gvk.Kind) == 0 {
+		return nil, false, runtime.NewMissingKindErr("object has no kind field ")
+	}
+	if len(gvk.Version) == 0 {
+		return nil, false, runtime.NewMissingVersionErr("object has no apiVersion field")
+	}
+
+	return []schema.GroupVersionKind{obj.GetObjectKind().GroupVersionKind()}, false, nil
+}
+
+func (t unstructuredObjectTyper) Recognizes(gvk schema.GroupVersionKind) bool {
+	return true
+}
+
+type unstructuredCreator struct{}
+
+// NewUnstructuredCreator returns a simple object creator that always returns an unstructured
+func NewUnstructuredCreator() runtime.ObjectCreater {
+	return unstructuredCreator{}
+}
+
+func (c unstructuredCreator) New(kind schema.GroupVersionKind) (runtime.Object, error) {
+	ret := &unstructured.Unstructured{}
+	ret.SetGroupVersionKind(kind)
+	return ret, nil
+}
+
+type unstructuredDefaulter struct {
+}
+
+// NewUnstructuredDefaulter returns defaulter suitable for unstructured types that doesn't default anything
+func NewUnstructuredDefaulter() runtime.ObjectDefaulter {
+	return unstructuredDefaulter{}
+}
+
+func (d unstructuredDefaulter) Default(in runtime.Object) {
+}

--- a/vendor/k8s.io/cli-runtime/CONTRIBUTING.md
+++ b/vendor/k8s.io/cli-runtime/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+# Contributing guidelines
+
+Do not open pull requests directly against this repository, they will be ignored. Instead, please open pull requests against [kubernetes/kubernetes](https://git.k8s.io/kubernetes/).  Please follow the same [contributing guide](https://git.k8s.io/kubernetes/CONTRIBUTING.md) you would follow for any other pull request made to kubernetes/kubernetes.
+
+This repository is published from [kubernetes/kubernetes/staging/src/k8s.io/cli-runtime](https://git.k8s.io/kubernetes/staging/src/k8s.io/cli-runtime) by the [kubernetes publishing-bot](https://git.k8s.io/publishing-bot).
+
+Please see [Staging Directory and Publishing](https://git.k8s.io/community/contributors/devel/staging.md) for more information

--- a/vendor/k8s.io/cli-runtime/LICENSE
+++ b/vendor/k8s.io/cli-runtime/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/k8s.io/cli-runtime/OWNERS
+++ b/vendor/k8s.io/cli-runtime/OWNERS
@@ -1,0 +1,14 @@
+approvers:
+- deads2k
+- pwittrock
+- seans3
+- soltysh
+- juanvallejo
+reviewers:
+- deads2k
+- juanvallejo
+- pwittrock
+- seans3
+- soltysh
+labels:
+- sig/cli

--- a/vendor/k8s.io/cli-runtime/README.md
+++ b/vendor/k8s.io/cli-runtime/README.md
@@ -1,0 +1,30 @@
+# cli-runtime
+
+Set of helpers for creating kubectl commands, as well as kubectl plugins.
+
+
+## Purpose
+
+This library is a shared dependency for clients to work with Kubernetes API infrastructure which allows
+to maintain kubectl compatible behavior.  Its first consumer is `k8s.io/kubectl`.
+
+
+## Compatibility
+
+There are *NO compatibility guarantees* for this repository.  It is in direct support of Kubernetes, so branches
+will track Kubernetes and be compatible with that repo.  As we more cleanly separate the layers, we will review the
+compatibility guarantee.
+
+
+## Where does it come from?
+
+`cli-runtime` is synced from https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/cli-runtime.
+Code changes are made in that location, merged into `k8s.io/kubernetes` and later synced here.
+
+
+## Things you should *NOT* do
+
+ 1. Add API types to this repo.  This is for the helpers, not for the types.
+ 2. Directly modify any files under `pkg` in this repo.  Those are driven from `k8s.io/kubernetes/staging/src/k8s.io/cli-runtime`.
+ 3. Expect compatibility.  This repo is direct support of Kubernetes and the API isn't yet stable enough for API guarantees.
+ 4. Add any type that only makes sense only for `kubectl`.

--- a/vendor/k8s.io/cli-runtime/SECURITY_CONTACTS
+++ b/vendor/k8s.io/cli-runtime/SECURITY_CONTACTS
@@ -1,0 +1,17 @@
+# Defined below are the security contacts for this repo.
+#
+# They are the contact point for the Product Security Team to reach out
+# to for triaging and handling of incoming issues.
+#
+# The below names agree to abide by the
+# [Embargo Policy](https://github.com/kubernetes/sig-release/blob/master/security-release-process-documentation/security-release-process.md#embargo-policy)
+# and will be removed and replaced if they violate that agreement.
+#
+# DO NOT REPORT SECURITY VULNERABILITIES DIRECTLY TO THESE NAMES, FOLLOW THE
+# INSTRUCTIONS AT https://kubernetes.io/security/
+
+cjcullen
+jessfraz
+liggitt
+philips
+tallclair

--- a/vendor/k8s.io/cli-runtime/code-of-conduct.md
+++ b/vendor/k8s.io/cli-runtime/code-of-conduct.md
@@ -1,0 +1,3 @@
+# Kubernetes Community Code of Conduct
+
+Please refer to our [Kubernetes Community Code of Conduct](https://git.k8s.io/community/code-of-conduct.md)

--- a/vendor/k8s.io/cli-runtime/pkg/genericclioptions/builder_flags.go
+++ b/vendor/k8s.io/cli-runtime/pkg/genericclioptions/builder_flags.go
@@ -1,0 +1,234 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package genericclioptions
+
+import (
+	"github.com/spf13/pflag"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/cli-runtime/pkg/genericclioptions/resource"
+)
+
+// ResourceBuilderFlags are flags for finding resources
+// TODO(juanvallejo): wire --local flag from commands through
+type ResourceBuilderFlags struct {
+	FileNameFlags *FileNameFlags
+
+	LabelSelector        *string
+	FieldSelector        *string
+	AllNamespaces        *bool
+	All                  *bool
+	Local                *bool
+	IncludeUninitialized *bool
+
+	Scheme           *runtime.Scheme
+	Latest           bool
+	StopOnFirstError bool
+}
+
+// NewResourceBuilderFlags returns a default ResourceBuilderFlags
+func NewResourceBuilderFlags() *ResourceBuilderFlags {
+	filenames := []string{}
+
+	return &ResourceBuilderFlags{
+		FileNameFlags: &FileNameFlags{
+			Usage:     "identifying the resource.",
+			Filenames: &filenames,
+			Recursive: boolPtr(true),
+		},
+	}
+}
+
+func (o *ResourceBuilderFlags) WithFile(recurse bool, files ...string) *ResourceBuilderFlags {
+	o.FileNameFlags = &FileNameFlags{
+		Usage:     "identifying the resource.",
+		Filenames: &files,
+		Recursive: boolPtr(recurse),
+	}
+
+	return o
+}
+
+func (o *ResourceBuilderFlags) WithLabelSelector(selector string) *ResourceBuilderFlags {
+	o.LabelSelector = &selector
+	return o
+}
+
+func (o *ResourceBuilderFlags) WithFieldSelector(selector string) *ResourceBuilderFlags {
+	o.FieldSelector = &selector
+	return o
+}
+
+func (o *ResourceBuilderFlags) WithAllNamespaces(defaultVal bool) *ResourceBuilderFlags {
+	o.AllNamespaces = &defaultVal
+	return o
+}
+
+func (o *ResourceBuilderFlags) WithAll(defaultVal bool) *ResourceBuilderFlags {
+	o.All = &defaultVal
+	return o
+}
+
+func (o *ResourceBuilderFlags) WithLocal(defaultVal bool) *ResourceBuilderFlags {
+	o.Local = &defaultVal
+	return o
+}
+
+// WithUninitialized is using an alpha feature and may be dropped
+func (o *ResourceBuilderFlags) WithUninitialized(defaultVal bool) *ResourceBuilderFlags {
+	o.IncludeUninitialized = &defaultVal
+	return o
+}
+
+func (o *ResourceBuilderFlags) WithScheme(scheme *runtime.Scheme) *ResourceBuilderFlags {
+	o.Scheme = scheme
+	return o
+}
+
+func (o *ResourceBuilderFlags) WithLatest() *ResourceBuilderFlags {
+	o.Latest = true
+	return o
+}
+
+func (o *ResourceBuilderFlags) StopOnError() *ResourceBuilderFlags {
+	o.StopOnFirstError = true
+	return o
+}
+
+// AddFlags registers flags for finding resources
+func (o *ResourceBuilderFlags) AddFlags(flagset *pflag.FlagSet) {
+	o.FileNameFlags.AddFlags(flagset)
+
+	if o.LabelSelector != nil {
+		flagset.StringVarP(o.LabelSelector, "selector", "l", *o.LabelSelector, "Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
+	}
+	if o.FieldSelector != nil {
+		flagset.StringVar(o.FieldSelector, "field-selector", *o.FieldSelector, "Selector (field query) to filter on, supports '=', '==', and '!='.(e.g. --field-selector key1=value1,key2=value2). The server only supports a limited number of field queries per type.")
+	}
+	if o.AllNamespaces != nil {
+		flagset.BoolVar(o.AllNamespaces, "all-namespaces", *o.AllNamespaces, "If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.")
+	}
+	if o.All != nil {
+		flagset.BoolVar(o.All, "all", *o.All, "Select all resources in the namespace of the specified resource types")
+	}
+	if o.Local != nil {
+		flagset.BoolVar(o.Local, "local", *o.Local, "If true, annotation will NOT contact api-server but run locally.")
+	}
+	if o.IncludeUninitialized != nil {
+		flagset.BoolVar(o.IncludeUninitialized, "include-uninitialized", *o.IncludeUninitialized, `If true, the kubectl command applies to uninitialized objects. If explicitly set to false, this flag overrides other flags that make the kubectl commands apply to uninitialized objects, e.g., "--all". Objects with empty metadata.initializers are regarded as initialized.`)
+	}
+}
+
+// ToBuilder gives you back a resource finder to visit resources that are located
+func (o *ResourceBuilderFlags) ToBuilder(restClientGetter RESTClientGetter, resources []string) ResourceFinder {
+	namespace, enforceNamespace, namespaceErr := restClientGetter.ToRawKubeConfigLoader().Namespace()
+
+	builder := resource.NewBuilder(restClientGetter).
+		NamespaceParam(namespace).DefaultNamespace()
+
+	if o.Scheme != nil {
+		builder.WithScheme(o.Scheme, o.Scheme.PrioritizedVersionsAllGroups()...)
+	} else {
+		builder.Unstructured()
+	}
+
+	if o.FileNameFlags != nil {
+		opts := o.FileNameFlags.ToOptions()
+		builder.FilenameParam(enforceNamespace, &opts)
+	}
+
+	if o.Local == nil || !*o.Local {
+		// resource type/name tuples only work non-local
+		if o.All != nil {
+			builder.ResourceTypeOrNameArgs(*o.All, resources...)
+		} else {
+			builder.ResourceTypeOrNameArgs(false, resources...)
+		}
+		// label selectors only work non-local (for now)
+		if o.LabelSelector != nil {
+			builder.LabelSelectorParam(*o.LabelSelector)
+		}
+		// field selectors only work non-local (forever)
+		if o.FieldSelector != nil {
+			builder.FieldSelectorParam(*o.FieldSelector)
+		}
+		// latest only works non-local (forever)
+		if o.Latest {
+			builder.Latest()
+		}
+
+	} else {
+		builder.Local()
+
+		if len(resources) > 0 {
+			builder.AddError(resource.LocalResourceError)
+		}
+	}
+
+	if o.IncludeUninitialized != nil {
+		builder.IncludeUninitialized(*o.IncludeUninitialized)
+	}
+
+	if !o.StopOnFirstError {
+		builder.ContinueOnError()
+	}
+
+	return &ResourceFindBuilderWrapper{
+		builder: builder.
+			Flatten(). // I think we're going to recommend this everywhere
+			AddError(namespaceErr),
+	}
+}
+
+// ResourceFindBuilderWrapper wraps a builder in an interface
+type ResourceFindBuilderWrapper struct {
+	builder *resource.Builder
+}
+
+// Do finds you resources to check
+func (b *ResourceFindBuilderWrapper) Do() resource.Visitor {
+	return b.builder.Do()
+}
+
+// ResourceFinder allows mocking the resource builder
+// TODO resource builders needs to become more interfacey
+type ResourceFinder interface {
+	Do() resource.Visitor
+}
+
+// ResourceFinderFunc is a handy way to make a  ResourceFinder
+type ResourceFinderFunc func() resource.Visitor
+
+// Do implements ResourceFinder
+func (fn ResourceFinderFunc) Do() resource.Visitor {
+	return fn()
+}
+
+// ResourceFinderForResult skins a visitor for re-use as a ResourceFinder
+func ResourceFinderForResult(result resource.Visitor) ResourceFinder {
+	return ResourceFinderFunc(func() resource.Visitor {
+		return result
+	})
+}
+
+func strPtr(val string) *string {
+	return &val
+}
+
+func boolPtr(val bool) *bool {
+	return &val
+}

--- a/vendor/k8s.io/cli-runtime/pkg/genericclioptions/builder_flags_fake.go
+++ b/vendor/k8s.io/cli-runtime/pkg/genericclioptions/builder_flags_fake.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package genericclioptions
+
+import (
+	"k8s.io/cli-runtime/pkg/genericclioptions/resource"
+)
+
+// NewSimpleResourceFinder builds a super simple ResourceFinder that just iterates over the objects you provided
+func NewSimpleFakeResourceFinder(infos ...*resource.Info) ResourceFinder {
+	return &fakeResourceFinder{
+		Infos: infos,
+	}
+}
+
+type fakeResourceFinder struct {
+	Infos []*resource.Info
+}
+
+// Do implements the interface
+func (f *fakeResourceFinder) Do() resource.Visitor {
+	return &fakeResourceResult{
+		Infos: f.Infos,
+	}
+}
+
+type fakeResourceResult struct {
+	Infos []*resource.Info
+}
+
+// Visit just iterates over info
+func (r *fakeResourceResult) Visit(fn resource.VisitorFunc) error {
+	for _, info := range r.Infos {
+		err := fn(info, nil)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/vendor/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go
+++ b/vendor/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go
@@ -1,0 +1,326 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package genericclioptions
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/spf13/pflag"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/homedir"
+)
+
+const (
+	flagClusterName      = "cluster"
+	flagAuthInfoName     = "user"
+	flagContext          = "context"
+	flagNamespace        = "namespace"
+	flagAPIServer        = "server"
+	flagInsecure         = "insecure-skip-tls-verify"
+	flagCertFile         = "client-certificate"
+	flagKeyFile          = "client-key"
+	flagCAFile           = "certificate-authority"
+	flagBearerToken      = "token"
+	flagImpersonate      = "as"
+	flagImpersonateGroup = "as-group"
+	flagUsername         = "username"
+	flagPassword         = "password"
+	flagTimeout          = "request-timeout"
+	flagHTTPCacheDir     = "cache-dir"
+)
+
+var defaultCacheDir = filepath.Join(homedir.HomeDir(), ".kube", "http-cache")
+
+// RESTClientGetter is an interface that the ConfigFlags describe to provide an easier way to mock for commands
+// and eliminate the direct coupling to a struct type.  Users may wish to duplicate this type in their own packages
+// as per the golang type overlapping.
+type RESTClientGetter interface {
+	// ToRESTConfig returns restconfig
+	ToRESTConfig() (*rest.Config, error)
+	// ToDiscoveryClient returns discovery client
+	ToDiscoveryClient() (discovery.CachedDiscoveryInterface, error)
+	// ToRESTMapper returns a restmapper
+	ToRESTMapper() (meta.RESTMapper, error)
+	// ToRawKubeConfigLoader return kubeconfig loader as-is
+	ToRawKubeConfigLoader() clientcmd.ClientConfig
+}
+
+var _ RESTClientGetter = &ConfigFlags{}
+
+// ConfigFlags composes the set of values necessary
+// for obtaining a REST client config
+type ConfigFlags struct {
+	CacheDir   *string
+	KubeConfig *string
+
+	// config flags
+	ClusterName      *string
+	AuthInfoName     *string
+	Context          *string
+	Namespace        *string
+	APIServer        *string
+	Insecure         *bool
+	CertFile         *string
+	KeyFile          *string
+	CAFile           *string
+	BearerToken      *string
+	Impersonate      *string
+	ImpersonateGroup *[]string
+	Username         *string
+	Password         *string
+	Timeout          *string
+}
+
+// ToRESTConfig implements RESTClientGetter.
+// Returns a REST client configuration based on a provided path
+// to a .kubeconfig file, loading rules, and config flag overrides.
+// Expects the AddFlags method to have been called.
+func (f *ConfigFlags) ToRESTConfig() (*rest.Config, error) {
+	return f.ToRawKubeConfigLoader().ClientConfig()
+}
+
+// ToRawKubeConfigLoader binds config flag values to config overrides
+// Returns an interactive clientConfig if the password flag is enabled,
+// or a non-interactive clientConfig otherwise.
+func (f *ConfigFlags) ToRawKubeConfigLoader() clientcmd.ClientConfig {
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	// use the standard defaults for this client command
+	// DEPRECATED: remove and replace with something more accurate
+	loadingRules.DefaultClientConfig = &clientcmd.DefaultClientConfig
+
+	if f.KubeConfig != nil {
+		loadingRules.ExplicitPath = *f.KubeConfig
+	}
+
+	overrides := &clientcmd.ConfigOverrides{ClusterDefaults: clientcmd.ClusterDefaults}
+
+	// bind auth info flag values to overrides
+	if f.CertFile != nil {
+		overrides.AuthInfo.ClientCertificate = *f.CertFile
+	}
+	if f.KeyFile != nil {
+		overrides.AuthInfo.ClientKey = *f.KeyFile
+	}
+	if f.BearerToken != nil {
+		overrides.AuthInfo.Token = *f.BearerToken
+	}
+	if f.Impersonate != nil {
+		overrides.AuthInfo.Impersonate = *f.Impersonate
+	}
+	if f.ImpersonateGroup != nil {
+		overrides.AuthInfo.ImpersonateGroups = *f.ImpersonateGroup
+	}
+	if f.Username != nil {
+		overrides.AuthInfo.Username = *f.Username
+	}
+	if f.Password != nil {
+		overrides.AuthInfo.Password = *f.Password
+	}
+
+	// bind cluster flags
+	if f.APIServer != nil {
+		overrides.ClusterInfo.Server = *f.APIServer
+	}
+	if f.CAFile != nil {
+		overrides.ClusterInfo.CertificateAuthority = *f.CAFile
+	}
+	if f.Insecure != nil {
+		overrides.ClusterInfo.InsecureSkipTLSVerify = *f.Insecure
+	}
+
+	// bind context flags
+	if f.Context != nil {
+		overrides.CurrentContext = *f.Context
+	}
+	if f.ClusterName != nil {
+		overrides.Context.Cluster = *f.ClusterName
+	}
+	if f.AuthInfoName != nil {
+		overrides.Context.AuthInfo = *f.AuthInfoName
+	}
+	if f.Namespace != nil {
+		overrides.Context.Namespace = *f.Namespace
+	}
+
+	if f.Timeout != nil {
+		overrides.Timeout = *f.Timeout
+	}
+
+	var clientConfig clientcmd.ClientConfig
+
+	// we only have an interactive prompt when a password is allowed
+	if f.Password == nil {
+		clientConfig = clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, overrides)
+	} else {
+		clientConfig = clientcmd.NewInteractiveDeferredLoadingClientConfig(loadingRules, overrides, os.Stdin)
+	}
+
+	return clientConfig
+}
+
+// ToDiscoveryClient implements RESTClientGetter.
+// Expects the AddFlags method to have been called.
+// Returns a CachedDiscoveryInterface using a computed RESTConfig.
+func (f *ConfigFlags) ToDiscoveryClient() (discovery.CachedDiscoveryInterface, error) {
+	config, err := f.ToRESTConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	// The more groups you have, the more discovery requests you need to make.
+	// given 25 groups (our groups + a few custom resources) with one-ish version each, discovery needs to make 50 requests
+	// double it just so we don't end up here again for a while.  This config is only used for discovery.
+	config.Burst = 100
+
+	// retrieve a user-provided value for the "cache-dir"
+	// defaulting to ~/.kube/http-cache if no user-value is given.
+	httpCacheDir := defaultCacheDir
+	if f.CacheDir != nil {
+		httpCacheDir = *f.CacheDir
+	}
+
+	discoveryCacheDir := computeDiscoverCacheDir(filepath.Join(homedir.HomeDir(), ".kube", "cache", "discovery"), config.Host)
+	return discovery.NewCachedDiscoveryClientForConfig(config, discoveryCacheDir, httpCacheDir, time.Duration(10*time.Minute))
+}
+
+// ToRESTMapper returns a mapper.
+func (f *ConfigFlags) ToRESTMapper() (meta.RESTMapper, error) {
+	discoveryClient, err := f.ToDiscoveryClient()
+	if err != nil {
+		return nil, err
+	}
+
+	mapper := restmapper.NewDeferredDiscoveryRESTMapper(discoveryClient)
+	expander := restmapper.NewShortcutExpander(mapper, discoveryClient)
+	return expander, nil
+}
+
+// AddFlags binds client configuration flags to a given flagset
+func (f *ConfigFlags) AddFlags(flags *pflag.FlagSet) {
+	if f.KubeConfig != nil {
+		flags.StringVar(f.KubeConfig, "kubeconfig", *f.KubeConfig, "Path to the kubeconfig file to use for CLI requests.")
+	}
+	if f.CacheDir != nil {
+		flags.StringVar(f.CacheDir, flagHTTPCacheDir, *f.CacheDir, "Default HTTP cache directory")
+	}
+
+	// add config options
+	if f.CertFile != nil {
+		flags.StringVar(f.CertFile, flagCertFile, *f.CertFile, "Path to a client certificate file for TLS")
+	}
+	if f.KeyFile != nil {
+		flags.StringVar(f.KeyFile, flagKeyFile, *f.KeyFile, "Path to a client key file for TLS")
+	}
+	if f.BearerToken != nil {
+		flags.StringVar(f.BearerToken, flagBearerToken, *f.BearerToken, "Bearer token for authentication to the API server")
+	}
+	if f.Impersonate != nil {
+		flags.StringVar(f.Impersonate, flagImpersonate, *f.Impersonate, "Username to impersonate for the operation")
+	}
+	if f.ImpersonateGroup != nil {
+		flags.StringArrayVar(f.ImpersonateGroup, flagImpersonateGroup, *f.ImpersonateGroup, "Group to impersonate for the operation, this flag can be repeated to specify multiple groups.")
+	}
+	if f.Username != nil {
+		flags.StringVar(f.Username, flagUsername, *f.Username, "Username for basic authentication to the API server")
+	}
+	if f.Password != nil {
+		flags.StringVar(f.Password, flagPassword, *f.Password, "Password for basic authentication to the API server")
+	}
+	if f.ClusterName != nil {
+		flags.StringVar(f.ClusterName, flagClusterName, *f.ClusterName, "The name of the kubeconfig cluster to use")
+	}
+	if f.AuthInfoName != nil {
+		flags.StringVar(f.AuthInfoName, flagAuthInfoName, *f.AuthInfoName, "The name of the kubeconfig user to use")
+	}
+	if f.Namespace != nil {
+		flags.StringVarP(f.Namespace, flagNamespace, "n", *f.Namespace, "If present, the namespace scope for this CLI request")
+	}
+	if f.Context != nil {
+		flags.StringVar(f.Context, flagContext, *f.Context, "The name of the kubeconfig context to use")
+	}
+
+	if f.APIServer != nil {
+		flags.StringVarP(f.APIServer, flagAPIServer, "s", *f.APIServer, "The address and port of the Kubernetes API server")
+	}
+	if f.Insecure != nil {
+		flags.BoolVar(f.Insecure, flagInsecure, *f.Insecure, "If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure")
+	}
+	if f.CAFile != nil {
+		flags.StringVar(f.CAFile, flagCAFile, *f.CAFile, "Path to a cert file for the certificate authority")
+	}
+	if f.Timeout != nil {
+		flags.StringVar(f.Timeout, flagTimeout, *f.Timeout, "The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests.")
+	}
+
+}
+
+// WithDeprecatedPasswordFlag enables the username and password config flags
+func (f *ConfigFlags) WithDeprecatedPasswordFlag() *ConfigFlags {
+	f.Username = stringptr("")
+	f.Password = stringptr("")
+	return f
+}
+
+// NewConfigFlags returns ConfigFlags with default values set
+func NewConfigFlags() *ConfigFlags {
+	impersonateGroup := []string{}
+	insecure := false
+
+	return &ConfigFlags{
+		Insecure:   &insecure,
+		Timeout:    stringptr("0"),
+		KubeConfig: stringptr(""),
+
+		CacheDir:         stringptr(defaultCacheDir),
+		ClusterName:      stringptr(""),
+		AuthInfoName:     stringptr(""),
+		Context:          stringptr(""),
+		Namespace:        stringptr(""),
+		APIServer:        stringptr(""),
+		CertFile:         stringptr(""),
+		KeyFile:          stringptr(""),
+		CAFile:           stringptr(""),
+		BearerToken:      stringptr(""),
+		Impersonate:      stringptr(""),
+		ImpersonateGroup: &impersonateGroup,
+	}
+}
+
+func stringptr(val string) *string {
+	return &val
+}
+
+// overlyCautiousIllegalFileCharacters matches characters that *might* not be supported.  Windows is really restrictive, so this is really restrictive
+var overlyCautiousIllegalFileCharacters = regexp.MustCompile(`[^(\w/\.)]`)
+
+// computeDiscoverCacheDir takes the parentDir and the host and comes up with a "usually non-colliding" name.
+func computeDiscoverCacheDir(parentDir, host string) string {
+	// strip the optional scheme from host if its there:
+	schemelessHost := strings.Replace(strings.Replace(host, "https://", "", 1), "http://", "", 1)
+	// now do a simple collapse of non-AZ09 characters.  Collisions are possible but unlikely.  Even if we do collide the problem is short lived
+	safeHost := overlyCautiousIllegalFileCharacters.ReplaceAllString(schemelessHost, "_")
+	return filepath.Join(parentDir, safeHost)
+}

--- a/vendor/k8s.io/cli-runtime/pkg/genericclioptions/config_flags_fake.go
+++ b/vendor/k8s.io/cli-runtime/pkg/genericclioptions/config_flags_fake.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package genericclioptions
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+type TestConfigFlags struct {
+	clientConfig    clientcmd.ClientConfig
+	discoveryClient discovery.CachedDiscoveryInterface
+	restMapper      meta.RESTMapper
+}
+
+func (f *TestConfigFlags) ToRawKubeConfigLoader() clientcmd.ClientConfig {
+	if f.clientConfig == nil {
+		panic("attempt to obtain a test RawKubeConfigLoader with no clientConfig specified")
+	}
+	return f.clientConfig
+}
+
+func (f *TestConfigFlags) ToRESTConfig() (*rest.Config, error) {
+	return f.ToRawKubeConfigLoader().ClientConfig()
+}
+
+func (f *TestConfigFlags) ToDiscoveryClient() (discovery.CachedDiscoveryInterface, error) {
+	return f.discoveryClient, nil
+}
+
+func (f *TestConfigFlags) ToRESTMapper() (meta.RESTMapper, error) {
+	if f.restMapper != nil {
+		return f.restMapper, nil
+	}
+	if f.discoveryClient != nil {
+		mapper := restmapper.NewDeferredDiscoveryRESTMapper(f.discoveryClient)
+		expander := restmapper.NewShortcutExpander(mapper, f.discoveryClient)
+		return expander, nil
+	}
+	return nil, fmt.Errorf("no restmapper")
+}
+
+func (f *TestConfigFlags) WithClientConfig(clientConfig clientcmd.ClientConfig) *TestConfigFlags {
+	f.clientConfig = clientConfig
+	return f
+}
+
+func (f *TestConfigFlags) WithRESTMapper(mapper meta.RESTMapper) *TestConfigFlags {
+	f.restMapper = mapper
+	return f
+}
+
+func (f *TestConfigFlags) WithDiscoveryClient(c discovery.CachedDiscoveryInterface) *TestConfigFlags {
+	f.discoveryClient = c
+	return f
+}
+
+func (f *TestConfigFlags) WithNamespace(ns string) *TestConfigFlags {
+	if f.clientConfig == nil {
+		panic("attempt to obtain a test RawKubeConfigLoader with no clientConfig specified")
+	}
+	f.clientConfig = &namespacedClientConfig{
+		delegate:  f.clientConfig,
+		namespace: ns,
+	}
+	return f
+}
+
+func NewTestConfigFlags() *TestConfigFlags {
+	return &TestConfigFlags{}
+}
+
+type namespacedClientConfig struct {
+	delegate  clientcmd.ClientConfig
+	namespace string
+}
+
+func (c *namespacedClientConfig) Namespace() (string, bool, error) {
+	return c.namespace, false, nil
+}
+
+func (c *namespacedClientConfig) RawConfig() (clientcmdapi.Config, error) {
+	return c.delegate.RawConfig()
+}
+func (c *namespacedClientConfig) ClientConfig() (*rest.Config, error) {
+	return c.delegate.ClientConfig()
+}
+func (c *namespacedClientConfig) ConfigAccess() clientcmd.ConfigAccess {
+	return c.delegate.ConfigAccess()
+}

--- a/vendor/k8s.io/cli-runtime/pkg/genericclioptions/doc.go
+++ b/vendor/k8s.io/cli-runtime/pkg/genericclioptions/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package genericclioptions contains flags which can be added to you command, bound, completed, and produce
+// useful helper functions.  Nothing in this package can depend on kube/kube
+package genericclioptions

--- a/vendor/k8s.io/cli-runtime/pkg/genericclioptions/filename_flags.go
+++ b/vendor/k8s.io/cli-runtime/pkg/genericclioptions/filename_flags.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package genericclioptions
+
+import (
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions/resource"
+)
+
+// Usage of this struct by itself is discouraged.
+// These flags are composed by ResourceBuilderFlags
+// which should be used instead.
+type FileNameFlags struct {
+	Usage string
+
+	Filenames *[]string
+	Recursive *bool
+}
+
+func (o *FileNameFlags) ToOptions() resource.FilenameOptions {
+	options := resource.FilenameOptions{}
+
+	if o == nil {
+		return options
+	}
+
+	if o.Recursive != nil {
+		options.Recursive = *o.Recursive
+	}
+	if o.Filenames != nil {
+		options.Filenames = *o.Filenames
+	}
+
+	return options
+}
+
+func (o *FileNameFlags) AddFlags(flags *pflag.FlagSet) {
+	if o == nil {
+		return
+	}
+
+	if o.Recursive != nil {
+		flags.BoolVarP(o.Recursive, "recursive", "R", *o.Recursive, "Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.")
+	}
+	if o.Filenames != nil {
+		flags.StringSliceVarP(o.Filenames, "filename", "f", *o.Filenames, o.Usage)
+		annotations := make([]string, 0, len(resource.FileExtensions))
+		for _, ext := range resource.FileExtensions {
+			annotations = append(annotations, strings.TrimLeft(ext, "."))
+		}
+		flags.SetAnnotation("filename", cobra.BashCompFilenameExt, annotations)
+	}
+}

--- a/vendor/k8s.io/cli-runtime/pkg/genericclioptions/io_options.go
+++ b/vendor/k8s.io/cli-runtime/pkg/genericclioptions/io_options.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package genericclioptions
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+)
+
+// IOStreams provides the standard names for iostreams.  This is useful for embedding and for unit testing.
+// Inconsistent and different names make it hard to read and review code
+type IOStreams struct {
+	// In think, os.Stdin
+	In io.Reader
+	// Out think, os.Stdout
+	Out io.Writer
+	// ErrOut think, os.Stderr
+	ErrOut io.Writer
+}
+
+// NewTestIOStreams returns a valid IOStreams and in, out, errout buffers for unit tests
+func NewTestIOStreams() (IOStreams, *bytes.Buffer, *bytes.Buffer, *bytes.Buffer) {
+	in := &bytes.Buffer{}
+	out := &bytes.Buffer{}
+	errOut := &bytes.Buffer{}
+
+	return IOStreams{
+		In:     in,
+		Out:    out,
+		ErrOut: errOut,
+	}, in, out, errOut
+}
+
+// NewTestIOStreamsDiscard returns a valid IOStreams that just discards
+func NewTestIOStreamsDiscard() IOStreams {
+	in := &bytes.Buffer{}
+	return IOStreams{
+		In:     in,
+		Out:    ioutil.Discard,
+		ErrOut: ioutil.Discard,
+	}
+}

--- a/vendor/k8s.io/cli-runtime/pkg/genericclioptions/json_yaml_flags.go
+++ b/vendor/k8s.io/cli-runtime/pkg/genericclioptions/json_yaml_flags.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package genericclioptions
+
+import (
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions/printers"
+)
+
+func (f *JSONYamlPrintFlags) AllowedFormats() []string {
+	if f == nil {
+		return []string{}
+	}
+	return []string{"json", "yaml"}
+}
+
+// JSONYamlPrintFlags provides default flags necessary for json/yaml printing.
+// Given the following flag values, a printer can be requested that knows
+// how to handle printing based on these values.
+type JSONYamlPrintFlags struct {
+}
+
+// ToPrinter receives an outputFormat and returns a printer capable of
+// handling --output=(yaml|json) printing.
+// Returns false if the specified outputFormat does not match a supported format.
+// Supported Format types can be found in pkg/printers/printers.go
+func (f *JSONYamlPrintFlags) ToPrinter(outputFormat string) (printers.ResourcePrinter, error) {
+	var printer printers.ResourcePrinter
+
+	outputFormat = strings.ToLower(outputFormat)
+	switch outputFormat {
+	case "json":
+		printer = &printers.JSONPrinter{}
+	case "yaml":
+		printer = &printers.YAMLPrinter{}
+	default:
+		return nil, NoCompatiblePrinterError{OutputFormat: &outputFormat, AllowedFormats: f.AllowedFormats()}
+	}
+
+	return printer, nil
+}
+
+// AddFlags receives a *cobra.Command reference and binds
+// flags related to JSON or Yaml printing to it
+func (f *JSONYamlPrintFlags) AddFlags(c *cobra.Command) {}
+
+// NewJSONYamlPrintFlags returns flags associated with
+// yaml or json printing, with default values set.
+func NewJSONYamlPrintFlags() *JSONYamlPrintFlags {
+	return &JSONYamlPrintFlags{}
+}

--- a/vendor/k8s.io/cli-runtime/pkg/genericclioptions/jsonpath_flags.go
+++ b/vendor/k8s.io/cli-runtime/pkg/genericclioptions/jsonpath_flags.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package genericclioptions
+
+import (
+	"fmt"
+	"io/ioutil"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions/printers"
+)
+
+// templates are logically optional for specifying a format.
+// this allows a user to specify a template format value
+// as --output=jsonpath=
+var jsonFormats = map[string]bool{
+	"jsonpath":      true,
+	"jsonpath-file": true,
+}
+
+// JSONPathPrintFlags provides default flags necessary for template printing.
+// Given the following flag values, a printer can be requested that knows
+// how to handle printing based on these values.
+type JSONPathPrintFlags struct {
+	// indicates if it is OK to ignore missing keys for rendering
+	// an output template.
+	AllowMissingKeys *bool
+	TemplateArgument *string
+}
+
+func (f *JSONPathPrintFlags) AllowedFormats() []string {
+	formats := make([]string, 0, len(jsonFormats))
+	for format := range jsonFormats {
+		formats = append(formats, format)
+	}
+	sort.Strings(formats)
+	return formats
+}
+
+// ToPrinter receives an templateFormat and returns a printer capable of
+// handling --template format printing.
+// Returns false if the specified templateFormat does not match a template format.
+func (f *JSONPathPrintFlags) ToPrinter(templateFormat string) (printers.ResourcePrinter, error) {
+	if (f.TemplateArgument == nil || len(*f.TemplateArgument) == 0) && len(templateFormat) == 0 {
+		return nil, NoCompatiblePrinterError{Options: f, OutputFormat: &templateFormat}
+	}
+
+	templateValue := ""
+
+	if f.TemplateArgument == nil || len(*f.TemplateArgument) == 0 {
+		for format := range jsonFormats {
+			format = format + "="
+			if strings.HasPrefix(templateFormat, format) {
+				templateValue = templateFormat[len(format):]
+				templateFormat = format[:len(format)-1]
+				break
+			}
+		}
+	} else {
+		templateValue = *f.TemplateArgument
+	}
+
+	if _, supportedFormat := jsonFormats[templateFormat]; !supportedFormat {
+		return nil, NoCompatiblePrinterError{OutputFormat: &templateFormat, AllowedFormats: f.AllowedFormats()}
+	}
+
+	if len(templateValue) == 0 {
+		return nil, fmt.Errorf("template format specified but no template given")
+	}
+
+	if templateFormat == "jsonpath-file" {
+		data, err := ioutil.ReadFile(templateValue)
+		if err != nil {
+			return nil, fmt.Errorf("error reading --template %s, %v\n", templateValue, err)
+		}
+
+		templateValue = string(data)
+	}
+
+	p, err := printers.NewJSONPathPrinter(templateValue)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing jsonpath %s, %v\n", templateValue, err)
+	}
+
+	allowMissingKeys := true
+	if f.AllowMissingKeys != nil {
+		allowMissingKeys = *f.AllowMissingKeys
+	}
+
+	p.AllowMissingKeys(allowMissingKeys)
+	return p, nil
+}
+
+// AddFlags receives a *cobra.Command reference and binds
+// flags related to template printing to it
+func (f *JSONPathPrintFlags) AddFlags(c *cobra.Command) {
+	if f.TemplateArgument != nil {
+		c.Flags().StringVar(f.TemplateArgument, "template", *f.TemplateArgument, "Template string or path to template file to use when --output=jsonpath, --output=jsonpath-file.")
+		c.MarkFlagFilename("template")
+	}
+	if f.AllowMissingKeys != nil {
+		c.Flags().BoolVar(f.AllowMissingKeys, "allow-missing-template-keys", *f.AllowMissingKeys, "If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.")
+	}
+}
+
+// NewJSONPathPrintFlags returns flags associated with
+// --template printing, with default values set.
+func NewJSONPathPrintFlags(templateValue string, allowMissingKeys bool) *JSONPathPrintFlags {
+	return &JSONPathPrintFlags{
+		TemplateArgument: &templateValue,
+		AllowMissingKeys: &allowMissingKeys,
+	}
+}

--- a/vendor/k8s.io/cli-runtime/pkg/genericclioptions/kube_template_flags.go
+++ b/vendor/k8s.io/cli-runtime/pkg/genericclioptions/kube_template_flags.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package genericclioptions
+
+import (
+	"github.com/spf13/cobra"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions/printers"
+)
+
+// KubeTemplatePrintFlags composes print flags that provide both a JSONPath and a go-template printer.
+// This is necessary if dealing with cases that require support both both printers, since both sets of flags
+// require overlapping flags.
+type KubeTemplatePrintFlags struct {
+	GoTemplatePrintFlags *GoTemplatePrintFlags
+	JSONPathPrintFlags   *JSONPathPrintFlags
+
+	AllowMissingKeys *bool
+	TemplateArgument *string
+}
+
+func (f *KubeTemplatePrintFlags) AllowedFormats() []string {
+	if f == nil {
+		return []string{}
+	}
+	return append(f.GoTemplatePrintFlags.AllowedFormats(), f.JSONPathPrintFlags.AllowedFormats()...)
+}
+
+func (f *KubeTemplatePrintFlags) ToPrinter(outputFormat string) (printers.ResourcePrinter, error) {
+	if f == nil {
+		return nil, NoCompatiblePrinterError{}
+	}
+
+	if p, err := f.JSONPathPrintFlags.ToPrinter(outputFormat); !IsNoCompatiblePrinterError(err) {
+		return p, err
+	}
+	return f.GoTemplatePrintFlags.ToPrinter(outputFormat)
+}
+
+// AddFlags receives a *cobra.Command reference and binds
+// flags related to template printing to it
+func (f *KubeTemplatePrintFlags) AddFlags(c *cobra.Command) {
+	if f == nil {
+		return
+	}
+
+	if f.TemplateArgument != nil {
+		c.Flags().StringVar(f.TemplateArgument, "template", *f.TemplateArgument, "Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].")
+		c.MarkFlagFilename("template")
+	}
+	if f.AllowMissingKeys != nil {
+		c.Flags().BoolVar(f.AllowMissingKeys, "allow-missing-template-keys", *f.AllowMissingKeys, "If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.")
+	}
+}
+
+// NewKubeTemplatePrintFlags returns flags associated with
+// --template printing, with default values set.
+func NewKubeTemplatePrintFlags() *KubeTemplatePrintFlags {
+	allowMissingKeysPtr := true
+	templateArgPtr := ""
+
+	return &KubeTemplatePrintFlags{
+		GoTemplatePrintFlags: &GoTemplatePrintFlags{
+			TemplateArgument: &templateArgPtr,
+			AllowMissingKeys: &allowMissingKeysPtr,
+		},
+		JSONPathPrintFlags: &JSONPathPrintFlags{
+			TemplateArgument: &templateArgPtr,
+			AllowMissingKeys: &allowMissingKeysPtr,
+		},
+
+		TemplateArgument: &templateArgPtr,
+		AllowMissingKeys: &allowMissingKeysPtr,
+	}
+}

--- a/vendor/k8s.io/cli-runtime/pkg/genericclioptions/name_flags.go
+++ b/vendor/k8s.io/cli-runtime/pkg/genericclioptions/name_flags.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package genericclioptions
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions/printers"
+)
+
+// NamePrintFlags provides default flags necessary for printing
+// a resource's fully-qualified Kind.group/name, or a successful
+// message about that resource if an Operation is provided.
+type NamePrintFlags struct {
+	// Operation describes the name of the action that
+	// took place on an object, to be included in the
+	// finalized "successful" message.
+	Operation string
+}
+
+func (f *NamePrintFlags) Complete(successTemplate string) error {
+	f.Operation = fmt.Sprintf(successTemplate, f.Operation)
+	return nil
+}
+
+func (f *NamePrintFlags) AllowedFormats() []string {
+	if f == nil {
+		return []string{}
+	}
+	return []string{"name"}
+}
+
+// ToPrinter receives an outputFormat and returns a printer capable of
+// handling --output=name printing.
+// Returns false if the specified outputFormat does not match a supported format.
+// Supported format types can be found in pkg/printers/printers.go
+func (f *NamePrintFlags) ToPrinter(outputFormat string) (printers.ResourcePrinter, error) {
+	namePrinter := &printers.NamePrinter{
+		Operation: f.Operation,
+	}
+
+	outputFormat = strings.ToLower(outputFormat)
+	switch outputFormat {
+	case "name":
+		namePrinter.ShortOutput = true
+		fallthrough
+	case "":
+		return namePrinter, nil
+	default:
+		return nil, NoCompatiblePrinterError{OutputFormat: &outputFormat, AllowedFormats: f.AllowedFormats()}
+	}
+}
+
+// AddFlags receives a *cobra.Command reference and binds
+// flags related to name printing to it
+func (f *NamePrintFlags) AddFlags(c *cobra.Command) {}
+
+// NewNamePrintFlags returns flags associated with
+// --name printing, with default values set.
+func NewNamePrintFlags(operation string) *NamePrintFlags {
+	return &NamePrintFlags{
+		Operation: operation,
+	}
+}

--- a/vendor/k8s.io/cli-runtime/pkg/genericclioptions/print_flags.go
+++ b/vendor/k8s.io/cli-runtime/pkg/genericclioptions/print_flags.go
@@ -1,0 +1,158 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package genericclioptions
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/cli-runtime/pkg/genericclioptions/printers"
+)
+
+type NoCompatiblePrinterError struct {
+	OutputFormat   *string
+	AllowedFormats []string
+	Options        interface{}
+}
+
+func (e NoCompatiblePrinterError) Error() string {
+	output := ""
+	if e.OutputFormat != nil {
+		output = *e.OutputFormat
+	}
+
+	sort.Strings(e.AllowedFormats)
+	return fmt.Sprintf("unable to match a printer suitable for the output format %q, allowed formats are: %s", output, strings.Join(e.AllowedFormats, ","))
+}
+
+func IsNoCompatiblePrinterError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	_, ok := err.(NoCompatiblePrinterError)
+	return ok
+}
+
+// PrintFlags composes common printer flag structs
+// used across all commands, and provides a method
+// of retrieving a known printer based on flag values provided.
+type PrintFlags struct {
+	JSONYamlPrintFlags   *JSONYamlPrintFlags
+	NamePrintFlags       *NamePrintFlags
+	TemplatePrinterFlags *KubeTemplatePrintFlags
+
+	TypeSetterPrinter *printers.TypeSetterPrinter
+
+	OutputFormat *string
+
+	// OutputFlagSpecified indicates whether the user specifically requested a certain kind of output.
+	// Using this function allows a sophisticated caller to change the flag binding logic if they so desire.
+	OutputFlagSpecified func() bool
+}
+
+func (f *PrintFlags) Complete(successTemplate string) error {
+	return f.NamePrintFlags.Complete(successTemplate)
+}
+
+func (f *PrintFlags) AllowedFormats() []string {
+	ret := []string{}
+	ret = append(ret, f.JSONYamlPrintFlags.AllowedFormats()...)
+	ret = append(ret, f.NamePrintFlags.AllowedFormats()...)
+	ret = append(ret, f.TemplatePrinterFlags.AllowedFormats()...)
+	return ret
+}
+
+func (f *PrintFlags) ToPrinter() (printers.ResourcePrinter, error) {
+	outputFormat := ""
+	if f.OutputFormat != nil {
+		outputFormat = *f.OutputFormat
+	}
+	// For backwards compatibility we want to support a --template argument given, even when no --output format is provided.
+	// If no explicit output format has been provided via the --output flag, fallback
+	// to honoring the --template argument.
+	templateFlagSpecified := f.TemplatePrinterFlags != nil &&
+		f.TemplatePrinterFlags.TemplateArgument != nil &&
+		len(*f.TemplatePrinterFlags.TemplateArgument) > 0
+	outputFlagSpecified := f.OutputFlagSpecified != nil && f.OutputFlagSpecified()
+	if templateFlagSpecified && !outputFlagSpecified {
+		outputFormat = "go-template"
+	}
+
+	if f.JSONYamlPrintFlags != nil {
+		if p, err := f.JSONYamlPrintFlags.ToPrinter(outputFormat); !IsNoCompatiblePrinterError(err) {
+			return f.TypeSetterPrinter.WrapToPrinter(p, err)
+		}
+	}
+
+	if f.NamePrintFlags != nil {
+		if p, err := f.NamePrintFlags.ToPrinter(outputFormat); !IsNoCompatiblePrinterError(err) {
+			return f.TypeSetterPrinter.WrapToPrinter(p, err)
+		}
+	}
+
+	if f.TemplatePrinterFlags != nil {
+		if p, err := f.TemplatePrinterFlags.ToPrinter(outputFormat); !IsNoCompatiblePrinterError(err) {
+			return f.TypeSetterPrinter.WrapToPrinter(p, err)
+		}
+	}
+
+	return nil, NoCompatiblePrinterError{OutputFormat: f.OutputFormat, AllowedFormats: f.AllowedFormats()}
+}
+
+func (f *PrintFlags) AddFlags(cmd *cobra.Command) {
+	f.JSONYamlPrintFlags.AddFlags(cmd)
+	f.NamePrintFlags.AddFlags(cmd)
+	f.TemplatePrinterFlags.AddFlags(cmd)
+
+	if f.OutputFormat != nil {
+		cmd.Flags().StringVarP(f.OutputFormat, "output", "o", *f.OutputFormat, fmt.Sprintf("Output format. One of: %s.", strings.Join(f.AllowedFormats(), "|")))
+		if f.OutputFlagSpecified == nil {
+			f.OutputFlagSpecified = func() bool {
+				return cmd.Flag("output").Changed
+			}
+		}
+	}
+}
+
+// WithDefaultOutput sets a default output format if one is not provided through a flag value
+func (f *PrintFlags) WithDefaultOutput(output string) *PrintFlags {
+	f.OutputFormat = &output
+	return f
+}
+
+// WithTypeSetter sets a wrapper than will surround the returned printer with a printer to type resources
+func (f *PrintFlags) WithTypeSetter(scheme *runtime.Scheme) *PrintFlags {
+	f.TypeSetterPrinter = printers.NewTypeSetter(scheme)
+	return f
+}
+
+func NewPrintFlags(operation string) *PrintFlags {
+	outputFormat := ""
+
+	return &PrintFlags{
+		OutputFormat: &outputFormat,
+
+		JSONYamlPrintFlags:   NewJSONYamlPrintFlags(),
+		NamePrintFlags:       NewNamePrintFlags(operation),
+		TemplatePrinterFlags: NewKubeTemplatePrintFlags(),
+	}
+}

--- a/vendor/k8s.io/cli-runtime/pkg/genericclioptions/printers/discard.go
+++ b/vendor/k8s.io/cli-runtime/pkg/genericclioptions/printers/discard.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package printers
+
+import (
+	"io"
+
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// NewDiscardingPrinter is a printer that discards all objects
+func NewDiscardingPrinter() ResourcePrinterFunc {
+	return ResourcePrinterFunc(func(runtime.Object, io.Writer) error {
+		return nil
+	})
+}

--- a/vendor/k8s.io/cli-runtime/pkg/genericclioptions/printers/interface.go
+++ b/vendor/k8s.io/cli-runtime/pkg/genericclioptions/printers/interface.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package printers
+
+import (
+	"io"
+
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// ResourcePrinterFunc is a function that can print objects
+type ResourcePrinterFunc func(runtime.Object, io.Writer) error
+
+// PrintObj implements ResourcePrinter
+func (fn ResourcePrinterFunc) PrintObj(obj runtime.Object, w io.Writer) error {
+	return fn(obj, w)
+}
+
+// ResourcePrinter is an interface that knows how to print runtime objects.
+type ResourcePrinter interface {
+	// Print receives a runtime object, formats it and prints it to a writer.
+	PrintObj(runtime.Object, io.Writer) error
+}

--- a/vendor/k8s.io/cli-runtime/pkg/genericclioptions/printers/json.go
+++ b/vendor/k8s.io/cli-runtime/pkg/genericclioptions/printers/json.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package printers
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"reflect"
+
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"sigs.k8s.io/yaml"
+)
+
+// JSONPrinter is an implementation of ResourcePrinter which outputs an object as JSON.
+type JSONPrinter struct{}
+
+// PrintObj is an implementation of ResourcePrinter.PrintObj which simply writes the object to the Writer.
+func (p *JSONPrinter) PrintObj(obj runtime.Object, w io.Writer) error {
+	// we use reflect.Indirect here in order to obtain the actual value from a pointer.
+	// we need an actual value in order to retrieve the package path for an object.
+	// using reflect.Indirect indiscriminately is valid here, as all runtime.Objects are supposed to be pointers.
+	if InternalObjectPreventer.IsForbidden(reflect.Indirect(reflect.ValueOf(obj)).Type().PkgPath()) {
+		return fmt.Errorf(InternalObjectPrinterErr)
+	}
+
+	switch obj := obj.(type) {
+	case *runtime.Unknown:
+		var buf bytes.Buffer
+		err := json.Indent(&buf, obj.Raw, "", "    ")
+		if err != nil {
+			return err
+		}
+		buf.WriteRune('\n')
+		_, err = buf.WriteTo(w)
+		return err
+	}
+
+	if obj.GetObjectKind().GroupVersionKind().Empty() {
+		return fmt.Errorf("missing apiVersion or kind; try GetObjectKind().SetGroupVersionKind() if you know the type")
+	}
+
+	data, err := json.MarshalIndent(obj, "", "    ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	_, err = w.Write(data)
+	return err
+}
+
+// YAMLPrinter is an implementation of ResourcePrinter which outputs an object as YAML.
+// The input object is assumed to be in the internal version of an API and is converted
+// to the given version first.
+type YAMLPrinter struct{}
+
+// PrintObj prints the data as YAML.
+func (p *YAMLPrinter) PrintObj(obj runtime.Object, w io.Writer) error {
+	// we use reflect.Indirect here in order to obtain the actual value from a pointer.
+	// we need an actual value in order to retrieve the package path for an object.
+	// using reflect.Indirect indiscriminately is valid here, as all runtime.Objects are supposed to be pointers.
+	if InternalObjectPreventer.IsForbidden(reflect.Indirect(reflect.ValueOf(obj)).Type().PkgPath()) {
+		return fmt.Errorf(InternalObjectPrinterErr)
+	}
+
+	switch obj := obj.(type) {
+	case *runtime.Unknown:
+		data, err := yaml.JSONToYAML(obj.Raw)
+		if err != nil {
+			return err
+		}
+		_, err = w.Write(data)
+		return err
+	}
+
+	if obj.GetObjectKind().GroupVersionKind().Empty() {
+		return fmt.Errorf("missing apiVersion or kind; try GetObjectKind().SetGroupVersionKind() if you know the type")
+	}
+
+	output, err := yaml.Marshal(obj)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprint(w, string(output))
+	return err
+}

--- a/vendor/k8s.io/cli-runtime/pkg/genericclioptions/printers/jsonpath.go
+++ b/vendor/k8s.io/cli-runtime/pkg/genericclioptions/printers/jsonpath.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package printers
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"reflect"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/util/jsonpath"
+)
+
+// exists returns true if it would be possible to call the index function
+// with these arguments.
+//
+// TODO: how to document this for users?
+//
+// index returns the result of indexing its first argument by the following
+// arguments.  Thus "index x 1 2 3" is, in Go syntax, x[1][2][3]. Each
+// indexed item must be a map, slice, or array.
+func exists(item interface{}, indices ...interface{}) bool {
+	v := reflect.ValueOf(item)
+	for _, i := range indices {
+		index := reflect.ValueOf(i)
+		var isNil bool
+		if v, isNil = indirect(v); isNil {
+			return false
+		}
+		switch v.Kind() {
+		case reflect.Array, reflect.Slice, reflect.String:
+			var x int64
+			switch index.Kind() {
+			case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+				x = index.Int()
+			case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+				x = int64(index.Uint())
+			default:
+				return false
+			}
+			if x < 0 || x >= int64(v.Len()) {
+				return false
+			}
+			v = v.Index(int(x))
+		case reflect.Map:
+			if !index.IsValid() {
+				index = reflect.Zero(v.Type().Key())
+			}
+			if !index.Type().AssignableTo(v.Type().Key()) {
+				return false
+			}
+			if x := v.MapIndex(index); x.IsValid() {
+				v = x
+			} else {
+				v = reflect.Zero(v.Type().Elem())
+			}
+		default:
+			return false
+		}
+	}
+	if _, isNil := indirect(v); isNil {
+		return false
+	}
+	return true
+}
+
+// stolen from text/template
+// indirect returns the item at the end of indirection, and a bool to indicate if it's nil.
+// We indirect through pointers and empty interfaces (only) because
+// non-empty interfaces have methods we might need.
+func indirect(v reflect.Value) (rv reflect.Value, isNil bool) {
+	for ; v.Kind() == reflect.Ptr || v.Kind() == reflect.Interface; v = v.Elem() {
+		if v.IsNil() {
+			return v, true
+		}
+		if v.Kind() == reflect.Interface && v.NumMethod() > 0 {
+			break
+		}
+	}
+	return v, false
+}
+
+// JSONPathPrinter is an implementation of ResourcePrinter which formats data with jsonpath expression.
+type JSONPathPrinter struct {
+	rawTemplate string
+	*jsonpath.JSONPath
+}
+
+func NewJSONPathPrinter(tmpl string) (*JSONPathPrinter, error) {
+	j := jsonpath.New("out")
+	if err := j.Parse(tmpl); err != nil {
+		return nil, err
+	}
+	return &JSONPathPrinter{
+		rawTemplate: tmpl,
+		JSONPath:    j,
+	}, nil
+}
+
+// PrintObj formats the obj with the JSONPath Template.
+func (j *JSONPathPrinter) PrintObj(obj runtime.Object, w io.Writer) error {
+	// we use reflect.Indirect here in order to obtain the actual value from a pointer.
+	// we need an actual value in order to retrieve the package path for an object.
+	// using reflect.Indirect indiscriminately is valid here, as all runtime.Objects are supposed to be pointers.
+	if InternalObjectPreventer.IsForbidden(reflect.Indirect(reflect.ValueOf(obj)).Type().PkgPath()) {
+		return fmt.Errorf(InternalObjectPrinterErr)
+	}
+
+	var queryObj interface{} = obj
+	if unstructured, ok := obj.(runtime.Unstructured); ok {
+		queryObj = unstructured.UnstructuredContent()
+	} else {
+		data, err := json.Marshal(obj)
+		if err != nil {
+			return err
+		}
+		queryObj = map[string]interface{}{}
+		if err := json.Unmarshal(data, &queryObj); err != nil {
+			return err
+		}
+	}
+
+	if err := j.JSONPath.Execute(w, queryObj); err != nil {
+		buf := bytes.NewBuffer(nil)
+		fmt.Fprintf(buf, "Error executing template: %v. Printing more information for debugging the template:\n", err)
+		fmt.Fprintf(buf, "\ttemplate was:\n\t\t%v\n", j.rawTemplate)
+		fmt.Fprintf(buf, "\tobject given to jsonpath engine was:\n\t\t%#v\n\n", queryObj)
+		return fmt.Errorf("error executing jsonpath %q: %v\n", j.rawTemplate, buf.String())
+	}
+	return nil
+}

--- a/vendor/k8s.io/cli-runtime/pkg/genericclioptions/printers/name.go
+++ b/vendor/k8s.io/cli-runtime/pkg/genericclioptions/printers/name.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package printers
+
+import (
+	"fmt"
+	"io"
+	"reflect"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// NamePrinter is an implementation of ResourcePrinter which outputs "resource/name" pair of an object.
+type NamePrinter struct {
+	// ShortOutput indicates whether an operation should be
+	// printed along side the "resource/name" pair for an object.
+	ShortOutput bool
+	// Operation describes the name of the action that
+	// took place on an object, to be included in the
+	// finalized "successful" message.
+	Operation string
+}
+
+// PrintObj is an implementation of ResourcePrinter.PrintObj which decodes the object
+// and print "resource/name" pair. If the object is a List, print all items in it.
+func (p *NamePrinter) PrintObj(obj runtime.Object, w io.Writer) error {
+	// we use reflect.Indirect here in order to obtain the actual value from a pointer.
+	// using reflect.Indirect indiscriminately is valid here, as all runtime.Objects are supposed to be pointers.
+	// we need an actual value in order to retrieve the package path for an object.
+	if InternalObjectPreventer.IsForbidden(reflect.Indirect(reflect.ValueOf(obj)).Type().PkgPath()) {
+		return fmt.Errorf(InternalObjectPrinterErr)
+	}
+
+	if meta.IsListType(obj) {
+		// we allow unstructured lists for now because they always contain the GVK information.  We should chase down
+		// callers and stop them from passing unflattened lists
+		// TODO chase the caller that is setting this and remove it.
+		if _, ok := obj.(*unstructured.UnstructuredList); !ok {
+			return fmt.Errorf("list types are not supported by name printing: %T", obj)
+		}
+
+		items, err := meta.ExtractList(obj)
+		if err != nil {
+			return err
+		}
+		for _, obj := range items {
+			if err := p.PrintObj(obj, w); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	if obj.GetObjectKind().GroupVersionKind().Empty() {
+		return fmt.Errorf("missing apiVersion or kind; try GetObjectKind().SetGroupVersionKind() if you know the type")
+	}
+
+	name := "<unknown>"
+	if acc, err := meta.Accessor(obj); err == nil {
+		if n := acc.GetName(); len(n) > 0 {
+			name = n
+		}
+	}
+
+	return printObj(w, name, p.Operation, p.ShortOutput, GetObjectGroupKind(obj))
+}
+
+func GetObjectGroupKind(obj runtime.Object) schema.GroupKind {
+	if obj == nil {
+		return schema.GroupKind{Kind: "<unknown>"}
+	}
+	groupVersionKind := obj.GetObjectKind().GroupVersionKind()
+	if len(groupVersionKind.Kind) > 0 {
+		return groupVersionKind.GroupKind()
+	}
+
+	if uns, ok := obj.(*unstructured.Unstructured); ok {
+		if len(uns.GroupVersionKind().Kind) > 0 {
+			return uns.GroupVersionKind().GroupKind()
+		}
+	}
+
+	return schema.GroupKind{Kind: "<unknown>"}
+}
+
+func printObj(w io.Writer, name string, operation string, shortOutput bool, groupKind schema.GroupKind) error {
+	if len(groupKind.Kind) == 0 {
+		return fmt.Errorf("missing kind for resource with name %v", name)
+	}
+
+	if len(operation) > 0 {
+		operation = " " + operation
+	}
+
+	if shortOutput {
+		operation = ""
+	}
+
+	if len(groupKind.Group) == 0 {
+		fmt.Fprintf(w, "%s/%s%s\n", strings.ToLower(groupKind.Kind), name, operation)
+		return nil
+	}
+
+	fmt.Fprintf(w, "%s.%s/%s%s\n", strings.ToLower(groupKind.Kind), groupKind.Group, name, operation)
+	return nil
+}

--- a/vendor/k8s.io/cli-runtime/pkg/genericclioptions/printers/sourcechecker.go
+++ b/vendor/k8s.io/cli-runtime/pkg/genericclioptions/printers/sourcechecker.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package printers
+
+import (
+	"strings"
+)
+
+var (
+	InternalObjectPrinterErr = "a versioned object must be passed to a printer"
+
+	// disallowedPackagePrefixes contains regular expression templates
+	// for object package paths that are not allowed by printers.
+	disallowedPackagePrefixes = []string{
+		"k8s.io/kubernetes/pkg/apis/",
+	}
+)
+
+var InternalObjectPreventer = &illegalPackageSourceChecker{disallowedPackagePrefixes}
+
+func IsInternalObjectError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	return err.Error() == InternalObjectPrinterErr
+}
+
+// illegalPackageSourceChecker compares a given
+// object's package path, and determines if the
+// object originates from a disallowed source.
+type illegalPackageSourceChecker struct {
+	// disallowedPrefixes is a slice of disallowed package path
+	// prefixes for a given runtime.Object that we are printing.
+	disallowedPrefixes []string
+}
+
+func (c *illegalPackageSourceChecker) IsForbidden(pkgPath string) bool {
+	for _, forbiddenPrefix := range c.disallowedPrefixes {
+		if strings.HasPrefix(pkgPath, forbiddenPrefix) || strings.Contains(pkgPath, "/vendor/"+forbiddenPrefix) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/vendor/k8s.io/cli-runtime/pkg/genericclioptions/printers/template.go
+++ b/vendor/k8s.io/cli-runtime/pkg/genericclioptions/printers/template.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package printers
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"reflect"
+	"text/template"
+
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// GoTemplatePrinter is an implementation of ResourcePrinter which formats data with a Go Template.
+type GoTemplatePrinter struct {
+	rawTemplate string
+	template    *template.Template
+}
+
+func NewGoTemplatePrinter(tmpl []byte) (*GoTemplatePrinter, error) {
+	t, err := template.New("output").
+		Funcs(template.FuncMap{
+			"exists":       exists,
+			"base64decode": base64decode,
+		}).
+		Parse(string(tmpl))
+	if err != nil {
+		return nil, err
+	}
+	return &GoTemplatePrinter{
+		rawTemplate: string(tmpl),
+		template:    t,
+	}, nil
+}
+
+// AllowMissingKeys tells the template engine if missing keys are allowed.
+func (p *GoTemplatePrinter) AllowMissingKeys(allow bool) {
+	if allow {
+		p.template.Option("missingkey=default")
+	} else {
+		p.template.Option("missingkey=error")
+	}
+}
+
+// PrintObj formats the obj with the Go Template.
+func (p *GoTemplatePrinter) PrintObj(obj runtime.Object, w io.Writer) error {
+	if InternalObjectPreventer.IsForbidden(reflect.Indirect(reflect.ValueOf(obj)).Type().PkgPath()) {
+		return fmt.Errorf(InternalObjectPrinterErr)
+	}
+
+	var data []byte
+	var err error
+	data, err = json.Marshal(obj)
+	if err != nil {
+		return err
+	}
+
+	out := map[string]interface{}{}
+	if err := json.Unmarshal(data, &out); err != nil {
+		return err
+	}
+	if err = p.safeExecute(w, out); err != nil {
+		// It is way easier to debug this stuff when it shows up in
+		// stdout instead of just stdin. So in addition to returning
+		// a nice error, also print useful stuff with the writer.
+		fmt.Fprintf(w, "Error executing template: %v. Printing more information for debugging the template:\n", err)
+		fmt.Fprintf(w, "\ttemplate was:\n\t\t%v\n", p.rawTemplate)
+		fmt.Fprintf(w, "\traw data was:\n\t\t%v\n", string(data))
+		fmt.Fprintf(w, "\tobject given to template engine was:\n\t\t%+v\n\n", out)
+		return fmt.Errorf("error executing template %q: %v", p.rawTemplate, err)
+	}
+	return nil
+}
+
+// safeExecute tries to execute the template, but catches panics and returns an error
+// should the template engine panic.
+func (p *GoTemplatePrinter) safeExecute(w io.Writer, obj interface{}) error {
+	var panicErr error
+	// Sorry for the double anonymous function. There's probably a clever way
+	// to do this that has the defer'd func setting the value to be returned, but
+	// that would be even less obvious.
+	retErr := func() error {
+		defer func() {
+			if x := recover(); x != nil {
+				panicErr = fmt.Errorf("caught panic: %+v", x)
+			}
+		}()
+		return p.template.Execute(w, obj)
+	}()
+	if panicErr != nil {
+		return panicErr
+	}
+	return retErr
+}
+
+func base64decode(v string) (string, error) {
+	data, err := base64.StdEncoding.DecodeString(v)
+	if err != nil {
+		return "", fmt.Errorf("base64 decode failed: %v", err)
+	}
+	return string(data), nil
+}

--- a/vendor/k8s.io/cli-runtime/pkg/genericclioptions/printers/typesetter.go
+++ b/vendor/k8s.io/cli-runtime/pkg/genericclioptions/printers/typesetter.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package printers
+
+import (
+	"fmt"
+	"io"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// TypeSetterPrinter is an implementation of ResourcePrinter wraps another printer with types set on the objects
+type TypeSetterPrinter struct {
+	Delegate ResourcePrinter
+
+	Typer runtime.ObjectTyper
+}
+
+// NewTypeSetter constructs a wrapping printer with required params
+func NewTypeSetter(typer runtime.ObjectTyper) *TypeSetterPrinter {
+	return &TypeSetterPrinter{Typer: typer}
+}
+
+// PrintObj is an implementation of ResourcePrinter.PrintObj which sets type information on the obj for the duration
+// of printing.  It is NOT threadsafe.
+func (p *TypeSetterPrinter) PrintObj(obj runtime.Object, w io.Writer) error {
+	if obj == nil {
+		return p.Delegate.PrintObj(obj, w)
+	}
+	if !obj.GetObjectKind().GroupVersionKind().Empty() {
+		return p.Delegate.PrintObj(obj, w)
+	}
+
+	// we were empty coming in, make sure we're empty going out.  This makes the call thread-unsafe
+	defer func() {
+		obj.GetObjectKind().SetGroupVersionKind(schema.GroupVersionKind{})
+	}()
+
+	gvks, _, err := p.Typer.ObjectKinds(obj)
+	if err != nil {
+		// printers wrapped by us expect to find the type information present
+		return fmt.Errorf("missing apiVersion or kind and cannot assign it; %v", err)
+	}
+
+	for _, gvk := range gvks {
+		if len(gvk.Kind) == 0 {
+			continue
+		}
+		if len(gvk.Version) == 0 || gvk.Version == runtime.APIVersionInternal {
+			continue
+		}
+		obj.GetObjectKind().SetGroupVersionKind(gvk)
+		break
+	}
+
+	return p.Delegate.PrintObj(obj, w)
+}
+
+// ToPrinter returns a printer (not threadsafe!) that has been wrapped
+func (p *TypeSetterPrinter) ToPrinter(delegate ResourcePrinter) ResourcePrinter {
+	if p == nil {
+		return delegate
+	}
+
+	p.Delegate = delegate
+	return p
+}
+
+// WrapToPrinter wraps the common ToPrinter method
+func (p *TypeSetterPrinter) WrapToPrinter(delegate ResourcePrinter, err error) (ResourcePrinter, error) {
+	if err != nil {
+		return delegate, err
+	}
+	if p == nil {
+		return delegate, nil
+	}
+
+	p.Delegate = delegate
+	return p, nil
+}

--- a/vendor/k8s.io/cli-runtime/pkg/genericclioptions/record_flags.go
+++ b/vendor/k8s.io/cli-runtime/pkg/genericclioptions/record_flags.go
@@ -1,0 +1,199 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package genericclioptions
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/evanphx/json-patch"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/json"
+)
+
+// ChangeCauseAnnotation is the annotation indicating a guess at "why" something was changed
+const ChangeCauseAnnotation = "kubernetes.io/change-cause"
+
+// RecordFlags contains all flags associated with the "--record" operation
+type RecordFlags struct {
+	// Record indicates the state of the recording flag.  It is a pointer so a caller can opt out or rebind
+	Record *bool
+
+	changeCause string
+}
+
+// ToRecorder returns a ChangeCause recorder if --record=false was not
+// explicitly given by the user
+func (f *RecordFlags) ToRecorder() (Recorder, error) {
+	if f == nil {
+		return NoopRecorder{}, nil
+	}
+
+	shouldRecord := false
+	if f.Record != nil {
+		shouldRecord = *f.Record
+	}
+
+	// if flag was explicitly set to false by the user,
+	// do not record
+	if !shouldRecord {
+		return NoopRecorder{}, nil
+	}
+
+	return &ChangeCauseRecorder{
+		changeCause: f.changeCause,
+	}, nil
+}
+
+// Complete is called before the command is run, but after it is invoked to finish the state of the struct before use.
+func (f *RecordFlags) Complete(cmd *cobra.Command) error {
+	if f == nil {
+		return nil
+	}
+
+	f.changeCause = parseCommandArguments(cmd)
+	return nil
+}
+
+func (f *RecordFlags) CompleteWithChangeCause(cause string) error {
+	if f == nil {
+		return nil
+	}
+
+	f.changeCause = cause
+	return nil
+}
+
+// AddFlags binds the requested flags to the provided flagset
+// TODO have this only take a flagset
+func (f *RecordFlags) AddFlags(cmd *cobra.Command) {
+	if f == nil {
+		return
+	}
+
+	if f.Record != nil {
+		cmd.Flags().BoolVar(f.Record, "record", *f.Record, "Record current kubectl command in the resource annotation. If set to false, do not record the command. If set to true, record the command. If not set, default to updating the existing annotation value only if one already exists.")
+	}
+}
+
+// NewRecordFlags provides a RecordFlags with reasonable default values set for use
+func NewRecordFlags() *RecordFlags {
+	record := false
+
+	return &RecordFlags{
+		Record: &record,
+	}
+}
+
+// Recorder is used to record why a runtime.Object was changed in an annotation.
+type Recorder interface {
+	// Record records why a runtime.Object was changed in an annotation.
+	Record(runtime.Object) error
+	MakeRecordMergePatch(runtime.Object) ([]byte, error)
+}
+
+// NoopRecorder does nothing.  It is a "do nothing" that can be returned so code doesn't switch on it.
+type NoopRecorder struct{}
+
+// Record implements Recorder
+func (r NoopRecorder) Record(obj runtime.Object) error {
+	return nil
+}
+
+// MakeRecordMergePatch implements Recorder
+func (r NoopRecorder) MakeRecordMergePatch(obj runtime.Object) ([]byte, error) {
+	return nil, nil
+}
+
+// ChangeCauseRecorder annotates a "change-cause" to an input runtime object
+type ChangeCauseRecorder struct {
+	changeCause string
+}
+
+// Record annotates a "change-cause" to a given info if either "shouldRecord" is true,
+// or the resource info previously contained a "change-cause" annotation.
+func (r *ChangeCauseRecorder) Record(obj runtime.Object) error {
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+	annotations := accessor.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	annotations[ChangeCauseAnnotation] = r.changeCause
+	accessor.SetAnnotations(annotations)
+	return nil
+}
+
+// MakeRecordMergePatch produces a merge patch for updating the recording annotation.
+func (r *ChangeCauseRecorder) MakeRecordMergePatch(obj runtime.Object) ([]byte, error) {
+	// copy so we don't mess with the original
+	objCopy := obj.DeepCopyObject()
+	if err := r.Record(objCopy); err != nil {
+		return nil, err
+	}
+
+	oldData, err := json.Marshal(obj)
+	if err != nil {
+		return nil, err
+	}
+	newData, err := json.Marshal(objCopy)
+	if err != nil {
+		return nil, err
+	}
+
+	return jsonpatch.CreateMergePatch(oldData, newData)
+}
+
+// parseCommandArguments will stringify and return all environment arguments ie. a command run by a client
+// using the factory.
+// Set showSecrets false to filter out stuff like secrets.
+func parseCommandArguments(cmd *cobra.Command) string {
+	if len(os.Args) == 0 {
+		return ""
+	}
+
+	flags := ""
+	parseFunc := func(flag *pflag.Flag, value string) error {
+		flags = flags + " --" + flag.Name
+		if set, ok := flag.Annotations["classified"]; !ok || len(set) == 0 {
+			flags = flags + "=" + value
+		} else {
+			flags = flags + "=CLASSIFIED"
+		}
+		return nil
+	}
+	var err error
+	err = cmd.Flags().ParseAll(os.Args[1:], parseFunc)
+	if err != nil || !cmd.Flags().Parsed() {
+		return ""
+	}
+
+	args := ""
+	if arguments := cmd.Flags().Args(); len(arguments) > 0 {
+		args = " " + strings.Join(arguments, " ")
+	}
+
+	base := filepath.Base(os.Args[0])
+	return base + args + flags
+}

--- a/vendor/k8s.io/cli-runtime/pkg/genericclioptions/resource/builder.go
+++ b/vendor/k8s.io/cli-runtime/pkg/genericclioptions/resource/builder.go
@@ -1,0 +1,1167 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructuredscheme"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/restmapper"
+)
+
+var FileExtensions = []string{".json", ".yaml", ".yml"}
+var InputExtensions = append(FileExtensions, "stdin")
+
+const defaultHttpGetAttempts int = 3
+
+// Builder provides convenience functions for taking arguments and parameters
+// from the command line and converting them to a list of resources to iterate
+// over using the Visitor interface.
+type Builder struct {
+	categoryExpanderFn CategoryExpanderFunc
+
+	// mapper is set explicitly by resource builders
+	mapper *mapper
+
+	// clientConfigFn is a function to produce a client, *if* you need one
+	clientConfigFn ClientConfigFunc
+
+	restMapperFn RESTMapperFunc
+
+	// objectTyper is statically determinant per-command invocation based on your internal or unstructured choice
+	// it does not ever need to rely upon discovery.
+	objectTyper runtime.ObjectTyper
+
+	// codecFactory describes which codecs you want to use
+	negotiatedSerializer runtime.NegotiatedSerializer
+
+	// local indicates that we cannot make server calls
+	local bool
+
+	errs []error
+
+	paths  []Visitor
+	stream bool
+	dir    bool
+
+	labelSelector        *string
+	fieldSelector        *string
+	selectAll            bool
+	includeUninitialized bool
+	limitChunks          int64
+	requestTransforms    []RequestTransform
+
+	resources []string
+
+	namespace    string
+	allNamespace bool
+	names        []string
+
+	resourceTuples []resourceTuple
+
+	defaultNamespace bool
+	requireNamespace bool
+
+	flatten bool
+	latest  bool
+
+	requireObject bool
+
+	singleResourceType bool
+	continueOnError    bool
+
+	singleItemImplied bool
+
+	export bool
+
+	schema ContentValidator
+
+	// fakeClientFn is used for testing
+	fakeClientFn FakeClientFunc
+}
+
+var missingResourceError = fmt.Errorf(`You must provide one or more resources by argument or filename.
+Example resource specifications include:
+   '-f rsrc.yaml'
+   '--filename=rsrc.json'
+   '<resource> <name>'
+   '<resource>'`)
+
+var LocalResourceError = errors.New(`error: you must specify resources by --filename when --local is set.
+Example resource specifications include:
+   '-f rsrc.yaml'
+   '--filename=rsrc.json'`)
+
+// TODO: expand this to include other errors.
+func IsUsageError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return err == missingResourceError
+}
+
+type FilenameOptions struct {
+	Filenames []string
+	Recursive bool
+}
+
+type resourceTuple struct {
+	Resource string
+	Name     string
+}
+
+type FakeClientFunc func(version schema.GroupVersion) (RESTClient, error)
+
+func NewFakeBuilder(fakeClientFn FakeClientFunc, restMapper RESTMapperFunc, categoryExpander CategoryExpanderFunc) *Builder {
+	ret := newBuilder(nil, restMapper, categoryExpander)
+	ret.fakeClientFn = fakeClientFn
+	return ret
+}
+
+// NewBuilder creates a builder that operates on generic objects. At least one of
+// internal or unstructured must be specified.
+// TODO: Add versioned client (although versioned is still lossy)
+// TODO remove internal and unstructured mapper and instead have them set the negotiated serializer for use in the client
+func newBuilder(clientConfigFn ClientConfigFunc, restMapper RESTMapperFunc, categoryExpander CategoryExpanderFunc) *Builder {
+	return &Builder{
+		clientConfigFn:     clientConfigFn,
+		restMapperFn:       restMapper,
+		categoryExpanderFn: categoryExpander,
+		requireObject:      true,
+	}
+}
+
+func NewBuilder(restClientGetter RESTClientGetter) *Builder {
+	categoryExpanderFn := func() (restmapper.CategoryExpander, error) {
+		discoveryClient, err := restClientGetter.ToDiscoveryClient()
+		if err != nil {
+			return nil, err
+		}
+		return restmapper.NewDiscoveryCategoryExpander(discoveryClient), err
+	}
+
+	return newBuilder(
+		restClientGetter.ToRESTConfig,
+		(&cachingRESTMapperFunc{delegate: restClientGetter.ToRESTMapper}).ToRESTMapper,
+		(&cachingCategoryExpanderFunc{delegate: categoryExpanderFn}).ToCategoryExpander,
+	)
+}
+
+func (b *Builder) Schema(schema ContentValidator) *Builder {
+	b.schema = schema
+	return b
+}
+
+func (b *Builder) AddError(err error) *Builder {
+	if err == nil {
+		return b
+	}
+	b.errs = append(b.errs, err)
+	return b
+}
+
+// FilenameParam groups input in two categories: URLs and files (files, directories, STDIN)
+// If enforceNamespace is false, namespaces in the specs will be allowed to
+// override the default namespace. If it is true, namespaces that don't match
+// will cause an error.
+// If ContinueOnError() is set prior to this method, objects on the path that are not
+// recognized will be ignored (but logged at V(2)).
+func (b *Builder) FilenameParam(enforceNamespace bool, filenameOptions *FilenameOptions) *Builder {
+	recursive := filenameOptions.Recursive
+	paths := filenameOptions.Filenames
+	for _, s := range paths {
+		switch {
+		case s == "-":
+			b.Stdin()
+		case strings.Index(s, "http://") == 0 || strings.Index(s, "https://") == 0:
+			url, err := url.Parse(s)
+			if err != nil {
+				b.errs = append(b.errs, fmt.Errorf("the URL passed to filename %q is not valid: %v", s, err))
+				continue
+			}
+			b.URL(defaultHttpGetAttempts, url)
+		default:
+			if !recursive {
+				b.singleItemImplied = true
+			}
+			b.Path(recursive, s)
+		}
+	}
+
+	if enforceNamespace {
+		b.RequireNamespace()
+	}
+
+	return b
+}
+
+// Unstructured updates the builder so that it will request and send unstructured
+// objects. Unstructured objects preserve all fields sent by the server in a map format
+// based on the object's JSON structure which means no data is lost when the client
+// reads and then writes an object. Use this mode in preference to Internal unless you
+// are working with Go types directly.
+func (b *Builder) Unstructured() *Builder {
+	if b.mapper != nil {
+		b.errs = append(b.errs, fmt.Errorf("another mapper was already selected, cannot use unstructured types"))
+		return b
+	}
+	b.objectTyper = unstructuredscheme.NewUnstructuredObjectTyper()
+	b.mapper = &mapper{
+		localFn:      b.isLocal,
+		restMapperFn: b.restMapperFn,
+		clientFn:     b.getClient,
+		decoder:      unstructured.UnstructuredJSONScheme,
+	}
+
+	return b
+}
+
+// WithScheme uses the scheme to manage typing, conversion (optional), and decoding.  If decodingVersions
+// is empty, then you can end up with internal types.  You have been warned.
+func (b *Builder) WithScheme(scheme *runtime.Scheme, decodingVersions ...schema.GroupVersion) *Builder {
+	if b.mapper != nil {
+		b.errs = append(b.errs, fmt.Errorf("another mapper was already selected, cannot use internal types"))
+		return b
+	}
+	b.objectTyper = scheme
+	codecFactory := serializer.NewCodecFactory(scheme)
+	negotiatedSerializer := runtime.NegotiatedSerializer(codecFactory)
+	// if you specified versions, you're specifying a desire for external types, which you don't want to round-trip through
+	// internal types
+	if len(decodingVersions) > 0 {
+		negotiatedSerializer = &serializer.DirectCodecFactory{CodecFactory: codecFactory}
+	}
+	b.negotiatedSerializer = negotiatedSerializer
+
+	b.mapper = &mapper{
+		localFn:      b.isLocal,
+		restMapperFn: b.restMapperFn,
+		clientFn:     b.getClient,
+		decoder:      codecFactory.UniversalDecoder(decodingVersions...),
+	}
+
+	return b
+}
+
+// LocalParam calls Local() if local is true.
+func (b *Builder) LocalParam(local bool) *Builder {
+	if local {
+		b.Local()
+	}
+	return b
+}
+
+// Local will avoid asking the server for results.
+func (b *Builder) Local() *Builder {
+	b.local = true
+	return b
+}
+
+func (b *Builder) isLocal() bool {
+	return b.local
+}
+
+// Mapper returns a copy of the current mapper.
+func (b *Builder) Mapper() *mapper {
+	mapper := *b.mapper
+	return &mapper
+}
+
+// URL accepts a number of URLs directly.
+func (b *Builder) URL(httpAttemptCount int, urls ...*url.URL) *Builder {
+	for _, u := range urls {
+		b.paths = append(b.paths, &URLVisitor{
+			URL:              u,
+			StreamVisitor:    NewStreamVisitor(nil, b.mapper, u.String(), b.schema),
+			HttpAttemptCount: httpAttemptCount,
+		})
+	}
+	return b
+}
+
+// Stdin will read objects from the standard input. If ContinueOnError() is set
+// prior to this method being called, objects in the stream that are unrecognized
+// will be ignored (but logged at V(2)).
+func (b *Builder) Stdin() *Builder {
+	b.stream = true
+	b.paths = append(b.paths, FileVisitorForSTDIN(b.mapper, b.schema))
+	return b
+}
+
+// Stream will read objects from the provided reader, and if an error occurs will
+// include the name string in the error message. If ContinueOnError() is set
+// prior to this method being called, objects in the stream that are unrecognized
+// will be ignored (but logged at V(2)).
+func (b *Builder) Stream(r io.Reader, name string) *Builder {
+	b.stream = true
+	b.paths = append(b.paths, NewStreamVisitor(r, b.mapper, name, b.schema))
+	return b
+}
+
+// Path accepts a set of paths that may be files, directories (all can containing
+// one or more resources). Creates a FileVisitor for each file and then each
+// FileVisitor is streaming the content to a StreamVisitor. If ContinueOnError() is set
+// prior to this method being called, objects on the path that are unrecognized will be
+// ignored (but logged at V(2)).
+func (b *Builder) Path(recursive bool, paths ...string) *Builder {
+	for _, p := range paths {
+		_, err := os.Stat(p)
+		if os.IsNotExist(err) {
+			b.errs = append(b.errs, fmt.Errorf("the path %q does not exist", p))
+			continue
+		}
+		if err != nil {
+			b.errs = append(b.errs, fmt.Errorf("the path %q cannot be accessed: %v", p, err))
+			continue
+		}
+
+		visitors, err := ExpandPathsToFileVisitors(b.mapper, p, recursive, FileExtensions, b.schema)
+		if err != nil {
+			b.errs = append(b.errs, fmt.Errorf("error reading %q: %v", p, err))
+		}
+		if len(visitors) > 1 {
+			b.dir = true
+		}
+
+		b.paths = append(b.paths, visitors...)
+	}
+	if len(b.paths) == 0 && len(b.errs) == 0 {
+		b.errs = append(b.errs, fmt.Errorf("error reading %v: recognized file extensions are %v", paths, FileExtensions))
+	}
+	return b
+}
+
+// ResourceTypes is a list of types of resources to operate on, when listing objects on
+// the server or retrieving objects that match a selector.
+func (b *Builder) ResourceTypes(types ...string) *Builder {
+	b.resources = append(b.resources, types...)
+	return b
+}
+
+// ResourceNames accepts a default type and one or more names, and creates tuples of
+// resources
+func (b *Builder) ResourceNames(resource string, names ...string) *Builder {
+	for _, name := range names {
+		// See if this input string is of type/name format
+		tuple, ok, err := splitResourceTypeName(name)
+		if err != nil {
+			b.errs = append(b.errs, err)
+			return b
+		}
+
+		if ok {
+			b.resourceTuples = append(b.resourceTuples, tuple)
+			continue
+		}
+		if len(resource) == 0 {
+			b.errs = append(b.errs, fmt.Errorf("the argument %q must be RESOURCE/NAME", name))
+			continue
+		}
+
+		// Use the given default type to create a resource tuple
+		b.resourceTuples = append(b.resourceTuples, resourceTuple{Resource: resource, Name: name})
+	}
+	return b
+}
+
+// LabelSelectorParam defines a selector that should be applied to the object types to load.
+// This will not affect files loaded from disk or URL. If the parameter is empty it is
+// a no-op - to select all resources invoke `b.LabelSelector(labels.Everything.String)`.
+func (b *Builder) LabelSelectorParam(s string) *Builder {
+	selector := strings.TrimSpace(s)
+	if len(selector) == 0 {
+		return b
+	}
+	if b.selectAll {
+		b.errs = append(b.errs, fmt.Errorf("found non-empty label selector %q with previously set 'all' parameter. ", s))
+		return b
+	}
+	return b.LabelSelector(selector)
+}
+
+// LabelSelector accepts a selector directly and will filter the resulting list by that object.
+// Use LabelSelectorParam instead for user input.
+func (b *Builder) LabelSelector(selector string) *Builder {
+	if len(selector) == 0 {
+		return b
+	}
+
+	b.labelSelector = &selector
+	return b
+}
+
+// FieldSelectorParam defines a selector that should be applied to the object types to load.
+// This will not affect files loaded from disk or URL. If the parameter is empty it is
+// a no-op - to select all resources.
+func (b *Builder) FieldSelectorParam(s string) *Builder {
+	s = strings.TrimSpace(s)
+	if len(s) == 0 {
+		return b
+	}
+	if b.selectAll {
+		b.errs = append(b.errs, fmt.Errorf("found non-empty field selector %q with previously set 'all' parameter. ", s))
+		return b
+	}
+	b.fieldSelector = &s
+	return b
+}
+
+// ExportParam accepts the export boolean for these resources
+func (b *Builder) ExportParam(export bool) *Builder {
+	b.export = export
+	return b
+}
+
+// IncludeUninitialized accepts the include-uninitialized boolean for these resources
+func (b *Builder) IncludeUninitialized(includeUninitialized bool) *Builder {
+	b.includeUninitialized = includeUninitialized
+	return b
+}
+
+// NamespaceParam accepts the namespace that these resources should be
+// considered under from - used by DefaultNamespace() and RequireNamespace()
+func (b *Builder) NamespaceParam(namespace string) *Builder {
+	b.namespace = namespace
+	return b
+}
+
+// DefaultNamespace instructs the builder to set the namespace value for any object found
+// to NamespaceParam() if empty.
+func (b *Builder) DefaultNamespace() *Builder {
+	b.defaultNamespace = true
+	return b
+}
+
+// AllNamespaces instructs the builder to metav1.NamespaceAll as a namespace to request resources
+// across all of the namespace. This overrides the namespace set by NamespaceParam().
+func (b *Builder) AllNamespaces(allNamespace bool) *Builder {
+	if allNamespace {
+		b.namespace = metav1.NamespaceAll
+	}
+	b.allNamespace = allNamespace
+	return b
+}
+
+// RequireNamespace instructs the builder to set the namespace value for any object found
+// to NamespaceParam() if empty, and if the value on the resource does not match
+// NamespaceParam() an error will be returned.
+func (b *Builder) RequireNamespace() *Builder {
+	b.requireNamespace = true
+	return b
+}
+
+// RequestChunksOf attempts to load responses from the server in batches of size limit
+// to avoid long delays loading and transferring very large lists. If unset defaults to
+// no chunking.
+func (b *Builder) RequestChunksOf(chunkSize int64) *Builder {
+	b.limitChunks = chunkSize
+	return b
+}
+
+// TransformRequests alters API calls made by clients requested from this builder. Pass
+// an empty list to clear modifiers.
+func (b *Builder) TransformRequests(opts ...RequestTransform) *Builder {
+	b.requestTransforms = opts
+	return b
+}
+
+// SelectEverythingParam
+func (b *Builder) SelectAllParam(selectAll bool) *Builder {
+	if selectAll && (b.labelSelector != nil || b.fieldSelector != nil) {
+		b.errs = append(b.errs, fmt.Errorf("setting 'all' parameter but found a non empty selector. "))
+		return b
+	}
+	b.selectAll = selectAll
+	return b
+}
+
+// ResourceTypeOrNameArgs indicates that the builder should accept arguments
+// of the form `(<type1>[,<type2>,...]|<type> <name1>[,<name2>,...])`. When one argument is
+// received, the types provided will be retrieved from the server (and be comma delimited).
+// When two or more arguments are received, they must be a single type and resource name(s).
+// The allowEmptySelector permits to select all the resources (via Everything func).
+func (b *Builder) ResourceTypeOrNameArgs(allowEmptySelector bool, args ...string) *Builder {
+	args = normalizeMultipleResourcesArgs(args)
+	if ok, err := hasCombinedTypeArgs(args); ok {
+		if err != nil {
+			b.errs = append(b.errs, err)
+			return b
+		}
+		for _, s := range args {
+			tuple, ok, err := splitResourceTypeName(s)
+			if err != nil {
+				b.errs = append(b.errs, err)
+				return b
+			}
+			if ok {
+				b.resourceTuples = append(b.resourceTuples, tuple)
+			}
+		}
+		return b
+	}
+	if len(args) > 0 {
+		// Try replacing aliases only in types
+		args[0] = b.ReplaceAliases(args[0])
+	}
+	switch {
+	case len(args) > 2:
+		b.names = append(b.names, args[1:]...)
+		b.ResourceTypes(SplitResourceArgument(args[0])...)
+	case len(args) == 2:
+		b.names = append(b.names, args[1])
+		b.ResourceTypes(SplitResourceArgument(args[0])...)
+	case len(args) == 1:
+		b.ResourceTypes(SplitResourceArgument(args[0])...)
+		if b.labelSelector == nil && allowEmptySelector {
+			selector := labels.Everything().String()
+			b.labelSelector = &selector
+		}
+	case len(args) == 0:
+	default:
+		b.errs = append(b.errs, fmt.Errorf("arguments must consist of a resource or a resource and name"))
+	}
+	return b
+}
+
+// ReplaceAliases accepts an argument and tries to expand any existing
+// aliases found in it
+func (b *Builder) ReplaceAliases(input string) string {
+	replaced := []string{}
+	for _, arg := range strings.Split(input, ",") {
+		if b.categoryExpanderFn == nil {
+			continue
+		}
+		categoryExpander, err := b.categoryExpanderFn()
+		if err != nil {
+			b.AddError(err)
+			continue
+		}
+
+		if resources, ok := categoryExpander.Expand(arg); ok {
+			asStrings := []string{}
+			for _, resource := range resources {
+				if len(resource.Group) == 0 {
+					asStrings = append(asStrings, resource.Resource)
+					continue
+				}
+				asStrings = append(asStrings, resource.Resource+"."+resource.Group)
+			}
+			arg = strings.Join(asStrings, ",")
+		}
+		replaced = append(replaced, arg)
+	}
+	return strings.Join(replaced, ",")
+}
+
+func hasCombinedTypeArgs(args []string) (bool, error) {
+	hasSlash := 0
+	for _, s := range args {
+		if strings.Contains(s, "/") {
+			hasSlash++
+		}
+	}
+	switch {
+	case hasSlash > 0 && hasSlash == len(args):
+		return true, nil
+	case hasSlash > 0 && hasSlash != len(args):
+		baseCmd := "cmd"
+		if len(os.Args) > 0 {
+			baseCmdSlice := strings.Split(os.Args[0], "/")
+			baseCmd = baseCmdSlice[len(baseCmdSlice)-1]
+		}
+		return true, fmt.Errorf("there is no need to specify a resource type as a separate argument when passing arguments in resource/name form (e.g. '%s get resource/<resource_name>' instead of '%s get resource resource/<resource_name>'", baseCmd, baseCmd)
+	default:
+		return false, nil
+	}
+}
+
+// Normalize args convert multiple resources to resource tuples, a,b,c d
+// as a transform to a/d b/d c/d
+func normalizeMultipleResourcesArgs(args []string) []string {
+	if len(args) >= 2 {
+		resources := []string{}
+		resources = append(resources, SplitResourceArgument(args[0])...)
+		if len(resources) > 1 {
+			names := []string{}
+			names = append(names, args[1:]...)
+			newArgs := []string{}
+			for _, resource := range resources {
+				for _, name := range names {
+					newArgs = append(newArgs, strings.Join([]string{resource, name}, "/"))
+				}
+			}
+			return newArgs
+		}
+	}
+	return args
+}
+
+// splitResourceTypeName handles type/name resource formats and returns a resource tuple
+// (empty or not), whether it successfully found one, and an error
+func splitResourceTypeName(s string) (resourceTuple, bool, error) {
+	if !strings.Contains(s, "/") {
+		return resourceTuple{}, false, nil
+	}
+	seg := strings.Split(s, "/")
+	if len(seg) != 2 {
+		return resourceTuple{}, false, fmt.Errorf("arguments in resource/name form may not have more than one slash")
+	}
+	resource, name := seg[0], seg[1]
+	if len(resource) == 0 || len(name) == 0 || len(SplitResourceArgument(resource)) != 1 {
+		return resourceTuple{}, false, fmt.Errorf("arguments in resource/name form must have a single resource and name")
+	}
+	return resourceTuple{Resource: resource, Name: name}, true, nil
+}
+
+// Flatten will convert any objects with a field named "Items" that is an array of runtime.Object
+// compatible types into individual entries and give them their own items. The original object
+// is not passed to any visitors.
+func (b *Builder) Flatten() *Builder {
+	b.flatten = true
+	return b
+}
+
+// Latest will fetch the latest copy of any objects loaded from URLs or files from the server.
+func (b *Builder) Latest() *Builder {
+	b.latest = true
+	return b
+}
+
+// RequireObject ensures that resulting infos have an object set. If false, resulting info may not have an object set.
+func (b *Builder) RequireObject(require bool) *Builder {
+	b.requireObject = require
+	return b
+}
+
+// ContinueOnError will attempt to load and visit as many objects as possible, even if some visits
+// return errors or some objects cannot be loaded. The default behavior is to terminate after
+// the first error is returned from a VisitorFunc.
+func (b *Builder) ContinueOnError() *Builder {
+	b.continueOnError = true
+	return b
+}
+
+// SingleResourceType will cause the builder to error if the user specifies more than a single type
+// of resource.
+func (b *Builder) SingleResourceType() *Builder {
+	b.singleResourceType = true
+	return b
+}
+
+// mappingFor returns the RESTMapping for the Kind given, or the Kind referenced by the resource.
+// Prefers a fully specified GroupVersionResource match. If one is not found, we match on a fully
+// specified GroupVersionKind, or fallback to a match on GroupKind.
+func (b *Builder) mappingFor(resourceOrKindArg string) (*meta.RESTMapping, error) {
+	fullySpecifiedGVR, groupResource := schema.ParseResourceArg(resourceOrKindArg)
+	gvk := schema.GroupVersionKind{}
+	restMapper, err := b.restMapperFn()
+	if err != nil {
+		return nil, err
+	}
+
+	if fullySpecifiedGVR != nil {
+		gvk, _ = restMapper.KindFor(*fullySpecifiedGVR)
+	}
+	if gvk.Empty() {
+		gvk, _ = restMapper.KindFor(groupResource.WithVersion(""))
+	}
+	if !gvk.Empty() {
+		return restMapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	}
+
+	fullySpecifiedGVK, groupKind := schema.ParseKindArg(resourceOrKindArg)
+	if fullySpecifiedGVK == nil {
+		gvk := groupKind.WithVersion("")
+		fullySpecifiedGVK = &gvk
+	}
+
+	if !fullySpecifiedGVK.Empty() {
+		if mapping, err := restMapper.RESTMapping(fullySpecifiedGVK.GroupKind(), fullySpecifiedGVK.Version); err == nil {
+			return mapping, nil
+		}
+	}
+
+	mapping, err := restMapper.RESTMapping(groupKind, gvk.Version)
+	if err != nil {
+		// if we error out here, it is because we could not match a resource or a kind
+		// for the given argument. To maintain consistency with previous behavior,
+		// announce that a resource type could not be found.
+		// if the error is a URL error, then we had trouble doing discovery, so we should return the original
+		// error since it may help a user diagnose what is actually wrong
+		if _, ok := err.(*url.Error); ok {
+			return nil, err
+		}
+		return nil, fmt.Errorf("the server doesn't have a resource type %q", groupResource.Resource)
+	}
+
+	return mapping, nil
+}
+
+func (b *Builder) resourceMappings() ([]*meta.RESTMapping, error) {
+	if len(b.resources) > 1 && b.singleResourceType {
+		return nil, fmt.Errorf("you may only specify a single resource type")
+	}
+	mappings := []*meta.RESTMapping{}
+	seen := map[schema.GroupVersionKind]bool{}
+	for _, r := range b.resources {
+		mapping, err := b.mappingFor(r)
+		if err != nil {
+			return nil, err
+		}
+		// This ensures the mappings for resources(shortcuts, plural) unique
+		if seen[mapping.GroupVersionKind] {
+			continue
+		}
+		seen[mapping.GroupVersionKind] = true
+
+		mappings = append(mappings, mapping)
+	}
+	return mappings, nil
+}
+
+func (b *Builder) resourceTupleMappings() (map[string]*meta.RESTMapping, error) {
+	mappings := make(map[string]*meta.RESTMapping)
+	canonical := make(map[schema.GroupVersionResource]struct{})
+	for _, r := range b.resourceTuples {
+		if _, ok := mappings[r.Resource]; ok {
+			continue
+		}
+		mapping, err := b.mappingFor(r.Resource)
+		if err != nil {
+			return nil, err
+		}
+
+		mappings[r.Resource] = mapping
+		canonical[mapping.Resource] = struct{}{}
+	}
+	if len(canonical) > 1 && b.singleResourceType {
+		return nil, fmt.Errorf("you may only specify a single resource type")
+	}
+	return mappings, nil
+}
+
+func (b *Builder) visitorResult() *Result {
+	if len(b.errs) > 0 {
+		return &Result{err: utilerrors.NewAggregate(b.errs)}
+	}
+
+	if b.selectAll {
+		selector := labels.Everything().String()
+		b.labelSelector = &selector
+	}
+
+	// visit items specified by paths
+	if len(b.paths) != 0 {
+		return b.visitByPaths()
+	}
+
+	// visit selectors
+	if b.labelSelector != nil || b.fieldSelector != nil {
+		return b.visitBySelector()
+	}
+
+	// visit items specified by resource and name
+	if len(b.resourceTuples) != 0 {
+		return b.visitByResource()
+	}
+
+	// visit items specified by name
+	if len(b.names) != 0 {
+		return b.visitByName()
+	}
+
+	if len(b.resources) != 0 {
+		return &Result{err: fmt.Errorf("resource(s) were provided, but no name, label selector, or --all flag specified")}
+	}
+	return &Result{err: missingResourceError}
+}
+
+func (b *Builder) visitBySelector() *Result {
+	result := &Result{
+		targetsSingleItems: false,
+	}
+
+	if len(b.names) != 0 {
+		return result.withError(fmt.Errorf("name cannot be provided when a selector is specified"))
+	}
+	if len(b.resourceTuples) != 0 {
+		return result.withError(fmt.Errorf("selectors and the all flag cannot be used when passing resource/name arguments"))
+	}
+	if len(b.resources) == 0 {
+		return result.withError(fmt.Errorf("at least one resource must be specified to use a selector"))
+	}
+	mappings, err := b.resourceMappings()
+	if err != nil {
+		result.err = err
+		return result
+	}
+
+	var labelSelector, fieldSelector string
+	if b.labelSelector != nil {
+		labelSelector = *b.labelSelector
+	}
+	if b.fieldSelector != nil {
+		fieldSelector = *b.fieldSelector
+	}
+
+	visitors := []Visitor{}
+	for _, mapping := range mappings {
+		client, err := b.getClient(mapping.GroupVersionKind.GroupVersion())
+		if err != nil {
+			result.err = err
+			return result
+		}
+		selectorNamespace := b.namespace
+		if mapping.Scope.Name() != meta.RESTScopeNameNamespace {
+			selectorNamespace = ""
+		}
+		visitors = append(visitors, NewSelector(client, mapping, selectorNamespace, labelSelector, fieldSelector, b.export, b.includeUninitialized, b.limitChunks))
+	}
+	if b.continueOnError {
+		result.visitor = EagerVisitorList(visitors)
+	} else {
+		result.visitor = VisitorList(visitors)
+	}
+	result.sources = visitors
+	return result
+}
+
+func (b *Builder) getClient(gv schema.GroupVersion) (RESTClient, error) {
+	var (
+		client RESTClient
+		err    error
+	)
+
+	switch {
+	case b.fakeClientFn != nil:
+		client, err = b.fakeClientFn(gv)
+	case b.negotiatedSerializer != nil:
+		client, err = b.clientConfigFn.clientForGroupVersion(gv, b.negotiatedSerializer)
+	default:
+		client, err = b.clientConfigFn.unstructuredClientForGroupVersion(gv)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return NewClientWithOptions(client, b.requestTransforms...), nil
+}
+
+func (b *Builder) visitByResource() *Result {
+	// if b.singleItemImplied is false, this could be by default, so double-check length
+	// of resourceTuples to determine if in fact it is singleItemImplied or not
+	isSingleItemImplied := b.singleItemImplied
+	if !isSingleItemImplied {
+		isSingleItemImplied = len(b.resourceTuples) == 1
+	}
+
+	result := &Result{
+		singleItemImplied:  isSingleItemImplied,
+		targetsSingleItems: true,
+	}
+
+	if len(b.resources) != 0 {
+		return result.withError(fmt.Errorf("you may not specify individual resources and bulk resources in the same call"))
+	}
+
+	// retrieve one client for each resource
+	mappings, err := b.resourceTupleMappings()
+	if err != nil {
+		result.err = err
+		return result
+	}
+	clients := make(map[string]RESTClient)
+	for _, mapping := range mappings {
+		s := fmt.Sprintf("%s/%s", mapping.GroupVersionKind.GroupVersion().String(), mapping.Resource.Resource)
+		if _, ok := clients[s]; ok {
+			continue
+		}
+		client, err := b.getClient(mapping.GroupVersionKind.GroupVersion())
+		if err != nil {
+			result.err = err
+			return result
+		}
+		clients[s] = client
+	}
+
+	items := []Visitor{}
+	for _, tuple := range b.resourceTuples {
+		mapping, ok := mappings[tuple.Resource]
+		if !ok {
+			return result.withError(fmt.Errorf("resource %q is not recognized: %v", tuple.Resource, mappings))
+		}
+		s := fmt.Sprintf("%s/%s", mapping.GroupVersionKind.GroupVersion().String(), mapping.Resource.Resource)
+		client, ok := clients[s]
+		if !ok {
+			return result.withError(fmt.Errorf("could not find a client for resource %q", tuple.Resource))
+		}
+
+		selectorNamespace := b.namespace
+		if mapping.Scope.Name() != meta.RESTScopeNameNamespace {
+			selectorNamespace = ""
+		} else {
+			if len(b.namespace) == 0 {
+				errMsg := "namespace may not be empty when retrieving a resource by name"
+				if b.allNamespace {
+					errMsg = "a resource cannot be retrieved by name across all namespaces"
+				}
+				return result.withError(fmt.Errorf(errMsg))
+			}
+		}
+
+		info := &Info{
+			Client:    client,
+			Mapping:   mapping,
+			Namespace: selectorNamespace,
+			Name:      tuple.Name,
+			Export:    b.export,
+		}
+		items = append(items, info)
+	}
+
+	var visitors Visitor
+	if b.continueOnError {
+		visitors = EagerVisitorList(items)
+	} else {
+		visitors = VisitorList(items)
+	}
+	result.visitor = visitors
+	result.sources = items
+	return result
+}
+
+func (b *Builder) visitByName() *Result {
+	result := &Result{
+		singleItemImplied:  len(b.names) == 1,
+		targetsSingleItems: true,
+	}
+
+	if len(b.paths) != 0 {
+		return result.withError(fmt.Errorf("when paths, URLs, or stdin is provided as input, you may not specify a resource by arguments as well"))
+	}
+	if len(b.resources) == 0 {
+		return result.withError(fmt.Errorf("you must provide a resource and a resource name together"))
+	}
+	if len(b.resources) > 1 {
+		return result.withError(fmt.Errorf("you must specify only one resource"))
+	}
+
+	mappings, err := b.resourceMappings()
+	if err != nil {
+		result.err = err
+		return result
+	}
+	mapping := mappings[0]
+
+	client, err := b.getClient(mapping.GroupVersionKind.GroupVersion())
+	if err != nil {
+		result.err = err
+		return result
+	}
+
+	selectorNamespace := b.namespace
+	if mapping.Scope.Name() != meta.RESTScopeNameNamespace {
+		selectorNamespace = ""
+	} else {
+		if len(b.namespace) == 0 {
+			errMsg := "namespace may not be empty when retrieving a resource by name"
+			if b.allNamespace {
+				errMsg = "a resource cannot be retrieved by name across all namespaces"
+			}
+			return result.withError(fmt.Errorf(errMsg))
+		}
+	}
+
+	visitors := []Visitor{}
+	for _, name := range b.names {
+		info := &Info{
+			Client:    client,
+			Mapping:   mapping,
+			Namespace: selectorNamespace,
+			Name:      name,
+			Export:    b.export,
+		}
+		visitors = append(visitors, info)
+	}
+	result.visitor = VisitorList(visitors)
+	result.sources = visitors
+	return result
+}
+
+func (b *Builder) visitByPaths() *Result {
+	result := &Result{
+		singleItemImplied:  !b.dir && !b.stream && len(b.paths) == 1,
+		targetsSingleItems: true,
+	}
+
+	if len(b.resources) != 0 {
+		return result.withError(fmt.Errorf("when paths, URLs, or stdin is provided as input, you may not specify resource arguments as well"))
+	}
+	if len(b.names) != 0 {
+		return result.withError(fmt.Errorf("name cannot be provided when a path is specified"))
+	}
+	if len(b.resourceTuples) != 0 {
+		return result.withError(fmt.Errorf("resource/name arguments cannot be provided when a path is specified"))
+	}
+
+	var visitors Visitor
+	if b.continueOnError {
+		visitors = EagerVisitorList(b.paths)
+	} else {
+		visitors = VisitorList(b.paths)
+	}
+
+	if b.flatten {
+		visitors = NewFlattenListVisitor(visitors, b.objectTyper, b.mapper)
+	}
+
+	// only items from disk can be refetched
+	if b.latest {
+		// must set namespace prior to fetching
+		if b.defaultNamespace {
+			visitors = NewDecoratedVisitor(visitors, SetNamespace(b.namespace))
+		}
+		visitors = NewDecoratedVisitor(visitors, RetrieveLatest)
+	}
+	if b.labelSelector != nil {
+		selector, err := labels.Parse(*b.labelSelector)
+		if err != nil {
+			return result.withError(fmt.Errorf("the provided selector %q is not valid: %v", *b.labelSelector, err))
+		}
+		visitors = NewFilteredVisitor(visitors, FilterByLabelSelector(selector))
+	}
+	result.visitor = visitors
+	result.sources = b.paths
+	return result
+}
+
+// Do returns a Result object with a Visitor for the resources identified by the Builder.
+// The visitor will respect the error behavior specified by ContinueOnError. Note that stream
+// inputs are consumed by the first execution - use Infos() or Object() on the Result to capture a list
+// for further iteration.
+func (b *Builder) Do() *Result {
+	r := b.visitorResult()
+	r.mapper = b.Mapper()
+	if r.err != nil {
+		return r
+	}
+	if b.flatten {
+		r.visitor = NewFlattenListVisitor(r.visitor, b.objectTyper, b.mapper)
+	}
+	helpers := []VisitorFunc{}
+	if b.defaultNamespace {
+		helpers = append(helpers, SetNamespace(b.namespace))
+	}
+	if b.requireNamespace {
+		helpers = append(helpers, RequireNamespace(b.namespace))
+	}
+	helpers = append(helpers, FilterNamespace)
+	if b.requireObject {
+		helpers = append(helpers, RetrieveLazy)
+	}
+	if b.continueOnError {
+		r.visitor = NewDecoratedVisitor(ContinueOnErrorVisitor{r.visitor}, helpers...)
+	} else {
+		r.visitor = NewDecoratedVisitor(r.visitor, helpers...)
+	}
+	return r
+}
+
+// SplitResourceArgument splits the argument with commas and returns unique
+// strings in the original order.
+func SplitResourceArgument(arg string) []string {
+	out := []string{}
+	set := sets.NewString()
+	for _, s := range strings.Split(arg, ",") {
+		if set.Has(s) {
+			continue
+		}
+		set.Insert(s)
+		out = append(out, s)
+	}
+	return out
+}
+
+// HasNames returns true if the provided args contain resource names
+func HasNames(args []string) (bool, error) {
+	args = normalizeMultipleResourcesArgs(args)
+	hasCombinedTypes, err := hasCombinedTypeArgs(args)
+	if err != nil {
+		return false, err
+	}
+	return hasCombinedTypes || len(args) > 1, nil
+}
+
+type cachingRESTMapperFunc struct {
+	delegate RESTMapperFunc
+
+	lock   sync.Mutex
+	cached meta.RESTMapper
+}
+
+func (c *cachingRESTMapperFunc) ToRESTMapper() (meta.RESTMapper, error) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	if c.cached != nil {
+		return c.cached, nil
+	}
+
+	ret, err := c.delegate()
+	if err != nil {
+		return nil, err
+	}
+	c.cached = ret
+	return c.cached, nil
+}
+
+type cachingCategoryExpanderFunc struct {
+	delegate CategoryExpanderFunc
+
+	lock   sync.Mutex
+	cached restmapper.CategoryExpander
+}
+
+func (c *cachingCategoryExpanderFunc) ToCategoryExpander() (restmapper.CategoryExpander, error) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	if c.cached != nil {
+		return c.cached, nil
+	}
+
+	ret, err := c.delegate()
+	if err != nil {
+		return nil, err
+	}
+	c.cached = ret
+	return c.cached, nil
+}

--- a/vendor/k8s.io/cli-runtime/pkg/genericclioptions/resource/client.go
+++ b/vendor/k8s.io/cli-runtime/pkg/genericclioptions/resource/client.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
+)
+
+// TODO require negotiatedSerializer.  leaving it optional lets us plumb current behavior and deal with the difference after major plumbing is complete
+func (clientConfigFn ClientConfigFunc) clientForGroupVersion(gv schema.GroupVersion, negotiatedSerializer runtime.NegotiatedSerializer) (RESTClient, error) {
+	cfg, err := clientConfigFn()
+	if err != nil {
+		return nil, err
+	}
+	if negotiatedSerializer != nil {
+		cfg.ContentConfig.NegotiatedSerializer = negotiatedSerializer
+	}
+	cfg.GroupVersion = &gv
+	if len(gv.Group) == 0 {
+		cfg.APIPath = "/api"
+	} else {
+		cfg.APIPath = "/apis"
+	}
+
+	return rest.RESTClientFor(cfg)
+}
+
+func (clientConfigFn ClientConfigFunc) unstructuredClientForGroupVersion(gv schema.GroupVersion) (RESTClient, error) {
+	cfg, err := clientConfigFn()
+	if err != nil {
+		return nil, err
+	}
+	cfg.ContentConfig = UnstructuredPlusDefaultContentConfig()
+	cfg.GroupVersion = &gv
+	if len(gv.Group) == 0 {
+		cfg.APIPath = "/api"
+	} else {
+		cfg.APIPath = "/apis"
+	}
+
+	return rest.RESTClientFor(cfg)
+}

--- a/vendor/k8s.io/cli-runtime/pkg/genericclioptions/resource/doc.go
+++ b/vendor/k8s.io/cli-runtime/pkg/genericclioptions/resource/doc.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package resource assists clients in dealing with RESTful objects that match the
+// Kubernetes API conventions. The Helper object provides simple CRUD operations
+// on resources. The Visitor interface makes it easy to deal with multiple resources
+// in bulk for retrieval and operation. The Builder object simplifies converting
+// standard command line arguments and parameters into a Visitor that can iterate
+// over all of the identified resources, whether on the server or on the local
+// filesystem.
+package resource

--- a/vendor/k8s.io/cli-runtime/pkg/genericclioptions/resource/fake.go
+++ b/vendor/k8s.io/cli-runtime/pkg/genericclioptions/resource/fake.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/restmapper"
+)
+
+// FakeCategoryExpander is for testing only
+var FakeCategoryExpander restmapper.CategoryExpander = restmapper.SimpleCategoryExpander{
+	Expansions: map[string][]schema.GroupResource{
+		"all": {
+			{Group: "", Resource: "pods"},
+			{Group: "", Resource: "replicationcontrollers"},
+			{Group: "", Resource: "services"},
+			{Group: "apps", Resource: "statefulsets"},
+			{Group: "autoscaling", Resource: "horizontalpodautoscalers"},
+			{Group: "batch", Resource: "jobs"},
+			{Group: "batch", Resource: "cronjobs"},
+			{Group: "extensions", Resource: "daemonsets"},
+			{Group: "extensions", Resource: "deployments"},
+			{Group: "extensions", Resource: "replicasets"},
+		},
+	},
+}

--- a/vendor/k8s.io/cli-runtime/pkg/genericclioptions/resource/helper.go
+++ b/vendor/k8s.io/cli-runtime/pkg/genericclioptions/resource/helper.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"strconv"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+var metadataAccessor = meta.NewAccessor()
+
+// Helper provides methods for retrieving or mutating a RESTful
+// resource.
+type Helper struct {
+	// The name of this resource as the server would recognize it
+	Resource string
+	// A RESTClient capable of mutating this resource.
+	RESTClient RESTClient
+	// True if the resource type is scoped to namespaces
+	NamespaceScoped bool
+}
+
+// NewHelper creates a Helper from a ResourceMapping
+func NewHelper(client RESTClient, mapping *meta.RESTMapping) *Helper {
+	return &Helper{
+		Resource:        mapping.Resource.Resource,
+		RESTClient:      client,
+		NamespaceScoped: mapping.Scope.Name() == meta.RESTScopeNameNamespace,
+	}
+}
+
+func (m *Helper) Get(namespace, name string, export bool) (runtime.Object, error) {
+	req := m.RESTClient.Get().
+		NamespaceIfScoped(namespace, m.NamespaceScoped).
+		Resource(m.Resource).
+		Name(name)
+	if export {
+		// TODO: I should be part of GetOptions
+		req.Param("export", strconv.FormatBool(export))
+	}
+	return req.Do().Get()
+}
+
+func (m *Helper) List(namespace, apiVersion string, export bool, options *metav1.ListOptions) (runtime.Object, error) {
+	req := m.RESTClient.Get().
+		NamespaceIfScoped(namespace, m.NamespaceScoped).
+		Resource(m.Resource).
+		VersionedParams(options, metav1.ParameterCodec)
+	if export {
+		// TODO: I should be part of ListOptions
+		req.Param("export", strconv.FormatBool(export))
+	}
+	return req.Do().Get()
+}
+
+func (m *Helper) Watch(namespace, apiVersion string, options *metav1.ListOptions) (watch.Interface, error) {
+	options.Watch = true
+	return m.RESTClient.Get().
+		NamespaceIfScoped(namespace, m.NamespaceScoped).
+		Resource(m.Resource).
+		VersionedParams(options, metav1.ParameterCodec).
+		Watch()
+}
+
+func (m *Helper) WatchSingle(namespace, name, resourceVersion string) (watch.Interface, error) {
+	return m.RESTClient.Get().
+		NamespaceIfScoped(namespace, m.NamespaceScoped).
+		Resource(m.Resource).
+		VersionedParams(&metav1.ListOptions{
+			ResourceVersion: resourceVersion,
+			Watch:           true,
+			FieldSelector:   fields.OneTermEqualSelector("metadata.name", name).String(),
+		}, metav1.ParameterCodec).
+		Watch()
+}
+
+func (m *Helper) Delete(namespace, name string) (runtime.Object, error) {
+	return m.DeleteWithOptions(namespace, name, nil)
+}
+
+func (m *Helper) DeleteWithOptions(namespace, name string, options *metav1.DeleteOptions) (runtime.Object, error) {
+	return m.RESTClient.Delete().
+		NamespaceIfScoped(namespace, m.NamespaceScoped).
+		Resource(m.Resource).
+		Name(name).
+		Body(options).
+		Do().
+		Get()
+}
+
+func (m *Helper) Create(namespace string, modify bool, obj runtime.Object, options *metav1.CreateOptions) (runtime.Object, error) {
+	if options == nil {
+		options = &metav1.CreateOptions{}
+	}
+	if modify {
+		// Attempt to version the object based on client logic.
+		version, err := metadataAccessor.ResourceVersion(obj)
+		if err != nil {
+			// We don't know how to clear the version on this object, so send it to the server as is
+			return m.createResource(m.RESTClient, m.Resource, namespace, obj, options)
+		}
+		if version != "" {
+			if err := metadataAccessor.SetResourceVersion(obj, ""); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return m.createResource(m.RESTClient, m.Resource, namespace, obj, options)
+}
+
+func (m *Helper) createResource(c RESTClient, resource, namespace string, obj runtime.Object, options *metav1.CreateOptions) (runtime.Object, error) {
+	return c.Post().
+		NamespaceIfScoped(namespace, m.NamespaceScoped).
+		Resource(resource).
+		VersionedParams(options, metav1.ParameterCodec).
+		Body(obj).
+		Do().
+		Get()
+}
+func (m *Helper) Patch(namespace, name string, pt types.PatchType, data []byte, options *metav1.UpdateOptions) (runtime.Object, error) {
+	if options == nil {
+		options = &metav1.UpdateOptions{}
+	}
+	return m.RESTClient.Patch(pt).
+		NamespaceIfScoped(namespace, m.NamespaceScoped).
+		Resource(m.Resource).
+		Name(name).
+		VersionedParams(options, metav1.ParameterCodec).
+		Body(data).
+		Do().
+		Get()
+}
+
+func (m *Helper) Replace(namespace, name string, overwrite bool, obj runtime.Object) (runtime.Object, error) {
+	c := m.RESTClient
+
+	// Attempt to version the object based on client logic.
+	version, err := metadataAccessor.ResourceVersion(obj)
+	if err != nil {
+		// We don't know how to version this object, so send it to the server as is
+		return m.replaceResource(c, m.Resource, namespace, name, obj)
+	}
+	if version == "" && overwrite {
+		// Retrieve the current version of the object to overwrite the server object
+		serverObj, err := c.Get().NamespaceIfScoped(namespace, m.NamespaceScoped).Resource(m.Resource).Name(name).Do().Get()
+		if err != nil {
+			// The object does not exist, but we want it to be created
+			return m.replaceResource(c, m.Resource, namespace, name, obj)
+		}
+		serverVersion, err := metadataAccessor.ResourceVersion(serverObj)
+		if err != nil {
+			return nil, err
+		}
+		if err := metadataAccessor.SetResourceVersion(obj, serverVersion); err != nil {
+			return nil, err
+		}
+	}
+
+	return m.replaceResource(c, m.Resource, namespace, name, obj)
+}
+
+func (m *Helper) replaceResource(c RESTClient, resource, namespace, name string, obj runtime.Object) (runtime.Object, error) {
+	return c.Put().NamespaceIfScoped(namespace, m.NamespaceScoped).Resource(resource).Name(name).Body(obj).Do().Get()
+}

--- a/vendor/k8s.io/cli-runtime/pkg/genericclioptions/resource/interfaces.go
+++ b/vendor/k8s.io/cli-runtime/pkg/genericclioptions/resource/interfaces.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
+)
+
+type RESTClientGetter interface {
+	ToRESTConfig() (*rest.Config, error)
+	ToDiscoveryClient() (discovery.CachedDiscoveryInterface, error)
+	ToRESTMapper() (meta.RESTMapper, error)
+}
+
+type ClientConfigFunc func() (*rest.Config, error)
+type RESTMapperFunc func() (meta.RESTMapper, error)
+type CategoryExpanderFunc func() (restmapper.CategoryExpander, error)
+
+// RESTClient is a client helper for dealing with RESTful resources
+// in a generic way.
+type RESTClient interface {
+	Get() *rest.Request
+	Post() *rest.Request
+	Patch(types.PatchType) *rest.Request
+	Delete() *rest.Request
+	Put() *rest.Request
+}
+
+// RequestTransform is a function that is given a chance to modify the outgoing request.
+type RequestTransform func(*rest.Request)
+
+// NewClientWithOptions wraps the provided RESTClient and invokes each transform on each
+// newly created request.
+func NewClientWithOptions(c RESTClient, transforms ...RequestTransform) RESTClient {
+	if len(transforms) == 0 {
+		return c
+	}
+	return &clientOptions{c: c, transforms: transforms}
+}
+
+type clientOptions struct {
+	c          RESTClient
+	transforms []RequestTransform
+}
+
+func (c *clientOptions) modify(req *rest.Request) *rest.Request {
+	for _, transform := range c.transforms {
+		transform(req)
+	}
+	return req
+}
+
+func (c *clientOptions) Get() *rest.Request {
+	return c.modify(c.c.Get())
+}
+
+func (c *clientOptions) Post() *rest.Request {
+	return c.modify(c.c.Post())
+}
+func (c *clientOptions) Patch(t types.PatchType) *rest.Request {
+	return c.modify(c.c.Patch(t))
+}
+func (c *clientOptions) Delete() *rest.Request {
+	return c.modify(c.c.Delete())
+}
+func (c *clientOptions) Put() *rest.Request {
+	return c.modify(c.c.Put())
+}
+
+// ContentValidator is an interface that knows how to validate an API object serialized to a byte array.
+type ContentValidator interface {
+	ValidateBytes(data []byte) error
+}
+
+// Visitor lets clients walk a list of resources.
+type Visitor interface {
+	Visit(VisitorFunc) error
+}
+
+// VisitorFunc implements the Visitor interface for a matching function.
+// If there was a problem walking a list of resources, the incoming error
+// will describe the problem and the function can decide how to handle that error.
+// A nil returned indicates to accept an error to continue loops even when errors happen.
+// This is useful for ignoring certain kinds of errors or aggregating errors in some way.
+type VisitorFunc func(*Info, error) error

--- a/vendor/k8s.io/cli-runtime/pkg/genericclioptions/resource/mapper.go
+++ b/vendor/k8s.io/cli-runtime/pkg/genericclioptions/resource/mapper.go
@@ -1,0 +1,161 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"fmt"
+	"reflect"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// Mapper is a convenience struct for holding references to the interfaces
+// needed to create Info for arbitrary objects.
+type mapper struct {
+	// localFn indicates the call can't make server requests
+	localFn func() bool
+
+	restMapperFn RESTMapperFunc
+	clientFn     func(version schema.GroupVersion) (RESTClient, error)
+	decoder      runtime.Decoder
+}
+
+// InfoForData creates an Info object for the given data. An error is returned
+// if any of the decoding or client lookup steps fail. Name and namespace will be
+// set into Info if the mapping's MetadataAccessor can retrieve them.
+func (m *mapper) infoForData(data []byte, source string) (*Info, error) {
+	obj, gvk, err := m.decoder.Decode(data, nil, nil)
+	if err != nil {
+		return nil, fmt.Errorf("unable to decode %q: %v", source, err)
+	}
+
+	name, _ := metadataAccessor.Name(obj)
+	namespace, _ := metadataAccessor.Namespace(obj)
+	resourceVersion, _ := metadataAccessor.ResourceVersion(obj)
+
+	ret := &Info{
+		Source:          source,
+		Namespace:       namespace,
+		Name:            name,
+		ResourceVersion: resourceVersion,
+
+		Object: obj,
+	}
+
+	if m.localFn == nil || !m.localFn() {
+		restMapper, err := m.restMapperFn()
+		if err != nil {
+			return nil, err
+		}
+		mapping, err := restMapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+		if err != nil {
+			return nil, fmt.Errorf("unable to recognize %q: %v", source, err)
+		}
+		ret.Mapping = mapping
+
+		client, err := m.clientFn(gvk.GroupVersion())
+		if err != nil {
+			return nil, fmt.Errorf("unable to connect to a server to handle %q: %v", mapping.Resource, err)
+		}
+		ret.Client = client
+	}
+
+	return ret, nil
+}
+
+// InfoForObject creates an Info object for the given Object. An error is returned
+// if the object cannot be introspected. Name and namespace will be set into Info
+// if the mapping's MetadataAccessor can retrieve them.
+func (m *mapper) infoForObject(obj runtime.Object, typer runtime.ObjectTyper, preferredGVKs []schema.GroupVersionKind) (*Info, error) {
+	groupVersionKinds, _, err := typer.ObjectKinds(obj)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get type info from the object %q: %v", reflect.TypeOf(obj), err)
+	}
+
+	gvk := groupVersionKinds[0]
+	if len(groupVersionKinds) > 1 && len(preferredGVKs) > 0 {
+		gvk = preferredObjectKind(groupVersionKinds, preferredGVKs)
+	}
+
+	name, _ := metadataAccessor.Name(obj)
+	namespace, _ := metadataAccessor.Namespace(obj)
+	resourceVersion, _ := metadataAccessor.ResourceVersion(obj)
+	ret := &Info{
+		Namespace:       namespace,
+		Name:            name,
+		ResourceVersion: resourceVersion,
+
+		Object: obj,
+	}
+
+	if m.localFn == nil || !m.localFn() {
+		restMapper, err := m.restMapperFn()
+		if err != nil {
+			return nil, err
+		}
+		mapping, err := restMapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+		if err != nil {
+			return nil, fmt.Errorf("unable to recognize %v", err)
+		}
+		ret.Mapping = mapping
+
+		client, err := m.clientFn(gvk.GroupVersion())
+		if err != nil {
+			return nil, fmt.Errorf("unable to connect to a server to handle %q: %v", mapping.Resource, err)
+		}
+		ret.Client = client
+	}
+
+	return ret, nil
+}
+
+// preferredObjectKind picks the possibility that most closely matches the priority list in this order:
+// GroupVersionKind matches (exact match)
+// GroupKind matches
+// Group matches
+func preferredObjectKind(possibilities []schema.GroupVersionKind, preferences []schema.GroupVersionKind) schema.GroupVersionKind {
+	// Exact match
+	for _, priority := range preferences {
+		for _, possibility := range possibilities {
+			if possibility == priority {
+				return possibility
+			}
+		}
+	}
+
+	// GroupKind match
+	for _, priority := range preferences {
+		for _, possibility := range possibilities {
+			if possibility.GroupKind() == priority.GroupKind() {
+				return possibility
+			}
+		}
+	}
+
+	// Group match
+	for _, priority := range preferences {
+		for _, possibility := range possibilities {
+			if possibility.Group == priority.Group {
+				return possibility
+			}
+		}
+	}
+
+	// Just pick the first
+	return possibilities[0]
+}

--- a/vendor/k8s.io/cli-runtime/pkg/genericclioptions/resource/result.go
+++ b/vendor/k8s.io/cli-runtime/pkg/genericclioptions/resource/result.go
@@ -1,0 +1,242 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"fmt"
+	"reflect"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+// ErrMatchFunc can be used to filter errors that may not be true failures.
+type ErrMatchFunc func(error) bool
+
+// Result contains helper methods for dealing with the outcome of a Builder.
+type Result struct {
+	err     error
+	visitor Visitor
+
+	sources            []Visitor
+	singleItemImplied  bool
+	targetsSingleItems bool
+
+	mapper       *mapper
+	ignoreErrors []utilerrors.Matcher
+
+	// populated by a call to Infos
+	info []*Info
+}
+
+// withError allows a fluent style for internal result code.
+func (r *Result) withError(err error) *Result {
+	r.err = err
+	return r
+}
+
+// TargetsSingleItems returns true if any of the builder arguments pointed
+// to non-list calls (if the user explicitly asked for any object by name).
+// This includes directories, streams, URLs, and resource name tuples.
+func (r *Result) TargetsSingleItems() bool {
+	return r.targetsSingleItems
+}
+
+// IgnoreErrors will filter errors that occur when by visiting the result
+// (but not errors that occur by creating the result in the first place),
+// eliminating any that match fns. This is best used in combination with
+// Builder.ContinueOnError(), where the visitors accumulate errors and return
+// them after visiting as a slice of errors. If no errors remain after
+// filtering, the various visitor methods on Result will return nil for
+// err.
+func (r *Result) IgnoreErrors(fns ...ErrMatchFunc) *Result {
+	for _, fn := range fns {
+		r.ignoreErrors = append(r.ignoreErrors, utilerrors.Matcher(fn))
+	}
+	return r
+}
+
+// Mapper returns a copy of the builder's mapper.
+func (r *Result) Mapper() *mapper {
+	return r.mapper
+}
+
+// Err returns one or more errors (via a util.ErrorList) that occurred prior
+// to visiting the elements in the visitor. To see all errors including those
+// that occur during visitation, invoke Infos().
+func (r *Result) Err() error {
+	return r.err
+}
+
+// Visit implements the Visitor interface on the items described in the Builder.
+// Note that some visitor sources are not traversable more than once, or may
+// return different results.  If you wish to operate on the same set of resources
+// multiple times, use the Infos() method.
+func (r *Result) Visit(fn VisitorFunc) error {
+	if r.err != nil {
+		return r.err
+	}
+	err := r.visitor.Visit(fn)
+	return utilerrors.FilterOut(err, r.ignoreErrors...)
+}
+
+// IntoSingleItemImplied sets the provided boolean pointer to true if the Builder input
+// implies a single item, or multiple.
+func (r *Result) IntoSingleItemImplied(b *bool) *Result {
+	*b = r.singleItemImplied
+	return r
+}
+
+// Infos returns an array of all of the resource infos retrieved via traversal.
+// Will attempt to traverse the entire set of visitors only once, and will return
+// a cached list on subsequent calls.
+func (r *Result) Infos() ([]*Info, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	if r.info != nil {
+		return r.info, nil
+	}
+
+	infos := []*Info{}
+	err := r.visitor.Visit(func(info *Info, err error) error {
+		if err != nil {
+			return err
+		}
+		infos = append(infos, info)
+		return nil
+	})
+	err = utilerrors.FilterOut(err, r.ignoreErrors...)
+
+	r.info, r.err = infos, err
+	return infos, err
+}
+
+// Object returns a single object representing the output of a single visit to all
+// found resources.  If the Builder was a singular context (expected to return a
+// single resource by user input) and only a single resource was found, the resource
+// will be returned as is.  Otherwise, the returned resources will be part of an
+// v1.List. The ResourceVersion of the v1.List will be set only if it is identical
+// across all infos returned.
+func (r *Result) Object() (runtime.Object, error) {
+	infos, err := r.Infos()
+	if err != nil {
+		return nil, err
+	}
+
+	versions := sets.String{}
+	objects := []runtime.Object{}
+	for _, info := range infos {
+		if info.Object != nil {
+			objects = append(objects, info.Object)
+			versions.Insert(info.ResourceVersion)
+		}
+	}
+
+	if len(objects) == 1 {
+		if r.singleItemImplied {
+			return objects[0], nil
+		}
+		// if the item is a list already, don't create another list
+		if meta.IsListType(objects[0]) {
+			return objects[0], nil
+		}
+	}
+
+	version := ""
+	if len(versions) == 1 {
+		version = versions.List()[0]
+	}
+
+	return toV1List(objects, version), err
+}
+
+// Compile time check to enforce that list implements the necessary interface
+var _ metav1.ListInterface = &v1.List{}
+var _ metav1.ListMetaAccessor = &v1.List{}
+
+// toV1List takes a slice of Objects + their version, and returns
+// a v1.List Object containing the objects in the Items field
+func toV1List(objects []runtime.Object, version string) runtime.Object {
+	raw := []runtime.RawExtension{}
+	for _, o := range objects {
+		raw = append(raw, runtime.RawExtension{Object: o})
+	}
+	return &v1.List{
+		ListMeta: metav1.ListMeta{
+			ResourceVersion: version,
+		},
+		Items: raw,
+	}
+}
+
+// ResourceMapping returns a single meta.RESTMapping representing the
+// resources located by the builder, or an error if more than one
+// mapping was found.
+func (r *Result) ResourceMapping() (*meta.RESTMapping, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	mappings := map[schema.GroupVersionResource]*meta.RESTMapping{}
+	for i := range r.sources {
+		m, ok := r.sources[i].(ResourceMapping)
+		if !ok {
+			return nil, fmt.Errorf("a resource mapping could not be loaded from %v", reflect.TypeOf(r.sources[i]))
+		}
+		mapping := m.ResourceMapping()
+		mappings[mapping.Resource] = mapping
+	}
+	if len(mappings) != 1 {
+		return nil, fmt.Errorf("expected only a single resource type")
+	}
+	for _, mapping := range mappings {
+		return mapping, nil
+	}
+	return nil, nil
+}
+
+// Watch retrieves changes that occur on the server to the specified resource.
+// It currently supports watching a single source - if the resource source
+// (selectors or pure types) can be watched, they will be, otherwise the list
+// will be visited (equivalent to the Infos() call) and if there is a single
+// resource present, it will be watched, otherwise an error will be returned.
+func (r *Result) Watch(resourceVersion string) (watch.Interface, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	if len(r.sources) != 1 {
+		return nil, fmt.Errorf("you may only watch a single resource or type of resource at a time")
+	}
+	w, ok := r.sources[0].(Watchable)
+	if !ok {
+		info, err := r.Infos()
+		if err != nil {
+			return nil, err
+		}
+		if len(info) != 1 {
+			return nil, fmt.Errorf("watch is only supported on individual resources and resource collections - %d resources were found", len(info))
+		}
+		return info[0].Watch(resourceVersion)
+	}
+	return w.Watch(resourceVersion)
+}

--- a/vendor/k8s.io/cli-runtime/pkg/genericclioptions/resource/scheme.go
+++ b/vendor/k8s.io/cli-runtime/pkg/genericclioptions/resource/scheme.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"encoding/json"
+	"io"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+)
+
+// dynamicCodec is a codec that wraps the standard unstructured codec
+// with special handling for Status objects.
+// Deprecated only used by test code and its wrong
+type dynamicCodec struct{}
+
+func (dynamicCodec) Decode(data []byte, gvk *schema.GroupVersionKind, obj runtime.Object) (runtime.Object, *schema.GroupVersionKind, error) {
+	obj, gvk, err := unstructured.UnstructuredJSONScheme.Decode(data, gvk, obj)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if _, ok := obj.(*metav1.Status); !ok && strings.ToLower(gvk.Kind) == "status" {
+		obj = &metav1.Status{}
+		err := json.Unmarshal(data, obj)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	return obj, gvk, nil
+}
+
+func (dynamicCodec) Encode(obj runtime.Object, w io.Writer) error {
+	return unstructured.UnstructuredJSONScheme.Encode(obj, w)
+}
+
+// ContentConfig returns a rest.ContentConfig for dynamic types.  It includes enough codecs to act as a "normal"
+// serializer for the rest.client with options, status and the like.
+func UnstructuredPlusDefaultContentConfig() rest.ContentConfig {
+	var jsonInfo runtime.SerializerInfo
+	// TODO: scheme.Codecs here should become "pkg/apis/server/scheme" which is the minimal core you need
+	// to talk to a kubernetes server
+	for _, info := range scheme.Codecs.SupportedMediaTypes() {
+		if info.MediaType == runtime.ContentTypeJSON {
+			jsonInfo = info
+			break
+		}
+	}
+
+	jsonInfo.Serializer = dynamicCodec{}
+	jsonInfo.PrettySerializer = nil
+	return rest.ContentConfig{
+		AcceptContentTypes:   runtime.ContentTypeJSON,
+		ContentType:          runtime.ContentTypeJSON,
+		NegotiatedSerializer: serializer.NegotiatedSerializerWrapper(jsonInfo),
+	}
+}

--- a/vendor/k8s.io/cli-runtime/pkg/genericclioptions/resource/selector.go
+++ b/vendor/k8s.io/cli-runtime/pkg/genericclioptions/resource/selector.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+// Selector is a Visitor for resources that match a label selector.
+type Selector struct {
+	Client               RESTClient
+	Mapping              *meta.RESTMapping
+	Namespace            string
+	LabelSelector        string
+	FieldSelector        string
+	Export               bool
+	IncludeUninitialized bool
+	LimitChunks          int64
+}
+
+// NewSelector creates a resource selector which hides details of getting items by their label selector.
+func NewSelector(client RESTClient, mapping *meta.RESTMapping, namespace, labelSelector, fieldSelector string, export, includeUninitialized bool, limitChunks int64) *Selector {
+	return &Selector{
+		Client:               client,
+		Mapping:              mapping,
+		Namespace:            namespace,
+		LabelSelector:        labelSelector,
+		FieldSelector:        fieldSelector,
+		Export:               export,
+		IncludeUninitialized: includeUninitialized,
+		LimitChunks:          limitChunks,
+	}
+}
+
+// Visit implements Visitor and uses request chunking by default.
+func (r *Selector) Visit(fn VisitorFunc) error {
+	var continueToken string
+	for {
+		list, err := NewHelper(r.Client, r.Mapping).List(
+			r.Namespace,
+			r.ResourceMapping().GroupVersionKind.GroupVersion().String(),
+			r.Export,
+			&metav1.ListOptions{
+				LabelSelector:        r.LabelSelector,
+				FieldSelector:        r.FieldSelector,
+				IncludeUninitialized: r.IncludeUninitialized,
+				Limit:                r.LimitChunks,
+				Continue:             continueToken,
+			},
+		)
+		if err != nil {
+			if errors.IsResourceExpired(err) {
+				return err
+			}
+			if errors.IsBadRequest(err) || errors.IsNotFound(err) {
+				if se, ok := err.(*errors.StatusError); ok {
+					// modify the message without hiding this is an API error
+					if len(r.LabelSelector) == 0 && len(r.FieldSelector) == 0 {
+						se.ErrStatus.Message = fmt.Sprintf("Unable to list %q: %v", r.Mapping.Resource, se.ErrStatus.Message)
+					} else {
+						se.ErrStatus.Message = fmt.Sprintf("Unable to find %q that match label selector %q, field selector %q: %v", r.Mapping.Resource, r.LabelSelector, r.FieldSelector, se.ErrStatus.Message)
+					}
+					return se
+				}
+				if len(r.LabelSelector) == 0 && len(r.FieldSelector) == 0 {
+					return fmt.Errorf("Unable to list %q: %v", r.Mapping.Resource, err)
+				}
+				return fmt.Errorf("Unable to find %q that match label selector %q, field selector %q: %v", r.Mapping.Resource, r.LabelSelector, r.FieldSelector, err)
+			}
+			return err
+		}
+		resourceVersion, _ := metadataAccessor.ResourceVersion(list)
+		nextContinueToken, _ := metadataAccessor.Continue(list)
+		info := &Info{
+			Client:  r.Client,
+			Mapping: r.Mapping,
+
+			Namespace:       r.Namespace,
+			ResourceVersion: resourceVersion,
+
+			Object: list,
+		}
+
+		if err := fn(info, nil); err != nil {
+			return err
+		}
+		if len(nextContinueToken) == 0 {
+			return nil
+		}
+		continueToken = nextContinueToken
+	}
+}
+
+func (r *Selector) Watch(resourceVersion string) (watch.Interface, error) {
+	return NewHelper(r.Client, r.Mapping).Watch(r.Namespace, r.ResourceMapping().GroupVersionKind.GroupVersion().String(),
+		&metav1.ListOptions{ResourceVersion: resourceVersion, LabelSelector: r.LabelSelector, FieldSelector: r.FieldSelector})
+}
+
+// ResourceMapping returns the mapping for this resource and implements ResourceMapping
+func (r *Selector) ResourceMapping() *meta.RESTMapping {
+	return r.Mapping
+}

--- a/vendor/k8s.io/cli-runtime/pkg/genericclioptions/resource/visitor.go
+++ b/vendor/k8s.io/cli-runtime/pkg/genericclioptions/resource/visitor.go
@@ -1,0 +1,723 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"time"
+
+	"golang.org/x/text/encoding/unicode"
+	"golang.org/x/text/transform"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+const (
+	constSTDINstr       string = "STDIN"
+	stopValidateMessage        = "if you choose to ignore these errors, turn validation off with --validate=false"
+)
+
+// Watchable describes a resource that can be watched for changes that occur on the server,
+// beginning after the provided resource version.
+type Watchable interface {
+	Watch(resourceVersion string) (watch.Interface, error)
+}
+
+// ResourceMapping allows an object to return the resource mapping associated with
+// the resource or resources it represents.
+type ResourceMapping interface {
+	ResourceMapping() *meta.RESTMapping
+}
+
+// Info contains temporary info to execute a REST call, or show the results
+// of an already completed REST call.
+type Info struct {
+	// Client will only be present if this builder was not local
+	Client RESTClient
+	// Mapping will only be present if this builder was not local
+	Mapping *meta.RESTMapping
+
+	// Namespace will be set if the object is namespaced and has a specified value.
+	Namespace string
+	Name      string
+
+	// Optional, Source is the filename or URL to template file (.json or .yaml),
+	// or stdin to use to handle the resource
+	Source string
+	// Optional, this is the most recent value returned by the server if available. It will
+	// typically be in unstructured or internal forms, depending on how the Builder was
+	// defined. If retrieved from the server, the Builder expects the mapping client to
+	// decide the final form. Use the AsVersioned, AsUnstructured, and AsInternal helpers
+	// to alter the object versions.
+	Object runtime.Object
+	// Optional, this is the most recent resource version the server knows about for
+	// this type of resource. It may not match the resource version of the object,
+	// but if set it should be equal to or newer than the resource version of the
+	// object (however the server defines resource version).
+	ResourceVersion string
+	// Optional, should this resource be exported, stripped of cluster-specific and instance specific fields
+	Export bool
+}
+
+// Visit implements Visitor
+func (i *Info) Visit(fn VisitorFunc) error {
+	return fn(i, nil)
+}
+
+// Get retrieves the object from the Namespace and Name fields
+func (i *Info) Get() (err error) {
+	obj, err := NewHelper(i.Client, i.Mapping).Get(i.Namespace, i.Name, i.Export)
+	if err != nil {
+		if errors.IsNotFound(err) && len(i.Namespace) > 0 && i.Namespace != metav1.NamespaceDefault && i.Namespace != metav1.NamespaceAll {
+			err2 := i.Client.Get().AbsPath("api", "v1", "namespaces", i.Namespace).Do().Error()
+			if err2 != nil && errors.IsNotFound(err2) {
+				return err2
+			}
+		}
+		return err
+	}
+	i.Object = obj
+	i.ResourceVersion, _ = metadataAccessor.ResourceVersion(obj)
+	return nil
+}
+
+// Refresh updates the object with another object. If ignoreError is set
+// the Object will be updated even if name, namespace, or resourceVersion
+// attributes cannot be loaded from the object.
+func (i *Info) Refresh(obj runtime.Object, ignoreError bool) error {
+	name, err := metadataAccessor.Name(obj)
+	if err != nil {
+		if !ignoreError {
+			return err
+		}
+	} else {
+		i.Name = name
+	}
+	namespace, err := metadataAccessor.Namespace(obj)
+	if err != nil {
+		if !ignoreError {
+			return err
+		}
+	} else {
+		i.Namespace = namespace
+	}
+	version, err := metadataAccessor.ResourceVersion(obj)
+	if err != nil {
+		if !ignoreError {
+			return err
+		}
+	} else {
+		i.ResourceVersion = version
+	}
+	i.Object = obj
+	return nil
+}
+
+// String returns the general purpose string representation
+func (i *Info) String() string {
+	basicInfo := fmt.Sprintf("Name: %q, Namespace: %q\nObject: %+q", i.Name, i.Namespace, i.Object)
+	if i.Mapping != nil {
+		mappingInfo := fmt.Sprintf("Resource: %q, GroupVersionKind: %q", i.Mapping.Resource.String(),
+			i.Mapping.GroupVersionKind.String())
+		return fmt.Sprint(mappingInfo, "\n", basicInfo)
+	}
+	return basicInfo
+}
+
+// Namespaced returns true if the object belongs to a namespace
+func (i *Info) Namespaced() bool {
+	return i.Mapping != nil && i.Mapping.Scope.Name() == meta.RESTScopeNameNamespace
+}
+
+// Watch returns server changes to this object after it was retrieved.
+func (i *Info) Watch(resourceVersion string) (watch.Interface, error) {
+	return NewHelper(i.Client, i.Mapping).WatchSingle(i.Namespace, i.Name, resourceVersion)
+}
+
+// ResourceMapping returns the mapping for this resource and implements ResourceMapping
+func (i *Info) ResourceMapping() *meta.RESTMapping {
+	return i.Mapping
+}
+
+// VisitorList implements Visit for the sub visitors it contains. The first error
+// returned from a child Visitor will terminate iteration.
+type VisitorList []Visitor
+
+// Visit implements Visitor
+func (l VisitorList) Visit(fn VisitorFunc) error {
+	for i := range l {
+		if err := l[i].Visit(fn); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// EagerVisitorList implements Visit for the sub visitors it contains. All errors
+// will be captured and returned at the end of iteration.
+type EagerVisitorList []Visitor
+
+// Visit implements Visitor, and gathers errors that occur during processing until
+// all sub visitors have been visited.
+func (l EagerVisitorList) Visit(fn VisitorFunc) error {
+	errs := []error(nil)
+	for i := range l {
+		if err := l[i].Visit(func(info *Info, err error) error {
+			if err != nil {
+				errs = append(errs, err)
+				return nil
+			}
+			if err := fn(info, nil); err != nil {
+				errs = append(errs, err)
+			}
+			return nil
+		}); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return utilerrors.NewAggregate(errs)
+}
+
+func ValidateSchema(data []byte, schema ContentValidator) error {
+	if schema == nil {
+		return nil
+	}
+	if err := schema.ValidateBytes(data); err != nil {
+		return fmt.Errorf("error validating data: %v; %s", err, stopValidateMessage)
+	}
+	return nil
+}
+
+// URLVisitor downloads the contents of a URL, and if successful, returns
+// an info object representing the downloaded object.
+type URLVisitor struct {
+	URL *url.URL
+	*StreamVisitor
+	HttpAttemptCount int
+}
+
+func (v *URLVisitor) Visit(fn VisitorFunc) error {
+	body, err := readHttpWithRetries(httpgetImpl, time.Second, v.URL.String(), v.HttpAttemptCount)
+	if err != nil {
+		return err
+	}
+	defer body.Close()
+	v.StreamVisitor.Reader = body
+	return v.StreamVisitor.Visit(fn)
+}
+
+// readHttpWithRetries tries to http.Get the v.URL retries times before giving up.
+func readHttpWithRetries(get httpget, duration time.Duration, u string, attempts int) (io.ReadCloser, error) {
+	var err error
+	var body io.ReadCloser
+	if attempts <= 0 {
+		return nil, fmt.Errorf("http attempts must be greater than 0, was %d", attempts)
+	}
+	for i := 0; i < attempts; i++ {
+		var statusCode int
+		var status string
+		if i > 0 {
+			time.Sleep(duration)
+		}
+
+		// Try to get the URL
+		statusCode, status, body, err = get(u)
+
+		// Retry Errors
+		if err != nil {
+			continue
+		}
+
+		// Error - Set the error condition from the StatusCode
+		if statusCode != http.StatusOK {
+			err = fmt.Errorf("unable to read URL %q, server reported %s, status code=%d", u, status, statusCode)
+		}
+
+		if statusCode >= 500 && statusCode < 600 {
+			// Retry 500's
+			continue
+		} else {
+			// Don't retry other StatusCodes
+			break
+		}
+	}
+	return body, err
+}
+
+// httpget Defines function to retrieve a url and return the results.  Exists for unit test stubbing.
+type httpget func(url string) (int, string, io.ReadCloser, error)
+
+// httpgetImpl Implements a function to retrieve a url and return the results.
+func httpgetImpl(url string) (int, string, io.ReadCloser, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return 0, "", nil, err
+	}
+	return resp.StatusCode, resp.Status, resp.Body, nil
+}
+
+// DecoratedVisitor will invoke the decorators in order prior to invoking the visitor function
+// passed to Visit. An error will terminate the visit.
+type DecoratedVisitor struct {
+	visitor    Visitor
+	decorators []VisitorFunc
+}
+
+// NewDecoratedVisitor will create a visitor that invokes the provided visitor functions before
+// the user supplied visitor function is invoked, giving them the opportunity to mutate the Info
+// object or terminate early with an error.
+func NewDecoratedVisitor(v Visitor, fn ...VisitorFunc) Visitor {
+	if len(fn) == 0 {
+		return v
+	}
+	return DecoratedVisitor{v, fn}
+}
+
+// Visit implements Visitor
+func (v DecoratedVisitor) Visit(fn VisitorFunc) error {
+	return v.visitor.Visit(func(info *Info, err error) error {
+		if err != nil {
+			return err
+		}
+		for i := range v.decorators {
+			if err := v.decorators[i](info, nil); err != nil {
+				return err
+			}
+		}
+		return fn(info, nil)
+	})
+}
+
+// ContinueOnErrorVisitor visits each item and, if an error occurs on
+// any individual item, returns an aggregate error after all items
+// are visited.
+type ContinueOnErrorVisitor struct {
+	Visitor
+}
+
+// Visit returns nil if no error occurs during traversal, a regular
+// error if one occurs, or if multiple errors occur, an aggregate
+// error.  If the provided visitor fails on any individual item it
+// will not prevent the remaining items from being visited. An error
+// returned by the visitor directly may still result in some items
+// not being visited.
+func (v ContinueOnErrorVisitor) Visit(fn VisitorFunc) error {
+	errs := []error{}
+	err := v.Visitor.Visit(func(info *Info, err error) error {
+		if err != nil {
+			errs = append(errs, err)
+			return nil
+		}
+		if err := fn(info, nil); err != nil {
+			errs = append(errs, err)
+		}
+		return nil
+	})
+	if err != nil {
+		errs = append(errs, err)
+	}
+	if len(errs) == 1 {
+		return errs[0]
+	}
+	return utilerrors.NewAggregate(errs)
+}
+
+// FlattenListVisitor flattens any objects that runtime.ExtractList recognizes as a list
+// - has an "Items" public field that is a slice of runtime.Objects or objects satisfying
+// that interface - into multiple Infos. An error on any sub item (for instance, if a List
+// contains an object that does not have a registered client or resource) will terminate
+// the visit.
+// TODO: allow errors to be aggregated?
+type FlattenListVisitor struct {
+	visitor Visitor
+	typer   runtime.ObjectTyper
+	mapper  *mapper
+}
+
+// NewFlattenListVisitor creates a visitor that will expand list style runtime.Objects
+// into individual items and then visit them individually.
+func NewFlattenListVisitor(v Visitor, typer runtime.ObjectTyper, mapper *mapper) Visitor {
+	return FlattenListVisitor{v, typer, mapper}
+}
+
+func (v FlattenListVisitor) Visit(fn VisitorFunc) error {
+	return v.visitor.Visit(func(info *Info, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.Object == nil {
+			return fn(info, nil)
+		}
+		if !meta.IsListType(info.Object) {
+			return fn(info, nil)
+		}
+
+		items := []runtime.Object{}
+		itemsToProcess := []runtime.Object{info.Object}
+
+		for i := 0; i < len(itemsToProcess); i++ {
+			currObj := itemsToProcess[i]
+			if !meta.IsListType(currObj) {
+				items = append(items, currObj)
+				continue
+			}
+
+			currItems, err := meta.ExtractList(currObj)
+			if err != nil {
+				return err
+			}
+			if errs := runtime.DecodeList(currItems, v.mapper.decoder); len(errs) > 0 {
+				return utilerrors.NewAggregate(errs)
+			}
+			itemsToProcess = append(itemsToProcess, currItems...)
+		}
+
+		// If we have a GroupVersionKind on the list, prioritize that when asking for info on the objects contained in the list
+		var preferredGVKs []schema.GroupVersionKind
+		if info.Mapping != nil && !info.Mapping.GroupVersionKind.Empty() {
+			preferredGVKs = append(preferredGVKs, info.Mapping.GroupVersionKind)
+		}
+
+		for i := range items {
+			item, err := v.mapper.infoForObject(items[i], v.typer, preferredGVKs)
+			if err != nil {
+				return err
+			}
+			if len(info.ResourceVersion) != 0 {
+				item.ResourceVersion = info.ResourceVersion
+			}
+			if err := fn(item, nil); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+func ignoreFile(path string, extensions []string) bool {
+	if len(extensions) == 0 {
+		return false
+	}
+	ext := filepath.Ext(path)
+	for _, s := range extensions {
+		if s == ext {
+			return false
+		}
+	}
+	return true
+}
+
+// FileVisitorForSTDIN return a special FileVisitor just for STDIN
+func FileVisitorForSTDIN(mapper *mapper, schema ContentValidator) Visitor {
+	return &FileVisitor{
+		Path:          constSTDINstr,
+		StreamVisitor: NewStreamVisitor(nil, mapper, constSTDINstr, schema),
+	}
+}
+
+// ExpandPathsToFileVisitors will return a slice of FileVisitors that will handle files from the provided path.
+// After FileVisitors open the files, they will pass an io.Reader to a StreamVisitor to do the reading. (stdin
+// is also taken care of). Paths argument also accepts a single file, and will return a single visitor
+func ExpandPathsToFileVisitors(mapper *mapper, paths string, recursive bool, extensions []string, schema ContentValidator) ([]Visitor, error) {
+	var visitors []Visitor
+	err := filepath.Walk(paths, func(path string, fi os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if fi.IsDir() {
+			if path != paths && !recursive {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		// Don't check extension if the filepath was passed explicitly
+		if path != paths && ignoreFile(path, extensions) {
+			return nil
+		}
+
+		visitor := &FileVisitor{
+			Path:          path,
+			StreamVisitor: NewStreamVisitor(nil, mapper, path, schema),
+		}
+
+		visitors = append(visitors, visitor)
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+	return visitors, nil
+}
+
+// FileVisitor is wrapping around a StreamVisitor, to handle open/close files
+type FileVisitor struct {
+	Path string
+	*StreamVisitor
+}
+
+// Visit in a FileVisitor is just taking care of opening/closing files
+func (v *FileVisitor) Visit(fn VisitorFunc) error {
+	var f *os.File
+	if v.Path == constSTDINstr {
+		f = os.Stdin
+	} else {
+		var err error
+		f, err = os.Open(v.Path)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+	}
+
+	// TODO: Consider adding a flag to force to UTF16, apparently some
+	// Windows tools don't write the BOM
+	utf16bom := unicode.BOMOverride(unicode.UTF8.NewDecoder())
+	v.StreamVisitor.Reader = transform.NewReader(f, utf16bom)
+
+	return v.StreamVisitor.Visit(fn)
+}
+
+// StreamVisitor reads objects from an io.Reader and walks them. A stream visitor can only be
+// visited once.
+// TODO: depends on objects being in JSON format before being passed to decode - need to implement
+// a stream decoder method on runtime.Codec to properly handle this.
+type StreamVisitor struct {
+	io.Reader
+	*mapper
+
+	Source string
+	Schema ContentValidator
+}
+
+// NewStreamVisitor is a helper function that is useful when we want to change the fields of the struct but keep calls the same.
+func NewStreamVisitor(r io.Reader, mapper *mapper, source string, schema ContentValidator) *StreamVisitor {
+	return &StreamVisitor{
+		Reader: r,
+		mapper: mapper,
+		Source: source,
+		Schema: schema,
+	}
+}
+
+// Visit implements Visitor over a stream. StreamVisitor is able to distinct multiple resources in one stream.
+func (v *StreamVisitor) Visit(fn VisitorFunc) error {
+	d := yaml.NewYAMLOrJSONDecoder(v.Reader, 4096)
+	for {
+		ext := runtime.RawExtension{}
+		if err := d.Decode(&ext); err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return fmt.Errorf("error parsing %s: %v", v.Source, err)
+		}
+		// TODO: This needs to be able to handle object in other encodings and schemas.
+		ext.Raw = bytes.TrimSpace(ext.Raw)
+		if len(ext.Raw) == 0 || bytes.Equal(ext.Raw, []byte("null")) {
+			continue
+		}
+		if err := ValidateSchema(ext.Raw, v.Schema); err != nil {
+			return fmt.Errorf("error validating %q: %v", v.Source, err)
+		}
+		info, err := v.infoForData(ext.Raw, v.Source)
+		if err != nil {
+			if fnErr := fn(info, err); fnErr != nil {
+				return fnErr
+			}
+			continue
+		}
+		if err := fn(info, nil); err != nil {
+			return err
+		}
+	}
+}
+
+func UpdateObjectNamespace(info *Info, err error) error {
+	if err != nil {
+		return err
+	}
+	if info.Object != nil {
+		return metadataAccessor.SetNamespace(info.Object, info.Namespace)
+	}
+	return nil
+}
+
+// FilterNamespace omits the namespace if the object is not namespace scoped
+func FilterNamespace(info *Info, err error) error {
+	if err != nil {
+		return err
+	}
+	if !info.Namespaced() {
+		info.Namespace = ""
+		UpdateObjectNamespace(info, nil)
+	}
+	return nil
+}
+
+// SetNamespace ensures that every Info object visited will have a namespace
+// set. If info.Object is set, it will be mutated as well.
+func SetNamespace(namespace string) VisitorFunc {
+	return func(info *Info, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.Namespaced() {
+			return nil
+		}
+		if len(info.Namespace) == 0 {
+			info.Namespace = namespace
+			UpdateObjectNamespace(info, nil)
+		}
+		return nil
+	}
+}
+
+// RequireNamespace will either set a namespace if none is provided on the
+// Info object, or if the namespace is set and does not match the provided
+// value, returns an error. This is intended to guard against administrators
+// accidentally operating on resources outside their namespace.
+func RequireNamespace(namespace string) VisitorFunc {
+	return func(info *Info, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.Namespaced() {
+			return nil
+		}
+		if len(info.Namespace) == 0 {
+			info.Namespace = namespace
+			UpdateObjectNamespace(info, nil)
+			return nil
+		}
+		if info.Namespace != namespace {
+			return fmt.Errorf("the namespace from the provided object %q does not match the namespace %q. You must pass '--namespace=%s' to perform this operation.", info.Namespace, namespace, info.Namespace)
+		}
+		return nil
+	}
+}
+
+// RetrieveLatest updates the Object on each Info by invoking a standard client
+// Get.
+func RetrieveLatest(info *Info, err error) error {
+	if err != nil {
+		return err
+	}
+	if meta.IsListType(info.Object) {
+		return fmt.Errorf("watch is only supported on individual resources and resource collections, but a list of resources is found")
+	}
+	if len(info.Name) == 0 {
+		return nil
+	}
+	if info.Namespaced() && len(info.Namespace) == 0 {
+		return fmt.Errorf("no namespace set on resource %s %q", info.Mapping.Resource, info.Name)
+	}
+	return info.Get()
+}
+
+// RetrieveLazy updates the object if it has not been loaded yet.
+func RetrieveLazy(info *Info, err error) error {
+	if err != nil {
+		return err
+	}
+	if info.Object == nil {
+		return info.Get()
+	}
+	return nil
+}
+
+// CreateAndRefresh creates an object from input info and refreshes info with that object
+func CreateAndRefresh(info *Info) error {
+	obj, err := NewHelper(info.Client, info.Mapping).Create(info.Namespace, true, info.Object, nil)
+	if err != nil {
+		return err
+	}
+	info.Refresh(obj, true)
+	return nil
+}
+
+type FilterFunc func(info *Info, err error) (bool, error)
+
+type FilteredVisitor struct {
+	visitor Visitor
+	filters []FilterFunc
+}
+
+func NewFilteredVisitor(v Visitor, fn ...FilterFunc) Visitor {
+	if len(fn) == 0 {
+		return v
+	}
+	return FilteredVisitor{v, fn}
+}
+
+func (v FilteredVisitor) Visit(fn VisitorFunc) error {
+	return v.visitor.Visit(func(info *Info, err error) error {
+		if err != nil {
+			return err
+		}
+		for _, filter := range v.filters {
+			ok, err := filter(info, nil)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return nil
+			}
+		}
+		return fn(info, nil)
+	})
+}
+
+func FilterByLabelSelector(s labels.Selector) FilterFunc {
+	return func(info *Info, err error) (bool, error) {
+		if err != nil {
+			return false, err
+		}
+		a, err := meta.Accessor(info.Object)
+		if err != nil {
+			return false, err
+		}
+		if !s.Matches(labels.Set(a.GetLabels())) {
+			return false, nil
+		}
+		return true, nil
+	}
+}
+
+type InfoListVisitor []*Info
+
+func (infos InfoListVisitor) Visit(fn VisitorFunc) error {
+	var err error
+	for _, i := range infos {
+		err = fn(i, err)
+	}
+	return err
+}

--- a/vendor/k8s.io/cli-runtime/pkg/genericclioptions/template_flags.go
+++ b/vendor/k8s.io/cli-runtime/pkg/genericclioptions/template_flags.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package genericclioptions
+
+import (
+	"fmt"
+	"io/ioutil"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions/printers"
+)
+
+// templates are logically optional for specifying a format.
+// this allows a user to specify a template format value
+// as --output=go-template=
+var templateFormats = map[string]bool{
+	"template":         true,
+	"go-template":      true,
+	"go-template-file": true,
+	"templatefile":     true,
+}
+
+// GoTemplatePrintFlags provides default flags necessary for template printing.
+// Given the following flag values, a printer can be requested that knows
+// how to handle printing based on these values.
+type GoTemplatePrintFlags struct {
+	// indicates if it is OK to ignore missing keys for rendering
+	// an output template.
+	AllowMissingKeys *bool
+	TemplateArgument *string
+}
+
+func (f *GoTemplatePrintFlags) AllowedFormats() []string {
+	formats := make([]string, 0, len(templateFormats))
+	for format := range templateFormats {
+		formats = append(formats, format)
+	}
+	sort.Strings(formats)
+	return formats
+}
+
+// ToPrinter receives an templateFormat and returns a printer capable of
+// handling --template format printing.
+// Returns false if the specified templateFormat does not match a template format.
+func (f *GoTemplatePrintFlags) ToPrinter(templateFormat string) (printers.ResourcePrinter, error) {
+	if (f.TemplateArgument == nil || len(*f.TemplateArgument) == 0) && len(templateFormat) == 0 {
+		return nil, NoCompatiblePrinterError{Options: f, OutputFormat: &templateFormat}
+	}
+
+	templateValue := ""
+
+	if f.TemplateArgument == nil || len(*f.TemplateArgument) == 0 {
+		for format := range templateFormats {
+			format = format + "="
+			if strings.HasPrefix(templateFormat, format) {
+				templateValue = templateFormat[len(format):]
+				templateFormat = format[:len(format)-1]
+				break
+			}
+		}
+	} else {
+		templateValue = *f.TemplateArgument
+	}
+
+	if _, supportedFormat := templateFormats[templateFormat]; !supportedFormat {
+		return nil, NoCompatiblePrinterError{OutputFormat: &templateFormat, AllowedFormats: f.AllowedFormats()}
+	}
+
+	if len(templateValue) == 0 {
+		return nil, fmt.Errorf("template format specified but no template given")
+	}
+
+	if templateFormat == "templatefile" || templateFormat == "go-template-file" {
+		data, err := ioutil.ReadFile(templateValue)
+		if err != nil {
+			return nil, fmt.Errorf("error reading --template %s, %v\n", templateValue, err)
+		}
+
+		templateValue = string(data)
+	}
+
+	p, err := printers.NewGoTemplatePrinter([]byte(templateValue))
+	if err != nil {
+		return nil, fmt.Errorf("error parsing template %s, %v\n", templateValue, err)
+	}
+
+	allowMissingKeys := true
+	if f.AllowMissingKeys != nil {
+		allowMissingKeys = *f.AllowMissingKeys
+	}
+
+	p.AllowMissingKeys(allowMissingKeys)
+	return p, nil
+}
+
+// AddFlags receives a *cobra.Command reference and binds
+// flags related to template printing to it
+func (f *GoTemplatePrintFlags) AddFlags(c *cobra.Command) {
+	if f.TemplateArgument != nil {
+		c.Flags().StringVar(f.TemplateArgument, "template", *f.TemplateArgument, "Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].")
+		c.MarkFlagFilename("template")
+	}
+	if f.AllowMissingKeys != nil {
+		c.Flags().BoolVar(f.AllowMissingKeys, "allow-missing-template-keys", *f.AllowMissingKeys, "If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.")
+	}
+}
+
+// NewGoTemplatePrintFlags returns flags associated with
+// --template printing, with default values set.
+func NewGoTemplatePrintFlags() *GoTemplatePrintFlags {
+	allowMissingKeysPtr := true
+	templateValuePtr := ""
+
+	return &GoTemplatePrintFlags{
+		TemplateArgument: &templateValuePtr,
+		AllowMissingKeys: &allowMissingKeysPtr,
+	}
+}

--- a/vendor/k8s.io/client-go/restmapper/category_expansion.go
+++ b/vendor/k8s.io/client-go/restmapper/category_expansion.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package restmapper
+
+import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+)
+
+// CategoryExpander maps category strings to GroupResouces.
+// Categories are classification or 'tag' of a group of resources.
+type CategoryExpander interface {
+	Expand(category string) ([]schema.GroupResource, bool)
+}
+
+// SimpleCategoryExpander implements CategoryExpander interface
+// using a static mapping of categories to GroupResource mapping.
+type SimpleCategoryExpander struct {
+	Expansions map[string][]schema.GroupResource
+}
+
+// Expand fulfills CategoryExpander
+func (e SimpleCategoryExpander) Expand(category string) ([]schema.GroupResource, bool) {
+	ret, ok := e.Expansions[category]
+	return ret, ok
+}
+
+// discoveryCategoryExpander struct lets a REST Client wrapper (discoveryClient) to retrieve list of APIResourceList,
+// and then convert to fallbackExpander
+type discoveryCategoryExpander struct {
+	discoveryClient discovery.DiscoveryInterface
+}
+
+// NewDiscoveryCategoryExpander returns a category expander that makes use of the "categories" fields from
+// the API, found through the discovery client. In case of any error or no category found (which likely
+// means we're at a cluster prior to categories support, fallback to the expander provided.
+func NewDiscoveryCategoryExpander(client discovery.DiscoveryInterface) CategoryExpander {
+	if client == nil {
+		panic("Please provide discovery client to shortcut expander")
+	}
+	return discoveryCategoryExpander{discoveryClient: client}
+}
+
+// Expand fulfills CategoryExpander
+func (e discoveryCategoryExpander) Expand(category string) ([]schema.GroupResource, bool) {
+	// Get all supported resources for groups and versions from server, if no resource found, fallback anyway.
+	apiResourceLists, _ := e.discoveryClient.ServerResources()
+	if len(apiResourceLists) == 0 {
+		return nil, false
+	}
+
+	discoveredExpansions := map[string][]schema.GroupResource{}
+	for _, apiResourceList := range apiResourceLists {
+		gv, err := schema.ParseGroupVersion(apiResourceList.GroupVersion)
+		if err != nil {
+			continue
+		}
+		// Collect GroupVersions by categories
+		for _, apiResource := range apiResourceList.APIResources {
+			if categories := apiResource.Categories; len(categories) > 0 {
+				for _, category := range categories {
+					groupResource := schema.GroupResource{
+						Group:    gv.Group,
+						Resource: apiResource.Name,
+					}
+					discoveredExpansions[category] = append(discoveredExpansions[category], groupResource)
+				}
+			}
+		}
+	}
+
+	ret, ok := discoveredExpansions[category]
+	return ret, ok
+}
+
+// UnionCategoryExpander implements CategoryExpander interface.
+// It maps given category string to union of expansions returned by all the CategoryExpanders in the list.
+type UnionCategoryExpander []CategoryExpander
+
+// Expand fulfills CategoryExpander
+func (u UnionCategoryExpander) Expand(category string) ([]schema.GroupResource, bool) {
+	ret := []schema.GroupResource{}
+	ok := false
+
+	// Expand the category for each CategoryExpander in the list and merge/combine the results.
+	for _, expansion := range u {
+		curr, currOk := expansion.Expand(category)
+
+		for _, currGR := range curr {
+			found := false
+			for _, existing := range ret {
+				if existing == currGR {
+					found = true
+					break
+				}
+			}
+			if !found {
+				ret = append(ret, currGR)
+			}
+		}
+		ok = ok || currOk
+	}
+
+	return ret, ok
+}

--- a/vendor/k8s.io/client-go/restmapper/discovery.go
+++ b/vendor/k8s.io/client-go/restmapper/discovery.go
@@ -1,0 +1,339 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package restmapper
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+
+	"k8s.io/klog"
+)
+
+// APIGroupResources is an API group with a mapping of versions to
+// resources.
+type APIGroupResources struct {
+	Group metav1.APIGroup
+	// A mapping of version string to a slice of APIResources for
+	// that version.
+	VersionedResources map[string][]metav1.APIResource
+}
+
+// NewDiscoveryRESTMapper returns a PriorityRESTMapper based on the discovered
+// groups and resources passed in.
+func NewDiscoveryRESTMapper(groupResources []*APIGroupResources) meta.RESTMapper {
+	unionMapper := meta.MultiRESTMapper{}
+
+	var groupPriority []string
+	// /v1 is special.  It should always come first
+	resourcePriority := []schema.GroupVersionResource{{Group: "", Version: "v1", Resource: meta.AnyResource}}
+	kindPriority := []schema.GroupVersionKind{{Group: "", Version: "v1", Kind: meta.AnyKind}}
+
+	for _, group := range groupResources {
+		groupPriority = append(groupPriority, group.Group.Name)
+
+		// Make sure the preferred version comes first
+		if len(group.Group.PreferredVersion.Version) != 0 {
+			preferred := group.Group.PreferredVersion.Version
+			if _, ok := group.VersionedResources[preferred]; ok {
+				resourcePriority = append(resourcePriority, schema.GroupVersionResource{
+					Group:    group.Group.Name,
+					Version:  group.Group.PreferredVersion.Version,
+					Resource: meta.AnyResource,
+				})
+
+				kindPriority = append(kindPriority, schema.GroupVersionKind{
+					Group:   group.Group.Name,
+					Version: group.Group.PreferredVersion.Version,
+					Kind:    meta.AnyKind,
+				})
+			}
+		}
+
+		for _, discoveryVersion := range group.Group.Versions {
+			resources, ok := group.VersionedResources[discoveryVersion.Version]
+			if !ok {
+				continue
+			}
+
+			// Add non-preferred versions after the preferred version, in case there are resources that only exist in those versions
+			if discoveryVersion.Version != group.Group.PreferredVersion.Version {
+				resourcePriority = append(resourcePriority, schema.GroupVersionResource{
+					Group:    group.Group.Name,
+					Version:  discoveryVersion.Version,
+					Resource: meta.AnyResource,
+				})
+
+				kindPriority = append(kindPriority, schema.GroupVersionKind{
+					Group:   group.Group.Name,
+					Version: discoveryVersion.Version,
+					Kind:    meta.AnyKind,
+				})
+			}
+
+			gv := schema.GroupVersion{Group: group.Group.Name, Version: discoveryVersion.Version}
+			versionMapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{gv})
+
+			for _, resource := range resources {
+				scope := meta.RESTScopeNamespace
+				if !resource.Namespaced {
+					scope = meta.RESTScopeRoot
+				}
+
+				// if we have a slash, then this is a subresource and we shouldn't create mappings for those.
+				if strings.Contains(resource.Name, "/") {
+					continue
+				}
+
+				plural := gv.WithResource(resource.Name)
+				singular := gv.WithResource(resource.SingularName)
+				// this is for legacy resources and servers which don't list singular forms.  For those we must still guess.
+				if len(resource.SingularName) == 0 {
+					_, singular = meta.UnsafeGuessKindToResource(gv.WithKind(resource.Kind))
+				}
+
+				versionMapper.AddSpecific(gv.WithKind(strings.ToLower(resource.Kind)), plural, singular, scope)
+				versionMapper.AddSpecific(gv.WithKind(resource.Kind), plural, singular, scope)
+				// TODO this is producing unsafe guesses that don't actually work, but it matches previous behavior
+				versionMapper.Add(gv.WithKind(resource.Kind+"List"), scope)
+			}
+			// TODO why is this type not in discovery (at least for "v1")
+			versionMapper.Add(gv.WithKind("List"), meta.RESTScopeRoot)
+			unionMapper = append(unionMapper, versionMapper)
+		}
+	}
+
+	for _, group := range groupPriority {
+		resourcePriority = append(resourcePriority, schema.GroupVersionResource{
+			Group:    group,
+			Version:  meta.AnyVersion,
+			Resource: meta.AnyResource,
+		})
+		kindPriority = append(kindPriority, schema.GroupVersionKind{
+			Group:   group,
+			Version: meta.AnyVersion,
+			Kind:    meta.AnyKind,
+		})
+	}
+
+	return meta.PriorityRESTMapper{
+		Delegate:         unionMapper,
+		ResourcePriority: resourcePriority,
+		KindPriority:     kindPriority,
+	}
+}
+
+// GetAPIGroupResources uses the provided discovery client to gather
+// discovery information and populate a slice of APIGroupResources.
+func GetAPIGroupResources(cl discovery.DiscoveryInterface) ([]*APIGroupResources, error) {
+	apiGroups, err := cl.ServerGroups()
+	if err != nil {
+		if apiGroups == nil || len(apiGroups.Groups) == 0 {
+			return nil, err
+		}
+		// TODO track the errors and update callers to handle partial errors.
+	}
+	var result []*APIGroupResources
+	for _, group := range apiGroups.Groups {
+		groupResources := &APIGroupResources{
+			Group:              group,
+			VersionedResources: make(map[string][]metav1.APIResource),
+		}
+		for _, version := range group.Versions {
+			resources, err := cl.ServerResourcesForGroupVersion(version.GroupVersion)
+			if err != nil {
+				// continue as best we can
+				// TODO track the errors and update callers to handle partial errors.
+				if resources == nil || len(resources.APIResources) == 0 {
+					continue
+				}
+			}
+			groupResources.VersionedResources[version.Version] = resources.APIResources
+		}
+		result = append(result, groupResources)
+	}
+	return result, nil
+}
+
+// DeferredDiscoveryRESTMapper is a RESTMapper that will defer
+// initialization of the RESTMapper until the first mapping is
+// requested.
+type DeferredDiscoveryRESTMapper struct {
+	initMu   sync.Mutex
+	delegate meta.RESTMapper
+	cl       discovery.CachedDiscoveryInterface
+}
+
+// NewDeferredDiscoveryRESTMapper returns a
+// DeferredDiscoveryRESTMapper that will lazily query the provided
+// client for discovery information to do REST mappings.
+func NewDeferredDiscoveryRESTMapper(cl discovery.CachedDiscoveryInterface) *DeferredDiscoveryRESTMapper {
+	return &DeferredDiscoveryRESTMapper{
+		cl: cl,
+	}
+}
+
+func (d *DeferredDiscoveryRESTMapper) getDelegate() (meta.RESTMapper, error) {
+	d.initMu.Lock()
+	defer d.initMu.Unlock()
+
+	if d.delegate != nil {
+		return d.delegate, nil
+	}
+
+	groupResources, err := GetAPIGroupResources(d.cl)
+	if err != nil {
+		return nil, err
+	}
+
+	d.delegate = NewDiscoveryRESTMapper(groupResources)
+	return d.delegate, err
+}
+
+// Reset resets the internally cached Discovery information and will
+// cause the next mapping request to re-discover.
+func (d *DeferredDiscoveryRESTMapper) Reset() {
+	klog.V(5).Info("Invalidating discovery information")
+
+	d.initMu.Lock()
+	defer d.initMu.Unlock()
+
+	d.cl.Invalidate()
+	d.delegate = nil
+}
+
+// KindFor takes a partial resource and returns back the single match.
+// It returns an error if there are multiple matches.
+func (d *DeferredDiscoveryRESTMapper) KindFor(resource schema.GroupVersionResource) (gvk schema.GroupVersionKind, err error) {
+	del, err := d.getDelegate()
+	if err != nil {
+		return schema.GroupVersionKind{}, err
+	}
+	gvk, err = del.KindFor(resource)
+	if err != nil && !d.cl.Fresh() {
+		d.Reset()
+		gvk, err = d.KindFor(resource)
+	}
+	return
+}
+
+// KindsFor takes a partial resource and returns back the list of
+// potential kinds in priority order.
+func (d *DeferredDiscoveryRESTMapper) KindsFor(resource schema.GroupVersionResource) (gvks []schema.GroupVersionKind, err error) {
+	del, err := d.getDelegate()
+	if err != nil {
+		return nil, err
+	}
+	gvks, err = del.KindsFor(resource)
+	if len(gvks) == 0 && !d.cl.Fresh() {
+		d.Reset()
+		gvks, err = d.KindsFor(resource)
+	}
+	return
+}
+
+// ResourceFor takes a partial resource and returns back the single
+// match. It returns an error if there are multiple matches.
+func (d *DeferredDiscoveryRESTMapper) ResourceFor(input schema.GroupVersionResource) (gvr schema.GroupVersionResource, err error) {
+	del, err := d.getDelegate()
+	if err != nil {
+		return schema.GroupVersionResource{}, err
+	}
+	gvr, err = del.ResourceFor(input)
+	if err != nil && !d.cl.Fresh() {
+		d.Reset()
+		gvr, err = d.ResourceFor(input)
+	}
+	return
+}
+
+// ResourcesFor takes a partial resource and returns back the list of
+// potential resource in priority order.
+func (d *DeferredDiscoveryRESTMapper) ResourcesFor(input schema.GroupVersionResource) (gvrs []schema.GroupVersionResource, err error) {
+	del, err := d.getDelegate()
+	if err != nil {
+		return nil, err
+	}
+	gvrs, err = del.ResourcesFor(input)
+	if len(gvrs) == 0 && !d.cl.Fresh() {
+		d.Reset()
+		gvrs, err = d.ResourcesFor(input)
+	}
+	return
+}
+
+// RESTMapping identifies a preferred resource mapping for the
+// provided group kind.
+func (d *DeferredDiscoveryRESTMapper) RESTMapping(gk schema.GroupKind, versions ...string) (m *meta.RESTMapping, err error) {
+	del, err := d.getDelegate()
+	if err != nil {
+		return nil, err
+	}
+	m, err = del.RESTMapping(gk, versions...)
+	if err != nil && !d.cl.Fresh() {
+		d.Reset()
+		m, err = d.RESTMapping(gk, versions...)
+	}
+	return
+}
+
+// RESTMappings returns the RESTMappings for the provided group kind
+// in a rough internal preferred order. If no kind is found, it will
+// return a NoResourceMatchError.
+func (d *DeferredDiscoveryRESTMapper) RESTMappings(gk schema.GroupKind, versions ...string) (ms []*meta.RESTMapping, err error) {
+	del, err := d.getDelegate()
+	if err != nil {
+		return nil, err
+	}
+	ms, err = del.RESTMappings(gk, versions...)
+	if len(ms) == 0 && !d.cl.Fresh() {
+		d.Reset()
+		ms, err = d.RESTMappings(gk, versions...)
+	}
+	return
+}
+
+// ResourceSingularizer converts a resource name from plural to
+// singular (e.g., from pods to pod).
+func (d *DeferredDiscoveryRESTMapper) ResourceSingularizer(resource string) (singular string, err error) {
+	del, err := d.getDelegate()
+	if err != nil {
+		return resource, err
+	}
+	singular, err = del.ResourceSingularizer(resource)
+	if err != nil && !d.cl.Fresh() {
+		d.Reset()
+		singular, err = d.ResourceSingularizer(resource)
+	}
+	return
+}
+
+func (d *DeferredDiscoveryRESTMapper) String() string {
+	del, err := d.getDelegate()
+	if err != nil {
+		return fmt.Sprintf("DeferredDiscoveryRESTMapper{%v}", err)
+	}
+	return fmt.Sprintf("DeferredDiscoveryRESTMapper{\n\t%v\n}", del)
+}
+
+// Make sure it satisfies the interface
+var _ meta.RESTMapper = &DeferredDiscoveryRESTMapper{}

--- a/vendor/k8s.io/client-go/restmapper/shortcut.go
+++ b/vendor/k8s.io/client-go/restmapper/shortcut.go
@@ -1,0 +1,172 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package restmapper
+
+import (
+	"strings"
+
+	"k8s.io/klog"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+)
+
+// shortcutExpander is a RESTMapper that can be used for Kubernetes resources.   It expands the resource first, then invokes the wrapped
+type shortcutExpander struct {
+	RESTMapper meta.RESTMapper
+
+	discoveryClient discovery.DiscoveryInterface
+}
+
+var _ meta.RESTMapper = &shortcutExpander{}
+
+// NewShortcutExpander wraps a restmapper in a layer that expands shortcuts found via discovery
+func NewShortcutExpander(delegate meta.RESTMapper, client discovery.DiscoveryInterface) meta.RESTMapper {
+	return shortcutExpander{RESTMapper: delegate, discoveryClient: client}
+}
+
+// KindFor fulfills meta.RESTMapper
+func (e shortcutExpander) KindFor(resource schema.GroupVersionResource) (schema.GroupVersionKind, error) {
+	return e.RESTMapper.KindFor(e.expandResourceShortcut(resource))
+}
+
+// KindsFor fulfills meta.RESTMapper
+func (e shortcutExpander) KindsFor(resource schema.GroupVersionResource) ([]schema.GroupVersionKind, error) {
+	return e.RESTMapper.KindsFor(e.expandResourceShortcut(resource))
+}
+
+// ResourcesFor fulfills meta.RESTMapper
+func (e shortcutExpander) ResourcesFor(resource schema.GroupVersionResource) ([]schema.GroupVersionResource, error) {
+	return e.RESTMapper.ResourcesFor(e.expandResourceShortcut(resource))
+}
+
+// ResourceFor fulfills meta.RESTMapper
+func (e shortcutExpander) ResourceFor(resource schema.GroupVersionResource) (schema.GroupVersionResource, error) {
+	return e.RESTMapper.ResourceFor(e.expandResourceShortcut(resource))
+}
+
+// ResourceSingularizer fulfills meta.RESTMapper
+func (e shortcutExpander) ResourceSingularizer(resource string) (string, error) {
+	return e.RESTMapper.ResourceSingularizer(e.expandResourceShortcut(schema.GroupVersionResource{Resource: resource}).Resource)
+}
+
+// RESTMapping fulfills meta.RESTMapper
+func (e shortcutExpander) RESTMapping(gk schema.GroupKind, versions ...string) (*meta.RESTMapping, error) {
+	return e.RESTMapper.RESTMapping(gk, versions...)
+}
+
+// RESTMappings fulfills meta.RESTMapper
+func (e shortcutExpander) RESTMappings(gk schema.GroupKind, versions ...string) ([]*meta.RESTMapping, error) {
+	return e.RESTMapper.RESTMappings(gk, versions...)
+}
+
+// getShortcutMappings returns a set of tuples which holds short names for resources.
+// First the list of potential resources will be taken from the API server.
+// Next we will append the hardcoded list of resources - to be backward compatible with old servers.
+// NOTE that the list is ordered by group priority.
+func (e shortcutExpander) getShortcutMappings() ([]*metav1.APIResourceList, []resourceShortcuts, error) {
+	res := []resourceShortcuts{}
+	// get server resources
+	// This can return an error *and* the results it was able to find.  We don't need to fail on the error.
+	apiResList, err := e.discoveryClient.ServerResources()
+	if err != nil {
+		klog.V(1).Infof("Error loading discovery information: %v", err)
+	}
+	for _, apiResources := range apiResList {
+		gv, err := schema.ParseGroupVersion(apiResources.GroupVersion)
+		if err != nil {
+			klog.V(1).Infof("Unable to parse groupversion = %s due to = %s", apiResources.GroupVersion, err.Error())
+			continue
+		}
+		for _, apiRes := range apiResources.APIResources {
+			for _, shortName := range apiRes.ShortNames {
+				rs := resourceShortcuts{
+					ShortForm: schema.GroupResource{Group: gv.Group, Resource: shortName},
+					LongForm:  schema.GroupResource{Group: gv.Group, Resource: apiRes.Name},
+				}
+				res = append(res, rs)
+			}
+		}
+	}
+
+	return apiResList, res, nil
+}
+
+// expandResourceShortcut will return the expanded version of resource
+// (something that a pkg/api/meta.RESTMapper can understand), if it is
+// indeed a shortcut. If no match has been found, we will match on group prefixing.
+// Lastly we will return resource unmodified.
+func (e shortcutExpander) expandResourceShortcut(resource schema.GroupVersionResource) schema.GroupVersionResource {
+	// get the shortcut mappings and return on first match.
+	if allResources, shortcutResources, err := e.getShortcutMappings(); err == nil {
+		// avoid expanding if there's an exact match to a full resource name
+		for _, apiResources := range allResources {
+			gv, err := schema.ParseGroupVersion(apiResources.GroupVersion)
+			if err != nil {
+				continue
+			}
+			if len(resource.Group) != 0 && resource.Group != gv.Group {
+				continue
+			}
+			for _, apiRes := range apiResources.APIResources {
+				if resource.Resource == apiRes.Name {
+					return resource
+				}
+				if resource.Resource == apiRes.SingularName {
+					return resource
+				}
+			}
+		}
+
+		for _, item := range shortcutResources {
+			if len(resource.Group) != 0 && resource.Group != item.ShortForm.Group {
+				continue
+			}
+			if resource.Resource == item.ShortForm.Resource {
+				resource.Resource = item.LongForm.Resource
+				resource.Group = item.LongForm.Group
+				return resource
+			}
+		}
+
+		// we didn't find exact match so match on group prefixing. This allows autoscal to match autoscaling
+		if len(resource.Group) == 0 {
+			return resource
+		}
+		for _, item := range shortcutResources {
+			if !strings.HasPrefix(item.ShortForm.Group, resource.Group) {
+				continue
+			}
+			if resource.Resource == item.ShortForm.Resource {
+				resource.Resource = item.LongForm.Resource
+				resource.Group = item.LongForm.Group
+				return resource
+			}
+		}
+	}
+
+	return resource
+}
+
+// ResourceShortcuts represents a structure that holds the information how to
+// transition from resource's shortcut to its full name.
+type resourceShortcuts struct {
+	ShortForm schema.GroupResource
+	LongForm  schema.GroupResource
+}


### PR DESCRIPTION
**What this PR does / why we need it**: This PR adds a kubectl plugin, `kubectl ingress-nginx`, that makes it easier to debug ingress-nginx. In the future, this plugin should also get the ability to add/remove/configure ingress-nginx deployments in a cluster (see https://gist.github.com/aledbf/db25dbc723fc7d71345a9657abfd766d). Right now, it just includes debugging functionality.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #3755

## Current features

- [x] `kubectl ingress-nginx backends`, which basically can query the output of `/dbg backends` inside ingress-nginx pods
- [x] `kubectl ingress-nginx general`, `kubectl ingress-nginx conf`, which do the same but for `/dbg general` and `/dbg conf`
- [x] `kubectl ingress-nginx ingress` which tries to output a table similar to `kubectl get ingress`, but with richer information including hostnames, paths, whether or not a rule is protected by TLS, and backend name.
- [x] `kubectl ingress-nginx info` Pretty sparse right now, just prints the internal and external addresses of the ingress-nginx deployment.

## Packaging

The plugin binaries + [krew](https://github.com/GoogleContainerTools/krew) manifest can be built using `make build-plugin`. Right now it builds for Linux, MacOS, and Windows, although I've only tested it on MacOS. Distributing the plugin would look something like this:

1. Before an `ingress-nginx` release, run `make build-plugin` and commit the generated `cmd/plugin/release` directory.
2. Add the binary tarballs to the github release (such as https://github.com/kubernetes/ingress-nginx/releases/tag/nginx-0.22.0)
3. Make the release.
4. Make a PR in https://github.com/GoogleContainerTools/krew-index/tree/master/plugins with the new generated `ingress-nginx.yaml` manifest

## To-do

-  [x] Right now, cloud authentication (like with GCP, AWS, etc.) is broken. It works when using the latest master versions of the various kubernetes dependencies, but not with the `1.13.3` versions we have vendored now. I'm still trying to fix this. (edit: fixed by https://github.com/kubernetes/ingress-nginx/pull/3793)
- [ ] Give the plugin the ability to actually manage `ingress-nginx` deployments as in https://gist.github.com/aledbf/db25dbc723fc7d71345a9657abfd766d. Although this may not be necessary for an MVP (edit: punting to a future PR)
- [ ] Documentation (edit: punting to a future PR)
- [ ] Handle `ingress-nginx` deployments that have names other than `ingress-nginx` (edit: punting to a future PR)
- [ ] Any other suggested improvements
- [ ] Testing (edit: punting to a future PR)

cc: @ElvinEfendi @aledbf 