### PR TITLE
Prevent e2e-tests from running on non-local clusters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ PKG = k8s.io/ingress-nginx
 ARCH ?= $(shell go env GOARCH)
 GOARCH = ${ARCH}
 DUMB_ARCH = ${ARCH}
+KUBECTL_CONTEXT = $(shell kubectl config current-context)
 
 GOBUILD_FLAGS :=
 
@@ -182,6 +183,14 @@ lua-test:
 
 .PHONY: e2e-test
 e2e-test:
+	if  [ "$(KUBECTL_CONTEXT)" != "minikube" ] && \
+		[ "$(KUBECTL_CONTEXT)" != "kind" ] && \
+		[ "$(KUBECTL_CONTEXT)" != "dind" ] && \
+		[ "$(KUBECTL_CONTEXT)" != "docker-for-desktop" ]; then \
+		echo "kubectl context is "$(KUBECTL_CONTEXT)", but must be one of [minikube, kind, dind, docker-for-deskop]"; \
+		exit 1; \
+	fi
+
 	echo "Granting permissions to ingress-nginx e2e service account..."
 	kubectl create serviceaccount ingress-nginx-e2e || true
 	kubectl create clusterrolebinding permissive-binding \


### PR DESCRIPTION
Right now, if you run `make e2e-test` with your kubectl context set to some other cluster, it will dump a bunch of stuff into it. With this PR `make e2e-test` will only run if the context is a local one (currently just checking if it's one of minikube, kind, and docker-for-desktop).

Just putting up PR now to see how CI reacts.