### PR TITLE
Don't try to create e2e runner rbac resources twice

### DIFF
--- a/test/e2e-image/e2e.sh
+++ b/test/e2e-image/e2e.sh
@@ -27,14 +27,6 @@ if [ ! -f ${HOME}/.kube/config ]; then
     kubectl config use-context default
 fi
 
-echo "Granting permissions to ingress-nginx e2e service account..."
-kubectl create serviceaccount ingress-nginx-e2e || true
-kubectl create clusterrolebinding permissive-binding \
---clusterrole=cluster-admin \
---user=admin \
---user=kubelet \
---serviceaccount=default:ingress-nginx-e2e || true
-
 kubectl apply -f manifests/rbac.yaml
 
 ginkgo_args=(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Every CI e2e run has this in its output:

```
Error from server (AlreadyExists): serviceaccounts "ingress-nginx-e2e" already exists
Error from server (AlreadyExists): clusterrolebindings.rbac.authorization.k8s.io "permissive-binding" already exists
Running e2e test suite...
```

This is because those resources are created in `make e2e-test`, and then `test/e2e-image/e2e.sh` tries to create them again.

This doesn't make sense: `e2e.sh` is run in a container which _uses_ that service account and binding.  It can't create them, because it needs them to already exist.  They have to be created in the make target, which then runs the container.

**Special notes for your reviewer**: