### PR TITLE
do not create empty access_by_lua_block

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -990,8 +990,12 @@ stream {
                 plugins.run()
             }
 
+            {{ if shouldConfigureLuaRestyWAF $all.Cfg.DisableLuaRestyWAF $location.LuaRestyWAF.Mode }}
+            # be careful with `access_by_lua_block` and `satisfy any` directives as satisfy any
+            # will always succeed when there's `access_by_lua_block` that does not have any lua code doing `ngx.exit(ngx.DECLINED)`
+            # that means currently `satisfy any` and lua-resty-waf together will potentiall render any
+            # other authentication method such as basic auth or external auth useless - all requests will be allowed.
             access_by_lua_block {
-                {{ if shouldConfigureLuaRestyWAF $all.Cfg.DisableLuaRestyWAF $location.LuaRestyWAF.Mode }}
                 local lua_resty_waf = require("resty.waf")
                 local waf = lua_resty_waf:new()
 
@@ -1032,10 +1036,8 @@ stream {
                 {{ end }}
 
                 waf:exec()
-                {{ end }}
-
-                plugins.run()
             }
+            {{ end }}
 
             header_filter_by_lua_block {
                 {{ if shouldConfigureLuaRestyWAF $all.Cfg.DisableLuaRestyWAF $location.LuaRestyWAF.Mode }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Temporary fix for being able to use multiple access mechanism at the same time (via `satisfy any`).

I don't know yet whether it is possible to properly use `satisfy any` and `access_by_lua`. Maybe making sure `access_by_lua` block ends with `ngx.exit(ngx.DECLINED)` when `satisfy any` is set is the way to go, but it might have some other issues. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes https://github.com/kubernetes/ingress-nginx/issues/4002

**Special notes for your reviewer**:
