### PR TITLE
Prevent dep from vendoring grpc-fortune-teller dependencies

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -20,6 +20,8 @@
 #  name = "github.com/x/y"
 #  version = "2.4.0"
 
+ignored = ["github.com/kubernetes/ingress-nginx/images/grpc-fortune-teller*"]
+
 [prune]
   non-go = true
   go-tests = true


### PR DESCRIPTION
**What this PR does / why we need it**: People (myself included) keep forgetting or not knowing that they have to delete the ```images/grpc-fortune-teller``` directory before running ```make dep-ensure``` to avoid vendoring its dependencies. This PR will cause dep to ignore that package, so we can just run ```make dep-ensure``` without doing anything else.

cc: @aledbf 