### PR TITLE
Remove stop controller endpoint

### DIFF
--- a/cmd/nginx/main.go
+++ b/cmd/nginx/main.go
@@ -254,13 +254,6 @@ func registerHandlers(mux *http.ServeMux) {
 		b, _ := json.Marshal(version.String())
 		w.Write(b)
 	})
-
-	mux.HandleFunc("/stop", func(w http.ResponseWriter, r *http.Request) {
-		err := syscall.Kill(syscall.Getpid(), syscall.SIGTERM)
-		if err != nil {
-			klog.Errorf("Unexpected error: %v", err)
-		}
-	})
 }
 
 func registerHealthz(ic *controller.NGINXController, mux *http.ServeMux) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes the /stop endpoint. This is something introduced in the first versions of the controller.
Related to https://github.com/kubernetes/ingress-nginx/issues/4052
