### PR TITLE
Typo fix: nginx-internal -> internal

### DIFF
--- a/docs/user-guide/multiple-ingress.md
+++ b/docs/user-guide/multiple-ingress.md
@@ -44,7 +44,7 @@ spec:
            args:
              - /nginx-ingress-controller
              - '--election-id=ingress-controller-leader-internal'
-             - '--ingress-class=nginx-internal'
+             - '--ingress-class=internal'
              - '--configmap=ingress/nginx-ingress-internal-controller'
 ```
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Typo fix: nginx-internal -> internal

**Special notes for your reviewer**:
This error is somewhat confusing to the users.