### PR TITLE
Fix dynamic SSL certificate for aliases and redirect-from-to-www

### DIFF
--- a/internal/ingress/controller/nginx.go
+++ b/internal/ingress/controller/nginx.go
@@ -964,6 +964,26 @@ func configureCertificates(pcfg *ingress.Configuration) error {
 				PemCertKey: server.SSLCert.PemCertKey,
 			},
 		})
+
+		if server.Alias != "" && server.SSLCert.PemCertKey != "" &&
+			ssl.IsValidHostname(server.Alias, server.SSLCert.CN) {
+			servers = append(servers, &ingress.Server{
+				Hostname: server.Alias,
+				SSLCert: ingress.SSLCert{
+					PemCertKey: server.SSLCert.PemCertKey,
+				},
+			})
+		}
+	}
+
+	redirects := buildRedirects(pcfg.Servers)
+	for _, redirect := range redirects {
+		servers = append(servers, &ingress.Server{
+			Hostname: redirect.From,
+			SSLCert: ingress.SSLCert{
+				PemCertKey: redirect.SSLCert.PemCertKey,
+			},
+		})
 	}
 
 	statusCode, _, err := nginx.NewPostStatusRequest("/configuration/servers", "application/json", servers)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

When dynamic SSL certificates is enabled we need to configure the aliases and redirect-from-to-www hosts with the proper certificate or NGINX will return the fake one

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
