### PR TITLE
Allow "ssl_verify_client optional_no_ca" without a CA file

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -867,9 +867,11 @@ stream {
         return 403;
         {{ else }}
 
+        {{ if not (empty $server.CertificateAuth.VerifyClient) }}
         {{ if not (empty $server.CertificateAuth.CAFileName) }}
         # PEM sha: {{ $server.CertificateAuth.PemSHA }}
         ssl_client_certificate                  {{ $server.CertificateAuth.CAFileName }};
+        {{ end }}
         ssl_verify_client                       {{ $server.CertificateAuth.VerifyClient }};
         ssl_verify_depth                        {{ $server.CertificateAuth.ValidationDepth }};
         {{ if not (empty $server.CertificateAuth.ErrorPage)}}
@@ -954,7 +956,7 @@ stream {
             {{ end }}
 
             # Pass the extracted client certificate to the auth provider
-            {{ if not (empty $server.CertificateAuth.CAFileName) }}
+            {{ if not (empty $server.CertificateAuth.VerifyClient) }}
             {{ if $server.CertificateAuth.PassCertToUpstream }}
             proxy_set_header ssl-client-cert        $ssl_client_escaped_cert;
             {{ end }}
@@ -1179,7 +1181,7 @@ stream {
             {{ end }}
 
             # Pass the extracted client certificate to the backend
-            {{ if not (empty $server.CertificateAuth.CAFileName) }}
+            {{ if not (empty $server.CertificateAuth.VerifyClient) }}
             {{ if $server.CertificateAuth.PassCertToUpstream }}
             {{ $proxySetHeader }} ssl-client-cert        $ssl_client_escaped_cert;
             {{ end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Current `nginx.tmpl` does not contemplate the use of `ssl_verify_client optional_no_ca` without a CA file. It relies on the `auth-tls-secret` annotation to render all configs related to ssl client authentication. In some particular cases, client auth may be enabled and not need a CA file at all. This is supported by Nginx using the `optional_no_ca` value.

This PR changes the template to rely on the `auth-tls-verify-client` annotation itself as a flag to enable this feature -- instead of `auth-tls-secret`.

**Which issue this PR fixes**: fixes #2922
