### PR TITLE
Fix segfault on reference to nonexistent configmap

### DIFF
--- a/internal/ingress/controller/nginx.go
+++ b/internal/ingress/controller/nginx.go
@@ -571,9 +571,9 @@ func (n *NGINXController) OnUpdate(ingressCfg ingress.Configuration) error {
 		cmap, err := n.store.GetConfigMap(cfg.ProxySetHeaders)
 		if err != nil {
 			klog.Warningf("Error reading ConfigMap %q from local store: %v", cfg.ProxySetHeaders, err)
+		} else {
+			setHeaders = cmap.Data
 		}
-
-		setHeaders = cmap.Data
 	}
 
 	addHeaders := map[string]string{}
@@ -581,9 +581,9 @@ func (n *NGINXController) OnUpdate(ingressCfg ingress.Configuration) error {
 		cmap, err := n.store.GetConfigMap(cfg.AddHeaders)
 		if err != nil {
 			klog.Warningf("Error reading ConfigMap %q from local store: %v", cfg.AddHeaders, err)
+		} else {
+			addHeaders = cmap.Data
 		}
-
-		addHeaders = cmap.Data
 	}
 
 	sslDHParam := ""


### PR DESCRIPTION
**What this PR does / why we need it**: The controller would previously segfault when the configmap referenced in `add-headers` or `proxy-set-headers` didn't exist.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #3937 

**Special notes for your reviewer**: @ElvinEfendi also suggested that we should be able to refer to a configmap in the same namespace without a namespace prefix. I've left that to do in a separate PR.
