### PR TITLE
Escape add headers quotes

### DIFF
--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -121,6 +121,7 @@ var (
 			}
 			return true
 		},
+		"escapeDoubleQuote":          escapeDoubleQuote,
 		"escapeLiteralDollar":        escapeLiteralDollar,
 		"shouldConfigureLuaRestyWAF": shouldConfigureLuaRestyWAF,
 		"buildLuaSharedDictionaries": buildLuaSharedDictionaries,
@@ -166,6 +167,10 @@ var (
 		"buildCustomErrorLocationsPerServer": buildCustomErrorLocationsPerServer,
 	}
 )
+
+func escapeDoubleQuote(input string) string {
+	return strings.Replace(input, `"`, `\"`, -1)
+}
 
 // escapeLiteralDollar will replace the $ character with ${literal_dollar}
 // which is made to work via the following configuration in the http section of

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -239,7 +239,7 @@ http {
 
     # Custom headers for response
     {{ range $k, $v := $addHeaders }}
-    add_header {{ $k }}            "{{ $v }}";
+    add_header {{ $k }}            "{{ escapeDoubleQuote $v }}";
     {{ end }}
 
     server_tokens {{ if $cfg.ShowServerTokens }}on{{ else }}off{{ end }};
@@ -1220,7 +1220,7 @@ stream {
 
             # Custom headers to proxied server
             {{ range $k, $v := $all.ProxySetHeaders }}
-            {{ $proxySetHeader }} {{ $k }}                    "{{ $v }}";
+            {{ $proxySetHeader }} {{ $k }}                    "{{ escapeDoubleQuote $v }}";
             {{ end }}
 
             proxy_connect_timeout                   {{ $location.Proxy.ConnectTimeout }}s;

--- a/test/e2e/settings/add_headers.go
+++ b/test/e2e/settings/add_headers.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package settings
+
+import (
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+
+	"k8s.io/ingress-nginx/test/e2e/framework"
+)
+
+var _ = framework.IngressNginxDescribe("add-headers and proxy-set-headers", func() {
+	f := framework.NewDefaultFramework("add-headers")
+
+	BeforeEach(func() {
+		f.NewEchoDeployment()
+	})
+
+	AfterEach(func() {
+	})
+
+	It("should escape double quotes in the header values", func() {
+		host := "escape"
+		addHeadersConfigMap := "add-headers-1"
+		proxySetHeadersConfigMap := "p-h-1"
+
+		ing := framework.NewSingleIngress(host, "/", host, f.Namespace, "http-svc", 80, nil)
+		f.EnsureIngress(ing)
+
+		f.CreateConfigMap(addHeadersConfigMap, map[string]string{
+			"NEL": `{"report_to":"network-errors","failure_fraction":0.01,"success_fraction":0.0001}`,
+		})
+
+		f.CreateConfigMap(proxySetHeadersConfigMap, map[string]string{
+			"Quux": `{"ack":["quack"]}`,
+		})
+
+		f.UpdateNginxConfigMapData("add-headers", f.Namespace+"/"+addHeadersConfigMap)
+		f.UpdateNginxConfigMapData("proxy-set-headers", f.Namespace+"/"+proxySetHeadersConfigMap)
+
+		f.WaitForNginxConfiguration(
+			func(cfg string) bool {
+				return strings.Contains(cfg, `add_header NEL "{\"report_to\":\"network-errors\",\"failure_fraction\":0.01,\"success_fraction\":0.0001}";`) &&
+					strings.Contains(cfg, `proxy_set_header Quux "{\"ack\":[\"quack\"]}"`)
+			})
+	})
+})


### PR DESCRIPTION
**What this PR does / why we need it**: Setting `add-headers` or `proxy-set-headers` header values would fail if those values contained double-quotes. This PR properly escapes those double quotes in the template, allowing you to use unescaped double quotes in your configmap value.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #4029

**Special notes for your reviewer**:

This PR makes some of the same changes to the e2e testing code as https://github.com/kubernetes/ingress-nginx/pull/4030. Whichever of the two are merged last will have to be rebased.

This PR is a breaking change. Anyone who was previously manually escaping double quotes in their configmap values will have to unescape them.

For example:
```yaml
Report-To: '{\"hello\":\"world\"}'
```

needs to be changed to

```yaml
Report-To: '{"hello":"world"}'
```

Whether or not anybody was actually doing this, I don't know.