### PR TITLE
Fix default Content-Type for custom-error-pages example

### DIFF
--- a/images/custom-error-pages/main.go
+++ b/images/custom-error-pages/main.go
@@ -106,6 +106,7 @@ func errorHandler(path string) func(http.ResponseWriter, *http.Request) {
 		cext, err := mime.ExtensionsByType(format)
 		if err != nil {
 			log.Printf("unexpected error reading media type extension: %v. Using %v", err, ext)
+			format = "text/html"
 		} else if len(cext) == 0 {
 			log.Printf("couldn't get media type extension. Using %v", ext)
 		} else {


### PR DESCRIPTION
This should fix issue [4039](https://github.com/kubernetes/ingress-nginx/issues/4039). This default backend fails to send the correct `Content-Type` header when it fails to decode the `Accept` request header.

This patch simply forces `text/html` in that specific scenario.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
