### PR TITLE
Add missing basic usage documentation link

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,7 @@ nav:
   - User guide:
       - NGINX Configuration:
           - Introduction: "user-guide/nginx-configuration/index.md"
+          - Basic usage: "user-guide/basic-usage.md"
           - Annotations: "user-guide/nginx-configuration/annotations.md"
           - ConfigMap: "user-guide/nginx-configuration/configmap.md"
           - Custom NGINX template: "user-guide/nginx-configuration/custom-template.md"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Working on #3802 I found out that `make live-docs` was reporting

```
INFO    -  The following pages exist in the docs directory, but are not
included in the "nav" configuration:
  - user-guide/basic-usage.md
```

making this documentation page unavailable from the public documentation.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
