### PR TITLE
Upgrade openresty/lua-resty-balancer

### DIFF
--- a/images/nginx/Makefile
+++ b/images/nginx/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # 0.0.0 shouldn't clobber any released builds
-TAG ?= 0.78
+TAG ?= 0.79
 REGISTRY ?= quay.io/kubernetes-ingress-controller
 ARCH ?= $(shell go env GOARCH)
 DOCKER ?= docker

--- a/images/nginx/rootfs/build.sh
+++ b/images/nginx/rootfs/build.sh
@@ -203,8 +203,8 @@ get_src 4aca34f324d543754968359672dcf5f856234574ee4da360ce02c778d244572a \
 get_src 095615fe94e64615c4a27f4f4475b91c047cf8d10bc2dbde8d5ba6aa625fc5ab \
         "https://github.com/openresty/lua-resty-string/archive/v0.11.tar.gz"
 
-get_src a77bf0d7cf6a9ba017d0dc973b1a58f13e48242dd3849c5e99c07d250667c44c \
-        "https://github.com/openresty/lua-resty-balancer/archive/v0.02rc4.tar.gz"
+get_src 89cedd6466801bfef20499689ebb34ecf17a2e60a34cd06e13c0204ea1775588 \
+        "https://github.com/openresty/lua-resty-balancer/archive/v0.02rc5.tar.gz"
 
 get_src d81b33129c6fb5203b571fa4d8394823bf473d8872c0357a1d0f14420b1483bd \
         "https://github.com/cloudflare/lua-resty-cookie/archive/v0.1.0.tar.gz"
@@ -273,7 +273,7 @@ make install
 cd "$BUILD_PATH/lua-resty-string-0.11"
 make install
 
-cd "$BUILD_PATH/lua-resty-balancer-0.02rc4"
+cd "$BUILD_PATH/lua-resty-balancer-0.02rc5"
 make all
 make install
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

This fixes bug in chash:reinit which prevents endpoints from being updated correctly.

See https://github.com/openresty/lua-resty-balancer/pull/25

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
