### PR TITLE
Refactor whitelist from map to standard allow directives

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -419,27 +419,6 @@ http {
         {{ end }}
     }
 
-    {{/* build the maps that will be use to validate the Whitelist */}}
-    {{ range $server := $servers }}
-    {{ $enforceRegex := enforceRegexModifier $server.Locations }}
-    {{ range $location := $server.Locations }}
-    {{ $path := buildLocation $location $enforceRegex }}
-
-    {{ if isLocationAllowed $location }}
-    {{ if gt (len $location.Whitelist.CIDR) 0 }}
-
-    # Deny for {{ print $server.Hostname  $path }}
-    geo $the_real_ip {{ buildDenyVariable (print $server.Hostname "_"  $path) }} {
-        default 1;
-
-        {{ range $ip := $location.Whitelist.CIDR }}
-        {{ $ip }} 0;{{ end }}
-    }
-    {{ end }}
-    {{ end }}
-    {{ end }}
-    {{ end }}
-
     {{ range $rl := (filterRateLimits $servers ) }}
     # Ratelimit {{ $rl.Name }}
     geo $the_real_ip $whitelist_{{ $rl.ID }} {
@@ -1134,9 +1113,9 @@ stream {
 
             {{ if isLocationAllowed $location }}
             {{ if gt (len $location.Whitelist.CIDR) 0 }}
-            if ({{ buildDenyVariable (print $server.Hostname "_"  $path) }}) {
-                return 403;
-            }
+            {{ range $ip := $location.Whitelist.CIDR }}
+            allow {{ $ip }};{{ end }}
+            deny all;
             {{ end }}
 
             {{ if not (isLocationInLocationList $location $all.Cfg.NoAuthLocations) }}

--- a/test/e2e/settings/configmap_change.go
+++ b/test/e2e/settings/configmap_change.go
@@ -60,8 +60,7 @@ var _ = framework.IngressNginxDescribe("Configmap change", func() {
 					checksum = match[1]
 				}
 
-				return strings.Contains(cfg, "geo $the_real_ip $deny_") &&
-					strings.Contains(cfg, "1.1.1.1 0")
+				return strings.Contains(cfg, "allow 1.1.1.1;")
 			})
 		Expect(checksum).NotTo(BeEmpty())
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Changes whitelist from a map to standard allow/deny directives.

After this PR I will add a new validation to the webhook to detect when the user defined a snippet containing the [satisfy](http://nginx.org/en/docs/http/ngx_http_core_module.html#satisfy) directive to avoid duplications