### PR TITLE
Update plugin krew manifest

### DIFF
--- a/build/build-plugin.sh
+++ b/build/build-plugin.sh
@@ -46,6 +46,7 @@ release=cmd/plugin/release
 function build_for_arch(){
   os=$1
   arch=$2
+  extension=$3
 
   env GOOS=${os} GOARCH=${arch} go build \
     ${GOBUILD_FLAGS} \
@@ -53,10 +54,10 @@ function build_for_arch(){
         -X ${PKG}/version.RELEASE=${TAG} \
         -X ${PKG}/version.COMMIT=${GIT_COMMIT} \
         -X ${PKG}/version.REPO=${REPO_INFO}" \
-    -o ${release}/kubectl-ingress_nginx ${PKG}/cmd/plugin
+    -o ${release}/kubectl-ingress_nginx${extension} ${PKG}/cmd/plugin
 
-    tar -C ${release} -zcvf ${release}/kubectl-ingress_nginx-${os}-${arch}.tar.gz kubectl-ingress_nginx
-    rm ${release}/kubectl-ingress_nginx
+    tar -C ${release} -zcvf ${release}/kubectl-ingress_nginx-${os}-${arch}.tar.gz kubectl-ingress_nginx${extension}
+    rm ${release}/kubectl-ingress_nginx${extension}
     hash=`sha256sum ${release}/kubectl-ingress_nginx-${os}-${arch}.tar.gz | awk '{ print $1 }'`
     sed -i "s/%%%shasum_${os}_${arch}%%%/${hash}/g" ${release}/ingress-nginx.yaml
 }
@@ -68,6 +69,6 @@ cp cmd/plugin/ingress-nginx.yaml.tmpl ${release}/ingress-nginx.yaml
 
 sed -i "s/%%%tag%%%/${TAG}/g" ${release}/ingress-nginx.yaml
 
-build_for_arch darwin amd64
-build_for_arch linux amd64
-build_for_arch windows amd64
+build_for_arch darwin amd64 ''
+build_for_arch linux amd64 ''
+build_for_arch windows amd64 '.exe'

--- a/cmd/plugin/ingress-nginx.yaml.tmpl
+++ b/cmd/plugin/ingress-nginx.yaml.tmpl
@@ -7,6 +7,7 @@ spec:
   description: |
     The official kubectl plugin for ingress-nginx.
   version: %%%tag%%%
+  homepage: https://kubernetes.github.io/ingress-nginx/kubectl-plugin/
   platforms:
   - uri: https://github.com/kubernetes/ingress-nginx/releases/download/nginx-%%%tag%%%/kubectl-ingress_nginx-darwin-amd64.tar.gz
     sha256: %%%shasum_darwin_amd64%%%
@@ -33,7 +34,7 @@ spec:
     files:
     - from: "*"
       to: "."
-    bin: "./kubectl-ingress_nginx"
+    bin: "./kubectl-ingress_nginx.exe"
     selector:
       matchLabels:
         os: windows


### PR DESCRIPTION
In first adding the kubectl plugin to the krew index, some changes were suggested: https://github.com/kubernetes-sigs/krew-index/pull/133

This PR:
- Adds the plugin docs URL to the manifest
- Ensures the windows binary ends with `.exe`