### PR TITLE
Removes unused const from customhttperrors e2e test

### DIFF
--- a/test/e2e/annotations/customhttperrors.go
+++ b/test/e2e/annotations/customhttperrors.go
@@ -27,8 +27,6 @@ import (
 	"k8s.io/ingress-nginx/test/e2e/framework"
 )
 
-const defaultBackendName = "upstream-default-backend"
-
 func errorBlockName(upstreamName string, errorCode string) string {
 	return fmt.Sprintf("@custom_%s_%s", upstreamName, errorCode)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Removes an unused var (leftover from https://github.com/kubernetes/ingress-nginx/pull/3730)

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
