### PR TITLE
Add clarification on how to enable path matching

### DIFF
--- a/docs/user-guide/ingress-path-matching.md
+++ b/docs/user-guide/ingress-path-matching.md
@@ -6,6 +6,7 @@
     Regular expressions and wild cards are not supported in the `spec.rules.host` field. Full hostnames must be used. 
 
 The ingress controller supports **case insensitive** regular expressions in the `spec.rules.http.paths.path` field.
+This can be enabled by setting the `nginx.ingress.kubernetes.io/use-regex` annotation to `true` (the default is false).
 
 See the [description](./nginx-configuration/annotations.md#use-regex) of the `use-regex` annotation for more details.
 


### PR DESCRIPTION
The fact that you need to explicitly add the annotation is easy to miss.
This makes this more explicit, while leaving the finer details to the
linked annotations document.

**Which issue this PR fixes**
Fixes #4144 