### PR TITLE
Docs have incorrect command in baremetal.md

### DIFF
--- a/docs/deploy/baremetal.md
+++ b/docs/deploy/baremetal.md
@@ -42,7 +42,7 @@ by a DHCP server.
     environments this value is <None\>)
 
     ```console
-    $ kubectl describe node
+    $ kubectl get node
     NAME     STATUS   ROLES    EXTERNAL-IP
     host-1   Ready    master   203.0.113.1
     host-2   Ready    node     203.0.113.2
@@ -126,7 +126,7 @@ requests.
     bare-metal environments this value is <None\>)
 
     ```console
-    $ kubectl describe node
+    $ kubectl get node
     NAME     STATUS   ROLES    EXTERNAL-IP
     host-1   Ready    master   203.0.113.1
     host-2   Ready    node     203.0.113.2
@@ -165,7 +165,7 @@ field of the `ingress-nginx` Service spec to `Local` ([example][preserve-ip]).
     this value is <None\>)
 
     ```console
-    $ kubectl describe node
+    $ kubectl get node
     NAME     STATUS   ROLES    EXTERNAL-IP
     host-1   Ready    master   203.0.113.1
     host-2   Ready    node     203.0.113.2
@@ -210,7 +210,7 @@ Service.
     environments this value is <None\>)
 
     ```console
-    $ kubectl describe node
+    $ kubectl get node
     NAME     STATUS   ROLES    EXTERNAL-IP
     host-1   Ready    master   203.0.113.1
     host-2   Ready    node     203.0.113.2
@@ -402,7 +402,7 @@ Service. These IP addresses **must belong to the target node**.
     environments this value is <None\>)
 
     ```console
-    $ kubectl describe node
+    $ kubectl get node
     NAME     STATUS   ROLES    EXTERNAL-IP
     host-1   Ready    master   203.0.113.1
     host-2   Ready    node     203.0.113.2


### PR DESCRIPTION




<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
The output shown is for `kubectl get node` and not `kubectl describe node`. this is incorrect and can confuse people

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
I've updated the docs to use the correct command.

**Special notes for your reviewer**:
