### PR TITLE
fix forwarding of auth header to GRPC backends

### DIFF
--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -374,11 +374,12 @@ func buildAuthResponseHeaders(input interface{}) []string {
 		return res
 	}
 
+	k := proxySetHeader(input)
 	for i, h := range location.ExternalAuth.ResponseHeaders {
 		hvar := strings.ToLower(h)
 		hvar = strings.NewReplacer("-", "_").Replace(hvar)
 		res = append(res, fmt.Sprintf("auth_request_set $authHeader%v $upstream_http_%v;", i, hvar))
-		res = append(res, fmt.Sprintf("proxy_set_header '%v' $authHeader%v;", h, i))
+		res = append(res, fmt.Sprintf("%s '%v' $authHeader%v;", k, h, i))
 	}
 	return res
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

With gRPC backends, Authorization header was not rewritten according to `auth-response-headers`. This patch resolves this, correctly using `grpc_set_header` for the Authorization header when a gRPC backend is specified.

**Which issue this PR fixes**:

fixes #3914


Here is an example snippet from nginx.conf **before** this patch:
```
            proxy_set_header 'Authorization' $authHeader0;
            
            client_max_body_size                    1m;
            
            grpc_set_header Host                   $best_http_host;
            
            # Pass the extracted client certificate to the backend
            
            # Allow websocket connections
            grpc_set_header                        Upgrade           $http_upgrade;
            
            grpc_set_header                        Connection        $connection_upgrade;
```

And **after** this patch:
```
            grpc_set_header 'Authorization' $authHeader0;
            
            client_max_body_size                    1m;
            
            grpc_set_header Host                   $best_http_host;
            
            # Pass the extracted client certificate to the backend
            
            # Allow websocket connections
            grpc_set_header                        Upgrade           $http_upgrade;
            
            grpc_set_header                        Connection        $connection_upgrade;
```