### PR TITLE
simplify sticky balancer and fix a bug

### DIFF
--- a/rootfs/etc/nginx/lua/util/split.lua
+++ b/rootfs/etc/nginx/lua/util/split.lua
@@ -16,12 +16,6 @@ function _M.get_first_value(var)
   return t[1]
 end
 
-function _M.get_last_value(var)
-  local t = _M.split_upstream_var(var) or {}
-  if #t == 0 then return nil end
-  return t[#t]
-end
-
 -- http://nginx.org/en/docs/http/ngx_http_upstream_module.html#example
 -- CAVEAT: nginx is giving out : instead of , so the docs are wrong
 -- 127.0.0.1:26157 : 127.0.0.1:26157 , ngx.var.upstream_addr


### PR DESCRIPTION
**What this PR does / why we need it**:

- Simplify sticky.lua
- Fix a bug in the feature introduced at https://github.com/kubernetes/ingress-nginx/pull/4048. The problem is the code looks at last failing upstream only. However if Nginx is configured to retry more than 2 upstreams then it is possible that sticky balancer picks a previously failing upstream again. This PR makes sure sticky balancer looks at all previously failing upstreams for given request and does not pick any of them as a new upstream. cc @fedunineyu 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
