### PR TITLE
Docs - Update capture group `placeholder`

### DIFF
--- a/docs/examples/rewrite/README.md
+++ b/docs/examples/rewrite/README.md
@@ -53,7 +53,7 @@ spec:
 ' | kubectl create -f -
 ```
 
-In this ingress definition, any characters captured by `(.*)` will be assigned to the placeholder `$1`, which is then used as a parameter in the `rewrite-target` annotation. 
+In this ingress definition, any characters captured by `(.*)` will be assigned to the placeholder `$2`, which is then used as a parameter in the `rewrite-target` annotation. 
 
 For example, the ingress definition above will result in the following rewrites:
 - `rewrite.bar.com/something` rewrites to `rewrite.bar.com/`


### PR DESCRIPTION
**What this PR does / why we need it**:

In the rewrite doc, the current ingress example uses the `$2` capture group placeholder, however the description refers to the `$1` placeholder (this was previously correct, but was not updated when the ingress example changed from $1 to $2).

