### PR TITLE
Add opentracing-trace-locations config to disable spans for locations

### DIFF
--- a/docs/user-guide/nginx-configuration/configmap.md
+++ b/docs/user-guide/nginx-configuration/configmap.md
@@ -115,6 +115,7 @@ The following table shows a configuration option's name, type, and the default v
 |[proxy-add-original-uri-header](#proxy-add-original-uri-header)|bool|"true"|
 |[generate-request-id](#generate-request-id)|bool|"true"|
 |[enable-opentracing](#enable-opentracing)|bool|"false"|
+|[opentracing-trace-locations](#opentracing-trace-locations)|bool|"true"|
 |[zipkin-collector-host](#zipkin-collector-host)|string|""|
 |[zipkin-collector-port](#zipkin-collector-port)|int|9411|
 |[zipkin-service-name](#zipkin-service-name)|string|"nginx"|
@@ -699,6 +700,13 @@ Enables the nginx Opentracing extension. _**default:**_ is disabled
 
 _References:_
 [https://github.com/opentracing-contrib/nginx-opentracing](https://github.com/opentracing-contrib/nginx-opentracing)
+
+## opentracing-trace-locations
+
+Specifies whether to trace locations as a separate span. _**default:**_ is enabled
+
+_References:_
+[https://github.com/opentracing-contrib/nginx-opentracing/blob/master/doc/Reference.md](https://github.com/opentracing-contrib/nginx-opentracing/blob/master/doc/Reference.md)
 
 ## zipkin-collector-host
 

--- a/docs/user-guide/third-party-addons/opentracing.md
+++ b/docs/user-guide/third-party-addons/opentracing.md
@@ -30,6 +30,9 @@ have been tested.
 
 Other optional configuration options:
 ```
+# specifies whether locations should be traced as a separate span. Boolean, Default: true
+opentracing-trace-locations
+
 # specifies the port to use when uploading traces, Default: 9411
 zipkin-collector-port
 

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -460,6 +460,11 @@ type Configuration struct {
 	// By default this is disabled
 	EnableOpentracing bool `json:"enable-opentracing"`
 
+	// OpentracingTraceLocations specifies whether locations should be traced as a separate span
+	// https://github.com/opentracing-contrib/nginx-opentracing
+	// By default this is enabled
+	OpentracingTraceLocations bool `json:"enable-opentracing"`
+
 	// ZipkinCollectorHost specifies the host to use when uploading traces
 	ZipkinCollectorHost string `json:"zipkin-collector-host"`
 
@@ -662,6 +667,7 @@ func NewDefault() Configuration {
 		NginxStatusIpv6Whitelist:         defNginxStatusIpv6Whitelist,
 		ProxyRealIPCIDR:                  defIPCIDR,
 		ProxyProtocolHeaderTimeout:       defProxyDeadlineDuration,
+		OpentracingTraceLocations:        true,
 		ServerNameHashMaxSize:            1024,
 		ProxyHeadersHashMaxSize:          512,
 		ProxyHeadersHashBucketSize:       64,

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -225,6 +225,9 @@ http {
 
     {{ if $cfg.EnableOpentracing }}
     opentracing on;
+    {{ if not $all.Cfg.OpentracingTraceLocations }}
+    opentracing_trace_locations off;
+    {{ end }}
     {{ end }}
 
     {{ buildOpentracing $cfg }}


### PR DESCRIPTION
**What this PR does / why we need it**:

By default an opentracing span is generated for each location, nested inside a server span; with this setting it can be disabled.

**Which issue this PR fixes**:

fixes #4115