### PR TITLE
Only load module ngx_http_modsecurity_module.so when option enable-mo…

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -16,7 +16,9 @@ pid {{ .PID }};
 load_module /etc/nginx/modules/ngx_http_geoip2_module.so;
 {{ end }}
 
+{{ if (shouldLoadModSecurityModule $cfg $servers) }}
 load_module /etc/nginx/modules/ngx_http_modsecurity_module.so;
+{{ end }}
 
 {{ if $cfg.EnableOpentracing }}
 load_module /etc/nginx/modules/ngx_http_opentracing_module.so;


### PR DESCRIPTION
**What this PR does / why we need it**:
Ensures the `load_module` directive for `ngx_http_modsecurity_module.so` is only present in `nginx.conf` when `enable-modsecurity: true` is present in the ConfigMap, instead of always. For everyone not using ModSecurity, this should provide a slightly more lean application.

**Which issue this PR fixes**: 
Fixes #3842

**Special notes for your reviewer**:
ModSecurity can be enabled on via ConfigMap *or* Annotation. However, in the documentation for the Annotation it clearly states:
>The ModSecurity module must first be enabled by enabling ModSecurity in the ConfigMap.

Because of this, I feel like we can simply place the loading of the module behind the ConfigMap option.
