### PR TITLE
Correctly format ipv6 resolver config for lua

### DIFF
--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -250,10 +250,14 @@ func buildResolversForLua(res interface{}, disableIpv6 interface{}) string {
 
 	r := []string{}
 	for _, ns := range nss {
-		if ing_net.IsIPV6(ns) && no6 {
-			continue
+		if ing_net.IsIPV6(ns) {
+			if no6 {
+				continue
+			}
+			r = append(r, fmt.Sprintf("\"[%v]\"", ns))
+		} else {
+			r = append(r, fmt.Sprintf("\"%v\"", ns))
 		}
-		r = append(r, fmt.Sprintf("\"%v\"", ns))
 	}
 
 	return strings.Join(r, ", ")

--- a/internal/ingress/controller/template/template_test.go
+++ b/internal/ingress/controller/template/template_test.go
@@ -516,7 +516,7 @@ func TestBuildResolversForLua(t *testing.T) {
 		t.Errorf("Expected '%v' but returned '%v'", expected, actual)
 	}
 
-	expected = "\"192.0.0.1\", \"2001:db8:1234::\""
+	expected = "\"192.0.0.1\", \"[2001:db8:1234::]\""
 	actual = buildResolversForLua(ipList, false)
 
 	if expected != actual {


### PR DESCRIPTION
**What this PR does / why we need it**: Fix for #3881 by correctly formatting ipv6 resolver addresses for lua.


There was some discussion RE this fix in #3882 as well