### PR TITLE
fix e2e-test make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,10 +184,11 @@ lua-test:
 .PHONY: e2e-test
 e2e-test:
 	if  [ "$(KUBECTL_CONTEXT)" != "minikube" ] && \
-		[ "$(KUBECTL_CONTEXT)" =~ .*kind* ] && \
+		! echo $(KUBECTL_CONTEXT) | grep kind && \
+		! echo $(KUBECTL_CONTEXT) | grep ingress-nginx-dev && \
 		[ "$(KUBECTL_CONTEXT)" != "dind" ] && \
 		[ "$(KUBECTL_CONTEXT)" != "docker-for-desktop" ]; then \
-		echo "kubectl context is "$(KUBECTL_CONTEXT)", but must be one of [minikube, *kind*, dind, docker-for-deskop]"; \
+		echo "kubectl context is "$(KUBECTL_CONTEXT)", but must be one of [minikube, *kind*, *ingress-nginx-dev*, dind, docker-for-deskop]"; \
 		exit 1; \
 	fi
 
@@ -198,6 +199,11 @@ e2e-test:
 		--user=admin \
 		--user=kubelet \
 		--serviceaccount=default:ingress-nginx-e2e || true
+
+	until kubectl get secret | grep -q ^ingress-nginx-e2e-token; do \
+		echo "waiting for api token"; \
+		sleep 3; \
+	done
 
 	kubectl run --rm -i --tty \
 		--attach \


### PR DESCRIPTION
- explicitly wait for api token
- only use posix shell conditionals

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

The e2e-test make target is run with `sh`, not bash, which means that the operator `=~` is not available, so the guard clause doesn't actually work.

output from ci:
```shell
if  [ "kubernetes-admin@ingress-nginx-dev" != "minikube" ] && \
		[ "kubernetes-admin@ingress-nginx-dev" =~ .*kind* ] && \
		[ "kubernetes-admin@ingress-nginx-dev" != "dind" ] && \
		[ "kubernetes-admin@ingress-nginx-dev" != "docker-for-desktop" ]; then \
		echo "kubectl context is "kubernetes-admin@ingress-nginx-dev", but must be one of [minikube, *kind*, dind, docker-for-deskop]"; \
		exit 1; \
	fi
/bin/sh: 2: [: kubernetes-admin@ingress-nginx-dev: unexpected operator
```

Another ci problem that's incredibly annoying is that the target has a chance to fail on the `kubectl run` command because the service account doesn't have a valid api token yet.

output from ci:
```console
kubectl run --rm -i --tty \
		--attach \
		--restart=Never \
		--generator=run-pod/v1 \
		--env="E2E_NODES=10" \
		--env="FOCUS=.*" \
		--env="SLOW_E2E_THRESHOLD=50" \
		--overrides='{ "apiVersion": "v1", "spec":{"serviceAccountName": "ingress-nginx-e2e"}}' \
		e2e --image=nginx-ingress-controller:e2e
Error from server (ServerTimeout): No API token found for service account "ingress-nginx-e2e", retry after the token is automatically created and added to the service account
make: *** [e2e-test] Error 1
make: Leaving directory `/home/travis/build/kubernetes/ingress-nginx'
The command "test/e2e/run.sh" exited with 2.
``` 

**Special notes for your reviewer**: spun out from #4055