### PR TITLE
Implement listen address override for the healthz port

### DIFF
--- a/cmd/nginx/flags.go
+++ b/cmd/nginx/flags.go
@@ -156,6 +156,7 @@ Feature backed by OpenResty Lua libraries. Requires that OCSP stapling is not en
 		sslProxyPort  = flags.Int("ssl-passthrough-proxy-port", 442, `Port to use internally for SSL Passthrough.`)
 		defServerPort = flags.Int("default-server-port", 8181, `Port to use for exposing the default server (catch-all).`)
 		healthzPort   = flags.Int("healthz-port", 10254, "Port to use for the healthz endpoint.")
+		healthzListenAddress = flags.String("healthz-listen-address", "", "Listen address to use for the healthz endpoint.")
 
 		disableCatchAll = flags.Bool("disable-catch-all", false,
 			`Disable support for catch-all Ingresses`)
@@ -259,6 +260,7 @@ Takes the form "<host>:port". If not provided, no admission controller is starte
 		ListenPorts: &ngx_config.ListenPorts{
 			Default:  *defServerPort,
 			Health:   *healthzPort,
+			HealthAddress: *healthzListenAddress,
 			HTTP:     *httpPort,
 			HTTPS:    *httpsPort,
 			SSLProxy: *sslProxyPort,

--- a/cmd/nginx/main.go
+++ b/cmd/nginx/main.go
@@ -144,7 +144,7 @@ func main() {
 	registerMetrics(reg, mux)
 	registerHandlers(mux)
 
-	go startHTTPServer(conf.ListenPorts.Health, mux)
+	go startHTTPServer(conf.ListenPorts.HealthAddress, conf.ListenPorts.Health, mux)
 
 	ngx.Start()
 }
@@ -288,9 +288,9 @@ func registerProfiler(mux *http.ServeMux) {
 	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
 }
 
-func startHTTPServer(port int, mux *http.ServeMux) {
+func startHTTPServer(listenAddr string, port int, mux *http.ServeMux) {
 	server := &http.Server{
-		Addr:              fmt.Sprintf(":%v", port),
+		Addr:              fmt.Sprintf("%s:%v", listenAddr, port),
 		Handler:           mux,
 		ReadTimeout:       10 * time.Second,
 		ReadHeaderTimeout: 10 * time.Second,

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -787,6 +787,7 @@ type ListenPorts struct {
 	HTTP     int
 	HTTPS    int
 	Health   int
+	HealthAddress string
 	Default  int
 	SSLProxy int
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Allows you to set a custom listen address for the `/metrics` and `/healthz` endpoint (e.g. `127.0.0.1`) and
possibly secure it with kube-rbac-proxy when running with hostNetwork

**Which issue this PR fixes**

- Related to #4052 
- Allows you to use kube-rbac-proxy
