### PR TITLE
[doc] fixing regex in example of rewrite

### DIFF
--- a/docs/examples/rewrite/README.md
+++ b/docs/examples/rewrite/README.md
@@ -38,7 +38,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   annotations:
-    nginx.ingress.kubernetes.io/rewrite-target: /$1
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
   name: rewrite
   namespace: default
 spec:
@@ -49,7 +49,7 @@ spec:
       - backend:
           serviceName: http-svc
           servicePort: 80
-        path: /something/?(.*)
+        path: /something(/|$)(.*)
 ' | kubectl create -f -
 ```
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the documentation example. The regex allowed an URL like /somethingfoo to be matched

**Special notes for your reviewer**:
We use 2nd capture group as the 1st one is the slash that is 'hardcoded'