### PR TITLE
Clear up some inconsistent / unclear wording

### DIFF
--- a/docs/user-guide/nginx-configuration/configmap.md
+++ b/docs/user-guide/nginx-configuration/configmap.md
@@ -259,11 +259,11 @@ _References:_
 
 ## disable-ipv6
 
-Disable listening on IPV6. _**default:**_ is disabled
+Disable listening on IPV6. _**default:**_ `false`; IPv6 listening is enabled
 
 ## disable-ipv6-dns
 
-Disable IPV6 for nginx DNS resolver. _**default:**_ is disabled
+Disable IPV6 for nginx DNS resolver. _**default:**_ `false`; IPv6 resolving enabled.
 
 ## enable-underscores-in-headers
 


### PR DESCRIPTION
IPv6 enabled/disabled working was confusing or contradicting itself. This updates the wording to what is expected, based on the default values in the table above, and the behaviour that I could find in code.

**What this PR does / why we need it**:

The current documentation is confusing with regards to IPv6 toggles. This fixes that issue.