### PR TITLE
Define Modsecurity Snippet via ConfigMap

### DIFF
--- a/docs/user-guide/nginx-configuration/configmap.md
+++ b/docs/user-guide/nginx-configuration/configmap.md
@@ -35,6 +35,7 @@ The following table shows a configuration option's name, type, and the default v
 |[enable-access-log-for-default-backend](#enable-access-log-for-default-backend)|bool|"false"|
 |[error-log-path](#error-log-path)|string|"/var/log/nginx/error.log"|
 |[enable-modsecurity](#enable-modsecurity)|bool|"false"|
+|[modsecurity-snippet](#modsecurity-snippet)|string|""|
 |[enable-owasp-modsecurity-crs](#enable-owasp-modsecurity-crs)|bool|"false"|
 |[client-header-buffer-size](#client-header-buffer-size)|string|"1k"|
 |[client-header-timeout](#client-header-timeout)|int|60|
@@ -220,6 +221,10 @@ Enables the modsecurity module for NGINX. _**default:**_ is disabled
 ## enable-owasp-modsecurity-crs
 
 Enables the OWASP ModSecurity Core Rule Set (CRS). _**default:**_ is disabled
+
+## modsecurity-snippet
+
+Adds custom rules to modsecurity section of nginx configration
 
 ## client-header-buffer-size
 

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -133,6 +133,9 @@ type Configuration struct {
 	// By default this is disabled
 	EnableOWASPCoreRules bool `json:"enable-owasp-modsecurity-crs"`
 
+	// ModSecuritySnippet adds custom rules to modsecurity section of nginx configuration
+	ModsecuritySnippet string `json:"modsecurity-snippet"`
+
 	// ClientHeaderBufferSize allows to configure a custom buffer
 	// size for reading client request header
 	// http://nginx.org/en/docs/http/ngx_http_core_module.html#client_header_buffer_size

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -143,6 +143,10 @@ http {
 
     {{ if $all.Cfg.EnableOWASPCoreRules }}
     modsecurity_rules_file /etc/nginx/owasp-modsecurity-crs/nginx-modsecurity.conf;
+    {{ else if (not (empty $all.Cfg.ModsecuritySnippet)) }}
+    modsecurity_rules '
+      {{ $all.Cfg.ModsecuritySnippet }}
+    ';
     {{ end }}
 
     {{ end }}

--- a/test/e2e/settings/modsecurity_snippet.go
+++ b/test/e2e/settings/modsecurity_snippet.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package settings
+
+import (
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+
+	"k8s.io/ingress-nginx/test/e2e/framework"
+)
+
+var _ = framework.IngressNginxDescribe("Modsecurity Snippet", func() {
+	f := framework.NewDefaultFramework("modsecurity-snippet")
+
+	It("should add value of modsecurity-snippet setting to nginx config", func() {
+		modsecSnippet := "modsecurity-snippet"
+		expectedComment := "# modsecurity snippet"
+
+		f.UpdateNginxConfigMapData("enable-modsecurity", "true")
+		f.UpdateNginxConfigMapData(modsecSnippet, expectedComment)
+
+		f.WaitForNginxConfiguration(
+			func(cfg string) bool {
+				return strings.Contains(cfg, expectedComment)
+			})
+	})
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
It would be handy to have a key in ConfigMap to define custom ModSecurity Rules shared across Ingresses, but now it's possible only with the annotation `nginx.ingress.kubernetes.io/modsecurity-snippet`.
This PR adds `modsecurity-snippet` key, whose loading is subordinated to what is defined by the annotation