### PR TITLE
Link to kubectl plugin docs in nav

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,6 +34,7 @@ nav:
       - Welcome: "index.md"
       - How it works: "how-it-works.md"
       - Troubleshooting: "troubleshooting.md"
+      - kubectl plugin: "kubectl-plugin.md"
       - Development: "development.md"
   - Deployment:
       - Installation Guide: "deploy/index.md"


### PR DESCRIPTION
Adds a link to the kubectl plugin docs in the top level navbar.