### PR TITLE
add default server location snippet

### DIFF
--- a/docs/user-guide/nginx-configuration/configmap.md
+++ b/docs/user-guide/nginx-configuration/configmap.md
@@ -130,6 +130,7 @@ The following table shows a configuration option's name, type, and the default v
 |[http-snippet](#http-snippet)|string|""|
 |[server-snippet](#server-snippet)|string|""|
 |[location-snippet](#location-snippet)|string|""|
+|[default-server-location-snippet](#default-server-location-snippet)|string|""|
 |[custom-http-errors](#custom-http-errors)|[]int|[]int{}|
 |[proxy-body-size](#proxy-body-size)|string|"1m"|
 |[proxy-connect-timeout](#proxy-connect-timeout)|int|5|
@@ -763,6 +764,10 @@ Adds custom configuration to all the servers in the nginx configuration.
 Adds custom configuration to all the locations in the nginx configuration.
 
 You can not use this to add new locations that proxy to the Kubernetes pods, as the snippet does not have access to the Go template functions. If you want to add custom locations you will have to [provide your own nginx.tmpl](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/custom-template/).
+
+## default-server-location-snippet
+
+Adds custom custom configuration to only the default server in the nginx configuration.
 
 ## custom-http-errors
 

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -530,6 +530,9 @@ type Configuration struct {
 	// LocationSnippet adds custom configuration to all the locations in the nginx configuration
 	LocationSnippet string `json:"location-snippet"`
 
+	// DefaultServerLocationSnippet adds custom configuration to the default server only
+	DefaultServerLocationSnippet string `json:"default-server-location-snippet"`
+
 	// HTTPRedirectCode sets the HTTP status code to be used in redirects.
 	// Supported codes are 301,302,307 and 308
 	// Default: 308

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -1298,6 +1298,11 @@ stream {
             return 200;
         }
 
+        {{ if not (empty $cfg.DefaultServerLocationSnippet) }}
+        # Custom default server location snippet via configmap
+        {{ $cfg.DefaultServerLocationSnippet }}
+        {{ end }}
+
         # this is required to avoid error if nginx is being monitored
         # with an external software (like sysdig)
         location /nginx_status {


### PR DESCRIPTION

**What this PR does / why we need it**:

This PR adds a new configmap entry `default-server-location-snippet`.  This allows for customizing locations in only the default server, eg. alternate and enhanced healthcheck endpoints.

**Which issue this PR fixes**:

fixes #4141 
