### PR TITLE
Update configmap about adding custom locations

### DIFF
--- a/docs/user-guide/nginx-configuration/configmap.md
+++ b/docs/user-guide/nginx-configuration/configmap.md
@@ -751,6 +751,8 @@ Adds custom configuration to all the servers in the nginx configuration.
 
 Adds custom configuration to all the locations in the nginx configuration.
 
+You can not use this to add new locations that proxy to the Kubernetes pods, as the snippet does not have access to the Go template functions. If you want to add custom locations you will have to [provide your own nginx.tmpl](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/custom-template/).
+
 ## custom-http-errors
 
 Enables which HTTP codes should be passed for processing with the [error_page directive](http://nginx.org/en/docs/http/ngx_http_core_module.html#error_page)


### PR DESCRIPTION
I tried using server-snippet and location-snippet to add a custom location, like this in 0.24.1:

```
  location-snippet: |
    allow 20.0.0.0/8;
    deny all;

    location /status {
        allow 100.0.0.0/8;
        deny all;

        set $proxy_upstream_name "{{ buildUpstreamName $server.Hostname $all.Backends $location $all.DynamicConfigurationEnabled }}";
        proxy_pass http://upstream_balancer;
    }
```

but that didn't work, I got 503, and I tried copying in the exact location, but then the nginx configuration doesn't load, and the last solution was to make my own nginx.tmpl and that worked.

It looks like others also have experienced the same and this feature has stopped working: https://github.com/kubernetes/ingress-nginx/issues/4084#issuecomment-493173939

It would be cool if you could avoid having to inherit the whole nginx.tmpl., but it is not bad, but it is just a bit of inconvenience to have to try the whole ordeal by providing your small customization with a location snippet and then debugging 😃 