### PR TITLE
[WIP] Enable e2e-like unit tests

### DIFF
--- a/build/cover.sh
+++ b/build/cover.sh
@@ -23,6 +23,8 @@ if [ -z "${PKG}" ]; then
     exit 1
 fi
 
+mkdir -p /var/log/nginx
+
 rm -rf coverage.txt
 for d in `go list ${PKG}/... | grep -v vendor | grep -v '/test/e2e' | grep -v images`; do
     t=$(date +%s);

--- a/build/test.sh
+++ b/build/test.sh
@@ -23,5 +23,7 @@ if [ -z "${PKG}" ]; then
     exit 1
 fi
 
+mkdir -p /var/log/nginx
+
 go test -v -race -tags "cgo" \
     $(go list ${PKG}/... | grep -v vendor | grep -v '/test/e2e' | grep -v images | grep -v "docs/examples")

--- a/cmd/nginx/flags.go
+++ b/cmd/nginx/flags.go
@@ -35,10 +35,6 @@ import (
 )
 
 func parseFlags() (bool, *controller.Configuration, error) {
-	return readFlags(os.Args)
-}
-
-func readFlags(args []string) (bool, *controller.Configuration, error) {
 	var (
 		flags = pflag.NewFlagSet("", pflag.ExitOnError)
 
@@ -170,14 +166,12 @@ Feature backed by OpenResty Lua libraries. Requires that OCSP stapling is not en
 
 	flag.Set("logtostderr", "true")
 
-	commandLine := flag.NewFlagSet(args[0], flag.ExitOnError)
-
-	flags.AddGoFlagSet(commandLine)
-	flags.Parse(args)
+	flags.AddGoFlagSet(flag.CommandLine)
+	flags.Parse(os.Args)
 
 	// Workaround for this issue:
 	// https://github.com/kubernetes/kubernetes/issues/17162
-	commandLine.Parse([]string{})
+	flag.CommandLine.Parse([]string{})
 
 	pflag.VisitAll(func(flag *pflag.Flag) {
 		klog.V(2).Infof("FLAG: --%s=%q", flag.Name, flag.Value)

--- a/cmd/nginx/flags.go
+++ b/cmd/nginx/flags.go
@@ -35,6 +35,10 @@ import (
 )
 
 func parseFlags() (bool, *controller.Configuration, error) {
+	return readFlags(os.Args)
+}
+
+func readFlags(args []string) (bool, *controller.Configuration, error) {
 	var (
 		flags = pflag.NewFlagSet("", pflag.ExitOnError)
 
@@ -166,12 +170,14 @@ Feature backed by OpenResty Lua libraries. Requires that OCSP stapling is not en
 
 	flag.Set("logtostderr", "true")
 
-	flags.AddGoFlagSet(flag.CommandLine)
-	flags.Parse(os.Args)
+	commandLine := flag.NewFlagSet(args[0], flag.ExitOnError)
+
+	flags.AddGoFlagSet(commandLine)
+	flags.Parse(args)
 
 	// Workaround for this issue:
 	// https://github.com/kubernetes/kubernetes/issues/17162
-	flag.CommandLine.Parse([]string{})
+	commandLine.Parse([]string{})
 
 	pflag.VisitAll(func(flag *pflag.Flag) {
 		klog.V(2).Infof("FLAG: --%s=%q", flag.Name, flag.Value)

--- a/cmd/nginx/main_test.go
+++ b/cmd/nginx/main_test.go
@@ -63,8 +63,12 @@ func (ct *configTest) GetController() *controller.NGINXController {
 	defer os.Setenv("POD_NAME", "")
 	defer os.Setenv("POD_NAMESPACE", "")
 
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+
+	os.Args = ct.args
 	ct.t.Logf("%v", ct.args)
-	_, conf, err := readFlags(ct.args)
+	_, conf, err := parseFlags()
 	if err != nil {
 		ct.t.Errorf("Unexpected error creating NGINX controller: %v", err)
 	}
@@ -112,7 +116,7 @@ func TestUseGeoIP2(t *testing.T) {
 	conf := ct.GetController().GenerateConfiguration()
 
 	if !strings.Contains(conf, "/etc/nginx/modules/ngx_http_geoip2_module.so") {
-		t.Fatalf("fuck")
+		t.Fatalf("The nginx.conf does not refer to ngx_http_geoip2_module.so")
 	}
 }
 
@@ -160,7 +164,7 @@ func TestProxyBufferSize(t *testing.T) {
 
 	conf := ct.GetController().GenerateConfiguration()
 	if !strings.Contains(conf, "99k") {
-		t.Fatalf(conf)
+		t.Fatalf("The nginx.conf does not contain the proxy-buffer-size value")
 	}
 }
 

--- a/cmd/nginx/main_test.go
+++ b/cmd/nginx/main_test.go
@@ -17,72 +17,167 @@ limitations under the License.
 package main
 
 import (
-	"fmt"
 	"os"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/fake"
 
 	"k8s.io/ingress-nginx/internal/file"
 	"k8s.io/ingress-nginx/internal/ingress/controller"
+	"k8s.io/ingress-nginx/internal/ingress/metric"
 )
 
-func TestCreateApiserverClient(t *testing.T) {
-	_, err := createApiserverClient("", "")
-	if err == nil {
-		t.Fatal("Expected an error creating REST client without an API server URL or kubeconfig file.")
+const PodName = "testpod"
+const PodNamespace = "ns"
+
+type configTest struct {
+	t         *testing.T
+	clientSet *fake.Clientset
+	args      []string
+}
+
+func (ct *configTest) GetController() *controller.NGINXController {
+	pod := v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      PodName,
+			Namespace: PodNamespace,
+		},
+	}
+
+	_, err := ct.clientSet.CoreV1().Pods(PodNamespace).Create(&pod)
+	if err != nil {
+		ct.t.Fatalf("error creating pod %v: %v", pod, err)
+	}
+
+	resetForTesting(func() { ct.t.Fatal("bad parse") })
+
+	os.Setenv("POD_NAME", PodName)
+	os.Setenv("POD_NAMESPACE", PodNamespace)
+	defer os.Setenv("POD_NAME", "")
+	defer os.Setenv("POD_NAMESPACE", "")
+
+	ct.t.Logf("%v", ct.args)
+	_, conf, err := readFlags(ct.args)
+	if err != nil {
+		ct.t.Errorf("Unexpected error creating NGINX controller: %v", err)
+	}
+	conf.Client = ct.clientSet
+
+	fs, err := file.NewFakeFS()
+	if err != nil {
+		ct.t.Fatalf("Unexpected error: %v", err)
+	}
+
+	return controller.NewNGINXController(conf, metric.NewDummyCollector(), fs)
+}
+
+func (ct *configTest) AddConfigMap(newConfigMap v1.ConfigMap) {
+	cm, err := ct.clientSet.CoreV1().ConfigMaps(PodNamespace).Create(&newConfigMap)
+	if err != nil {
+		ct.t.Errorf("error creating the configuration map: %v", err)
+	}
+	ct.t.Logf("Temporal configmap %v created", cm)
+}
+
+func (ct *configTest) AddIngress(newIngress v1beta1.Ingress) {
+	ing, err := ct.clientSet.ExtensionsV1beta1().Ingresses(PodNamespace).Create(&newIngress)
+	if err != nil {
+		ct.t.Errorf("error creating the ingress map: %v", err)
+	}
+	ct.t.Logf("Temporal ingress %v created", ing)
+}
+
+func TestUseGeoIP2(t *testing.T) {
+	ct := configTest{
+		t:         t,
+		clientSet: fake.NewSimpleClientset(),
+	}
+	ct.AddConfigMap(v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "fooconfig",
+		},
+		Data: map[string]string{
+			"use-geoip2": "true",
+		},
+	})
+	ct.args = []string{"cmd", "--configmap", PodNamespace + "/fooconfig"}
+
+	conf := ct.GetController().GenerateConfiguration()
+
+	if !strings.Contains(conf, "/etc/nginx/modules/ngx_http_geoip2_module.so") {
+		t.Fatalf("fuck")
+	}
+}
+
+func TestProxyBufferSize(t *testing.T) {
+	ct := configTest{
+		t:         t,
+		clientSet: fake.NewSimpleClientset(),
+	}
+	ct.AddConfigMap(v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "barconfig",
+		},
+		Data: map[string]string{},
+	})
+	ct.args = []string{"cmd", "--configmap", PodNamespace + "/barconfig"}
+
+	ct.AddIngress(v1beta1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "testingress",
+			Annotations: map[string]string{
+				"nginx.ingress.kubernetes.io/proxy-buffer-size": "99k",
+			},
+		},
+		Spec: v1beta1.IngressSpec{
+			Rules: []v1beta1.IngressRule{
+				{
+					Host: "testaddr.local",
+					IngressRuleValue: v1beta1.IngressRuleValue{
+						HTTP: &v1beta1.HTTPIngressRuleValue{
+							Paths: []v1beta1.HTTPIngressPath{
+								{
+									Path: "/thepath",
+									Backend: v1beta1.IngressBackend{
+										ServiceName: "foo-service",
+										ServicePort: intstr.FromInt(8080),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	conf := ct.GetController().GenerateConfiguration()
+	if !strings.Contains(conf, "99k") {
+		t.Fatalf(conf)
 	}
 }
 
 func TestHandleSigterm(t *testing.T) {
-	clientSet := fake.NewSimpleClientset()
-
-	ns := "test"
-
-	cm := createConfigMap(clientSet, ns, t)
-	defer deleteConfigMap(cm, ns, clientSet, t)
-
-	name := "test"
-	pod := v1.Pod{
+	ct := configTest{
+		t:         t,
+		clientSet: fake.NewSimpleClientset(),
+	}
+	ct.AddConfigMap(v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: ns,
+			Name: "barconfig",
 		},
-	}
+		Data: map[string]string{},
+	})
+	ct.args = []string{"cmd", "--configmap", PodNamespace + "/barconfig"}
 
-	_, err := clientSet.CoreV1().Pods(ns).Create(&pod)
-	if err != nil {
-		t.Fatalf("error creating pod %v: %v", pod, err)
-	}
-
-	resetForTesting(func() { t.Fatal("bad parse") })
-
-	os.Setenv("POD_NAME", name)
-	os.Setenv("POD_NAMESPACE", ns)
-	defer os.Setenv("POD_NAME", "")
-	defer os.Setenv("POD_NAMESPACE", "")
-
-	oldArgs := os.Args
-	defer func() { os.Args = oldArgs }()
-	os.Args = []string{"cmd", "--default-backend-service", "ingress-nginx/default-backend-http", "--http-port", "0", "--https-port", "0"}
-
-	_, conf, err := parseFlags()
-	if err != nil {
-		t.Errorf("Unexpected error creating NGINX controller: %v", err)
-	}
-	conf.Client = clientSet
-
-	fs, err := file.NewFakeFS()
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-
-	ngx := controller.NewNGINXController(conf, nil, fs)
+	ngx := ct.GetController()
 
 	go handleSigterm(ngx, func(code int) {
 		if code != 1 {
@@ -95,44 +190,8 @@ func TestHandleSigterm(t *testing.T) {
 	time.Sleep(1 * time.Second)
 
 	t.Logf("Sending SIGTERM to PID %d", syscall.Getpid())
-	err = syscall.Kill(syscall.Getpid(), syscall.SIGTERM)
+	err := syscall.Kill(syscall.Getpid(), syscall.SIGTERM)
 	if err != nil {
 		t.Error("Unexpected error sending SIGTERM signal.")
 	}
-
-	err = clientSet.CoreV1().Pods(ns).Delete(name, &metav1.DeleteOptions{})
-	if err != nil {
-		t.Fatalf("error deleting pod %v: %v", pod, err)
-	}
-}
-
-func createConfigMap(clientSet kubernetes.Interface, ns string, t *testing.T) string {
-	t.Helper()
-	t.Log("Creating temporal config map")
-
-	configMap := &v1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:     "config",
-			SelfLink: fmt.Sprintf("/api/v1/namespaces/%s/configmaps/config", ns),
-		},
-	}
-
-	cm, err := clientSet.CoreV1().ConfigMaps(ns).Create(configMap)
-	if err != nil {
-		t.Errorf("error creating the configuration map: %v", err)
-	}
-	t.Logf("Temporal configmap %v created", cm)
-
-	return cm.Name
-}
-
-func deleteConfigMap(cm, ns string, clientSet kubernetes.Interface, t *testing.T) {
-	t.Helper()
-	t.Logf("Deleting temporal configmap %v", cm)
-
-	err := clientSet.CoreV1().ConfigMaps(ns).Delete(cm, &metav1.DeleteOptions{})
-	if err != nil {
-		t.Errorf("error deleting the configmap: %v", err)
-	}
-	t.Logf("Temporal configmap %v deleted", cm)
 }

--- a/internal/file/file.go
+++ b/internal/file/file.go
@@ -20,6 +20,7 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"io/ioutil"
+
 	"k8s.io/klog"
 )
 

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -99,7 +99,7 @@ type Configuration struct {
 }
 
 // GetPublishService returns the Service used to set the load-balancer status of Ingresses.
-func (n NGINXController) GetPublishService() *apiv1.Service {
+func (n *NGINXController) GetPublishService() *apiv1.Service {
 	s, err := n.store.GetService(n.cfg.PublishService)
 	if err != nil {
 		return nil
@@ -182,6 +182,10 @@ func (n *NGINXController) syncIngress(interface{}) error {
 			n.metricCollector.ConfigSuccess(hash, false)
 			klog.Errorf("Unexpected failure reloading the backend:\n%v", err)
 			return err
+		}
+
+		if n.isTest {
+			return nil
 		}
 
 		n.metricCollector.SetHosts(hosts)

--- a/internal/ingress/controller/nginx.go
+++ b/internal/ingress/controller/nginx.go
@@ -682,13 +682,17 @@ func (n *NGINXController) OnUpdate(ingressCfg ingress.Configuration) error {
 	}
 
 	err = n.testTemplate(content)
-	if err != nil {
-		return err
-	}
-
 	if n.isTest {
+		if err != nil {
+			panic(err)
+		}
+
 		n.generatedConfCh <- string(content)
 		return nil
+	}
+
+	if err != nil {
+		return err
 	}
 
 	if klog.V(2) {

--- a/internal/ingress/controller/util.go
+++ b/internal/ingress/controller/util.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"fmt"
 	"os/exec"
+	"sync/atomic"
 	"syscall"
 
 	"k8s.io/klog"
@@ -29,6 +30,25 @@ import (
 
 	"k8s.io/ingress-nginx/internal/ingress"
 )
+
+// AtomicBool is a simple implementation of an atomic boolean
+type AtomicBool struct {
+	inner int32
+}
+
+// Store sets the value of the AtomicBool
+func (b *AtomicBool) Store(value bool) {
+	var new int32
+	if value {
+		new = 1
+	}
+	atomic.StoreInt32(&b.inner, new)
+}
+
+// Load retreives the value of the atomic bool
+func (b *AtomicBool) Load() bool {
+	return atomic.LoadInt32(&b.inner) == 1
+}
 
 // newUpstream creates an upstream without servers.
 func newUpstream(name string) *ingress.Backend {


### PR DESCRIPTION
**What this PR does / why we need it**: Running e2e tests is slow. It now takes more than 30 minutes to run the full suite, and that will only increase as new tests are added. 

However, many of our e2e tests don't really need to spin up a full pod, as they mostly just check that a given configmap or annotation value produces a certain change in the generated `nginx.conf`. 

This PR adds infrastructure to test these kinds of things as unit tests, running the controller without running nginx and inspecting the generated configuration. The controller also runs `nginx -t` on the configuration, and the test will fail if `nginx -t` is not successful. 2 example tests are added, with many more that can be moved from e2e tests once this is merged.

Additionally, this PR fixes 2 race conditions that were revealed by the added tests:

- `NGINXController.isShuttingDown` is set/read from different goroutines, but was not thread-safe
- Several methods on `NGINXController` did not have pointer receivers, causing those method calls to copy the controller. Since the controller contains variables that are set/read across goroutines, and the copy is non atomic, a race condition occurred. At least this is my theory, all I know is that the error went away when I changed the methods ;-).

fixes #4015 

Todos:

- [ ] Right now, the controller gives a few warnings about missing files or missing selflinks on kubernetes objects. Fixing these would be good.
- [ ] Parallelize the tests. This would require some finagling with `os.Args` and env variables. I'll probably leave this to another pr. Given that each of these new unit tests seem like they take ~1-2 seconds to run, this probably isn't even necessary.
- [ ] Add some helper functions to generate ingress/configmap definitions without writing out the entire literal. I'll probably just end up using something like what we have in `framework.go`
- [ ] Create a new e2e-test image that includes `/var/log/nginx` so that nginx -t runs correctly. Right now I work around this by running `mkdir` in the test scripts.