### PR TITLE
update modsecurity to latest, libmodsecurity to v3.0.3 and owasp-scrs…

### DIFF
--- a/images/nginx/Makefile
+++ b/images/nginx/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # 0.0.0 shouldn't clobber any released builds
-TAG ?= 0.86
+TAG ?= 0.87
 REGISTRY ?= quay.io/kubernetes-ingress-controller
 ARCH ?= $(shell go env GOARCH)
 DOCKER ?= docker

--- a/images/nginx/rootfs/build.sh
+++ b/images/nginx/rootfs/build.sh
@@ -31,8 +31,10 @@ export ZIPKIN_CPP_VERSION=0.5.2
 export JAEGER_VERSION=cdfaf5bb25ff5f8ec179fd548e6c7c2ade9a6a09
 export MSGPACK_VERSION=3.1.1
 export DATADOG_CPP_VERSION=0.4.2
+export MODSECURITY_VERSION=d7101e13685efd7e7c9f808871b202656a969f4b
+export MODSECURITY_LIB_VERSION=3.0.3
+export OWASP_MODSECURITY_CRS_VERSION=3.1.0
 export LUA_BRIDGE_TRACER_VERSION=0.1.0
-export MODSECURITY_VERSION=fc061a57a8b0abda79b17cbe103d78db803fa575
 export LUA_NGX_VERSION=0.10.15
 export LUA_STREAM_NGX_VERSION=0.0.7
 export LUA_UPSTREAM_VERSION=0.07
@@ -156,7 +158,7 @@ get_src 015c4187f7a6426a2b5196f0ccd982aa87f010cf61f507ae3ce5c90523f92301 \
 get_src 30affaf0f3a84193f7127cc0135da91773ce45d902414082273dae78914f73df \
         "https://github.com/rnburn/zipkin-cpp-opentracing/archive/v$ZIPKIN_CPP_VERSION.tar.gz"
 
-get_src 073deba39f74eff81da917907465e1343c89b335244349d3d3b4ae9331de86f2 \
+get_src 5c8d25e68fb852f61489b669aebb7bd8ca8c88ebb5e5f969212fcceff3ee2d0b \
         "https://github.com/SpiderLabs/ModSecurity-nginx/archive/$MODSECURITY_VERSION.tar.gz"
 
 get_src 3183450d897baa9309347c8617edc0c97c5b29ffc32bd2d12f498edf2dcbeffa \
@@ -406,9 +408,8 @@ git submodule update
 
 # build modsecurity library
 cd "$BUILD_PATH"
-git clone -b v3/master --single-branch https://github.com/SpiderLabs/ModSecurity
+git clone -b v$MODSECURITY_LIB_VERSION https://github.com/SpiderLabs/ModSecurity
 cd ModSecurity/
-git checkout 145f2f35b751cc10ea6fe2b329f68eac20e2bb74
 git submodule init
 git submodule update
 sh build.sh
@@ -422,9 +423,8 @@ cp unicode.mapping /etc/nginx/modsecurity/unicode.mapping
 
 # Download owasp modsecurity crs
 cd /etc/nginx/
-git clone -b v3.0/master --single-branch https://github.com/SpiderLabs/owasp-modsecurity-crs
+git clone -b v$OWASP_MODSECURITY_CRS_VERSION https://github.com/SpiderLabs/owasp-modsecurity-crs
 cd owasp-modsecurity-crs
-git checkout a216353c97dd6ef767a6db4dbf9b724627811c9b
 
 mv crs-setup.conf.example crs-setup.conf
 mv rules/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf.example rules/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf


### PR DESCRIPTION
… to v3.1.0

**What this PR does / why we need it**:
Update modsecurity to latest, libmodsecurity to v3.0.3 and owasp-crs to v3.1.0.
This is to benefit from improvements and fixes in these releases.


**Special notes for your reviewer**:
- modsecurity-nginx connector: I noticed there is a v1.0.0 release, but after this release there are plenty commits with fixes worth including, so I chose the latest available commit. 
I've run it on our cluster and no issues so far.
- libmodsecurity: SpiderLabs recommend updating to v3.0.3 as it has plenty improvements.
- owasp-crs: current version is v3.0.2, I can use an init container to update to v3.1.0 by downloading the rules from git, but it will slightly increase the start-up time
