### PR TITLE
Migrate to new networking.k8s.io/v1beta1 package

### DIFF
--- a/cmd/nginx/main.go
+++ b/cmd/nginx/main.go
@@ -110,6 +110,11 @@ func main() {
 	conf.FakeCertificate = ssl.GetFakeSSLCert(fs)
 	klog.Infof("Created fake certificate with PemFileName: %v", conf.FakeCertificate.PemFileName)
 
+	k8s.IsNetworkingIngressAvailable = k8s.NetworkingIngressAvailable(kubeClient)
+	if !k8s.IsNetworkingIngressAvailable {
+		klog.Warningf("Using deprecated \"k8s.io/api/extensions/v1beta1\" package because Kubernetes version is < v1.14.0")
+	}
+
 	conf.Client = kubeClient
 
 	reg := prometheus.NewRegistry()

--- a/cmd/plugin/commands/backends/backends.go
+++ b/cmd/plugin/commands/backends/backends.go
@@ -18,6 +18,7 @@ package backends
 
 import (
 	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"

--- a/cmd/plugin/commands/certs/certs.go
+++ b/cmd/plugin/commands/certs/certs.go
@@ -18,6 +18,7 @@ package certs
 
 import (
 	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"

--- a/cmd/plugin/commands/conf/conf.go
+++ b/cmd/plugin/commands/conf/conf.go
@@ -18,8 +18,9 @@ package conf
 
 import (
 	"fmt"
-	"github.com/spf13/cobra"
 	"strings"
+
+	"github.com/spf13/cobra"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 

--- a/cmd/plugin/commands/general/general.go
+++ b/cmd/plugin/commands/general/general.go
@@ -18,6 +18,7 @@ package general
 
 import (
 	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"

--- a/cmd/plugin/commands/info/info.go
+++ b/cmd/plugin/commands/info/info.go
@@ -18,6 +18,7 @@ package info
 
 import (
 	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"

--- a/cmd/plugin/commands/ingresses/ingresses.go
+++ b/cmd/plugin/commands/ingresses/ingresses.go
@@ -18,11 +18,11 @@ package ingresses
 
 import (
 	"fmt"
-	"github.com/spf13/cobra"
 	"os"
 	"text/tabwriter"
 
-	"k8s.io/api/extensions/v1beta1"
+	"github.com/spf13/cobra"
+	networking "k8s.io/api/networking/v1beta1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
 	"k8s.io/ingress-nginx/cmd/plugin/request"
@@ -130,7 +130,7 @@ type ingressRow struct {
 	NumEndpoints string
 }
 
-func getIngressRows(ingresses *[]v1beta1.Ingress) []ingressRow {
+func getIngressRows(ingresses *[]networking.Ingress) []ingressRow {
 	rows := make([]ingressRow, 0)
 
 	for _, ing := range *ingresses {

--- a/cmd/plugin/commands/lint/main.go
+++ b/cmd/plugin/commands/lint/main.go
@@ -22,10 +22,10 @@ import (
 	"github.com/spf13/cobra"
 
 	appsv1 "k8s.io/api/apps/v1"
-
-	"k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	kmeta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+
 	"k8s.io/ingress-nginx/cmd/plugin/lints"
 	"k8s.io/ingress-nginx/cmd/plugin/request"
 	"k8s.io/ingress-nginx/cmd/plugin/util"
@@ -178,7 +178,7 @@ func checkObjectArray(lints []lint, objects []kmeta.Object, opts lintOptions) {
 }
 
 func ingresses(opts lintOptions) error {
-	var ings []v1beta1.Ingress
+	var ings []networking.Ingress
 	var err error
 	if opts.allNamespaces {
 		ings, err = request.GetIngressDefinitions(opts.flags, "")

--- a/cmd/plugin/commands/logs/logs.go
+++ b/cmd/plugin/commands/logs/logs.go
@@ -18,6 +18,7 @@ package logs
 
 import (
 	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"

--- a/cmd/plugin/kubectl/kubectl.go
+++ b/cmd/plugin/kubectl/kubectl.go
@@ -20,12 +20,13 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	apiv1 "k8s.io/api/core/v1"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"os"
 	"os/exec"
 	"strings"
 	"syscall"
+
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
 // PodExecString takes a pod and a command, uses kubectl exec to run the command in the pod

--- a/cmd/plugin/lints/ingress.go
+++ b/cmd/plugin/lints/ingress.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"strings"
 
-	"k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	kmeta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/ingress-nginx/cmd/plugin/util"
 )
@@ -30,12 +30,12 @@ type IngressLint struct {
 	message string
 	issue   int
 	version string
-	f       func(ing v1beta1.Ingress) bool
+	f       func(ing networking.Ingress) bool
 }
 
 // Check returns true if the lint detects an issue
 func (lint IngressLint) Check(obj kmeta.Object) bool {
-	ing := obj.(*v1beta1.Ingress)
+	ing := obj.(*networking.Ingress)
 	return lint.f(*ing)
 }
 
@@ -87,7 +87,7 @@ func GetIngressLints() []IngressLint {
 	}
 }
 
-func xForwardedPrefixIsBool(ing v1beta1.Ingress) bool {
+func xForwardedPrefixIsBool(ing networking.Ingress) bool {
 	for name, val := range ing.Annotations {
 		if strings.HasSuffix(name, "/x-forwarded-prefix") && (val == "true" || val == "false") {
 			return true
@@ -96,7 +96,7 @@ func xForwardedPrefixIsBool(ing v1beta1.Ingress) bool {
 	return false
 }
 
-func annotationPrefixIsNginxCom(ing v1beta1.Ingress) bool {
+func annotationPrefixIsNginxCom(ing networking.Ingress) bool {
 	for name := range ing.Annotations {
 		if strings.HasPrefix(name, "nginx.com/") {
 			return true
@@ -105,7 +105,7 @@ func annotationPrefixIsNginxCom(ing v1beta1.Ingress) bool {
 	return false
 }
 
-func annotationPrefixIsNginxOrg(ing v1beta1.Ingress) bool {
+func annotationPrefixIsNginxOrg(ing networking.Ingress) bool {
 	for name := range ing.Annotations {
 		if strings.HasPrefix(name, "nginx.org/") {
 			return true
@@ -114,7 +114,7 @@ func annotationPrefixIsNginxOrg(ing v1beta1.Ingress) bool {
 	return false
 }
 
-func rewriteTargetWithoutCaptureGroup(ing v1beta1.Ingress) bool {
+func rewriteTargetWithoutCaptureGroup(ing networking.Ingress) bool {
 	for name, val := range ing.Annotations {
 		if strings.HasSuffix(name, "/rewrite-target") && !strings.Contains(val, "$1") {
 			return true
@@ -128,7 +128,7 @@ func removedAnnotation(annotationName string, issueNumber int, version string) I
 		message: fmt.Sprintf("Contains the removed %v annotation.", annotationName),
 		issue:   issueNumber,
 		version: version,
-		f: func(ing v1beta1.Ingress) bool {
+		f: func(ing networking.Ingress) bool {
 			for annotation := range ing.Annotations {
 				if strings.HasSuffix(annotation, "/"+annotationName) {
 					return true

--- a/cmd/plugin/request/request.go
+++ b/cmd/plugin/request/request.go
@@ -21,12 +21,13 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	appsv1client "k8s.io/client-go/kubernetes/typed/apps/v1"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
-	extensions "k8s.io/client-go/kubernetes/typed/extensions/v1beta1"
+	typednetworking "k8s.io/client-go/kubernetes/typed/networking/v1beta1"
+
 	"k8s.io/ingress-nginx/cmd/plugin/util"
 )
 
@@ -90,20 +91,20 @@ func GetDeployments(flags *genericclioptions.ConfigFlags, namespace string) ([]a
 }
 
 // GetIngressDefinitions returns an array of Ingress resource definitions
-func GetIngressDefinitions(flags *genericclioptions.ConfigFlags, namespace string) ([]v1beta1.Ingress, error) {
+func GetIngressDefinitions(flags *genericclioptions.ConfigFlags, namespace string) ([]networking.Ingress, error) {
 	rawConfig, err := flags.ToRESTConfig()
 	if err != nil {
-		return make([]v1beta1.Ingress, 0), err
+		return make([]networking.Ingress, 0), err
 	}
 
-	api, err := extensions.NewForConfig(rawConfig)
+	api, err := typednetworking.NewForConfig(rawConfig)
 	if err != nil {
-		return make([]v1beta1.Ingress, 0), err
+		return make([]networking.Ingress, 0), err
 	}
 
 	pods, err := api.Ingresses(namespace).List(metav1.ListOptions{})
 	if err != nil {
-		return make([]v1beta1.Ingress, 0), err
+		return make([]networking.Ingress, 0), err
 	}
 
 	return pods.Items, nil

--- a/deploy/cluster-wide/cluster-role.yaml
+++ b/deploy/cluster-wide/cluster-role.yaml
@@ -29,14 +29,6 @@ rules:
       - list
       - watch
   - apiGroups:
-      - "extensions"
-    resources:
-      - ingresses
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
       - ""
     resources:
       - events
@@ -45,6 +37,28 @@ rules:
       - patch
   - apiGroups:
       - "extensions"
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "extensions"
+    resources:
+      - ingresses/status
+    verbs:
+      - update
+  - apiGroups:
+      - "networking.k8s.io"
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "networking.k8s.io"
     resources:
       - ingresses/status
     verbs:

--- a/docs/examples/auth/external-auth/README.md
+++ b/docs/examples/auth/external-auth/README.md
@@ -23,7 +23,7 @@ metadata:
   name: external-auth
   namespace: default
   resourceVersion: "2068378"
-  selfLink: /apis/extensions/v1beta1/namespaces/default/ingresses/external-auth
+  selfLink: /apis/networking/v1beta1/namespaces/default/ingresses/external-auth
   uid: 5c388f1d-8970-11e6-9004-080027d2dc94
 spec:
   rules:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -32,7 +32,7 @@ Rules:
             /tea      tea-svc:80 (<none>)
             /coffee   coffee-svc:80 (<none>)
 Annotations:
-  kubectl.kubernetes.io/last-applied-configuration:  {"apiVersion":"extensions/v1beta1","kind":"Ingress","metadata":{"annotations":{},"name":"cafe-ingress","namespace":"default","selfLink":"/apis/extensions/v1beta1/namespaces/default/ingresses/cafe-ingress"},"spec":{"rules":[{"host":"cafe.com","http":{"paths":[{"backend":{"serviceName":"tea-svc","servicePort":80},"path":"/tea"},{"backend":{"serviceName":"coffee-svc","servicePort":80},"path":"/coffee"}]}}]},"status":{"loadBalancer":{"ingress":[{"ip":"169.48.142.110"}]}}}
+  kubectl.kubernetes.io/last-applied-configuration:  {"apiVersion":"extensions/v1beta1","kind":"Ingress","metadata":{"annotations":{},"name":"cafe-ingress","namespace":"default","selfLink":"/apis/networking/v1beta1/namespaces/default/ingresses/cafe-ingress"},"spec":{"rules":[{"host":"cafe.com","http":{"paths":[{"backend":{"serviceName":"tea-svc","servicePort":80},"path":"/tea"},{"backend":{"serviceName":"coffee-svc","servicePort":80},"path":"/coffee"}]}}]},"status":{"loadBalancer":{"ingress":[{"ip":"169.48.142.110"}]}}}
 
 Events:
   Type    Reason  Age   From                      Message
@@ -218,8 +218,8 @@ $ kubectl exec test-701078429-s5kca -- curl --cacert /var/run/secrets/kubernetes
     "/apis/batch/v2alpha1",
     "/apis/certificates.k8s.io",
     "/apis/certificates.k8s.io/v1alpha1",
-    "/apis/extensions",
-    "/apis/extensions/v1beta1",
+    "/apis/networking",
+    "/apis/networking/v1beta1",
     "/apis/policy",
     "/apis/policy/v1alpha1",
     "/apis/rbac.authorization.k8s.io",

--- a/go.sum
+++ b/go.sum
@@ -89,7 +89,6 @@ github.com/golang/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:tluoj9z5200j
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.2.0 h1:28o5sBqPkBsMGnC6b4MvE2TzSr5/AT4c/1fLqVGIwlk=
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
-github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -246,7 +245,6 @@ github.com/zakjan/cert-chain-resolver v0.0.0-20180703112424-6076e1ded272 h1:scDk
 github.com/zakjan/cert-chain-resolver v0.0.0-20180703112424-6076e1ded272/go.mod h1:KNkcm66cr4ilOiEcjydK+tc2ShPUhqmuoXCljXUBPu8=
 go.opencensus.io v0.18.0/go.mod h1:vKdFvxhtzZ9onBp9VKHK8z/sRpBMnKAsufL7wlDrCOA=
 go.opencensus.io v0.19.1/go.mod h1:gug0GbSHa8Pafr0d2urOSgoXHZ6x/RUlaiT0d9pqb4A=
-go.opencensus.io v0.19.2 h1:ZZpq6xI6kv/LuE/5s5UQvBU5vMjvRnPb8PvJrIntAnc=
 go.opencensus.io v0.19.2/go.mod h1:NO/8qkisMZLZ1FCsKNqtJPwc8/TaclWyY0B6wcYNg9M=
 go.opencensus.io v0.20.1/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
 go.opencensus.io v0.20.2 h1:NAfh7zF0/3/HqtMvJNZ/RFrSlCE6ZTlHmKfhL/Dm1Jk=
@@ -308,7 +306,6 @@ golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181218192612-074acd46bca6/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190209173611-3b5209105503/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a h1:1BGLXjeY4akVXGgbC9HugT3Jv3hCI0z56oJR5vAMgBU=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313 h1:pczuHS43Cp2ktBEEmLwScxgjWsBSzdaQiKzUyf3DTTc=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -336,7 +333,6 @@ google.golang.org/api v0.0.0-20180910000450-7ca32eb868bf/go.mod h1:4mhQ8q/RsB7i+
 google.golang.org/api v0.0.0-20181030000543-1d582fd0359e/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
 google.golang.org/api v0.0.0-20181220000619-583d854617af/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
 google.golang.org/api v0.2.0/go.mod h1:IfRCZScioGtypHNTlz3gFk67J8uePVW7uDTBzXuIkhU=
-google.golang.org/api v0.3.0 h1:UIJY20OEo3+tK5MBlcdx37kmdH6EnRjGkW78mc6+EeA=
 google.golang.org/api v0.3.0/go.mod h1:IuvZyQh8jgscv8qWfQ4ABd8m7hEudgBFM/EdhA3BnXw=
 google.golang.org/api v0.3.1 h1:oJra/lMfmtm13/rgY/8i3MzjFWYXvQIAKjQ3HqofMk8=
 google.golang.org/api v0.3.1/go.mod h1:6wY9I6uQWHQ8EM57III9mq/AjF+i8G65rmVagqKMtkk=
@@ -354,7 +350,6 @@ google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRn
 google.golang.org/grpc v1.14.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.16.0/go.mod h1:0JHn/cJsOMiMfNA9+DeHDlAU7KAAB5GDlYFpa9MZMio=
 google.golang.org/grpc v1.17.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=
-google.golang.org/grpc v1.19.0 h1:cfg4PD8YEdSFnm7qLV4++93WcmhH2nIUhMjhdCvl3j8=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.19.1 h1:TrBcJ1yqAl1G++wO39nD/qtgpsW9/1+QGrluyMGEYgM=
 google.golang.org/grpc v1.19.1/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=

--- a/internal/admission/controller/main.go
+++ b/internal/admission/controller/main.go
@@ -19,8 +19,8 @@ package controller
 import (
 	"github.com/google/uuid"
 	"k8s.io/api/admission/v1beta1"
-	extensions "k8s.io/api/extensions/v1beta1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	networking "k8s.io/api/networking/v1beta1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	"k8s.io/klog"
@@ -29,7 +29,7 @@ import (
 // Checker must return an error if the ingress provided as argument
 // contains invalid instructions
 type Checker interface {
-	CheckIngress(ing *extensions.Ingress) error
+	CheckIngress(ing *networking.Ingress) error
 }
 
 // IngressAdmission implements the AdmissionController interface
@@ -52,14 +52,14 @@ func (ia *IngressAdmission) HandleAdmission(ar *v1beta1.AdmissionReview) error {
 	}
 	klog.V(3).Infof("handling ingress admission webhook request for {%s}  %s in namespace %s", ar.Request.Resource.String(), ar.Request.Name, ar.Request.Namespace)
 
-	ingressResource := v1.GroupVersionResource{Group: extensions.SchemeGroupVersion.Group, Version: extensions.SchemeGroupVersion.Version, Resource: "ingresses"}
+	ingressResource := v1.GroupVersionResource{Group: networking.SchemeGroupVersion.Group, Version: networking.SchemeGroupVersion.Version, Resource: "ingresses"}
 
 	if ar.Request.Resource == ingressResource {
 		ar.Response = &v1beta1.AdmissionResponse{
 			UID:     types.UID(uuid.New().String()),
 			Allowed: false,
 		}
-		ingress := extensions.Ingress{}
+		ingress := networking.Ingress{}
 		deserializer := codecs.UniversalDeserializer()
 		if _, _, err := deserializer.Decode(ar.Request.Object.Raw, nil, &ingress); err != nil {
 			ar.Response.Result = &v1.Status{Message: err.Error()}

--- a/internal/admission/controller/main_test.go
+++ b/internal/admission/controller/main_test.go
@@ -21,8 +21,8 @@ import (
 	"testing"
 
 	"k8s.io/api/admission/v1beta1"
-	extensions "k8s.io/api/extensions/v1beta1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	networking "k8s.io/api/networking/v1beta1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/json"
 )
 
@@ -32,7 +32,7 @@ type failTestChecker struct {
 	t *testing.T
 }
 
-func (ftc failTestChecker) CheckIngress(ing *extensions.Ingress) error {
+func (ftc failTestChecker) CheckIngress(ing *networking.Ingress) error {
 	ftc.t.Error("checker should not be called")
 	return nil
 }
@@ -42,7 +42,7 @@ type testChecker struct {
 	err error
 }
 
-func (tc testChecker) CheckIngress(ing *extensions.Ingress) error {
+func (tc testChecker) CheckIngress(ing *networking.Ingress) error {
 	if ing.ObjectMeta.Name != testIngressName {
 		tc.t.Errorf("CheckIngress should be called with %v ingress, but got %v", testIngressName, ing.ObjectMeta.Name)
 	}
@@ -66,7 +66,7 @@ func TestHandleAdmission(t *testing.T) {
 		t.Errorf("with a non ingress resource, no error should be returned")
 	}
 
-	review.Request.Resource = v1.GroupVersionResource{Group: extensions.SchemeGroupVersion.Group, Version: extensions.SchemeGroupVersion.Version, Resource: "ingresses"}
+	review.Request.Resource = v1.GroupVersionResource{Group: networking.SchemeGroupVersion.Group, Version: networking.SchemeGroupVersion.Version, Resource: "ingresses"}
 	review.Request.Object.Raw = []byte{0xff}
 
 	err = adm.HandleAdmission(review)
@@ -77,7 +77,7 @@ func TestHandleAdmission(t *testing.T) {
 		t.Errorf("when the request object is not decodable, an error should be returned")
 	}
 
-	raw, err := json.Marshal(extensions.Ingress{ObjectMeta: v1.ObjectMeta{Name: testIngressName}})
+	raw, err := json.Marshal(networking.Ingress{ObjectMeta: v1.ObjectMeta{Name: testIngressName}})
 	if err != nil {
 		t.Errorf("failed to prepare test ingress data: %v", err.Error())
 	}

--- a/internal/ingress/annotations/alias/main.go
+++ b/internal/ingress/annotations/alias/main.go
@@ -17,7 +17,7 @@ limitations under the License.
 package alias
 
 import (
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
@@ -34,6 +34,6 @@ func NewParser(r resolver.Resolver) parser.IngressAnnotation {
 
 // Parse parses the annotations contained in the ingress rule
 // used to add an alias to the provided hosts
-func (a alias) Parse(ing *extensions.Ingress) (interface{}, error) {
+func (a alias) Parse(ing *networking.Ingress) (interface{}, error) {
 	return parser.GetStringAnnotation("server-alias", ing)
 }

--- a/internal/ingress/annotations/alias/main_test.go
+++ b/internal/ingress/annotations/alias/main_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	api "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
@@ -46,12 +46,12 @@ func TestParse(t *testing.T) {
 		{nil, ""},
 	}
 
-	ing := &extensions.Ingress{
+	ing := &networking.Ingress{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "foo",
 			Namespace: api.NamespaceDefault,
 		},
-		Spec: extensions.IngressSpec{},
+		Spec: networking.IngressSpec{},
 	}
 
 	for _, testCase := range testCases {

--- a/internal/ingress/annotations/annotations.go
+++ b/internal/ingress/annotations/annotations.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/klog"
 
 	apiv1 "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"k8s.io/ingress-nginx/internal/ingress/annotations/alias"
@@ -158,7 +158,7 @@ func NewAnnotationExtractor(cfg resolver.Resolver) Extractor {
 }
 
 // Extract extracts the annotations from an Ingress
-func (e Extractor) Extract(ing *extensions.Ingress) *Ingress {
+func (e Extractor) Extract(ing *networking.Ingress) *Ingress {
 	pia := &Ingress{
 		ObjectMeta: ing.ObjectMeta,
 	}

--- a/internal/ingress/annotations/annotations_test.go
+++ b/internal/ingress/annotations/annotations_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	apiv1 "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
@@ -74,28 +74,28 @@ func (m mockCfg) GetAuthCertificate(name string) (*resolver.AuthSSLCert, error) 
 	return nil, nil
 }
 
-func buildIngress() *extensions.Ingress {
-	defaultBackend := extensions.IngressBackend{
+func buildIngress() *networking.Ingress {
+	defaultBackend := networking.IngressBackend{
 		ServiceName: "default-backend",
 		ServicePort: intstr.FromInt(80),
 	}
 
-	return &extensions.Ingress{
+	return &networking.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "foo",
 			Namespace: apiv1.NamespaceDefault,
 		},
-		Spec: extensions.IngressSpec{
-			Backend: &extensions.IngressBackend{
+		Spec: networking.IngressSpec{
+			Backend: &networking.IngressBackend{
 				ServiceName: "default-backend",
 				ServicePort: intstr.FromInt(80),
 			},
-			Rules: []extensions.IngressRule{
+			Rules: []networking.IngressRule{
 				{
 					Host: "foo.bar.com",
-					IngressRuleValue: extensions.IngressRuleValue{
-						HTTP: &extensions.HTTPIngressRuleValue{
-							Paths: []extensions.HTTPIngressPath{
+					IngressRuleValue: networking.IngressRuleValue{
+						HTTP: &networking.HTTPIngressRuleValue{
+							Paths: []networking.HTTPIngressPath{
 								{
 									Path:    "/foo",
 									Backend: defaultBackend,

--- a/internal/ingress/annotations/auth/main.go
+++ b/internal/ingress/annotations/auth/main.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/pkg/errors"
 	api "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	"k8s.io/client-go/tools/cache"
 
 	"k8s.io/ingress-nginx/internal/file"
@@ -92,7 +92,7 @@ func NewParser(authDirectory string, r resolver.Resolver) parser.IngressAnnotati
 // rule used to add authentication in the paths defined in the rule
 // and generated an htpasswd compatible file to be used as source
 // during the authentication process
-func (a auth) Parse(ing *extensions.Ingress) (interface{}, error) {
+func (a auth) Parse(ing *networking.Ingress) (interface{}, error) {
 	at, err := parser.GetStringAnnotation("auth-type", ing)
 	if err != nil {
 		return nil, err

--- a/internal/ingress/annotations/auth/main_test.go
+++ b/internal/ingress/annotations/auth/main_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/pkg/errors"
 
 	api "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
@@ -34,28 +34,28 @@ import (
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
 )
 
-func buildIngress() *extensions.Ingress {
-	defaultBackend := extensions.IngressBackend{
+func buildIngress() *networking.Ingress {
+	defaultBackend := networking.IngressBackend{
 		ServiceName: "default-backend",
 		ServicePort: intstr.FromInt(80),
 	}
 
-	return &extensions.Ingress{
+	return &networking.Ingress{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "foo",
 			Namespace: api.NamespaceDefault,
 		},
-		Spec: extensions.IngressSpec{
-			Backend: &extensions.IngressBackend{
+		Spec: networking.IngressSpec{
+			Backend: &networking.IngressBackend{
 				ServiceName: "default-backend",
 				ServicePort: intstr.FromInt(80),
 			},
-			Rules: []extensions.IngressRule{
+			Rules: []networking.IngressRule{
 				{
 					Host: "foo.bar.com",
-					IngressRuleValue: extensions.IngressRuleValue{
-						HTTP: &extensions.HTTPIngressRuleValue{
-							Paths: []extensions.HTTPIngressPath{
+					IngressRuleValue: networking.IngressRuleValue{
+						HTTP: &networking.HTTPIngressRuleValue{
+							Paths: []networking.HTTPIngressPath{
 								{
 									Path:    "/foo",
 									Backend: defaultBackend,

--- a/internal/ingress/annotations/authreq/main.go
+++ b/internal/ingress/annotations/authreq/main.go
@@ -24,7 +24,7 @@ import (
 
 	"k8s.io/klog"
 
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	ing_errors "k8s.io/ingress-nginx/internal/ingress/errors"
@@ -115,7 +115,7 @@ func NewParser(r resolver.Resolver) parser.IngressAnnotation {
 
 // ParseAnnotations parses the annotations contained in the ingress
 // rule used to use an Config URL as source for authentication
-func (a authReq) Parse(ing *extensions.Ingress) (interface{}, error) {
+func (a authReq) Parse(ing *networking.Ingress) (interface{}, error) {
 	// Required Parameters
 	urlString, err := parser.GetStringAnnotation("auth-url", ing)
 	if err != nil {

--- a/internal/ingress/annotations/authreq/main_test.go
+++ b/internal/ingress/annotations/authreq/main_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 
 	api "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
@@ -31,28 +31,28 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func buildIngress() *extensions.Ingress {
-	defaultBackend := extensions.IngressBackend{
+func buildIngress() *networking.Ingress {
+	defaultBackend := networking.IngressBackend{
 		ServiceName: "default-backend",
 		ServicePort: intstr.FromInt(80),
 	}
 
-	return &extensions.Ingress{
+	return &networking.Ingress{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "foo",
 			Namespace: api.NamespaceDefault,
 		},
-		Spec: extensions.IngressSpec{
-			Backend: &extensions.IngressBackend{
+		Spec: networking.IngressSpec{
+			Backend: &networking.IngressBackend{
 				ServiceName: "default-backend",
 				ServicePort: intstr.FromInt(80),
 			},
-			Rules: []extensions.IngressRule{
+			Rules: []networking.IngressRule{
 				{
 					Host: "foo.bar.com",
-					IngressRuleValue: extensions.IngressRuleValue{
-						HTTP: &extensions.HTTPIngressRuleValue{
-							Paths: []extensions.HTTPIngressPath{
+					IngressRuleValue: networking.IngressRuleValue{
+						HTTP: &networking.HTTPIngressRuleValue{
+							Paths: []networking.HTTPIngressPath{
 								{
 									Path:    "/foo",
 									Backend: defaultBackend,

--- a/internal/ingress/annotations/authreqglobal/main.go
+++ b/internal/ingress/annotations/authreqglobal/main.go
@@ -17,7 +17,7 @@ limitations under the License.
 package authreqglobal
 
 import (
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
@@ -34,7 +34,7 @@ func NewParser(r resolver.Resolver) parser.IngressAnnotation {
 
 // ParseAnnotations parses the annotations contained in the ingress
 // rule used to enable or disable global external authentication
-func (a authReqGlobal) Parse(ing *extensions.Ingress) (interface{}, error) {
+func (a authReqGlobal) Parse(ing *networking.Ingress) (interface{}, error) {
 
 	enableGlobalAuth, err := parser.GetBoolAnnotation("enable-global-auth", ing)
 	if err != nil {

--- a/internal/ingress/annotations/authreqglobal/main_test.go
+++ b/internal/ingress/annotations/authreqglobal/main_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	api "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
@@ -28,28 +28,28 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func buildIngress() *extensions.Ingress {
-	defaultBackend := extensions.IngressBackend{
+func buildIngress() *networking.Ingress {
+	defaultBackend := networking.IngressBackend{
 		ServiceName: "default-backend",
 		ServicePort: intstr.FromInt(80),
 	}
 
-	return &extensions.Ingress{
+	return &networking.Ingress{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "foo",
 			Namespace: api.NamespaceDefault,
 		},
-		Spec: extensions.IngressSpec{
-			Backend: &extensions.IngressBackend{
+		Spec: networking.IngressSpec{
+			Backend: &networking.IngressBackend{
 				ServiceName: "default-backend",
 				ServicePort: intstr.FromInt(80),
 			},
-			Rules: []extensions.IngressRule{
+			Rules: []networking.IngressRule{
 				{
 					Host: "foo.bar.com",
-					IngressRuleValue: extensions.IngressRuleValue{
-						HTTP: &extensions.HTTPIngressRuleValue{
-							Paths: []extensions.HTTPIngressPath{
+					IngressRuleValue: networking.IngressRuleValue{
+						HTTP: &networking.HTTPIngressRuleValue{
+							Paths: []networking.HTTPIngressPath{
 								{
 									Path:    "/foo",
 									Backend: defaultBackend,

--- a/internal/ingress/annotations/authtls/main.go
+++ b/internal/ingress/annotations/authtls/main.go
@@ -18,7 +18,7 @@ package authtls
 
 import (
 	"github.com/pkg/errors"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 
 	"regexp"
 
@@ -86,7 +86,7 @@ type authTLS struct {
 
 // Parse parses the annotations contained in the ingress
 // rule used to use a Certificate as authentication method
-func (a authTLS) Parse(ing *extensions.Ingress) (interface{}, error) {
+func (a authTLS) Parse(ing *networking.Ingress) (interface{}, error) {
 	var err error
 	config := &Config{}
 

--- a/internal/ingress/annotations/authtls/main_test.go
+++ b/internal/ingress/annotations/authtls/main_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	api "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
@@ -28,28 +28,28 @@ import (
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
 )
 
-func buildIngress() *extensions.Ingress {
-	defaultBackend := extensions.IngressBackend{
+func buildIngress() *networking.Ingress {
+	defaultBackend := networking.IngressBackend{
 		ServiceName: "default-backend",
 		ServicePort: intstr.FromInt(80),
 	}
 
-	return &extensions.Ingress{
+	return &networking.Ingress{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "foo",
 			Namespace: api.NamespaceDefault,
 		},
-		Spec: extensions.IngressSpec{
-			Backend: &extensions.IngressBackend{
+		Spec: networking.IngressSpec{
+			Backend: &networking.IngressBackend{
 				ServiceName: "default-backend",
 				ServicePort: intstr.FromInt(80),
 			},
-			Rules: []extensions.IngressRule{
+			Rules: []networking.IngressRule{
 				{
 					Host: "foo.bar.com",
-					IngressRuleValue: extensions.IngressRuleValue{
-						HTTP: &extensions.HTTPIngressRuleValue{
-							Paths: []extensions.HTTPIngressPath{
+					IngressRuleValue: networking.IngressRuleValue{
+						HTTP: &networking.HTTPIngressRuleValue{
+							Paths: []networking.HTTPIngressPath{
 								{
 									Path:    "/foo",
 									Backend: defaultBackend,

--- a/internal/ingress/annotations/backendprotocol/main.go
+++ b/internal/ingress/annotations/backendprotocol/main.go
@@ -20,7 +20,7 @@ import (
 	"regexp"
 	"strings"
 
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	"k8s.io/klog"
 
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
@@ -45,7 +45,7 @@ func NewParser(r resolver.Resolver) parser.IngressAnnotation {
 
 // ParseAnnotations parses the annotations contained in the ingress
 // rule used to indicate the backend protocol.
-func (a backendProtocol) Parse(ing *extensions.Ingress) (interface{}, error) {
+func (a backendProtocol) Parse(ing *networking.Ingress) (interface{}, error) {
 	if ing.GetAnnotations() == nil {
 		return HTTP, nil
 	}

--- a/internal/ingress/annotations/backendprotocol/main_test.go
+++ b/internal/ingress/annotations/backendprotocol/main_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	api "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
@@ -28,14 +28,14 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func buildIngress() *extensions.Ingress {
-	return &extensions.Ingress{
+func buildIngress() *networking.Ingress {
+	return &networking.Ingress{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "foo",
 			Namespace: api.NamespaceDefault,
 		},
-		Spec: extensions.IngressSpec{
-			Backend: &extensions.IngressBackend{
+		Spec: networking.IngressSpec{
+			Backend: &networking.IngressBackend{
 				ServiceName: "default-backend",
 				ServicePort: intstr.FromInt(80),
 			},

--- a/internal/ingress/annotations/canary/main.go
+++ b/internal/ingress/annotations/canary/main.go
@@ -17,7 +17,7 @@ limitations under the License.
 package canary
 
 import (
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	"k8s.io/ingress-nginx/internal/ingress/errors"
@@ -44,7 +44,7 @@ func NewParser(r resolver.Resolver) parser.IngressAnnotation {
 
 // Parse parses the annotations contained in the ingress
 // rule used to indicate if the canary should be enabled and with what config
-func (c canary) Parse(ing *extensions.Ingress) (interface{}, error) {
+func (c canary) Parse(ing *networking.Ingress) (interface{}, error) {
 	config := &Config{}
 	var err error
 

--- a/internal/ingress/annotations/canary/main_test.go
+++ b/internal/ingress/annotations/canary/main_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	api "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
@@ -30,28 +30,28 @@ import (
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
 )
 
-func buildIngress() *extensions.Ingress {
-	defaultBackend := extensions.IngressBackend{
+func buildIngress() *networking.Ingress {
+	defaultBackend := networking.IngressBackend{
 		ServiceName: "default-backend",
 		ServicePort: intstr.FromInt(80),
 	}
 
-	return &extensions.Ingress{
+	return &networking.Ingress{
 		ObjectMeta: metaV1.ObjectMeta{
 			Name:      "foo",
 			Namespace: api.NamespaceDefault,
 		},
-		Spec: extensions.IngressSpec{
-			Backend: &extensions.IngressBackend{
+		Spec: networking.IngressSpec{
+			Backend: &networking.IngressBackend{
 				ServiceName: "default-backend",
 				ServicePort: intstr.FromInt(80),
 			},
-			Rules: []extensions.IngressRule{
+			Rules: []networking.IngressRule{
 				{
 					Host: "foo.bar.com",
-					IngressRuleValue: extensions.IngressRuleValue{
-						HTTP: &extensions.HTTPIngressRuleValue{
-							Paths: []extensions.HTTPIngressPath{
+					IngressRuleValue: networking.IngressRuleValue{
+						HTTP: &networking.HTTPIngressRuleValue{
+							Paths: []networking.HTTPIngressPath{
 								{
 									Path:    "/foo",
 									Backend: defaultBackend,

--- a/internal/ingress/annotations/class/main.go
+++ b/internal/ingress/annotations/class/main.go
@@ -17,8 +17,9 @@ limitations under the License.
 package class
 
 import (
-	extensions "k8s.io/api/extensions/v1beta1"
 	"k8s.io/klog"
+
+	networking "k8s.io/api/networking/v1beta1"
 )
 
 const (
@@ -41,7 +42,7 @@ var (
 // IsValid returns true if the given Ingress either doesn't specify
 // the ingress.class annotation, or it's set to the configured in the
 // ingress controller.
-func IsValid(ing *extensions.Ingress) bool {
+func IsValid(ing *networking.Ingress) bool {
 	ingress, ok := ing.GetAnnotations()[IngressKey]
 	if !ok {
 		klog.V(3).Infof("annotation %v is not present in ingress %v/%v", IngressKey, ing.Namespace, ing.Name)

--- a/internal/ingress/annotations/class/main_test.go
+++ b/internal/ingress/annotations/class/main_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	api "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -47,7 +47,7 @@ func TestIsValidClass(t *testing.T) {
 		{"custom", "nginx", "nginx", false},
 	}
 
-	ing := &extensions.Ingress{
+	ing := &networking.Ingress{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "foo",
 			Namespace: api.NamespaceDefault,

--- a/internal/ingress/annotations/clientbodybuffersize/main.go
+++ b/internal/ingress/annotations/clientbodybuffersize/main.go
@@ -17,7 +17,7 @@ limitations under the License.
 package clientbodybuffersize
 
 import (
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
@@ -34,6 +34,6 @@ func NewParser(r resolver.Resolver) parser.IngressAnnotation {
 
 // Parse parses the annotations contained in the ingress rule
 // used to add an client-body-buffer-size to the provided locations
-func (cbbs clientBodyBufferSize) Parse(ing *extensions.Ingress) (interface{}, error) {
+func (cbbs clientBodyBufferSize) Parse(ing *networking.Ingress) (interface{}, error) {
 	return parser.GetStringAnnotation("client-body-buffer-size", ing)
 }

--- a/internal/ingress/annotations/clientbodybuffersize/main_test.go
+++ b/internal/ingress/annotations/clientbodybuffersize/main_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	api "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
@@ -44,12 +44,12 @@ func TestParse(t *testing.T) {
 		{nil, ""},
 	}
 
-	ing := &extensions.Ingress{
+	ing := &networking.Ingress{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "foo",
 			Namespace: api.NamespaceDefault,
 		},
-		Spec: extensions.IngressSpec{},
+		Spec: networking.IngressSpec{},
 	}
 
 	for _, testCase := range testCases {

--- a/internal/ingress/annotations/connection/main.go
+++ b/internal/ingress/annotations/connection/main.go
@@ -17,7 +17,7 @@ limitations under the License.
 package connection
 
 import (
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
@@ -40,7 +40,7 @@ func NewParser(r resolver.Resolver) parser.IngressAnnotation {
 
 // Parse parses the annotations contained in the ingress
 // rule used to indicate if the connection header should be overridden.
-func (a connection) Parse(ing *extensions.Ingress) (interface{}, error) {
+func (a connection) Parse(ing *networking.Ingress) (interface{}, error) {
 	cp, err := parser.GetStringAnnotation("connection-proxy-header", ing)
 	if err != nil {
 		return &Config{

--- a/internal/ingress/annotations/connection/main_test.go
+++ b/internal/ingress/annotations/connection/main_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	api "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
@@ -43,12 +43,12 @@ func TestParse(t *testing.T) {
 		{nil, &Config{Enabled: false}},
 	}
 
-	ing := &extensions.Ingress{
+	ing := &networking.Ingress{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "foo",
 			Namespace: api.NamespaceDefault,
 		},
-		Spec: extensions.IngressSpec{},
+		Spec: networking.IngressSpec{},
 	}
 
 	for _, testCase := range testCases {

--- a/internal/ingress/annotations/cors/main.go
+++ b/internal/ingress/annotations/cors/main.go
@@ -19,7 +19,7 @@ package cors
 import (
 	"regexp"
 
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
@@ -96,7 +96,7 @@ func (c1 *Config) Equal(c2 *Config) bool {
 
 // Parse parses the annotations contained in the ingress
 // rule used to indicate if the location/s should allows CORS
-func (c cors) Parse(ing *extensions.Ingress) (interface{}, error) {
+func (c cors) Parse(ing *networking.Ingress) (interface{}, error) {
 	var err error
 	config := &Config{}
 

--- a/internal/ingress/annotations/cors/main_test.go
+++ b/internal/ingress/annotations/cors/main_test.go
@@ -20,35 +20,35 @@ import (
 	"testing"
 
 	api "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
 )
 
-func buildIngress() *extensions.Ingress {
-	defaultBackend := extensions.IngressBackend{
+func buildIngress() *networking.Ingress {
+	defaultBackend := networking.IngressBackend{
 		ServiceName: "default-backend",
 		ServicePort: intstr.FromInt(80),
 	}
 
-	return &extensions.Ingress{
+	return &networking.Ingress{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "foo",
 			Namespace: api.NamespaceDefault,
 		},
-		Spec: extensions.IngressSpec{
-			Backend: &extensions.IngressBackend{
+		Spec: networking.IngressSpec{
+			Backend: &networking.IngressBackend{
 				ServiceName: "default-backend",
 				ServicePort: intstr.FromInt(80),
 			},
-			Rules: []extensions.IngressRule{
+			Rules: []networking.IngressRule{
 				{
 					Host: "foo.bar.com",
-					IngressRuleValue: extensions.IngressRuleValue{
-						HTTP: &extensions.HTTPIngressRuleValue{
-							Paths: []extensions.HTTPIngressPath{
+					IngressRuleValue: networking.IngressRuleValue{
+						HTTP: &networking.HTTPIngressRuleValue{
+							Paths: []networking.HTTPIngressPath{
 								{
 									Path:    "/foo",
 									Backend: defaultBackend,

--- a/internal/ingress/annotations/customhttperrors/main.go
+++ b/internal/ingress/annotations/customhttperrors/main.go
@@ -20,7 +20,7 @@ import (
 	"strconv"
 	"strings"
 
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
@@ -37,7 +37,7 @@ func NewParser(r resolver.Resolver) parser.IngressAnnotation {
 
 // Parse parses the annotations contained in the ingress to use
 // custom http errors
-func (e customhttperrors) Parse(ing *extensions.Ingress) (interface{}, error) {
+func (e customhttperrors) Parse(ing *networking.Ingress) (interface{}, error) {
 	c, err := parser.GetStringAnnotation("custom-http-errors", ing)
 	if err != nil {
 		return nil, err

--- a/internal/ingress/annotations/customhttperrors/main_test.go
+++ b/internal/ingress/annotations/customhttperrors/main_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	api "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
@@ -30,14 +30,14 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func buildIngress() *extensions.Ingress {
-	return &extensions.Ingress{
+func buildIngress() *networking.Ingress {
+	return &networking.Ingress{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "foo",
 			Namespace: api.NamespaceDefault,
 		},
-		Spec: extensions.IngressSpec{
-			Backend: &extensions.IngressBackend{
+		Spec: networking.IngressSpec{
+			Backend: &networking.IngressBackend{
 				ServiceName: "default-backend",
 				ServicePort: intstr.FromInt(80),
 			},

--- a/internal/ingress/annotations/defaultbackend/main.go
+++ b/internal/ingress/annotations/defaultbackend/main.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
@@ -37,7 +37,7 @@ func NewParser(r resolver.Resolver) parser.IngressAnnotation {
 
 // Parse parses the annotations contained in the ingress to use
 // a custom default backend
-func (db backend) Parse(ing *extensions.Ingress) (interface{}, error) {
+func (db backend) Parse(ing *networking.Ingress) (interface{}, error) {
 	s, err := parser.GetStringAnnotation("default-backend", ing)
 	if err != nil {
 		return nil, err

--- a/internal/ingress/annotations/defaultbackend/main_test.go
+++ b/internal/ingress/annotations/defaultbackend/main_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	api "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	"k8s.io/ingress-nginx/internal/ingress/errors"
@@ -29,28 +29,28 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func buildIngress() *extensions.Ingress {
-	defaultBackend := extensions.IngressBackend{
+func buildIngress() *networking.Ingress {
+	defaultBackend := networking.IngressBackend{
 		ServiceName: "default-backend",
 		ServicePort: intstr.FromInt(80),
 	}
 
-	return &extensions.Ingress{
+	return &networking.Ingress{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "foo",
 			Namespace: api.NamespaceDefault,
 		},
-		Spec: extensions.IngressSpec{
-			Backend: &extensions.IngressBackend{
+		Spec: networking.IngressSpec{
+			Backend: &networking.IngressBackend{
 				ServiceName: "default-backend",
 				ServicePort: intstr.FromInt(80),
 			},
-			Rules: []extensions.IngressRule{
+			Rules: []networking.IngressRule{
 				{
 					Host: "foo.bar.com",
-					IngressRuleValue: extensions.IngressRuleValue{
-						HTTP: &extensions.HTTPIngressRuleValue{
-							Paths: []extensions.HTTPIngressPath{
+					IngressRuleValue: networking.IngressRuleValue{
+						HTTP: &networking.HTTPIngressRuleValue{
+							Paths: []networking.HTTPIngressPath{
 								{
 									Path:    "/foo",
 									Backend: defaultBackend,

--- a/internal/ingress/annotations/http2pushpreload/main.go
+++ b/internal/ingress/annotations/http2pushpreload/main.go
@@ -17,7 +17,7 @@ limitations under the License.
 package http2pushpreload
 
 import (
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
@@ -34,6 +34,6 @@ func NewParser(r resolver.Resolver) parser.IngressAnnotation {
 
 // Parse parses the annotations contained in the ingress rule
 // used to add http2 push preload to the server
-func (h2pp http2PushPreload) Parse(ing *extensions.Ingress) (interface{}, error) {
+func (h2pp http2PushPreload) Parse(ing *networking.Ingress) (interface{}, error) {
 	return parser.GetBoolAnnotation("http2-push-preload", ing)
 }

--- a/internal/ingress/annotations/http2pushpreload/main_test.go
+++ b/internal/ingress/annotations/http2pushpreload/main_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	api "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
@@ -44,12 +44,12 @@ func TestParse(t *testing.T) {
 		{nil, false},
 	}
 
-	ing := &extensions.Ingress{
+	ing := &networking.Ingress{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "foo",
 			Namespace: api.NamespaceDefault,
 		},
-		Spec: extensions.IngressSpec{},
+		Spec: networking.IngressSpec{},
 	}
 
 	for _, testCase := range testCases {

--- a/internal/ingress/annotations/influxdb/main.go
+++ b/internal/ingress/annotations/influxdb/main.go
@@ -17,7 +17,7 @@ limitations under the License.
 package influxdb
 
 import (
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
@@ -42,7 +42,7 @@ func NewParser(r resolver.Resolver) parser.IngressAnnotation {
 }
 
 // Parse parses the annotations to look for InfluxDB configurations
-func (c influxdb) Parse(ing *extensions.Ingress) (interface{}, error) {
+func (c influxdb) Parse(ing *networking.Ingress) (interface{}, error) {
 	var err error
 	config := &Config{}
 

--- a/internal/ingress/annotations/influxdb/main_test.go
+++ b/internal/ingress/annotations/influxdb/main_test.go
@@ -20,35 +20,35 @@ import (
 	"testing"
 
 	api "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
 )
 
-func buildIngress() *extensions.Ingress {
-	defaultBackend := extensions.IngressBackend{
+func buildIngress() *networking.Ingress {
+	defaultBackend := networking.IngressBackend{
 		ServiceName: "default-backend",
 		ServicePort: intstr.FromInt(80),
 	}
 
-	return &extensions.Ingress{
+	return &networking.Ingress{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "foo",
 			Namespace: api.NamespaceDefault,
 		},
-		Spec: extensions.IngressSpec{
-			Backend: &extensions.IngressBackend{
+		Spec: networking.IngressSpec{
+			Backend: &networking.IngressBackend{
 				ServiceName: "default-backend",
 				ServicePort: intstr.FromInt(80),
 			},
-			Rules: []extensions.IngressRule{
+			Rules: []networking.IngressRule{
 				{
 					Host: "foo.bar.com",
-					IngressRuleValue: extensions.IngressRuleValue{
-						HTTP: &extensions.HTTPIngressRuleValue{
-							Paths: []extensions.HTTPIngressPath{
+					IngressRuleValue: networking.IngressRuleValue{
+						HTTP: &networking.HTTPIngressRuleValue{
+							Paths: []networking.HTTPIngressPath{
 								{
 									Path:    "/foo",
 									Backend: defaultBackend,

--- a/internal/ingress/annotations/ipwhitelist/main.go
+++ b/internal/ingress/annotations/ipwhitelist/main.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	"k8s.io/ingress-nginx/internal/net"
 
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
@@ -66,7 +66,7 @@ func NewParser(r resolver.Resolver) parser.IngressAnnotation {
 // rule used to limit access to certain client addresses or networks.
 // Multiple ranges can specified using commas as separator
 // e.g. `18.0.0.0/8,56.0.0.0/8`
-func (a ipwhitelist) Parse(ing *extensions.Ingress) (interface{}, error) {
+func (a ipwhitelist) Parse(ing *networking.Ingress) (interface{}, error) {
 	defBackend := a.r.GetDefaultBackend()
 	sort.Strings(defBackend.WhitelistSourceRange)
 

--- a/internal/ingress/annotations/ipwhitelist/main_test.go
+++ b/internal/ingress/annotations/ipwhitelist/main_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	api "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
@@ -28,28 +28,28 @@ import (
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
 )
 
-func buildIngress() *extensions.Ingress {
-	defaultBackend := extensions.IngressBackend{
+func buildIngress() *networking.Ingress {
+	defaultBackend := networking.IngressBackend{
 		ServiceName: "default-backend",
 		ServicePort: intstr.FromInt(80),
 	}
 
-	return &extensions.Ingress{
+	return &networking.Ingress{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "foo",
 			Namespace: api.NamespaceDefault,
 		},
-		Spec: extensions.IngressSpec{
-			Backend: &extensions.IngressBackend{
+		Spec: networking.IngressSpec{
+			Backend: &networking.IngressBackend{
 				ServiceName: "default-backend",
 				ServicePort: intstr.FromInt(80),
 			},
-			Rules: []extensions.IngressRule{
+			Rules: []networking.IngressRule{
 				{
 					Host: "foo.bar.com",
-					IngressRuleValue: extensions.IngressRuleValue{
-						HTTP: &extensions.HTTPIngressRuleValue{
-							Paths: []extensions.HTTPIngressPath{
+					IngressRuleValue: networking.IngressRuleValue{
+						HTTP: &networking.HTTPIngressRuleValue{
+							Paths: []networking.HTTPIngressPath{
 								{
 									Path:    "/foo",
 									Backend: defaultBackend,

--- a/internal/ingress/annotations/loadbalancing/main.go
+++ b/internal/ingress/annotations/loadbalancing/main.go
@@ -17,7 +17,7 @@ limitations under the License.
 package loadbalancing
 
 import (
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
@@ -35,6 +35,6 @@ func NewParser(r resolver.Resolver) parser.IngressAnnotation {
 // Parse parses the annotations contained in the ingress rule
 // used to indicate if the location/s contains a fragment of
 // configuration to be included inside the paths of the rules
-func (a loadbalancing) Parse(ing *extensions.Ingress) (interface{}, error) {
+func (a loadbalancing) Parse(ing *networking.Ingress) (interface{}, error) {
 	return parser.GetStringAnnotation("load-balance", ing)
 }

--- a/internal/ingress/annotations/loadbalancing/main_test.go
+++ b/internal/ingress/annotations/loadbalancing/main_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	api "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
@@ -43,12 +43,12 @@ func TestParse(t *testing.T) {
 		{nil, ""},
 	}
 
-	ing := &extensions.Ingress{
+	ing := &networking.Ingress{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "foo",
 			Namespace: api.NamespaceDefault,
 		},
-		Spec: extensions.IngressSpec{},
+		Spec: networking.IngressSpec{},
 	}
 
 	for _, testCase := range testCases {

--- a/internal/ingress/annotations/log/main.go
+++ b/internal/ingress/annotations/log/main.go
@@ -17,7 +17,7 @@ limitations under the License.
 package log
 
 import (
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
@@ -53,7 +53,7 @@ func NewParser(r resolver.Resolver) parser.IngressAnnotation {
 
 // Parse parses the annotations contained in the ingress
 // rule used to indicate if the location/s should enable logs
-func (l log) Parse(ing *extensions.Ingress) (interface{}, error) {
+func (l log) Parse(ing *networking.Ingress) (interface{}, error) {
 	var err error
 	config := &Config{}
 

--- a/internal/ingress/annotations/log/main_test.go
+++ b/internal/ingress/annotations/log/main_test.go
@@ -20,35 +20,35 @@ import (
 	"testing"
 
 	api "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
 )
 
-func buildIngress() *extensions.Ingress {
-	defaultBackend := extensions.IngressBackend{
+func buildIngress() *networking.Ingress {
+	defaultBackend := networking.IngressBackend{
 		ServiceName: "default-backend",
 		ServicePort: intstr.FromInt(80),
 	}
 
-	return &extensions.Ingress{
+	return &networking.Ingress{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "foo",
 			Namespace: api.NamespaceDefault,
 		},
-		Spec: extensions.IngressSpec{
-			Backend: &extensions.IngressBackend{
+		Spec: networking.IngressSpec{
+			Backend: &networking.IngressBackend{
 				ServiceName: "default-backend",
 				ServicePort: intstr.FromInt(80),
 			},
-			Rules: []extensions.IngressRule{
+			Rules: []networking.IngressRule{
 				{
 					Host: "foo.bar.com",
-					IngressRuleValue: extensions.IngressRuleValue{
-						HTTP: &extensions.HTTPIngressRuleValue{
-							Paths: []extensions.HTTPIngressPath{
+					IngressRuleValue: networking.IngressRuleValue{
+						HTTP: &networking.HTTPIngressRuleValue{
+							Paths: []networking.HTTPIngressPath{
 								{
 									Path:    "/foo",
 									Backend: defaultBackend,

--- a/internal/ingress/annotations/luarestywaf/main.go
+++ b/internal/ingress/annotations/luarestywaf/main.go
@@ -19,7 +19,7 @@ package luarestywaf
 import (
 	"strings"
 
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	"k8s.io/ingress-nginx/internal/ingress/errors"
@@ -88,7 +88,7 @@ func NewParser(r resolver.Resolver) parser.IngressAnnotation {
 // Parse parses the annotations contained in the ingress rule
 // used to indicate if the location/s contains a fragment of
 // configuration to be included inside the paths of the rules
-func (a luarestywaf) Parse(ing *extensions.Ingress) (interface{}, error) {
+func (a luarestywaf) Parse(ing *networking.Ingress) (interface{}, error) {
 	var err error
 	config := &Config{}
 

--- a/internal/ingress/annotations/luarestywaf/main_test.go
+++ b/internal/ingress/annotations/luarestywaf/main_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	api "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
@@ -67,12 +67,12 @@ func TestParse(t *testing.T) {
 		{map[string]string{luaRestyWAFAnnotation: "active", luaRestyWAFProcessMultipartBody: "false"}, &Config{Mode: "ACTIVE", ProcessMultipartBody: false, IgnoredRuleSets: []string{}}},
 	}
 
-	ing := &extensions.Ingress{
+	ing := &networking.Ingress{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "foo",
 			Namespace: api.NamespaceDefault,
 		},
-		Spec: extensions.IngressSpec{},
+		Spec: networking.IngressSpec{},
 	}
 
 	for _, testCase := range testCases {

--- a/internal/ingress/annotations/modsecurity/main.go
+++ b/internal/ingress/annotations/modsecurity/main.go
@@ -17,7 +17,7 @@ limitations under the License.
 package modsecurity
 
 import (
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
 )
@@ -65,7 +65,7 @@ type modSecurity struct {
 
 // Parse parses the annotations contained in the ingress
 // rule used to enable ModSecurity in a particular location
-func (a modSecurity) Parse(ing *extensions.Ingress) (interface{}, error) {
+func (a modSecurity) Parse(ing *networking.Ingress) (interface{}, error) {
 	var err error
 	config := &Config{}
 

--- a/internal/ingress/annotations/modsecurity/main_test.go
+++ b/internal/ingress/annotations/modsecurity/main_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	api "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
@@ -59,12 +59,12 @@ func TestParse(t *testing.T) {
 		{nil, Config{false, false, "", ""}},
 	}
 
-	ing := &extensions.Ingress{
+	ing := &networking.Ingress{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "foo",
 			Namespace: api.NamespaceDefault,
 		},
-		Spec: extensions.IngressSpec{},
+		Spec: networking.IngressSpec{},
 	}
 
 	for _, testCase := range testCases {

--- a/internal/ingress/annotations/parser/main.go
+++ b/internal/ingress/annotations/parser/main.go
@@ -21,7 +21,7 @@ import (
 	"strconv"
 	"strings"
 
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 
 	"k8s.io/ingress-nginx/internal/ingress/errors"
 )
@@ -33,7 +33,7 @@ var (
 
 // IngressAnnotation has a method to parse annotations located in Ingress
 type IngressAnnotation interface {
-	Parse(ing *extensions.Ingress) (interface{}, error)
+	Parse(ing *networking.Ingress) (interface{}, error)
 }
 
 type ingAnnotations map[string]string
@@ -75,7 +75,7 @@ func (a ingAnnotations) parseInt(name string) (int, error) {
 	return 0, errors.ErrMissingAnnotations
 }
 
-func checkAnnotation(name string, ing *extensions.Ingress) error {
+func checkAnnotation(name string, ing *networking.Ingress) error {
 	if ing == nil || len(ing.GetAnnotations()) == 0 {
 		return errors.ErrMissingAnnotations
 	}
@@ -87,7 +87,7 @@ func checkAnnotation(name string, ing *extensions.Ingress) error {
 }
 
 // GetBoolAnnotation extracts a boolean from an Ingress annotation
-func GetBoolAnnotation(name string, ing *extensions.Ingress) (bool, error) {
+func GetBoolAnnotation(name string, ing *networking.Ingress) (bool, error) {
 	v := GetAnnotationWithPrefix(name)
 	err := checkAnnotation(v, ing)
 	if err != nil {
@@ -97,7 +97,7 @@ func GetBoolAnnotation(name string, ing *extensions.Ingress) (bool, error) {
 }
 
 // GetStringAnnotation extracts a string from an Ingress annotation
-func GetStringAnnotation(name string, ing *extensions.Ingress) (string, error) {
+func GetStringAnnotation(name string, ing *networking.Ingress) (string, error) {
 	v := GetAnnotationWithPrefix(name)
 	err := checkAnnotation(v, ing)
 	if err != nil {
@@ -108,7 +108,7 @@ func GetStringAnnotation(name string, ing *extensions.Ingress) (string, error) {
 }
 
 // GetIntAnnotation extracts an int from an Ingress annotation
-func GetIntAnnotation(name string, ing *extensions.Ingress) (int, error) {
+func GetIntAnnotation(name string, ing *networking.Ingress) (int, error) {
 	v := GetAnnotationWithPrefix(name)
 	err := checkAnnotation(v, ing)
 	if err != nil {

--- a/internal/ingress/annotations/parser/main_test.go
+++ b/internal/ingress/annotations/parser/main_test.go
@@ -20,17 +20,17 @@ import (
 	"testing"
 
 	api "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func buildIngress() *extensions.Ingress {
-	return &extensions.Ingress{
+func buildIngress() *networking.Ingress {
+	return &networking.Ingress{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "foo",
 			Namespace: api.NamespaceDefault,
 		},
-		Spec: extensions.IngressSpec{},
+		Spec: networking.IngressSpec{},
 	}
 }
 

--- a/internal/ingress/annotations/portinredirect/main.go
+++ b/internal/ingress/annotations/portinredirect/main.go
@@ -17,7 +17,7 @@ limitations under the License.
 package portinredirect
 
 import (
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
@@ -34,7 +34,7 @@ func NewParser(r resolver.Resolver) parser.IngressAnnotation {
 
 // Parse parses the annotations contained in the ingress
 // rule used to indicate if the redirects must
-func (a portInRedirect) Parse(ing *extensions.Ingress) (interface{}, error) {
+func (a portInRedirect) Parse(ing *networking.Ingress) (interface{}, error) {
 	up, err := parser.GetBoolAnnotation("use-port-in-redirects", ing)
 	if err != nil {
 		return a.r.GetDefaultBackend().UsePortInRedirects, nil

--- a/internal/ingress/annotations/portinredirect/main_test.go
+++ b/internal/ingress/annotations/portinredirect/main_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	api "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
@@ -30,28 +30,28 @@ import (
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
 )
 
-func buildIngress() *extensions.Ingress {
-	defaultBackend := extensions.IngressBackend{
+func buildIngress() *networking.Ingress {
+	defaultBackend := networking.IngressBackend{
 		ServiceName: "default-backend",
 		ServicePort: intstr.FromInt(80),
 	}
 
-	return &extensions.Ingress{
+	return &networking.Ingress{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "foo",
 			Namespace: api.NamespaceDefault,
 		},
-		Spec: extensions.IngressSpec{
-			Backend: &extensions.IngressBackend{
+		Spec: networking.IngressSpec{
+			Backend: &networking.IngressBackend{
 				ServiceName: "default-backend",
 				ServicePort: intstr.FromInt(80),
 			},
-			Rules: []extensions.IngressRule{
+			Rules: []networking.IngressRule{
 				{
 					Host: "foo.bar.com",
-					IngressRuleValue: extensions.IngressRuleValue{
-						HTTP: &extensions.HTTPIngressRuleValue{
-							Paths: []extensions.HTTPIngressPath{
+					IngressRuleValue: networking.IngressRuleValue{
+						HTTP: &networking.HTTPIngressRuleValue{
+							Paths: []networking.HTTPIngressPath{
 								{
 									Path:    "/foo",
 									Backend: defaultBackend,

--- a/internal/ingress/annotations/proxy/main.go
+++ b/internal/ingress/annotations/proxy/main.go
@@ -17,7 +17,7 @@ limitations under the License.
 package proxy
 
 import (
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
@@ -110,7 +110,7 @@ func NewParser(r resolver.Resolver) parser.IngressAnnotation {
 
 // ParseAnnotations parses the annotations contained in the ingress
 // rule used to configure upstream check parameters
-func (a proxy) Parse(ing *extensions.Ingress) (interface{}, error) {
+func (a proxy) Parse(ing *networking.Ingress) (interface{}, error) {
 	defBackend := a.r.GetDefaultBackend()
 	config := &Config{}
 

--- a/internal/ingress/annotations/proxy/main_test.go
+++ b/internal/ingress/annotations/proxy/main_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	api "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
@@ -29,28 +29,28 @@ import (
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
 )
 
-func buildIngress() *extensions.Ingress {
-	defaultBackend := extensions.IngressBackend{
+func buildIngress() *networking.Ingress {
+	defaultBackend := networking.IngressBackend{
 		ServiceName: "default-backend",
 		ServicePort: intstr.FromInt(80),
 	}
 
-	return &extensions.Ingress{
+	return &networking.Ingress{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "foo",
 			Namespace: api.NamespaceDefault,
 		},
-		Spec: extensions.IngressSpec{
-			Backend: &extensions.IngressBackend{
+		Spec: networking.IngressSpec{
+			Backend: &networking.IngressBackend{
 				ServiceName: "default-backend",
 				ServicePort: intstr.FromInt(80),
 			},
-			Rules: []extensions.IngressRule{
+			Rules: []networking.IngressRule{
 				{
 					Host: "foo.bar.com",
-					IngressRuleValue: extensions.IngressRuleValue{
-						HTTP: &extensions.HTTPIngressRuleValue{
-							Paths: []extensions.HTTPIngressPath{
+					IngressRuleValue: networking.IngressRuleValue{
+						HTTP: &networking.HTTPIngressRuleValue{
+							Paths: []networking.HTTPIngressPath{
 								{
 									Path:    "/foo",
 									Backend: defaultBackend,

--- a/internal/ingress/annotations/ratelimit/main.go
+++ b/internal/ingress/annotations/ratelimit/main.go
@@ -22,7 +22,7 @@ import (
 	"sort"
 	"strings"
 
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
@@ -148,7 +148,7 @@ func NewParser(r resolver.Resolver) parser.IngressAnnotation {
 
 // ParseAnnotations parses the annotations contained in the ingress
 // rule used to rewrite the defined paths
-func (a ratelimit) Parse(ing *extensions.Ingress) (interface{}, error) {
+func (a ratelimit) Parse(ing *networking.Ingress) (interface{}, error) {
 	defBackend := a.r.GetDefaultBackend()
 	lr, err := parser.GetIntAnnotation("limit-rate", ing)
 	if err != nil {

--- a/internal/ingress/annotations/ratelimit/main_test.go
+++ b/internal/ingress/annotations/ratelimit/main_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	api "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -31,28 +31,28 @@ import (
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
 )
 
-func buildIngress() *extensions.Ingress {
-	defaultBackend := extensions.IngressBackend{
+func buildIngress() *networking.Ingress {
+	defaultBackend := networking.IngressBackend{
 		ServiceName: "default-backend",
 		ServicePort: intstr.FromInt(80),
 	}
 
-	return &extensions.Ingress{
+	return &networking.Ingress{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "foo",
 			Namespace: api.NamespaceDefault,
 		},
-		Spec: extensions.IngressSpec{
-			Backend: &extensions.IngressBackend{
+		Spec: networking.IngressSpec{
+			Backend: &networking.IngressBackend{
 				ServiceName: "default-backend",
 				ServicePort: intstr.FromInt(80),
 			},
-			Rules: []extensions.IngressRule{
+			Rules: []networking.IngressRule{
 				{
 					Host: "foo.bar.com",
-					IngressRuleValue: extensions.IngressRuleValue{
-						HTTP: &extensions.HTTPIngressRuleValue{
-							Paths: []extensions.HTTPIngressPath{
+					IngressRuleValue: networking.IngressRuleValue{
+						HTTP: &networking.HTTPIngressRuleValue{
+							Paths: []networking.HTTPIngressPath{
 								{
 									Path:    "/foo",
 									Backend: defaultBackend,

--- a/internal/ingress/annotations/redirect/redirect.go
+++ b/internal/ingress/annotations/redirect/redirect.go
@@ -21,7 +21,7 @@ import (
 	"net/url"
 	"strings"
 
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	"k8s.io/ingress-nginx/internal/ingress/errors"
@@ -50,7 +50,7 @@ func NewParser(r resolver.Resolver) parser.IngressAnnotation {
 // rule used to create a redirect in the paths defined in the rule.
 // If the Ingress contains both annotations the execution order is
 // temporal and then permanent
-func (r redirect) Parse(ing *extensions.Ingress) (interface{}, error) {
+func (r redirect) Parse(ing *networking.Ingress) (interface{}, error) {
 	r3w, _ := parser.GetBoolAnnotation("from-to-www-redirect", ing)
 
 	tr, err := parser.GetStringAnnotation("temporal-redirect", ing)

--- a/internal/ingress/annotations/redirect/redirect_test.go
+++ b/internal/ingress/annotations/redirect/redirect_test.go
@@ -23,7 +23,7 @@ import (
 	"strconv"
 	"testing"
 
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	"k8s.io/ingress-nginx/internal/ingress/errors"
@@ -40,7 +40,7 @@ func TestPermanentRedirectWithDefaultCode(t *testing.T) {
 		t.Fatalf("Expected a parser.IngressAnnotation but returned nil")
 	}
 
-	ing := new(extensions.Ingress)
+	ing := new(networking.Ingress)
 
 	data := make(map[string]string, 1)
 	data[parser.GetAnnotationWithPrefix("permanent-redirect")] = defRedirectURL
@@ -78,7 +78,7 @@ func TestPermanentRedirectWithCustomCode(t *testing.T) {
 
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
-			ing := new(extensions.Ingress)
+			ing := new(networking.Ingress)
 
 			data := make(map[string]string, 2)
 			data[parser.GetAnnotationWithPrefix("permanent-redirect")] = defRedirectURL
@@ -109,7 +109,7 @@ func TestTemporalRedirect(t *testing.T) {
 		t.Fatalf("Expected a parser.IngressAnnotation but returned nil")
 	}
 
-	ing := new(extensions.Ingress)
+	ing := new(networking.Ingress)
 
 	data := make(map[string]string, 1)
 	data[parser.GetAnnotationWithPrefix("from-to-www-redirect")] = "true"

--- a/internal/ingress/annotations/rewrite/main.go
+++ b/internal/ingress/annotations/rewrite/main.go
@@ -17,7 +17,7 @@ limitations under the License.
 package rewrite
 
 import (
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
@@ -75,7 +75,7 @@ func NewParser(r resolver.Resolver) parser.IngressAnnotation {
 
 // ParseAnnotations parses the annotations contained in the ingress
 // rule used to rewrite the defined paths
-func (a rewrite) Parse(ing *extensions.Ingress) (interface{}, error) {
+func (a rewrite) Parse(ing *networking.Ingress) (interface{}, error) {
 	var err error
 	config := &Config{}
 

--- a/internal/ingress/annotations/rewrite/main_test.go
+++ b/internal/ingress/annotations/rewrite/main_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	api "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
@@ -33,28 +33,28 @@ const (
 	defRoute = "/demo"
 )
 
-func buildIngress() *extensions.Ingress {
-	defaultBackend := extensions.IngressBackend{
+func buildIngress() *networking.Ingress {
+	defaultBackend := networking.IngressBackend{
 		ServiceName: "default-backend",
 		ServicePort: intstr.FromInt(80),
 	}
 
-	return &extensions.Ingress{
+	return &networking.Ingress{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "foo",
 			Namespace: api.NamespaceDefault,
 		},
-		Spec: extensions.IngressSpec{
-			Backend: &extensions.IngressBackend{
+		Spec: networking.IngressSpec{
+			Backend: &networking.IngressBackend{
 				ServiceName: "default-backend",
 				ServicePort: intstr.FromInt(80),
 			},
-			Rules: []extensions.IngressRule{
+			Rules: []networking.IngressRule{
 				{
 					Host: "foo.bar.com",
-					IngressRuleValue: extensions.IngressRuleValue{
-						HTTP: &extensions.HTTPIngressRuleValue{
-							Paths: []extensions.HTTPIngressPath{
+					IngressRuleValue: networking.IngressRuleValue{
+						HTTP: &networking.HTTPIngressRuleValue{
+							Paths: []networking.HTTPIngressPath{
 								{
 									Path:    "/foo",
 									Backend: defaultBackend,

--- a/internal/ingress/annotations/satisfy/main.go
+++ b/internal/ingress/annotations/satisfy/main.go
@@ -17,7 +17,7 @@ limitations under the License.
 package satisfy
 
 import (
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
@@ -33,7 +33,7 @@ func NewParser(r resolver.Resolver) parser.IngressAnnotation {
 }
 
 // Parse parses annotation contained in the ingress
-func (s satisfy) Parse(ing *extensions.Ingress) (interface{}, error) {
+func (s satisfy) Parse(ing *networking.Ingress) (interface{}, error) {
 	satisfy, err := parser.GetStringAnnotation("satisfy", ing)
 
 	if err != nil || (satisfy != "any" && satisfy != "all") {

--- a/internal/ingress/annotations/satisfy/main_test.go
+++ b/internal/ingress/annotations/satisfy/main_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	api "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -28,28 +28,28 @@ import (
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
 )
 
-func buildIngress() *extensions.Ingress {
-	defaultBackend := extensions.IngressBackend{
+func buildIngress() *networking.Ingress {
+	defaultBackend := networking.IngressBackend{
 		ServiceName: "default-backend",
 		ServicePort: intstr.FromInt(80),
 	}
 
-	return &extensions.Ingress{
+	return &networking.Ingress{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "fake",
 			Namespace: api.NamespaceDefault,
 		},
-		Spec: extensions.IngressSpec{
-			Backend: &extensions.IngressBackend{
+		Spec: networking.IngressSpec{
+			Backend: &networking.IngressBackend{
 				ServiceName: "default-backend",
 				ServicePort: intstr.FromInt(80),
 			},
-			Rules: []extensions.IngressRule{
+			Rules: []networking.IngressRule{
 				{
 					Host: "fake.host.com",
-					IngressRuleValue: extensions.IngressRuleValue{
-						HTTP: &extensions.HTTPIngressRuleValue{
-							Paths: []extensions.HTTPIngressPath{
+					IngressRuleValue: networking.IngressRuleValue{
+						HTTP: &networking.HTTPIngressRuleValue{
+							Paths: []networking.HTTPIngressPath{
 								{
 									Path:    "/fake",
 									Backend: defaultBackend,

--- a/internal/ingress/annotations/secureupstream/main.go
+++ b/internal/ingress/annotations/secureupstream/main.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
@@ -42,7 +42,7 @@ func NewParser(r resolver.Resolver) parser.IngressAnnotation {
 
 // Parse parses the annotations contained in the ingress
 // rule used to indicate if the upstream servers should use SSL
-func (a su) Parse(ing *extensions.Ingress) (interface{}, error) {
+func (a su) Parse(ing *networking.Ingress) (interface{}, error) {
 	bp, _ := parser.GetStringAnnotation("backend-protocol", ing)
 	ca, _ := parser.GetStringAnnotation("secure-verify-ca-secret", ing)
 	secure := &Config{

--- a/internal/ingress/annotations/secureupstream/main_test.go
+++ b/internal/ingress/annotations/secureupstream/main_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	api "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -29,28 +29,28 @@ import (
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
 )
 
-func buildIngress() *extensions.Ingress {
-	defaultBackend := extensions.IngressBackend{
+func buildIngress() *networking.Ingress {
+	defaultBackend := networking.IngressBackend{
 		ServiceName: "default-backend",
 		ServicePort: intstr.FromInt(80),
 	}
 
-	return &extensions.Ingress{
+	return &networking.Ingress{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "foo",
 			Namespace: api.NamespaceDefault,
 		},
-		Spec: extensions.IngressSpec{
-			Backend: &extensions.IngressBackend{
+		Spec: networking.IngressSpec{
+			Backend: &networking.IngressBackend{
 				ServiceName: "default-backend",
 				ServicePort: intstr.FromInt(80),
 			},
-			Rules: []extensions.IngressRule{
+			Rules: []networking.IngressRule{
 				{
 					Host: "foo.bar.com",
-					IngressRuleValue: extensions.IngressRuleValue{
-						HTTP: &extensions.HTTPIngressRuleValue{
-							Paths: []extensions.HTTPIngressPath{
+					IngressRuleValue: networking.IngressRuleValue{
+						HTTP: &networking.HTTPIngressRuleValue{
+							Paths: []networking.HTTPIngressPath{
 								{
 									Path:    "/foo",
 									Backend: defaultBackend,

--- a/internal/ingress/annotations/serversnippet/main.go
+++ b/internal/ingress/annotations/serversnippet/main.go
@@ -17,7 +17,7 @@ limitations under the License.
 package serversnippet
 
 import (
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
@@ -35,6 +35,6 @@ func NewParser(r resolver.Resolver) parser.IngressAnnotation {
 // Parse parses the annotations contained in the ingress rule
 // used to indicate if the location/s contains a fragment of
 // configuration to be included inside the paths of the rules
-func (a serverSnippet) Parse(ing *extensions.Ingress) (interface{}, error) {
+func (a serverSnippet) Parse(ing *networking.Ingress) (interface{}, error) {
 	return parser.GetStringAnnotation("server-snippet", ing)
 }

--- a/internal/ingress/annotations/serversnippet/main_test.go
+++ b/internal/ingress/annotations/serversnippet/main_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	api "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
@@ -44,12 +44,12 @@ func TestParse(t *testing.T) {
 		{nil, ""},
 	}
 
-	ing := &extensions.Ingress{
+	ing := &networking.Ingress{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "foo",
 			Namespace: api.NamespaceDefault,
 		},
-		Spec: extensions.IngressSpec{},
+		Spec: networking.IngressSpec{},
 	}
 
 	for _, testCase := range testCases {

--- a/internal/ingress/annotations/serviceupstream/main.go
+++ b/internal/ingress/annotations/serviceupstream/main.go
@@ -17,7 +17,7 @@ limitations under the License.
 package serviceupstream
 
 import (
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
@@ -32,6 +32,6 @@ func NewParser(r resolver.Resolver) parser.IngressAnnotation {
 	return serviceUpstream{r}
 }
 
-func (s serviceUpstream) Parse(ing *extensions.Ingress) (interface{}, error) {
+func (s serviceUpstream) Parse(ing *networking.Ingress) (interface{}, error) {
 	return parser.GetBoolAnnotation("service-upstream", ing)
 }

--- a/internal/ingress/annotations/serviceupstream/main_test.go
+++ b/internal/ingress/annotations/serviceupstream/main_test.go
@@ -20,35 +20,35 @@ import (
 	"testing"
 
 	api "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
 )
 
-func buildIngress() *extensions.Ingress {
-	defaultBackend := extensions.IngressBackend{
+func buildIngress() *networking.Ingress {
+	defaultBackend := networking.IngressBackend{
 		ServiceName: "default-backend",
 		ServicePort: intstr.FromInt(80),
 	}
 
-	return &extensions.Ingress{
+	return &networking.Ingress{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "foo",
 			Namespace: api.NamespaceDefault,
 		},
-		Spec: extensions.IngressSpec{
-			Backend: &extensions.IngressBackend{
+		Spec: networking.IngressSpec{
+			Backend: &networking.IngressBackend{
 				ServiceName: "default-backend",
 				ServicePort: intstr.FromInt(80),
 			},
-			Rules: []extensions.IngressRule{
+			Rules: []networking.IngressRule{
 				{
 					Host: "foo.bar.com",
-					IngressRuleValue: extensions.IngressRuleValue{
-						HTTP: &extensions.HTTPIngressRuleValue{
-							Paths: []extensions.HTTPIngressPath{
+					IngressRuleValue: networking.IngressRuleValue{
+						HTTP: &networking.HTTPIngressRuleValue{
+							Paths: []networking.HTTPIngressPath{
 								{
 									Path:    "/foo",
 									Backend: defaultBackend,

--- a/internal/ingress/annotations/sessionaffinity/main.go
+++ b/internal/ingress/annotations/sessionaffinity/main.go
@@ -19,7 +19,7 @@ package sessionaffinity
 import (
 	"regexp"
 
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	"k8s.io/klog"
 
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
@@ -76,7 +76,7 @@ type Cookie struct {
 
 // cookieAffinityParse gets the annotation values related to Cookie Affinity
 // It also sets default values when no value or incorrect value is found
-func (a affinity) cookieAffinityParse(ing *extensions.Ingress) *Cookie {
+func (a affinity) cookieAffinityParse(ing *networking.Ingress) *Cookie {
 	var err error
 
 	cookie := &Cookie{}
@@ -109,6 +109,11 @@ func (a affinity) cookieAffinityParse(ing *extensions.Ingress) *Cookie {
 		klog.V(3).Infof("Invalid or no annotation value found in Ingress %v: %v. Ignoring it", ing.Name, annotationAffinityCookieChangeOnFailure)
 	}
 
+	cookie.ChangeOnFailure, err = parser.GetBoolAnnotation(annotationAffinityCookieChangeOnFailure, ing)
+	if err != nil {
+		klog.V(3).Infof("Invalid or no annotation value found in Ingress %v: %v. Ignoring it", ing.Name, annotationAffinityCookieChangeOnFailure)
+	}
+
 	return cookie
 }
 
@@ -123,7 +128,7 @@ type affinity struct {
 
 // ParseAnnotations parses the annotations contained in the ingress
 // rule used to configure the affinity directives
-func (a affinity) Parse(ing *extensions.Ingress) (interface{}, error) {
+func (a affinity) Parse(ing *networking.Ingress) (interface{}, error) {
 	cookie := &Cookie{}
 	// Check the type of affinity that will be used
 	at, err := parser.GetStringAnnotation(annotationAffinityType, ing)

--- a/internal/ingress/annotations/sessionaffinity/main_test.go
+++ b/internal/ingress/annotations/sessionaffinity/main_test.go
@@ -20,35 +20,35 @@ import (
 	"testing"
 
 	api "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
 )
 
-func buildIngress() *extensions.Ingress {
-	defaultBackend := extensions.IngressBackend{
+func buildIngress() *networking.Ingress {
+	defaultBackend := networking.IngressBackend{
 		ServiceName: "default-backend",
 		ServicePort: intstr.FromInt(80),
 	}
 
-	return &extensions.Ingress{
+	return &networking.Ingress{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "foo",
 			Namespace: api.NamespaceDefault,
 		},
-		Spec: extensions.IngressSpec{
-			Backend: &extensions.IngressBackend{
+		Spec: networking.IngressSpec{
+			Backend: &networking.IngressBackend{
 				ServiceName: "default-backend",
 				ServicePort: intstr.FromInt(80),
 			},
-			Rules: []extensions.IngressRule{
+			Rules: []networking.IngressRule{
 				{
 					Host: "foo.bar.com",
-					IngressRuleValue: extensions.IngressRuleValue{
-						HTTP: &extensions.HTTPIngressRuleValue{
-							Paths: []extensions.HTTPIngressPath{
+					IngressRuleValue: networking.IngressRuleValue{
+						HTTP: &networking.HTTPIngressRuleValue{
+							Paths: []networking.HTTPIngressPath{
 								{
 									Path:    "/foo",
 									Backend: defaultBackend,
@@ -98,6 +98,10 @@ func TestIngressAffinityCookieConfig(t *testing.T) {
 
 	if nginxAffinity.Cookie.Path != "/foo" {
 		t.Errorf("expected /foo as session-cookie-path but returned %v", nginxAffinity.Cookie.Path)
+	}
+
+	if !nginxAffinity.Cookie.ChangeOnFailure {
+		t.Errorf("expected change of failure parameter set to true but returned %v", nginxAffinity.Cookie.ChangeOnFailure)
 	}
 
 	if !nginxAffinity.Cookie.ChangeOnFailure {

--- a/internal/ingress/annotations/snippet/main.go
+++ b/internal/ingress/annotations/snippet/main.go
@@ -17,7 +17,7 @@ limitations under the License.
 package snippet
 
 import (
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
@@ -35,6 +35,6 @@ func NewParser(r resolver.Resolver) parser.IngressAnnotation {
 // Parse parses the annotations contained in the ingress rule
 // used to indicate if the location/s contains a fragment of
 // configuration to be included inside the paths of the rules
-func (a snippet) Parse(ing *extensions.Ingress) (interface{}, error) {
+func (a snippet) Parse(ing *networking.Ingress) (interface{}, error) {
 	return parser.GetStringAnnotation("configuration-snippet", ing)
 }

--- a/internal/ingress/annotations/snippet/main_test.go
+++ b/internal/ingress/annotations/snippet/main_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	api "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
@@ -44,12 +44,12 @@ func TestParse(t *testing.T) {
 		{nil, ""},
 	}
 
-	ing := &extensions.Ingress{
+	ing := &networking.Ingress{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "foo",
 			Namespace: api.NamespaceDefault,
 		},
-		Spec: extensions.IngressSpec{},
+		Spec: networking.IngressSpec{},
 	}
 
 	for _, testCase := range testCases {

--- a/internal/ingress/annotations/sslcipher/main.go
+++ b/internal/ingress/annotations/sslcipher/main.go
@@ -17,7 +17,7 @@ limitations under the License.
 package sslcipher
 
 import (
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
@@ -34,6 +34,6 @@ func NewParser(r resolver.Resolver) parser.IngressAnnotation {
 
 // Parse parses the annotations contained in the ingress rule
 // used to add ssl-ciphers to the server name
-func (sc sslCipher) Parse(ing *extensions.Ingress) (interface{}, error) {
+func (sc sslCipher) Parse(ing *networking.Ingress) (interface{}, error) {
 	return parser.GetStringAnnotation("ssl-ciphers", ing)
 }

--- a/internal/ingress/annotations/sslcipher/main_test.go
+++ b/internal/ingress/annotations/sslcipher/main_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	api "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
@@ -45,12 +45,12 @@ func TestParse(t *testing.T) {
 		{nil, ""},
 	}
 
-	ing := &extensions.Ingress{
+	ing := &networking.Ingress{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "foo",
 			Namespace: api.NamespaceDefault,
 		},
-		Spec: extensions.IngressSpec{},
+		Spec: networking.IngressSpec{},
 	}
 
 	for _, testCase := range testCases {

--- a/internal/ingress/annotations/sslpassthrough/main.go
+++ b/internal/ingress/annotations/sslpassthrough/main.go
@@ -17,7 +17,7 @@ limitations under the License.
 package sslpassthrough
 
 import (
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	ing_errors "k8s.io/ingress-nginx/internal/ingress/errors"
@@ -35,7 +35,7 @@ func NewParser(r resolver.Resolver) parser.IngressAnnotation {
 
 // ParseAnnotations parses the annotations contained in the ingress
 // rule used to indicate if is required to configure
-func (a sslpt) Parse(ing *extensions.Ingress) (interface{}, error) {
+func (a sslpt) Parse(ing *networking.Ingress) (interface{}, error) {
 	if ing.GetAnnotations() == nil {
 		return false, ing_errors.ErrMissingAnnotations
 	}

--- a/internal/ingress/annotations/sslpassthrough/main_test.go
+++ b/internal/ingress/annotations/sslpassthrough/main_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	api "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
@@ -28,14 +28,14 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func buildIngress() *extensions.Ingress {
-	return &extensions.Ingress{
+func buildIngress() *networking.Ingress {
+	return &networking.Ingress{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "foo",
 			Namespace: api.NamespaceDefault,
 		},
-		Spec: extensions.IngressSpec{
-			Backend: &extensions.IngressBackend{
+		Spec: networking.IngressSpec{
+			Backend: &networking.IngressBackend{
 				ServiceName: "default-backend",
 				ServicePort: intstr.FromInt(80),
 			},
@@ -61,7 +61,7 @@ func TestParseAnnotations(t *testing.T) {
 	}
 
 	// test with a valid host
-	ing.Spec.TLS = []extensions.IngressTLS{
+	ing.Spec.TLS = []networking.IngressTLS{
 		{
 			Hosts: []string{"foo.bar.com"},
 		},

--- a/internal/ingress/annotations/upstreamhashby/main.go
+++ b/internal/ingress/annotations/upstreamhashby/main.go
@@ -17,7 +17,7 @@ limitations under the License.
 package upstreamhashby
 
 import (
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
@@ -40,7 +40,7 @@ func NewParser(r resolver.Resolver) parser.IngressAnnotation {
 }
 
 // Parse parses the annotations contained in the ingress rule
-func (a upstreamhashby) Parse(ing *extensions.Ingress) (interface{}, error) {
+func (a upstreamhashby) Parse(ing *networking.Ingress) (interface{}, error) {
 	upstreamHashBy, _ := parser.GetStringAnnotation("upstream-hash-by", ing)
 	upstreamHashBySubset, _ := parser.GetBoolAnnotation("upstream-hash-by-subset", ing)
 	upstreamHashbySubsetSize, _ := parser.GetIntAnnotation("upstream-hash-by-subset-size", ing)

--- a/internal/ingress/annotations/upstreamhashby/main_test.go
+++ b/internal/ingress/annotations/upstreamhashby/main_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	api "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
@@ -44,12 +44,12 @@ func TestParse(t *testing.T) {
 		{nil, ""},
 	}
 
-	ing := &extensions.Ingress{
+	ing := &networking.Ingress{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "foo",
 			Namespace: api.NamespaceDefault,
 		},
-		Spec: extensions.IngressSpec{},
+		Spec: networking.IngressSpec{},
 	}
 
 	for _, testCase := range testCases {

--- a/internal/ingress/annotations/upstreamvhost/main.go
+++ b/internal/ingress/annotations/upstreamvhost/main.go
@@ -17,7 +17,7 @@ limitations under the License.
 package upstreamvhost
 
 import (
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
@@ -35,6 +35,6 @@ func NewParser(r resolver.Resolver) parser.IngressAnnotation {
 // Parse parses the annotations contained in the ingress rule
 // used to indicate if the location/s contains a fragment of
 // configuration to be included inside the paths of the rules
-func (a upstreamVhost) Parse(ing *extensions.Ingress) (interface{}, error) {
+func (a upstreamVhost) Parse(ing *networking.Ingress) (interface{}, error) {
 	return parser.GetStringAnnotation("upstream-vhost", ing)
 }

--- a/internal/ingress/annotations/upstreamvhost/main_test.go
+++ b/internal/ingress/annotations/upstreamvhost/main_test.go
@@ -20,19 +20,19 @@ import (
 	"testing"
 
 	api "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
 )
 
 func TestParse(t *testing.T) {
-	ing := &extensions.Ingress{
+	ing := &networking.Ingress{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "foo",
 			Namespace: api.NamespaceDefault,
 		},
-		Spec: extensions.IngressSpec{},
+		Spec: networking.IngressSpec{},
 	}
 
 	data := map[string]string{}

--- a/internal/ingress/annotations/xforwardedprefix/main.go
+++ b/internal/ingress/annotations/xforwardedprefix/main.go
@@ -17,7 +17,7 @@ limitations under the License.
 package xforwardedprefix
 
 import (
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
@@ -34,6 +34,6 @@ func NewParser(r resolver.Resolver) parser.IngressAnnotation {
 
 // Parse parses the annotations contained in the ingress rule
 // used to add an x-forwarded-prefix header to the request
-func (cbbs xforwardedprefix) Parse(ing *extensions.Ingress) (interface{}, error) {
+func (cbbs xforwardedprefix) Parse(ing *networking.Ingress) (interface{}, error) {
 	return parser.GetStringAnnotation("x-forwarded-prefix", ing)
 }

--- a/internal/ingress/annotations/xforwardedprefix/main_test.go
+++ b/internal/ingress/annotations/xforwardedprefix/main_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	api "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
@@ -44,12 +44,12 @@ func TestParse(t *testing.T) {
 		{nil, ""},
 	}
 
-	ing := &extensions.Ingress{
+	ing := &networking.Ingress{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "foo",
 			Namespace: api.NamespaceDefault,
 		},
-		Spec: extensions.IngressSpec{},
+		Spec: networking.IngressSpec{},
 	}
 
 	for _, testCase := range testCases {

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/mitchellh/hashstructure"
 	apiv1 "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -200,7 +200,7 @@ func (n *NGINXController) syncIngress(interface{}) error {
 
 // CheckIngress returns an error in case the provided ingress, when added
 // to the current configuration, generates an invalid configuration
-func (n *NGINXController) CheckIngress(ing *extensions.Ingress) error {
+func (n *NGINXController) CheckIngress(ing *networking.Ingress) error {
 	//TODO: this is wrong
 	if n == nil {
 		return fmt.Errorf("cannot check ingress on a nil ingress controller")
@@ -808,7 +808,7 @@ func (n *NGINXController) createUpstreams(data []*ingress.Ingress, du *ingress.B
 
 // getServiceClusterEndpoint returns an Endpoint corresponding to the ClusterIP
 // field of a Service.
-func (n *NGINXController) getServiceClusterEndpoint(svcKey string, backend *extensions.IngressBackend) (endpoint ingress.Endpoint, err error) {
+func (n *NGINXController) getServiceClusterEndpoint(svcKey string, backend *networking.IngressBackend) (endpoint ingress.Endpoint, err error) {
 	svc, err := n.store.GetService(svcKey)
 	if err != nil {
 		return endpoint, fmt.Errorf("service %q does not exist", svcKey)

--- a/internal/ingress/controller/controller_test.go
+++ b/internal/ingress/controller/controller_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/eapache/channels"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/fake"
@@ -169,14 +169,14 @@ func TestCheckIngress(t *testing.T) {
 		ingresses: []*ingress.Ingress{},
 	}
 
-	ing := &extensions.Ingress{
+	ing := &networking.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "test-ingress",
 			Namespace:   "user-namespace",
 			Annotations: map[string]string{},
 		},
-		Spec: extensions.IngressSpec{
-			Rules: []extensions.IngressRule{
+		Spec: networking.IngressSpec{
+			Rules: []networking.IngressRule{
 				{
 					Host: "example.com",
 				},
@@ -262,20 +262,20 @@ func TestMergeAlternativeBackends(t *testing.T) {
 	}{
 		"alternative backend has no server and embeds into matching real backend": {
 			&ingress.Ingress{
-				Ingress: extensions.Ingress{
+				Ingress: networking.Ingress{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "example",
 					},
-					Spec: extensions.IngressSpec{
-						Rules: []extensions.IngressRule{
+					Spec: networking.IngressSpec{
+						Rules: []networking.IngressRule{
 							{
 								Host: "example.com",
-								IngressRuleValue: extensions.IngressRuleValue{
-									HTTP: &extensions.HTTPIngressRuleValue{
-										Paths: []extensions.HTTPIngressPath{
+								IngressRuleValue: networking.IngressRuleValue{
+									HTTP: &networking.HTTPIngressRuleValue{
+										Paths: []networking.HTTPIngressPath{
 											{
 												Path: "/",
-												Backend: extensions.IngressBackend{
+												Backend: networking.IngressBackend{
 													ServiceName: "http-svc-canary",
 													ServicePort: intstr.IntOrString{
 														Type:   intstr.Int,
@@ -343,20 +343,20 @@ func TestMergeAlternativeBackends(t *testing.T) {
 		},
 		"alternative backend merges with the correct real backend when multiple are present": {
 			&ingress.Ingress{
-				Ingress: extensions.Ingress{
+				Ingress: networking.Ingress{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "example",
 					},
-					Spec: extensions.IngressSpec{
-						Rules: []extensions.IngressRule{
+					Spec: networking.IngressSpec{
+						Rules: []networking.IngressRule{
 							{
 								Host: "foo.bar",
-								IngressRuleValue: extensions.IngressRuleValue{
-									HTTP: &extensions.HTTPIngressRuleValue{
-										Paths: []extensions.HTTPIngressPath{
+								IngressRuleValue: networking.IngressRuleValue{
+									HTTP: &networking.HTTPIngressRuleValue{
+										Paths: []networking.HTTPIngressPath{
 											{
 												Path: "/",
-												Backend: extensions.IngressBackend{
+												Backend: networking.IngressBackend{
 													ServiceName: "foo-http-svc-canary",
 													ServicePort: intstr.IntOrString{
 														Type:   intstr.Int,
@@ -370,12 +370,12 @@ func TestMergeAlternativeBackends(t *testing.T) {
 							},
 							{
 								Host: "example.com",
-								IngressRuleValue: extensions.IngressRuleValue{
-									HTTP: &extensions.HTTPIngressRuleValue{
-										Paths: []extensions.HTTPIngressPath{
+								IngressRuleValue: networking.IngressRuleValue{
+									HTTP: &networking.HTTPIngressRuleValue{
+										Paths: []networking.HTTPIngressPath{
 											{
 												Path: "/",
-												Backend: extensions.IngressBackend{
+												Backend: networking.IngressBackend{
 													ServiceName: "http-svc-canary",
 													ServicePort: intstr.IntOrString{
 														Type:   intstr.Int,
@@ -476,20 +476,20 @@ func TestMergeAlternativeBackends(t *testing.T) {
 		},
 		"alternative backend does not merge into itself": {
 			&ingress.Ingress{
-				Ingress: extensions.Ingress{
+				Ingress: networking.Ingress{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "example",
 					},
-					Spec: extensions.IngressSpec{
-						Rules: []extensions.IngressRule{
+					Spec: networking.IngressSpec{
+						Rules: []networking.IngressRule{
 							{
 								Host: "example.com",
-								IngressRuleValue: extensions.IngressRuleValue{
-									HTTP: &extensions.HTTPIngressRuleValue{
-										Paths: []extensions.HTTPIngressPath{
+								IngressRuleValue: networking.IngressRuleValue{
+									HTTP: &networking.HTTPIngressRuleValue{
+										Paths: []networking.HTTPIngressPath{
 											{
 												Path: "/",
-												Backend: extensions.IngressBackend{
+												Backend: networking.IngressBackend{
 													ServiceName: "http-svc-canary",
 													ServicePort: intstr.IntOrString{
 														Type:   intstr.Int,
@@ -520,12 +520,12 @@ func TestMergeAlternativeBackends(t *testing.T) {
 		},
 		"catch-all alternative backend has no server and embeds into matching real backend": {
 			&ingress.Ingress{
-				Ingress: extensions.Ingress{
+				Ingress: networking.Ingress{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "example",
 					},
-					Spec: extensions.IngressSpec{
-						Backend: &extensions.IngressBackend{
+					Spec: networking.IngressSpec{
+						Backend: &networking.IngressBackend{
 							ServiceName: "http-svc-canary",
 							ServicePort: intstr.IntOrString{
 								IntVal: 80,
@@ -586,12 +586,12 @@ func TestMergeAlternativeBackends(t *testing.T) {
 		},
 		"catch-all alternative backend does not merge into itself": {
 			&ingress.Ingress{
-				Ingress: extensions.Ingress{
+				Ingress: networking.Ingress{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "example",
 					},
-					Spec: extensions.IngressSpec{
-						Backend: &extensions.IngressBackend{
+					Spec: networking.IngressSpec{
+						Backend: &networking.IngressBackend{
 							ServiceName: "http-svc-canary",
 							ServicePort: intstr.IntOrString{
 								IntVal: 80,
@@ -696,15 +696,15 @@ func TestExtractTLSSecretName(t *testing.T) {
 		"ingress tls, nil secret": {
 			"foo.bar",
 			&ingress.Ingress{
-				Ingress: extensions.Ingress{
+				Ingress: networking.Ingress{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "test",
 					},
-					Spec: extensions.IngressSpec{
-						TLS: []extensions.IngressTLS{
+					Spec: networking.IngressSpec{
+						TLS: []networking.IngressTLS{
 							{SecretName: "demo"},
 						},
-						Rules: []extensions.IngressRule{
+						Rules: []networking.IngressRule{
 							{
 								Host: "foo.bar",
 							},
@@ -720,15 +720,15 @@ func TestExtractTLSSecretName(t *testing.T) {
 		"ingress tls, no host, matching cert cn": {
 			"foo.bar",
 			&ingress.Ingress{
-				Ingress: extensions.Ingress{
+				Ingress: networking.Ingress{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "test",
 					},
-					Spec: extensions.IngressSpec{
-						TLS: []extensions.IngressTLS{
+					Spec: networking.IngressSpec{
+						TLS: []networking.IngressTLS{
 							{SecretName: "demo"},
 						},
-						Rules: []extensions.IngressRule{
+						Rules: []networking.IngressRule{
 							{
 								Host: "foo.bar",
 							},
@@ -746,17 +746,17 @@ func TestExtractTLSSecretName(t *testing.T) {
 		"ingress tls, no host, wildcard cert with matching cn": {
 			"foo.bar",
 			&ingress.Ingress{
-				Ingress: extensions.Ingress{
+				Ingress: networking.Ingress{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "test",
 					},
-					Spec: extensions.IngressSpec{
-						TLS: []extensions.IngressTLS{
+					Spec: networking.IngressSpec{
+						TLS: []networking.IngressTLS{
 							{
 								SecretName: "demo",
 							},
 						},
-						Rules: []extensions.IngressRule{
+						Rules: []networking.IngressRule{
 							{
 								Host: "test.foo.bar",
 							},
@@ -774,18 +774,18 @@ func TestExtractTLSSecretName(t *testing.T) {
 		"ingress tls, hosts, matching cert cn": {
 			"foo.bar",
 			&ingress.Ingress{
-				Ingress: extensions.Ingress{
+				Ingress: networking.Ingress{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "test",
 					},
-					Spec: extensions.IngressSpec{
-						TLS: []extensions.IngressTLS{
+					Spec: networking.IngressSpec{
+						TLS: []networking.IngressTLS{
 							{
 								Hosts:      []string{"foo.bar", "example.com"},
 								SecretName: "demo",
 							},
 						},
-						Rules: []extensions.IngressRule{
+						Rules: []networking.IngressRule{
 							{
 								Host: "foo.bar",
 							},
@@ -820,12 +820,12 @@ func TestGetBackendServers(t *testing.T) {
 		{
 			Ingresses: []*ingress.Ingress{
 				{
-					Ingress: extensions.Ingress{
+					Ingress: networking.Ingress{
 						ObjectMeta: metav1.ObjectMeta{
 							Namespace: "example",
 						},
-						Spec: extensions.IngressSpec{
-							Backend: &extensions.IngressBackend{
+						Spec: networking.IngressSpec{
+							Backend: &networking.IngressBackend{
 								ServiceName: "http-svc-canary",
 								ServicePort: intstr.IntOrString{
 									IntVal: 80,
@@ -862,12 +862,12 @@ func TestGetBackendServers(t *testing.T) {
 		{
 			Ingresses: []*ingress.Ingress{
 				{
-					Ingress: extensions.Ingress{
+					Ingress: networking.Ingress{
 						ObjectMeta: metav1.ObjectMeta{
 							Namespace: "example",
 						},
-						Spec: extensions.IngressSpec{
-							Backend: &extensions.IngressBackend{
+						Spec: networking.IngressSpec{
+							Backend: &networking.IngressBackend{
 								ServiceName: "http-svc-canary",
 								ServicePort: intstr.IntOrString{
 									IntVal: 80,
@@ -882,12 +882,12 @@ func TestGetBackendServers(t *testing.T) {
 					},
 				},
 				{
-					Ingress: extensions.Ingress{
+					Ingress: networking.Ingress{
 						ObjectMeta: metav1.ObjectMeta{
 							Namespace: "example",
 						},
-						Spec: extensions.IngressSpec{
-							Backend: &extensions.IngressBackend{
+						Spec: networking.IngressSpec{
+							Backend: &networking.IngressBackend{
 								ServiceName: "http-svc",
 								ServicePort: intstr.IntOrString{
 									IntVal: 80,
@@ -924,20 +924,20 @@ func TestGetBackendServers(t *testing.T) {
 		{
 			Ingresses: []*ingress.Ingress{
 				{
-					Ingress: extensions.Ingress{
+					Ingress: networking.Ingress{
 						ObjectMeta: metav1.ObjectMeta{
 							Namespace: "example",
 						},
-						Spec: extensions.IngressSpec{
-							Rules: []extensions.IngressRule{
+						Spec: networking.IngressSpec{
+							Rules: []networking.IngressRule{
 								{
 									Host: "example.com",
-									IngressRuleValue: extensions.IngressRuleValue{
-										HTTP: &extensions.HTTPIngressRuleValue{
-											Paths: []extensions.HTTPIngressPath{
+									IngressRuleValue: networking.IngressRuleValue{
+										HTTP: &networking.HTTPIngressRuleValue{
+											Paths: []networking.HTTPIngressPath{
 												{
 													Path: "/",
-													Backend: extensions.IngressBackend{
+													Backend: networking.IngressBackend{
 														ServiceName: "http-svc-canary",
 														ServicePort: intstr.IntOrString{
 															Type:   intstr.Int,
@@ -981,21 +981,21 @@ func TestGetBackendServers(t *testing.T) {
 		{
 			Ingresses: []*ingress.Ingress{
 				{
-					Ingress: extensions.Ingress{
+					Ingress: networking.Ingress{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "example",
 							Namespace: "example",
 						},
-						Spec: extensions.IngressSpec{
-							Rules: []extensions.IngressRule{
+						Spec: networking.IngressSpec{
+							Rules: []networking.IngressRule{
 								{
 									Host: "example.com",
-									IngressRuleValue: extensions.IngressRuleValue{
-										HTTP: &extensions.HTTPIngressRuleValue{
-											Paths: []extensions.HTTPIngressPath{
+									IngressRuleValue: networking.IngressRuleValue{
+										HTTP: &networking.HTTPIngressRuleValue{
+											Paths: []networking.HTTPIngressPath{
 												{
 													Path: "/",
-													Backend: extensions.IngressBackend{
+													Backend: networking.IngressBackend{
 														ServiceName: "http-svc",
 														ServicePort: intstr.IntOrString{
 															Type:   intstr.Int,
@@ -1017,21 +1017,21 @@ func TestGetBackendServers(t *testing.T) {
 					},
 				},
 				{
-					Ingress: extensions.Ingress{
+					Ingress: networking.Ingress{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "example-canary",
 							Namespace: "example",
 						},
-						Spec: extensions.IngressSpec{
-							Rules: []extensions.IngressRule{
+						Spec: networking.IngressSpec{
+							Rules: []networking.IngressRule{
 								{
 									Host: "example.com",
-									IngressRuleValue: extensions.IngressRuleValue{
-										HTTP: &extensions.HTTPIngressRuleValue{
-											Paths: []extensions.HTTPIngressPath{
+									IngressRuleValue: networking.IngressRuleValue{
+										HTTP: &networking.HTTPIngressRuleValue{
+											Paths: []networking.HTTPIngressPath{
 												{
 													Path: "/",
-													Backend: extensions.IngressBackend{
+													Backend: networking.IngressBackend{
 														ServiceName: "http-svc-canary",
 														ServicePort: intstr.IntOrString{
 															Type:   intstr.Int,

--- a/internal/ingress/controller/store/backend_ssl.go
+++ b/internal/ingress/controller/store/backend_ssl.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/klog"
 
 	apiv1 "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"k8s.io/ingress-nginx/internal/file"
@@ -208,7 +208,7 @@ func (s *k8sStore) checkSSLChainIssues() {
 func (s *k8sStore) sendDummyEvent() {
 	s.updateCh.In() <- Event{
 		Type: UpdateEvent,
-		Obj: &extensions.Ingress{
+		Obj: &networking.Ingress{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "dummy",
 				Namespace: "dummy",

--- a/internal/ingress/controller/store/ingress.go
+++ b/internal/ingress/controller/store/ingress.go
@@ -17,7 +17,7 @@ limitations under the License.
 package store
 
 import (
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -27,7 +27,7 @@ type IngressLister struct {
 }
 
 // ByKey returns the Ingress matching key in the local Ingress Store.
-func (il IngressLister) ByKey(key string) (*extensions.Ingress, error) {
+func (il IngressLister) ByKey(key string) (*networking.Ingress, error) {
 	i, exists, err := il.GetByKey(key)
 	if err != nil {
 		return nil, err
@@ -35,5 +35,5 @@ func (il IngressLister) ByKey(key string) (*extensions.Ingress, error) {
 	if !exists {
 		return nil, NotExistsError(key)
 	}
-	return i.(*extensions.Ingress), nil
+	return i.(*networking.Ingress), nil
 }

--- a/internal/ingress/controller/template/template_test.go
+++ b/internal/ingress/controller/template/template_test.go
@@ -29,7 +29,7 @@ import (
 	"fmt"
 
 	jsoniter "github.com/json-iterator/go"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	"k8s.io/ingress-nginx/internal/file"
 	"k8s.io/ingress-nginx/internal/ingress"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/authreq"
@@ -909,7 +909,7 @@ func TestGetIngressInformation(t *testing.T) {
 	validIngress.Annotations = map[string]string{
 		"ingress.annotation": "ok",
 	}
-	validIngress.Spec.Backend = &extensions.IngressBackend{
+	validIngress.Spec.Backend = &networking.IngressBackend{
 		ServiceName: "a-svc",
 	}
 
@@ -927,15 +927,15 @@ func TestGetIngressInformation(t *testing.T) {
 	}
 
 	validIngress.Spec.Backend = nil
-	validIngress.Spec.Rules = []extensions.IngressRule{
+	validIngress.Spec.Rules = []networking.IngressRule{
 		{
 			Host: host,
-			IngressRuleValue: extensions.IngressRuleValue{
-				HTTP: &extensions.HTTPIngressRuleValue{
-					Paths: []extensions.HTTPIngressPath{
+			IngressRuleValue: networking.IngressRuleValue{
+				HTTP: &networking.HTTPIngressRuleValue{
+					Paths: []networking.HTTPIngressPath{
 						{
 							Path: "/ok",
-							Backend: extensions.IngressBackend{
+							Backend: networking.IngressBackend{
 								ServiceName: "b-svc",
 							},
 						},
@@ -959,14 +959,14 @@ func TestGetIngressInformation(t *testing.T) {
 		t.Errorf("Expected %v, but got %v", expected, info)
 	}
 
-	validIngress.Spec.Rules = append(validIngress.Spec.Rules, extensions.IngressRule{
+	validIngress.Spec.Rules = append(validIngress.Spec.Rules, networking.IngressRule{
 		Host: "host2",
-		IngressRuleValue: extensions.IngressRuleValue{
-			HTTP: &extensions.HTTPIngressRuleValue{
-				Paths: []extensions.HTTPIngressPath{
+		IngressRuleValue: networking.IngressRuleValue{
+			HTTP: &networking.HTTPIngressRuleValue{
+				Paths: []networking.HTTPIngressPath{
 					{
 						Path: "/ok",
-						Backend: extensions.IngressBackend{
+						Backend: networking.IngressBackend{
 							ServiceName: "c-svc",
 						},
 					},

--- a/internal/ingress/status/status.go
+++ b/internal/ingress/status/status.go
@@ -286,18 +286,32 @@ func runUpdate(ing *ingress.Ingress, status []apiv1.LoadBalancerIngress,
 			return nil, nil
 		}
 
-		ingClient := client.ExtensionsV1beta1().Ingresses(ing.Namespace)
+		if k8s.IsNetworkingIngressAvailable {
+			ingClient := client.NetworkingV1beta1().Ingresses(ing.Namespace)
+			currIng, err := ingClient.Get(ing.Name, metav1.GetOptions{})
+			if err != nil {
+				return nil, errors.Wrap(err, fmt.Sprintf("unexpected error searching Ingress %v/%v", ing.Namespace, ing.Name))
+			}
 
-		currIng, err := ingClient.Get(ing.Name, metav1.GetOptions{})
-		if err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("unexpected error searching Ingress %v/%v", ing.Namespace, ing.Name))
-		}
+			klog.Infof("updating Ingress %v/%v status from %v to %v", currIng.Namespace, currIng.Name, currIng.Status.LoadBalancer.Ingress, status)
+			currIng.Status.LoadBalancer.Ingress = status
+			_, err = ingClient.UpdateStatus(currIng)
+			if err != nil {
+				klog.Warningf("error updating ingress rule: %v", err)
+			}
+		} else {
+			ingClient := client.ExtensionsV1beta1().Ingresses(ing.Namespace)
+			currIng, err := ingClient.Get(ing.Name, metav1.GetOptions{})
+			if err != nil {
+				return nil, errors.Wrap(err, fmt.Sprintf("unexpected error searching Ingress %v/%v", ing.Namespace, ing.Name))
+			}
 
-		klog.Infof("updating Ingress %v/%v status from %v to %v", currIng.Namespace, currIng.Name, currIng.Status.LoadBalancer.Ingress, status)
-		currIng.Status.LoadBalancer.Ingress = status
-		_, err = ingClient.UpdateStatus(currIng)
-		if err != nil {
-			klog.Warningf("error updating ingress rule: %v", err)
+			klog.Infof("updating Ingress %v/%v status from %v to %v", currIng.Namespace, currIng.Name, currIng.Status.LoadBalancer.Ingress, status)
+			currIng.Status.LoadBalancer.Ingress = status
+			_, err = ingClient.UpdateStatus(currIng)
+			if err != nil {
+				klog.Warningf("error updating ingress rule: %v", err)
+			}
 		}
 
 		return true, nil

--- a/internal/ingress/types.go
+++ b/internal/ingress/types.go
@@ -18,11 +18,10 @@ package ingress
 
 import (
 	apiv1 "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/ingress-nginx/internal/ingress/annotations"
-	"k8s.io/ingress-nginx/internal/ingress/annotations/modsecurity"
 
+	"k8s.io/ingress-nginx/internal/ingress/annotations"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/auth"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/authreq"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/authtls"
@@ -32,6 +31,7 @@ import (
 	"k8s.io/ingress-nginx/internal/ingress/annotations/ipwhitelist"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/log"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/luarestywaf"
+	"k8s.io/ingress-nginx/internal/ingress/annotations/modsecurity"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/proxy"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/ratelimit"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/redirect"
@@ -361,7 +361,7 @@ type ProxyProtocol struct {
 
 // Ingress holds the definition of an Ingress plus its annotations
 type Ingress struct {
-	extensions.Ingress
+	networking.Ingress
 	ParsedAnnotations *annotations.Ingress
 }
 

--- a/internal/k8s/main.go
+++ b/internal/k8s/main.go
@@ -21,11 +21,13 @@ import (
 	"os"
 	"strings"
 
+	"k8s.io/klog"
+
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/version"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/klog"
 )
 
 // ParseNameNS parses a string searching a namespace and name
@@ -106,4 +108,32 @@ func MetaNamespaceKey(obj interface{}) string {
 	}
 
 	return key
+}
+
+// IsNetworkingIngressAvailable indicates if package "k8s.io/api/networking/v1beta1" is available or not
+var IsNetworkingIngressAvailable bool
+
+// NetworkingIngressAvailable checks if the package "k8s.io/api/networking/v1beta1" is available or not
+func NetworkingIngressAvailable(client clientset.Interface) bool {
+	// check kubernetes version to use new ingress package or not
+	version114, err := version.ParseGeneric("v1.14.0")
+	if err != nil {
+		klog.Errorf("unexpected error parsing version: %v", err)
+		return false
+	}
+
+	serverVersion, _ := client.Discovery().ServerVersion()
+	if err != nil {
+		klog.Errorf("unexpected error parsing Kubernetes version: %v", err)
+		return false
+	}
+
+	klog.Errorf("%v", serverVersion)
+	runningVersion, _ := version.ParseGeneric(serverVersion.String())
+	if err != nil {
+		klog.Errorf("unexpected error parsing running Kubernetes version: %v", err)
+		return false
+	}
+
+	return runningVersion.AtLeast(version114)
 }

--- a/test/data/config.json
+++ b/test/data/config.json
@@ -3,8 +3,8 @@
 	"isIPV6Enabled": true,
 	"cfg": {
 		"disable-ipv6": false,
-		"bind-address-ipv4": [ "1.1.1.1" , "2.2.2.2"],
-		"bind-address-ipv6": [ "[2001:db8:a0b:12f0::1]" ,"[3731:54:65fe:2::a7]" ,"[33:33:33::33::33]" ],
+		"bind-address-ipv4": ["1.1.1.1", "2.2.2.2"],
+		"bind-address-ipv6": ["[2001:db8:a0b:12f0::1]", "[3731:54:65fe:2::a7]", "[33:33:33::33::33]"],
 		"backend": {
 			"custom-http-errors": [404],
 			"proxy-buffers-number": "4",

--- a/test/e2e-image/overlay/kustomization.yaml
+++ b/test/e2e-image/overlay/kustomization.yaml
@@ -28,6 +28,12 @@ patchesJson6902:
     kind: Deployment
     name: nginx-ingress-controller
     version: v1
+- path: role.yaml
+  target:
+    group: rbac.authorization.k8s.io
+    kind: Role
+    name: nginx-ingress-role
+    version: v1beta1
 images:
 - name: quay.io/kubernetes-ingress-controller/nginx-ingress-controller
   newName: ingress-controller/nginx-ingress-controller

--- a/test/e2e-image/overlay/role.yaml
+++ b/test/e2e-image/overlay/role.yaml
@@ -1,0 +1,3 @@
+- op: add
+  path: /rules/1/resourceNames/-1
+  value: "ingress-controller-leader-testclass"

--- a/test/e2e/annotations/affinity.go
+++ b/test/e2e/annotations/affinity.go
@@ -26,7 +26,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/parnurzeal/gorequest"
 
-	"k8s.io/api/extensions/v1beta1"
+	extensions "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
@@ -142,29 +142,29 @@ var _ = framework.IngressNginxDescribe("Annotations - Affinity/Sticky Sessions",
 			"nginx.ingress.kubernetes.io/session-cookie-name": "SERVERID",
 		}
 
-		f.EnsureIngress(&v1beta1.Ingress{
+		f.EnsureIngress(&extensions.Ingress{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        host,
 				Namespace:   f.Namespace,
 				Annotations: annotations,
 			},
-			Spec: v1beta1.IngressSpec{
-				Rules: []v1beta1.IngressRule{
+			Spec: extensions.IngressSpec{
+				Rules: []extensions.IngressRule{
 					{
 						Host: host,
-						IngressRuleValue: v1beta1.IngressRuleValue{
-							HTTP: &v1beta1.HTTPIngressRuleValue{
-								Paths: []v1beta1.HTTPIngressPath{
+						IngressRuleValue: extensions.IngressRuleValue{
+							HTTP: &extensions.HTTPIngressRuleValue{
+								Paths: []extensions.HTTPIngressPath{
 									{
 										Path: "/something",
-										Backend: v1beta1.IngressBackend{
+										Backend: extensions.IngressBackend{
 											ServiceName: "http-svc",
 											ServicePort: intstr.FromInt(80),
 										},
 									},
 									{
 										Path: "/somewhereelese",
-										Backend: v1beta1.IngressBackend{
+										Backend: extensions.IngressBackend{
 											ServiceName: "http-svc",
 											ServicePort: intstr.FromInt(80),
 										},

--- a/test/e2e/defaultbackend/with_hosts.go
+++ b/test/e2e/defaultbackend/with_hosts.go
@@ -19,13 +19,15 @@ package defaultbackend
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"net/http"
+	"strings"
+
 	"github.com/parnurzeal/gorequest"
 	extensions "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/ingress-nginx/test/e2e/framework"
-	"net/http"
-	"strings"
 )
 
 var _ = framework.IngressNginxDescribe("Default backend with hosts", func() {

--- a/test/e2e/servicebackend/service_backend.go
+++ b/test/e2e/servicebackend/service_backend.go
@@ -25,7 +25,7 @@ import (
 	"github.com/parnurzeal/gorequest"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	extensions "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
@@ -85,23 +85,23 @@ var _ = framework.IngressNginxDescribe("Service backend - 503", func() {
 
 })
 
-func buildIngressWithNonexistentService(host, namespace, path string) *v1beta1.Ingress {
+func buildIngressWithNonexistentService(host, namespace, path string) *extensions.Ingress {
 	backendService := "nonexistent-svc"
-	return &v1beta1.Ingress{
+	return &extensions.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      host,
 			Namespace: namespace,
 		},
-		Spec: v1beta1.IngressSpec{
-			Rules: []v1beta1.IngressRule{
+		Spec: extensions.IngressSpec{
+			Rules: []extensions.IngressRule{
 				{
 					Host: host,
-					IngressRuleValue: v1beta1.IngressRuleValue{
-						HTTP: &v1beta1.HTTPIngressRuleValue{
-							Paths: []v1beta1.HTTPIngressPath{
+					IngressRuleValue: extensions.IngressRuleValue{
+						HTTP: &extensions.HTTPIngressRuleValue{
+							Paths: []extensions.HTTPIngressPath{
 								{
 									Path: path,
-									Backend: v1beta1.IngressBackend{
+									Backend: extensions.IngressBackend{
 										ServiceName: backendService,
 										ServicePort: intstr.FromInt(80),
 									},
@@ -115,23 +115,23 @@ func buildIngressWithNonexistentService(host, namespace, path string) *v1beta1.I
 	}
 }
 
-func buildIngressWithUnavailableServiceEndpoints(host, namespace, path string) (*v1beta1.Ingress, *corev1.Service) {
+func buildIngressWithUnavailableServiceEndpoints(host, namespace, path string) (*extensions.Ingress, *corev1.Service) {
 	backendService := "unavailable-svc"
-	return &v1beta1.Ingress{
+	return &extensions.Ingress{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      host,
 				Namespace: namespace,
 			},
-			Spec: v1beta1.IngressSpec{
-				Rules: []v1beta1.IngressRule{
+			Spec: extensions.IngressSpec{
+				Rules: []extensions.IngressRule{
 					{
 						Host: host,
-						IngressRuleValue: v1beta1.IngressRuleValue{
-							HTTP: &v1beta1.HTTPIngressRuleValue{
-								Paths: []v1beta1.HTTPIngressPath{
+						IngressRuleValue: extensions.IngressRuleValue{
+							HTTP: &extensions.HTTPIngressRuleValue{
+								Paths: []extensions.HTTPIngressPath{
 									{
 										Path: path,
-										Backend: v1beta1.IngressBackend{
+										Backend: extensions.IngressBackend{
 											ServiceName: backendService,
 											ServicePort: intstr.FromInt(80),
 										},

--- a/test/e2e/settings/no_auth_locations.go
+++ b/test/e2e/settings/no_auth_locations.go
@@ -26,7 +26,7 @@ import (
 	"github.com/parnurzeal/gorequest"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	extensions "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/ingress-nginx/test/e2e/framework"
@@ -104,8 +104,8 @@ var _ = framework.IngressNginxDescribe("No Auth locations", func() {
 	})
 })
 
-func buildBasicAuthIngressWithSecondPath(host, namespace, secretName, pathName string) *v1beta1.Ingress {
-	return &v1beta1.Ingress{
+func buildBasicAuthIngressWithSecondPath(host, namespace, secretName, pathName string) *extensions.Ingress {
+	return &extensions.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      host,
 			Namespace: namespace,
@@ -114,23 +114,23 @@ func buildBasicAuthIngressWithSecondPath(host, namespace, secretName, pathName s
 				"nginx.ingress.kubernetes.io/auth-realm":  "test auth",
 			},
 		},
-		Spec: v1beta1.IngressSpec{
-			Rules: []v1beta1.IngressRule{
+		Spec: extensions.IngressSpec{
+			Rules: []extensions.IngressRule{
 				{
 					Host: host,
-					IngressRuleValue: v1beta1.IngressRuleValue{
-						HTTP: &v1beta1.HTTPIngressRuleValue{
-							Paths: []v1beta1.HTTPIngressPath{
+					IngressRuleValue: extensions.IngressRuleValue{
+						HTTP: &extensions.HTTPIngressRuleValue{
+							Paths: []extensions.HTTPIngressPath{
 								{
 									Path: "/",
-									Backend: v1beta1.IngressBackend{
+									Backend: extensions.IngressBackend{
 										ServiceName: "http-svc",
 										ServicePort: intstr.FromInt(80),
 									},
 								},
 								{
 									Path: pathName,
-									Backend: v1beta1.IngressBackend{
+									Backend: extensions.IngressBackend{
 										ServiceName: "http-svc",
 										ServicePort: intstr.FromInt(80),
 									},

--- a/test/e2e/settings/server_tokens.go
+++ b/test/e2e/settings/server_tokens.go
@@ -21,7 +21,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 
-	"k8s.io/api/extensions/v1beta1"
+	extensions "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/ingress-nginx/test/e2e/framework"
@@ -53,22 +53,22 @@ var _ = framework.IngressNginxDescribe("Server Tokens", func() {
 	It("should exists Server header in the response when is enabled", func() {
 		f.UpdateNginxConfigMapData(serverTokens, "true")
 
-		f.EnsureIngress(&v1beta1.Ingress{
+		f.EnsureIngress(&extensions.Ingress{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        serverTokens,
 				Namespace:   f.Namespace,
 				Annotations: map[string]string{},
 			},
-			Spec: v1beta1.IngressSpec{
-				Rules: []v1beta1.IngressRule{
+			Spec: extensions.IngressSpec{
+				Rules: []extensions.IngressRule{
 					{
 						Host: serverTokens,
-						IngressRuleValue: v1beta1.IngressRuleValue{
-							HTTP: &v1beta1.HTTPIngressRuleValue{
-								Paths: []v1beta1.HTTPIngressPath{
+						IngressRuleValue: extensions.IngressRuleValue{
+							HTTP: &extensions.HTTPIngressRuleValue{
+								Paths: []extensions.HTTPIngressPath{
 									{
 										Path: "/",
-										Backend: v1beta1.IngressBackend{
+										Backend: extensions.IngressBackend{
 											ServiceName: "http-svc",
 											ServicePort: intstr.FromInt(80),
 										},

--- a/vendor/k8s.io/apimachinery/pkg/util/version/doc.go
+++ b/vendor/k8s.io/apimachinery/pkg/util/version/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package version provides utilities for version number comparisons
+package version // import "k8s.io/apimachinery/pkg/util/version"

--- a/vendor/k8s.io/apimachinery/pkg/util/version/version.go
+++ b/vendor/k8s.io/apimachinery/pkg/util/version/version.go
@@ -1,0 +1,314 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// Version is an opqaue representation of a version number
+type Version struct {
+	components    []uint
+	semver        bool
+	preRelease    string
+	buildMetadata string
+}
+
+var (
+	// versionMatchRE splits a version string into numeric and "extra" parts
+	versionMatchRE = regexp.MustCompile(`^\s*v?([0-9]+(?:\.[0-9]+)*)(.*)*$`)
+	// extraMatchRE splits the "extra" part of versionMatchRE into semver pre-release and build metadata; it does not validate the "no leading zeroes" constraint for pre-release
+	extraMatchRE = regexp.MustCompile(`^(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?\s*$`)
+)
+
+func parse(str string, semver bool) (*Version, error) {
+	parts := versionMatchRE.FindStringSubmatch(str)
+	if parts == nil {
+		return nil, fmt.Errorf("could not parse %q as version", str)
+	}
+	numbers, extra := parts[1], parts[2]
+
+	components := strings.Split(numbers, ".")
+	if (semver && len(components) != 3) || (!semver && len(components) < 2) {
+		return nil, fmt.Errorf("illegal version string %q", str)
+	}
+
+	v := &Version{
+		components: make([]uint, len(components)),
+		semver:     semver,
+	}
+	for i, comp := range components {
+		if (i == 0 || semver) && strings.HasPrefix(comp, "0") && comp != "0" {
+			return nil, fmt.Errorf("illegal zero-prefixed version component %q in %q", comp, str)
+		}
+		num, err := strconv.ParseUint(comp, 10, 0)
+		if err != nil {
+			return nil, fmt.Errorf("illegal non-numeric version component %q in %q: %v", comp, str, err)
+		}
+		v.components[i] = uint(num)
+	}
+
+	if semver && extra != "" {
+		extraParts := extraMatchRE.FindStringSubmatch(extra)
+		if extraParts == nil {
+			return nil, fmt.Errorf("could not parse pre-release/metadata (%s) in version %q", extra, str)
+		}
+		v.preRelease, v.buildMetadata = extraParts[1], extraParts[2]
+
+		for _, comp := range strings.Split(v.preRelease, ".") {
+			if _, err := strconv.ParseUint(comp, 10, 0); err == nil {
+				if strings.HasPrefix(comp, "0") && comp != "0" {
+					return nil, fmt.Errorf("illegal zero-prefixed version component %q in %q", comp, str)
+				}
+			}
+		}
+	}
+
+	return v, nil
+}
+
+// ParseGeneric parses a "generic" version string. The version string must consist of two
+// or more dot-separated numeric fields (the first of which can't have leading zeroes),
+// followed by arbitrary uninterpreted data (which need not be separated from the final
+// numeric field by punctuation). For convenience, leading and trailing whitespace is
+// ignored, and the version can be preceded by the letter "v". See also ParseSemantic.
+func ParseGeneric(str string) (*Version, error) {
+	return parse(str, false)
+}
+
+// MustParseGeneric is like ParseGeneric except that it panics on error
+func MustParseGeneric(str string) *Version {
+	v, err := ParseGeneric(str)
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+
+// ParseSemantic parses a version string that exactly obeys the syntax and semantics of
+// the "Semantic Versioning" specification (http://semver.org/) (although it ignores
+// leading and trailing whitespace, and allows the version to be preceded by "v"). For
+// version strings that are not guaranteed to obey the Semantic Versioning syntax, use
+// ParseGeneric.
+func ParseSemantic(str string) (*Version, error) {
+	return parse(str, true)
+}
+
+// MustParseSemantic is like ParseSemantic except that it panics on error
+func MustParseSemantic(str string) *Version {
+	v, err := ParseSemantic(str)
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+
+// Major returns the major release number
+func (v *Version) Major() uint {
+	return v.components[0]
+}
+
+// Minor returns the minor release number
+func (v *Version) Minor() uint {
+	return v.components[1]
+}
+
+// Patch returns the patch release number if v is a Semantic Version, or 0
+func (v *Version) Patch() uint {
+	if len(v.components) < 3 {
+		return 0
+	}
+	return v.components[2]
+}
+
+// BuildMetadata returns the build metadata, if v is a Semantic Version, or ""
+func (v *Version) BuildMetadata() string {
+	return v.buildMetadata
+}
+
+// PreRelease returns the prerelease metadata, if v is a Semantic Version, or ""
+func (v *Version) PreRelease() string {
+	return v.preRelease
+}
+
+// Components returns the version number components
+func (v *Version) Components() []uint {
+	return v.components
+}
+
+// WithMajor returns copy of the version object with requested major number
+func (v *Version) WithMajor(major uint) *Version {
+	result := *v
+	result.components = []uint{major, v.Minor(), v.Patch()}
+	return &result
+}
+
+// WithMinor returns copy of the version object with requested minor number
+func (v *Version) WithMinor(minor uint) *Version {
+	result := *v
+	result.components = []uint{v.Major(), minor, v.Patch()}
+	return &result
+}
+
+// WithPatch returns copy of the version object with requested patch number
+func (v *Version) WithPatch(patch uint) *Version {
+	result := *v
+	result.components = []uint{v.Major(), v.Minor(), patch}
+	return &result
+}
+
+// WithPreRelease returns copy of the version object with requested prerelease
+func (v *Version) WithPreRelease(preRelease string) *Version {
+	result := *v
+	result.components = []uint{v.Major(), v.Minor(), v.Patch()}
+	result.preRelease = preRelease
+	return &result
+}
+
+// String converts a Version back to a string; note that for versions parsed with
+// ParseGeneric, this will not include the trailing uninterpreted portion of the version
+// number.
+func (v *Version) String() string {
+	var buffer bytes.Buffer
+
+	for i, comp := range v.components {
+		if i > 0 {
+			buffer.WriteString(".")
+		}
+		buffer.WriteString(fmt.Sprintf("%d", comp))
+	}
+	if v.preRelease != "" {
+		buffer.WriteString("-")
+		buffer.WriteString(v.preRelease)
+	}
+	if v.buildMetadata != "" {
+		buffer.WriteString("+")
+		buffer.WriteString(v.buildMetadata)
+	}
+
+	return buffer.String()
+}
+
+// compareInternal returns -1 if v is less than other, 1 if it is greater than other, or 0
+// if they are equal
+func (v *Version) compareInternal(other *Version) int {
+
+	vLen := len(v.components)
+	oLen := len(other.components)
+	for i := 0; i < vLen && i < oLen; i++ {
+		switch {
+		case other.components[i] < v.components[i]:
+			return 1
+		case other.components[i] > v.components[i]:
+			return -1
+		}
+	}
+
+	// If components are common but one has more items and they are not zeros, it is bigger
+	switch {
+	case oLen < vLen && !onlyZeros(v.components[oLen:]):
+		return 1
+	case oLen > vLen && !onlyZeros(other.components[vLen:]):
+		return -1
+	}
+
+	if !v.semver || !other.semver {
+		return 0
+	}
+
+	switch {
+	case v.preRelease == "" && other.preRelease != "":
+		return 1
+	case v.preRelease != "" && other.preRelease == "":
+		return -1
+	case v.preRelease == other.preRelease: // includes case where both are ""
+		return 0
+	}
+
+	vPR := strings.Split(v.preRelease, ".")
+	oPR := strings.Split(other.preRelease, ".")
+	for i := 0; i < len(vPR) && i < len(oPR); i++ {
+		vNum, err := strconv.ParseUint(vPR[i], 10, 0)
+		if err == nil {
+			oNum, err := strconv.ParseUint(oPR[i], 10, 0)
+			if err == nil {
+				switch {
+				case oNum < vNum:
+					return 1
+				case oNum > vNum:
+					return -1
+				default:
+					continue
+				}
+			}
+		}
+		if oPR[i] < vPR[i] {
+			return 1
+		} else if oPR[i] > vPR[i] {
+			return -1
+		}
+	}
+
+	switch {
+	case len(oPR) < len(vPR):
+		return 1
+	case len(oPR) > len(vPR):
+		return -1
+	}
+
+	return 0
+}
+
+// returns false if array contain any non-zero element
+func onlyZeros(array []uint) bool {
+	for _, num := range array {
+		if num != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// AtLeast tests if a version is at least equal to a given minimum version. If both
+// Versions are Semantic Versions, this will use the Semantic Version comparison
+// algorithm. Otherwise, it will compare only the numeric components, with non-present
+// components being considered "0" (ie, "1.4" is equal to "1.4.0").
+func (v *Version) AtLeast(min *Version) bool {
+	return v.compareInternal(min) != -1
+}
+
+// LessThan tests if a version is less than a given version. (It is exactly the opposite
+// of AtLeast, for situations where asking "is v too old?" makes more sense than asking
+// "is v new enough?".)
+func (v *Version) LessThan(other *Version) bool {
+	return v.compareInternal(other) == -1
+}
+
+// Compare compares v against a version string (which will be parsed as either Semantic
+// or non-Semantic depending on v). On success it returns -1 if v is less than other, 1 if
+// it is greater than other, or 0 if they are equal.
+func (v *Version) Compare(other string) (int, error) {
+	ov, err := parse(other, v.semver)
+	if err != nil {
+		return 0, err
+	}
+	return v.compareInternal(ov), nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -461,6 +461,7 @@ k8s.io/apimachinery/pkg/util/sets
 k8s.io/apimachinery/pkg/labels
 k8s.io/apimachinery/pkg/util/runtime
 k8s.io/apimachinery/pkg/watch
+k8s.io/apimachinery/pkg/util/version
 k8s.io/apimachinery/pkg/fields
 k8s.io/apimachinery/pkg/util/uuid
 k8s.io/apimachinery/pkg/api/resource

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -404,15 +404,16 @@ gopkg.in/tomb.v1
 gopkg.in/yaml.v2
 # k8s.io/api v0.0.0-20190313235455-40a48860b5ab
 k8s.io/api/core/v1
-k8s.io/api/extensions/v1beta1
+k8s.io/api/networking/v1beta1
 k8s.io/api/apps/v1
 k8s.io/api/admission/v1beta1
-k8s.io/api/apps/v1beta1
+k8s.io/api/extensions/v1beta1
 k8s.io/api/rbac/v1
 k8s.io/api/autoscaling/v1
 k8s.io/api/authentication/v1
 k8s.io/api/policy/v1beta1
 k8s.io/api/admissionregistration/v1beta1
+k8s.io/api/apps/v1beta1
 k8s.io/api/apps/v1beta2
 k8s.io/api/auditregistration/v1alpha1
 k8s.io/api/authentication/v1beta1
@@ -428,7 +429,6 @@ k8s.io/api/coordination/v1
 k8s.io/api/coordination/v1beta1
 k8s.io/api/events/v1beta1
 k8s.io/api/networking/v1
-k8s.io/api/networking/v1beta1
 k8s.io/api/node/v1alpha1
 k8s.io/api/node/v1beta1
 k8s.io/api/rbac/v1alpha1
@@ -460,6 +460,7 @@ k8s.io/apimachinery/pkg/util/intstr
 k8s.io/apimachinery/pkg/util/sets
 k8s.io/apimachinery/pkg/labels
 k8s.io/apimachinery/pkg/util/runtime
+k8s.io/apimachinery/pkg/util/version
 k8s.io/apimachinery/pkg/watch
 k8s.io/apimachinery/pkg/util/version
 k8s.io/apimachinery/pkg/fields
@@ -520,7 +521,7 @@ k8s.io/client-go/tools/clientcmd
 k8s.io/client-go/plugin/pkg/client/auth
 k8s.io/client-go/kubernetes/typed/apps/v1
 k8s.io/client-go/kubernetes/typed/core/v1
-k8s.io/client-go/kubernetes/typed/extensions/v1beta1
+k8s.io/client-go/kubernetes/typed/networking/v1beta1
 k8s.io/client-go/tools/cache
 k8s.io/client-go/kubernetes/scheme
 k8s.io/client-go/tools/leaderelection
@@ -550,8 +551,8 @@ k8s.io/client-go/kubernetes/typed/certificates/v1beta1
 k8s.io/client-go/kubernetes/typed/coordination/v1
 k8s.io/client-go/kubernetes/typed/coordination/v1beta1
 k8s.io/client-go/kubernetes/typed/events/v1beta1
+k8s.io/client-go/kubernetes/typed/extensions/v1beta1
 k8s.io/client-go/kubernetes/typed/networking/v1
-k8s.io/client-go/kubernetes/typed/networking/v1beta1
 k8s.io/client-go/kubernetes/typed/node/v1alpha1
 k8s.io/client-go/kubernetes/typed/node/v1beta1
 k8s.io/client-go/kubernetes/typed/policy/v1beta1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Migrates from the `extensions` package to the new one `networking.k8s.io/v1beta1`.
There are some restrictions:

- We cannot break existing installations in clusters < 1.14
- This is the reason why e2e tests keep the old package
- Internally we detect the version and convert the object to the new one
- After k8s 1.21 (three releases after 1.18 we can change the tests and remove the extensions package)


Migrates from the `"k8s.io/api/networking/v1beta1"` package to `"k8s.io/api/networking/v1beta1"` for Kubernetes versions >= 1.14.0 and keeps the extension package for older versions.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

replaces #4081

**Special notes for your reviewer**:
