### PR TITLE
Explain references in custom-headers documentation

### DIFF
--- a/docs/examples/customization/custom-headers/README.md
+++ b/docs/examples/customization/custom-headers/README.md
@@ -1,19 +1,24 @@
 # Custom Headers
 
-This example aims to demonstrate the deployment of an nginx ingress controller and
-use a ConfigMap to configure a custom list of headers to be passed to the upstream
-server
+This example demonstrates configuration of the nginx ingress controller via
+a ConfigMap to pass a custom list of headers to the upstream
+server.
+
+[custom-headers.yaml](custom-headers.yaml) defines a ConfigMap in the `ingress-nginx` namespace named `custom-headers`, holding several custom X-prefixed HTTP headers.
 
 ```console
-curl https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/docs/examples/customization/custom-headers/configmap.yaml \
-    | kubectl apply -f -
-
-curl https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/docs/examples/customization/custom-headers/custom-headers.yaml \
-    | kubectl apply -f -
-
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/docs/examples/customization/custom-headers/custom-headers.yaml
 ```
+
+[configmap.yaml](configmap.yaml) defines a ConfigMap in the `ingress-nginx` namespace named `nginx-configuration`. This controls the [global configuration](../../../user-guide/nginx-configuration/configmap.md) of the ingress controller, and already exists in a standard installation. The key `proxy-set-headers` is set to cite the previously-created `ingress-nginx/custom-headers` ConfigMap.
+
+```console
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/docs/examples/customization/custom-headers/configmap.yaml
+```
+
+The nginx ingress controller will read the `ingress-nginx/nginx-configuration` ConfigMap, find the `proxy-set-headers` key, read HTTP headers from the `ingress-nginx/custom-headers` ConfigMap, and include those HTTP headers in all requests flowing from nginx to the backends.
 
 ## Test
 
-Check the contents of the configmap is present in the nginx.conf file using:
-`kubectl exec nginx-ingress-controller-873061567-4n3k2 -n kube-system cat /etc/nginx/nginx.conf`
+Check the contents of the ConfigMaps are present in the nginx.conf file using:
+`kubectl exec nginx-ingress-controller-873061567-4n3k2 -n ingress-nginx cat /etc/nginx/nginx.conf`


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Link the two example yaml files, so they're more easily navigated to from a browser looking at https://kubernetes.github.io/ingress-nginx/examples/customization/custom-headers/

Campfire: grammar, standard installation is in the `ingress-nginx` namespace, explain the purpose of the two configmaps, making explicit that one cites the other by `namespace/name`.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

No issue.

**Special notes for your reviewer**:

Many places in the docs (eg https://kubernetes.github.io/ingress-nginx/examples/customization/external-auth-headers/ and https://kubernetes.github.io/ingress-nginx/examples/customization/custom-headers/) describe commands interacting with (yaml) files in the repo. Very frequently these files are cited by relative paths (eg `kubectl create -f deploy/`) or absolute urls (eg https://raw.githubusercontent.com/kub….). The lack of links to the yaml files (or lack of a current working directory) make them annoying to read in the markdown-rendered-to-html view on https://kubernetes.github.io/

How do you feel about more PRs like this which add (probably relative) links to the yaml files in the markdown?