### PR TITLE
feature(collectors): Added services to collectorLabels

### DIFF
--- a/internal/ingress/metric/collectors/socket.go
+++ b/internal/ingress/metric/collectors/socket.go
@@ -169,7 +169,7 @@ func NewSocketCollector(pod, namespace, class string, metricsPerHost bool) (*Soc
 				Namespace:   PrometheusNamespace,
 				ConstLabels: constLabels,
 			},
-			[]string{"ingress", "namespace", "status"},
+			[]string{"ingress", "namespace", "status", "service"},
 		),
 
 		bytesSent: prometheus.NewHistogramVec(
@@ -243,6 +243,7 @@ func (sc *SocketCollector) handleMessage(msg []byte) {
 			"namespace": stats.Namespace,
 			"ingress":   stats.Ingress,
 			"status":    stats.Status,
+			"service":   stats.Service,
 		}
 
 		latencyLabels := prometheus.Labels{


### PR DESCRIPTION
Added services to collectorLabels and requests Countervec to capture the name of the kubernetes services used to serve the client request.

**What this PR does / why we need it**:

It's add the string "service" to the colelctorLabels so the total number of client requests also includes the service used to serve that request.
This adds better support for more details telemetry, something useful (and needed) when using this information to trigger autoscalling policies on different deployments inside Kubernetes.
With this change, and little effort, you can use Prometheus/Grafana or Datadog to display the requests per seconds and error codes for every  service on your cluster.

**Special notes for your reviewer**:
This change was based on the tag nginx-0.24.1 