### PR TITLE
Adds a log warning when falling back to default fake cert

### DIFF
--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -866,10 +866,14 @@ func (n *NGINXController) createServers(data []*ingress.Ingress,
 	defaultPemSHA := n.cfg.FakeCertificateSHA
 
 	// read custom default SSL certificate, fall back to generated default certificate
-	defaultCertificate, err := n.store.GetLocalSSLCert(n.cfg.DefaultSSLCertificate)
-	if err == nil {
-		defaultPemFileName = defaultCertificate.PemFileName
-		defaultPemSHA = defaultCertificate.PemSHA
+	if n.cfg.DefaultSSLCertificate != "" {
+		defaultCertificate, err := n.store.GetLocalSSLCert(n.cfg.DefaultSSLCertificate)
+		if err == nil {
+			defaultPemFileName = defaultCertificate.PemFileName
+			defaultPemSHA = defaultCertificate.PemSHA
+		} else {
+			klog.Warningf("Error loading custom default certificate, falling back to generated default:\n%v", err)
+		}
 	}
 
 	// initialize default server and root location


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Adds a warning to the controller's log messages if a custom default certificate was passed but the controller falls back for #reason (`err`)

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #3278

**Special notes for your reviewer**:
