### PR TITLE
Add retry to  LookupHost used to check the content of ExternalName

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -31,6 +31,7 @@ CODEGEN_PKG=${CODEGEN_PKG:-$(cd "${SCRIPT_ROOT}"; ls -d -1 ./vendor/k8s.io/code-
 #  --output-base "$(dirname ${BASH_SOURCE})/../../.."
 mkdir -p ${CODEGEN_PKG}/hack
 cp ${SCRIPT_ROOT}/hack/boilerplate/boilerplate.go.txt ${CODEGEN_PKG}/hack/boilerplate.go.txt
+chmod +x ${CODEGEN_PKG}/*.sh
 
 ${CODEGEN_PKG}/generate-groups.sh "deepcopy" \
   k8s.io/ingress-nginx/internal k8s.io/ingress-nginx/internal \

--- a/internal/ingress/controller/endpoints.go
+++ b/internal/ingress/controller/endpoints.go
@@ -21,7 +21,9 @@ import (
 	"net"
 	"reflect"
 	"strconv"
+	"time"
 
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog"
 
 	corev1 "k8s.io/api/core/v1"
@@ -56,10 +58,28 @@ func getEndpoints(s *corev1.Service, port *corev1.ServicePort, proto corev1.Prot
 			return upsServers
 		}
 
+		// if the externalName is not an IP address we need to validate is a valid FQDN
 		if net.ParseIP(s.Spec.ExternalName) == nil {
-			_, err := net.LookupHost(s.Spec.ExternalName)
+			defaultRetry := wait.Backoff{
+				Steps:    2,
+				Duration: 1 * time.Second,
+				Factor:   1.5,
+				Jitter:   0.2,
+			}
+
+			var lastErr error
+			err := wait.ExponentialBackoff(defaultRetry, func() (bool, error) {
+				_, err := net.LookupHost(s.Spec.ExternalName)
+				if err == nil {
+					return true, nil
+				}
+
+				lastErr = err
+				return false, nil
+			})
+
 			if err != nil {
-				klog.Errorf("Error resolving host %q: %v", s.Spec.ExternalName, err)
+				klog.Errorf("Error resolving host %q: %v", s.Spec.ExternalName, lastErr)
 				return upsServers
 			}
 		}

--- a/internal/ingress/controller/endpoints_test.go
+++ b/internal/ingress/controller/endpoints_test.go
@@ -83,7 +83,7 @@ func TestGetEndpoints(t *testing.T) {
 			&corev1.Service{
 				Spec: corev1.ServiceSpec{
 					Type:         corev1.ServiceTypeExternalName,
-					ExternalName: "10.0.0.1.xip.io",
+					ExternalName: "www.10.0.0.1.xip.io",
 					Ports: []corev1.ServicePort{
 						{
 							Name:       "default",
@@ -102,7 +102,7 @@ func TestGetEndpoints(t *testing.T) {
 			},
 			[]ingress.Endpoint{
 				{
-					Address: "10.0.0.1.xip.io",
+					Address: "www.10.0.0.1.xip.io",
 					Port:    "80",
 				},
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes issues like https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/ingress-nginx/4101/pull-ingress-nginx-test/1131168173970690052 resolving DNS names
