### PR TITLE
Plugin select deployment using replicaset name

### DIFF
--- a/cmd/plugin/request/request.go
+++ b/cmd/plugin/request/request.go
@@ -253,7 +253,7 @@ func getDeploymentPods(flags *genericclioptions.ConfigFlags, deployment string) 
 
 	ingressPods := make([]apiv1.Pod, 0)
 	for _, pod := range pods {
-		if pod.Spec.Containers[0].Name == deployment {
+		if util.PodInDeployment(pod, deployment) {
 			ingressPods = append(ingressPods, pod)
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**: The `--deployment` flag was recently added to some `kubectl ingress-nginx` subcommands in order to specify the deployment we would like to query. The criterion that the plugin was previously using to check if a pod was in a deployment was not actually connected to the deployment name.

This PR lets the plugin check whether the deployment name is a prefix of the name of the ReplicaSet that owns the pod, which should actually match the deployment name.

