### PR TITLE
UPT: Add variable to define custom sampler host and port

### DIFF
--- a/docs/user-guide/nginx-configuration/configmap.md
+++ b/docs/user-guide/nginx-configuration/configmap.md
@@ -124,6 +124,8 @@ The following table shows a configuration option's name, type, and the default v
 |[jaeger-service-name](#jaeger-service-name)|string|"nginx"|
 |[jaeger-sampler-type](#jaeger-sampler-type)|string|"const"|
 |[jaeger-sampler-param](#jaeger-sampler-param)|string|"1"|
+|[jaeger-sampler-host](#jaeger-sampler-host)|string|"http://127.0.0.1"|
+|[jaeger-sampler-port](#jaeger-sampler-port)|int|5778|
 |[main-snippet](#main-snippet)|string|""|
 |[http-snippet](#http-snippet)|string|""|
 |[server-snippet](#server-snippet)|string|""|
@@ -734,6 +736,15 @@ Specifies the sampler to be used when sampling traces. The available samplers ar
 
 Specifies the argument to be passed to the sampler constructor. Must be a number.
 For const this should be 0 to never sample and 1 to always sample. _**default:**_ 1
+
+## jaeger-sampler-host
+
+Specifies the custom remote sampler host to be passed to the sampler constructor. Must be a valid URL.
+Leave blank to use default value (localhost). _**default:**_ http://127.0.0.1
+
+## jaeger-sampler-port
+
+Specifies the custom remote sampler port to be passed to the sampler constructor. Must be a number. _**default:**_ 5778
 
 ## main-snippet
 

--- a/docs/user-guide/third-party-addons/opentracing.md
+++ b/docs/user-guide/third-party-addons/opentracing.md
@@ -52,6 +52,13 @@ jaeger-sampler-type
 # specifies the argument to be passed to the sampler constructor, Default: 1
 jaeger-sampler-param
 
+# Specifies the custom remote sampler host to be passed to the sampler constructor. Must be a valid URL.
+# Default: http://127.0.0.1
+jaeger-sampler-host
+
+# Specifies the custom remote sampler port to be passed to the sampler constructor. Must be a number. Default: 5778
+jaeger-sampler-port
+
 # specifies the port to use when uploading traces, Default 8126
 datadog-collector-port
 

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -495,6 +495,14 @@ type Configuration struct {
 	// Default: 1
 	JaegerSamplerParam string `json:"jaeger-sampler-param"`
 
+	// JaegerSamplerHost specifies the host used for remote sampling consultation
+	// Default: http://127.0.0.1
+	JaegerSamplerHost string `json:"jaeger-sampler-host"`
+
+	// JaegerSamplerHost specifies the host used for remote sampling consultation
+	// Default: 5778
+	JaegerSamplerPort int `json:"jaeger-sampler-port"`
+
 	// DatadogCollectorHost specifies the datadog agent host to use when uploading traces
 	DatadogCollectorHost string `json:"datadog-collector-host"`
 
@@ -714,6 +722,8 @@ func NewDefault() Configuration {
 		JaegerServiceName:            "nginx",
 		JaegerSamplerType:            "const",
 		JaegerSamplerParam:           "1",
+		JaegerSamplerPort:            5778,
+		JaegerSamplerHost:            "http://127.0.0.1",
 		DatadogServiceName:           "nginx",
 		DatadogCollectorPort:         8126,
 		DatadogOperationNameOverride: "nginx.handle",

--- a/internal/ingress/controller/nginx.go
+++ b/internal/ingress/controller/nginx.go
@@ -1044,7 +1044,8 @@ const jaegerTmpl = `{
   "service_name": "{{ .JaegerServiceName }}",
   "sampler": {
 	"type": "{{ .JaegerSamplerType }}",
-	"param": {{ .JaegerSamplerParam }}
+	"param": {{ .JaegerSamplerParam }},
+	"samplingServerURL": "{{ .JaegerSamplerHost }}:{{ .JaegerSamplerPort }}/sampling"
   },
   "reporter": {
 	"localAgentHostPort": "{{ .JaegerCollectorHost }}:{{ .JaegerCollectorPort }}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This PR will accommodate custom Jaeger Sampler Remote Host and Remote Port. In many cases we want a centralize sampler configuration (in collector). The current implementation of nginx ingress will only use localhost jaeger agent for this purpose. The url given does not include `/sampling` as well, which is not going to work if it is not included 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
fixes #3894 

**Special notes for your reviewer**:
Some documentation in pull request is not updated, e.g. `make verify` is no longer exist in Makefile