### PR TITLE
Implement MetalLB LoadBalancer support

### DIFF
--- a/deploy/metallb/kustomization.yaml
+++ b/deploy/metallb/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+- ../cloud-generic
+patchesStrategicMerge:
+- service-loadbalancer.yaml

--- a/deploy/metallb/service-loadbalancer.yaml
+++ b/deploy/metallb/service-loadbalancer.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingress-nginx
+spec:
+  type: LoadBalancer
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80
+      protocol: TCP
+    - name: https
+      port: 443
+      targetPort: 443
+      protocol: TCP
+  externalTrafficPolicy: Cluster


### PR DESCRIPTION
**What this PR does / why we need it**:
The current implementation of bare metal deployment uses a `NodePort` type service to expose the ingress controller. This PR implements support for the `LoadBalancer` type service as an alternative that works well with an on-premise (L2) MetalLB deployment.