### PR TITLE
Add publish service annotation

### DIFF
--- a/internal/ingress/annotations/annotations.go
+++ b/internal/ingress/annotations/annotations.go
@@ -46,6 +46,7 @@ import (
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/portinredirect"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/proxy"
+	"k8s.io/ingress-nginx/internal/ingress/annotations/publishservice"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/ratelimit"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/redirect"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/rewrite"
@@ -85,6 +86,7 @@ type Ingress struct {
 	ExternalAuth       authreq.Config
 	HTTP2PushPreload   bool
 	Proxy              proxy.Config
+	PublishService     string
 	RateLimit          ratelimit.Config
 	Redirect           redirect.Config
 	Rewrite            rewrite.Config
@@ -129,6 +131,7 @@ func NewAnnotationExtractor(cfg resolver.Resolver) Extractor {
 			"ExternalAuth":         authreq.NewParser(cfg),
 			"HTTP2PushPreload":     http2pushpreload.NewParser(cfg),
 			"Proxy":                proxy.NewParser(cfg),
+			"PublishService":       publishservice.NewParser(cfg),
 			"RateLimit":            ratelimit.NewParser(cfg),
 			"Redirect":             redirect.NewParser(cfg),
 			"Rewrite":              rewrite.NewParser(cfg),

--- a/internal/ingress/annotations/publishservice/main.go
+++ b/internal/ingress/annotations/publishservice/main.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package publishservice
+
+import (
+	extensions "k8s.io/api/extensions/v1beta1"
+
+	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
+	"k8s.io/ingress-nginx/internal/ingress/resolver"
+)
+
+type publishService struct {
+	r resolver.Resolver
+}
+
+// NewParser creates a new publish service annotation parser
+func NewParser(r resolver.Resolver) parser.IngressAnnotation {
+	return publishService{r}
+}
+
+// Parse parses the annotations contained in the ingress rule
+// used to identify the ingress service that is actually connecting this ingrees
+// this overwrites the automatically detected address of the controller pod 
+// and also the service specified globally with the publishservice parameter
+// on a per ingress level
+func (a publishService) Parse(ing *extensions.Ingress) (interface{}, error) {
+	return parser.GetStringAnnotation("publish-service", ing)
+}

--- a/internal/ingress/annotations/publishservice/main_test.go
+++ b/internal/ingress/annotations/publishservice/main_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package publishservice
+
+import (
+	"testing"
+
+	api "k8s.io/api/core/v1"
+	extensions "k8s.io/api/extensions/v1beta1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
+	"k8s.io/ingress-nginx/internal/ingress/resolver"
+)
+
+func TestParse(t *testing.T) {
+	ing := &extensions.Ingress{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      "foo",
+			Namespace: api.NamespaceDefault,
+		},
+		Spec: extensions.IngressSpec{},
+	}
+
+	data := map[string]string{}
+	data[parser.GetAnnotationWithPrefix("publish-service")] = "default/ingress-service"
+
+	ing.SetAnnotations(data)
+
+	i, err := NewParser(&resolver.Mock{}).Parse(ing)
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+
+	publishService, ok := i.(string)
+	if !ok {
+		t.Errorf("expected string but got %v", publishService)
+	}
+	if publishService != "default/ingress-service" {
+		t.Errorf("expected %v but got %v", "ok.com", publishService)
+	}
+}

--- a/internal/ingress/status/status.go
+++ b/internal/ingress/status/status.go
@@ -379,23 +379,11 @@ func (s *statusSync) updateStatus(newIngressPoint []apiv1.LoadBalancerIngress) {
 
 	batch := p.Batch()
 	sort.SliceStable(newIngressPoint, lessLoadBalancerIngress(newIngressPoint))
-	// serviceIngressPoint:= []apiv1.LoadBalancerIngress{}
+	
 	serviceIngressPoint := newIngressPoint
 	for _, ing := range ings {
 		curIPs := ing.Status.LoadBalancer.Ingress
 		serviceIngressPoint = s.updateIngressPoint(newIngressPoint, ing)
-		// Override IngressPoint from annotation service
-		// if ing.ParsedAnnotations.PublishService != "" {
-		// 	klog.V(3).Infof("Using Enpoints of service %v for ingress %v", ing.ParsedAnnotations.PublishService, ing.Name)
-		// 	serviceEndPoint, err := s.getEndpointsFromService(ing.ParsedAnnotations.PublishService)
-		// 	if err != nil {
-		// 		serviceIngressPoint = newIngressPoint
-		// 	}else {
-		// 		serviceIngressPoint = sliceToStatus(serviceEndPoint)
-		// 	}
-		// }else {
-			
-		// }
 
 		sort.SliceStable(curIPs, lessLoadBalancerIngress(curIPs))
 		if ingressSliceEqual(curIPs, serviceIngressPoint) {

--- a/internal/ingress/status/status.go
+++ b/internal/ingress/status/status.go
@@ -266,27 +266,7 @@ func (s *statusSync) runningAddresses() ([]string, error) {
 	addrs := []string{}
 
 	if s.PublishService != "" {
-		ns, name, _ := k8s.ParseNameNS(s.PublishService)
-		svc, err := s.Client.CoreV1().Services(ns).Get(name, metav1.GetOptions{})
-		if err != nil {
-			return nil, err
-		}
-
-		if svc.Spec.Type == apiv1.ServiceTypeExternalName {
-			addrs = append(addrs, svc.Spec.ExternalName)
-			return addrs, nil
-		}
-
-		for _, ip := range svc.Status.LoadBalancer.Ingress {
-			if ip.IP == "" {
-				addrs = append(addrs, ip.Hostname)
-			} else {
-				addrs = append(addrs, ip.IP)
-			}
-		}
-
-		addrs = append(addrs, svc.Spec.ExternalIPs...)
-		return addrs, nil
+		return s.getExternalIngressFromService(s.PublishService)
 	}
 
 	if s.PublishStatusAddress != "" {
@@ -314,6 +294,37 @@ func (s *statusSync) runningAddresses() ([]string, error) {
 		}
 	}
 
+	return addrs, nil
+}
+
+// return external name/ip from a service
+func (s *statusSync) getExternalIngressFromService(service string) ([]string, error) {
+	addrs := []string{}
+
+	if service == "" {
+		return nil, errors.New("Cannot get external name/ip from empty service string")
+	}
+
+	ns, name, _ := k8s.ParseNameNS(service)
+	svc, err := s.Client.CoreV1().Services(ns).Get(name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	if svc.Spec.Type == apiv1.ServiceTypeExternalName {
+		addrs = append(addrs, svc.Spec.ExternalName)
+		return addrs, nil
+	}
+
+	for _, ip := range svc.Status.LoadBalancer.Ingress {
+		if ip.IP == "" {
+			addrs = append(addrs, ip.Hostname)
+		} else {
+			addrs = append(addrs, ip.IP)
+		}
+	}
+
+	addrs = append(addrs, svc.Spec.ExternalIPs...)
 	return addrs, nil
 }
 
@@ -346,6 +357,19 @@ func sliceToStatus(endpoints []string) []apiv1.LoadBalancerIngress {
 	return lbi
 }
 
+// checks if the ingress is annotated with "publish-service", if yes it returns the ingress point for that service instead of the defaults
+func (s *statusSync) updateIngressPoint(ingressPoint []apiv1.LoadBalancerIngress, ing *ingress.Ingress) []apiv1.LoadBalancerIngress {
+	// empty ingressPoint check is needed as for shutdown only a update with an empty ingressPoint is performed
+	if ing.ParsedAnnotations.PublishService != "" && len(ingressPoint) >0  {
+		klog.V(3).Infof("Using Enpoints of service %v for ingress %v", ing.ParsedAnnotations.PublishService, ing.Name)
+		serviceEndPoint, err := s.getExternalIngressFromService(ing.ParsedAnnotations.PublishService)
+		if err == nil {
+			return sliceToStatus(serviceEndPoint)
+		}
+	}
+	return ingressPoint
+}
+
 // updateStatus changes the status information of Ingress rules
 func (s *statusSync) updateStatus(newIngressPoint []apiv1.LoadBalancerIngress) {
 	ings := s.IngressLister.ListIngresses()
@@ -355,16 +379,31 @@ func (s *statusSync) updateStatus(newIngressPoint []apiv1.LoadBalancerIngress) {
 
 	batch := p.Batch()
 	sort.SliceStable(newIngressPoint, lessLoadBalancerIngress(newIngressPoint))
-
+	// serviceIngressPoint:= []apiv1.LoadBalancerIngress{}
+	serviceIngressPoint := newIngressPoint
 	for _, ing := range ings {
 		curIPs := ing.Status.LoadBalancer.Ingress
+		serviceIngressPoint = s.updateIngressPoint(newIngressPoint, ing)
+		// Override IngressPoint from annotation service
+		// if ing.ParsedAnnotations.PublishService != "" {
+		// 	klog.V(3).Infof("Using Enpoints of service %v for ingress %v", ing.ParsedAnnotations.PublishService, ing.Name)
+		// 	serviceEndPoint, err := s.getEndpointsFromService(ing.ParsedAnnotations.PublishService)
+		// 	if err != nil {
+		// 		serviceIngressPoint = newIngressPoint
+		// 	}else {
+		// 		serviceIngressPoint = sliceToStatus(serviceEndPoint)
+		// 	}
+		// }else {
+			
+		// }
+
 		sort.SliceStable(curIPs, lessLoadBalancerIngress(curIPs))
-		if ingressSliceEqual(curIPs, newIngressPoint) {
+		if ingressSliceEqual(curIPs, serviceIngressPoint) {
 			klog.V(3).Infof("skipping update of Ingress %v/%v (no change)", ing.Namespace, ing.Name)
 			continue
 		}
 
-		batch.Queue(runUpdate(ing, newIngressPoint, s.Client))
+		batch.Queue(runUpdate(ing, serviceIngressPoint, s.Client))
 	}
 
 	batch.QueueComplete()


### PR DESCRIPTION
**Pull request for issue Issue #3867 - Support for multiple publish services**

**Brief**
I would like to extend ingress-nginx to be able to support different publish services on a per ingress basis for one ingress controller pod. 
![screenshot from 2019-03-07 15-38-22](https://user-images.githubusercontent.com/4409163/53964203-25613600-40ef-11e9-895e-653b0d662a63.png)

**Scenario:**
I am running several pods in my kubernetes installation that require me have a mixed scenario of ingresses for http(s) and tcp/udp ports I want to forward. 

**Example in the picture:**
I have a pod with a webservice container and a samba container where the samba container shares the configuration files for the webservice so they can be edited via filesharing mount.
I want the fileshare and webservice to be accessible under the same FQDN. And this should work for multiple different webservices but all with e.g. a samba share container.
I cant expose the samba ports for different webservices on the same loadbalancer service as they all have the same name and there is no hostname based routing for tcp/udp as for http.

**Problem:**
The scenario in the picture above technically already works with ingress-nginx. There is however one caveat, all the ingresses in kubernetes get the same IP assigned as status, which is the IP of the single publish service that is passed via the `--publish-service` arg.
When using external-dns this creates a problem as in the example in the picture above both urls (myservice1.example.com and myservice2.example.com) would resolve to the same IP. Which is no problem for HTTP proxying as this happens via hostname, but the tcp/udp proxy are going to the wrong destination.

**Proposal:**
Add an annotation to the ingress (e.g. `nginx.ingress.kubernetes.io/publish-service: default/podsvc2`) that will tell ingress-nginx on a per ingress base to which service the ingress belongs, so it can update this ingress with the correct IP. So this would overwrite the default publish service IP on a per ingress basis.

I have been running this now for a bit over a day in my kubernetes cluster - everything seems to be working fine for now.


