### PR TITLE
Fix plugin install location

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -97,7 +97,12 @@ Use the `ingress-nginx` kubectl plugin
 
 Install [krew](https://github.com/GoogleContainerTools/krew), then run
 ```console
-$ kubectl krew install --manifest https://github.com/kubernetes/ingress-nginx/releases/download/nginx-0.23.0/ingress-nginx.yaml
+$ (
+  set -x; cd "$(mktemp -d)" &&
+  curl -fsSLO "https://github.com/kubernetes/ingress-nginx/releases/download/nginx-0.23.0/{ingress-nginx.yaml,kubectl-ingress_nginx-$(uname | tr '[:upper:]' '[:lower:]')-amd64.tar.gz}" &&
+  kubectl krew install \
+    --manifest=ingress-nginx.yaml --archive=kubectl-ingress_nginx-$(uname | tr '[:upper:]' '[:lower:]')-amd64.tar.gz
+)
 ```
 to install the plugin. Then run
 ```console

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -97,7 +97,7 @@ Use the `ingress-nginx` kubectl plugin
 
 Install [krew](https://github.com/GoogleContainerTools/krew), then run
 ```console
-$ kubectl krew install --manifest https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/cmd/plugin/release/ingress-nginx.yaml
+$ kubectl krew install --manifest https://github.com/kubernetes/ingress-nginx/releases/download/nginx-0.23.0/ingress-nginx.yaml
 ```
 to install the plugin. Then run
 ```console


### PR DESCRIPTION
The url for the plugin manifest should actually be under `releases`.

cc: @aledbf 