### PR TITLE
Force GOOS to linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,11 +52,14 @@ QEMUVERSION = v4.0.0
 
 BUSTED_ARGS =-v --pattern=_test
 
+GOOS = linux
+
 export ARCH
 export DUMB_ARCH
 export TAG
 export PKG
 export GOARCH
+export GOOS
 export GIT_COMMIT
 export GOBUILD_FLAGS
 export REPO_INFO


### PR DESCRIPTION
**What this PR does / why we need it**:

Since https://github.com/kubernetes/ingress-nginx/pull/4088 `ingress-nginx` is no longer build in a docker container (linux).
Which break the build in non linux environment:
```
make build
k8s.io/ingress-nginx/internal/runtime
# k8s.io/ingress-nginx/internal/runtime
internal/runtime/cpu.go:37:21: undefined: cgroups.FindCgroupMountpoint
make: *** [build] Error 2
```

the `cgroups` library here is only build on linux `vendor/github.com/opencontainers/runc/libcontainer/cgroups/` => `// +build linux`

This change force go to build the binary for a linux environment using go cross platform build.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

Cc @ElvinEfendi 