### PR TITLE
Avoid X-Forwarded-Host to be copied to Host header

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -305,6 +305,17 @@ http {
         ''                $server_port;
     }
 
+    # Obtain best http host
+    map $http_host $this_host {
+        default          $http_host;
+        ''               $host;
+    }
+
+    map $http_x_forwarded_host $best_http_forwarded_host {
+        default          $http_x_forwarded_host;
+        ''               $this_host;
+    }
+
     {{ else }}
     map '' $pass_access_scheme {
         default          $scheme;
@@ -1249,7 +1260,7 @@ stream {
             {{ else }}
             {{ $proxySetHeader }} X-Forwarded-For        $the_real_ip;
             {{ end }}
-            {{ $proxySetHeader }} X-Forwarded-Host       $best_http_host;
+            {{ $proxySetHeader }} X-Forwarded-Host       $best_http_forwarded_host;
             {{ $proxySetHeader }} X-Forwarded-Port       $pass_port;
             {{ $proxySetHeader }} X-Forwarded-Proto      $pass_access_scheme;
             {{ if $all.Cfg.ProxyAddOriginalURIHeader }}

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -305,16 +305,6 @@ http {
         ''                $server_port;
     }
 
-    # Obtain best http host
-    map $http_host $this_host {
-        default          $http_host;
-        ''               $host;
-    }
-
-    map $http_x_forwarded_host $best_http_host {
-        default          $http_x_forwarded_host;
-        ''               $this_host;
-    }
     {{ else }}
     map '' $pass_access_scheme {
         default          $scheme;
@@ -323,13 +313,13 @@ http {
     map '' $pass_server_port {
         default          $server_port;
     }
+    {{ end }}
 
     # Obtain best http host
     map $http_host $best_http_host {
         default          $http_host;
         ''               $host;
     }
-    {{ end }}
 
     # validate $pass_access_scheme and $scheme are http to force a redirect
     map "$scheme:$pass_access_scheme" $redirect_to_https {


### PR DESCRIPTION

**What this PR does / why we need it**: This PR reviews nginx template in order to avoid the overwriting of `Host` header with the values inherited from `X-Forwarded-Host`. The related variable assignment map has been deleted together with the related `best_http_host` assigment within the `UseForwardedHeaders` conditional. Now `best_http_host` gets populated only once with the right value independently from the usage of `X-forwarded-*` headers through related cfm key.

**Which issue this PR fixes**: fixes #3790 

**Special notes for your reviewer**: Another PR has been submitted concerning this issue (#3798) which involves Lua migration of part of nginx template logic. As that one covers a lot more aspects, this PR is intended only to provide a behaviour fix while bigger WIP will be implemented :) 
