### PR TITLE
Set default for satisfy annotation to nothing

### DIFF
--- a/internal/ingress/annotations/satisfy/main.go
+++ b/internal/ingress/annotations/satisfy/main.go
@@ -35,8 +35,9 @@ func NewParser(r resolver.Resolver) parser.IngressAnnotation {
 // Parse parses annotation contained in the ingress
 func (s satisfy) Parse(ing *extensions.Ingress) (interface{}, error) {
 	satisfy, err := parser.GetStringAnnotation("satisfy", ing)
-	if err != nil || satisfy != "any" {
-		satisfy = "all"
+
+	if err != nil || (satisfy != "any" && satisfy != "all") {
+		satisfy = ""
 	}
 
 	return satisfy, nil

--- a/internal/ingress/annotations/satisfy/main_test.go
+++ b/internal/ingress/annotations/satisfy/main_test.go
@@ -69,7 +69,8 @@ func TestSatisfyParser(t *testing.T) {
 	data := map[string]string{
 		"any":     "any",
 		"all":     "all",
-		"invalid": "all",
+		"invalid": "",
+		"":        "",
 	}
 
 	annotations := map[string]string{}

--- a/test/e2e/annotations/satisfy.go
+++ b/test/e2e/annotations/satisfy.go
@@ -43,15 +43,13 @@ var _ = framework.IngressNginxDescribe("Annotations - SATISFY", func() {
 		annotationKey := "nginx.ingress.kubernetes.io/satisfy"
 
 		annotations := map[string]string{
-			"any":     "any",
-			"all":     "all",
-			"invalid": "all",
+			"any": "any",
+			"all": "all",
 		}
 
 		results := map[string]string{
-			"any":     "satisfy any",
-			"all":     "satisfy all",
-			"invalid": "satisfy all",
+			"any": "satisfy any",
+			"all": "satisfy all",
 		}
 
 		initAnnotations := map[string]string{


### PR DESCRIPTION
**What this PR does / why we need it**: ingress-nginx recently added the `satisfy` annotation. This change caused the nginx.conf `satisfy` directive to always be set, even if the annotation is not set. This presents a problem as it breaks any ingress definition that sets `satisfy` using a `server-snippet` or `configuration-snippet`, because then there are two `satisfy` directives at once. This PR prevents the `satisfy` directive from being applied unless the annotation is actually present and valid.

This should not change the behaviour of ingress-nginx as leaving out the `satisfy` directive is the same as setting `satisfy all;`, which is the previous default value.

cc: @ElvinEfendi 
