### PR TITLE
reduce memory footprint and cpu usage when modsecurity and owasp rule…

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -137,6 +137,17 @@ http {
     {{ end }}
     {{ end }}
 
+    {{ if $all.Cfg.EnableModsecurity }}
+    modsecurity on;
+
+    modsecurity_rules_file /etc/nginx/modsecurity/modsecurity.conf;
+
+    {{ if $all.Cfg.EnableOWASPCoreRules }}
+    modsecurity_rules_file /etc/nginx/owasp-modsecurity-crs/nginx-modsecurity.conf;
+    {{ end }}
+
+    {{ end }}
+
     {{ if $cfg.UseGeoIP }}
     {{/* databases used to determine the country depending on the client IP address */}}
     {{/* http://nginx.org/en/docs/http/ngx_http_geoip_module.html */}}
@@ -1102,15 +1113,17 @@ stream {
             set $proxy_host             $proxy_upstream_name;
 
             {{ if (or $location.ModSecurity.Enable $all.Cfg.EnableModsecurity) }}
+            {{ if not $all.Cfg.EnableModsecurity }}
             modsecurity on;
 
             modsecurity_rules_file /etc/nginx/modsecurity/modsecurity.conf;
+            {{ end }}
 
             {{ if $location.ModSecurity.Snippet }}
             modsecurity_rules '
                 {{ $location.ModSecurity.Snippet }}
             ';
-            {{ else if (or $location.ModSecurity.OWASPRules $all.Cfg.EnableOWASPCoreRules) }}
+            {{ else if (and ((not $all.Cfg.EnableOWASPCoreRules) $location.ModSecurity.OWASPRules))}}
             modsecurity_rules_file /etc/nginx/owasp-modsecurity-crs/nginx-modsecurity.conf;
             {{ end }}
 


### PR DESCRIPTION
…s are enabled globally

**What this PR does / why we need it**:
We have 72 ingress configurations on one cluster. The nginx ingress handles that fine, with a memory footprint of a few hundred MB. But when modsecurity and owasp rules are enabled that memory footprint increased to 3.5GB at startup and over 7GB on config reload. Additionally the CPU usage was way too high, we had long startup times and some of the times on a config reload the health checks failed.
After some research I found this [issue](https://github.com/SpiderLabs/ModSecurity-nginx/issues/92) at the ModSecurity-nginx repo. After reading it I thought maybe ModSecurity also keeps a set of rules for each location and this seems to be the case.
When enabling ModSecurity and OWASP rules globally the ingress-nginx applies the rules to each location. This pull request changes that and applies the rules to the http block.
Memory consumption went down from the numbers above back to a few hundred MB. Also the cpu usage went down noticeably.
It is still possible to apply the rules for each ingress resource separately.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*:

maybe fixes #4041
maybe fixes #3926

it is not clear if they have modsecurity enabled or not

**Special notes for your reviewer**:
