### PR TITLE
Remove valgrind

### DIFF
--- a/images/nginx/rootfs/build.sh
+++ b/images/nginx/rootfs/build.sh
@@ -94,7 +94,6 @@ clean-install \
   libmaxminddb-dev \
   dumb-init \
   gdb \
-  valgrind \
   bc \
   || exit 1
 

--- a/internal/ingress/controller/util.go
+++ b/internal/ingress/controller/util.go
@@ -18,7 +18,6 @@ package controller
 
 import (
 	"fmt"
-	"os"
 	"os/exec"
 	"syscall"
 
@@ -80,22 +79,8 @@ const (
 	cfgPath   = "/etc/nginx/nginx.conf"
 )
 
-var valgrind = []string{
-	"--tool=memcheck",
-	"--leak-check=full",
-	"--show-leak-kinds=all",
-	"--leak-check=yes",
-}
-
 func nginxExecCommand(args ...string) *exec.Cmd {
 	cmdArgs := []string{}
-
-	if os.Getenv("RUN_WITH_VALGRIND") == "true" {
-		cmdArgs = append(cmdArgs, valgrind...)
-		cmdArgs = append(cmdArgs, defBinary, "-c", cfgPath)
-		cmdArgs = append(cmdArgs, args...)
-		return exec.Command("valgrind", cmdArgs...)
-	}
 
 	cmdArgs = append(cmdArgs, "-c", cfgPath)
 	cmdArgs = append(cmdArgs, args...)


### PR DESCRIPTION
**What this PR does / why we need it**: This PR removes valgrind from the nginx base image, and also the hidden env variable that enables it. Based on my testing, this decreases the final image size by about 40M from 245 to 205.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #3997

**Special notes for your reviewer**: To actually remove valgrind from the final image, a new nginx base image must be released and then referenced in the Makefile.
