### PR TITLE
update GKE header to match link in contents

### DIFF
--- a/docs/deploy/index.md
+++ b/docs/deploy/index.md
@@ -133,7 +133,7 @@ This type of load balancer is supported since v1.10.0 as an ALPHA feature.
 kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/provider/aws/service-nlb.yaml
 ```
 
-#### GCE - GKE
+#### GCE-GKE
 
 ```console
 kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/provider/cloud-generic.yaml


### PR DESCRIPTION
A small fix in the deploy index.md. I noticed the link to GKE-GCP didn't work as the header didn't match the link. I updated the header to match the link so it works now.