### PR TITLE
Add Example for `k8s.gcr.io/proxy-to-service:v2`

### DIFF
--- a/deploy/static/provider/aws/service-l4.yaml
+++ b/deploy/static/provider/aws/service-l4.yaml
@@ -1,5 +1,5 @@
-kind: Service
 apiVersion: v1
+kind: Service
 metadata:
   name: ingress-nginx
   namespace: ingress-nginx

--- a/deploy/static/provider/aws/service-l7.yaml
+++ b/deploy/static/provider/aws/service-l7.yaml
@@ -1,5 +1,5 @@
-kind: Service
 apiVersion: v1
+kind: Service
 metadata:
   name: ingress-nginx
   namespace: ingress-nginx
@@ -28,7 +28,7 @@ spec:
       targetPort: http
     - name: https
       port: 443
-      targetPort: http
+      targetPort: https
 
 ---
 

--- a/deploy/static/provider/aws/service-nlb.yaml
+++ b/deploy/static/provider/aws/service-nlb.yaml
@@ -1,5 +1,5 @@
-kind: Service
 apiVersion: v1
+kind: Service
 metadata:
   name: ingress-nginx
   namespace: ingress-nginx

--- a/deploy/static/provider/baremetal/service-nodeport.yaml
+++ b/deploy/static/provider/baremetal/service-nodeport.yaml
@@ -8,18 +8,16 @@ metadata:
     app.kubernetes.io/part-of: ingress-nginx
 spec:
   type: NodePort
-  ports:
-    - name: http
-      port: 80
-      targetPort: 80
-      protocol: TCP
-    - name: https
-      port: 443
-      targetPort: 443
-      protocol: TCP
   selector:
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+    - name: https
+      port: 443
+      targetPort: https
 
 ---
 

--- a/deploy/static/provider/proxy-to-service/daemonset-proxy-to-service.yaml
+++ b/deploy/static/provider/proxy-to-service/daemonset-proxy-to-service.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: nginx-ingress-proxy-to-service
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: nginx-ingress-proxy-to-service
+    app.kubernetes.io/part-of: ingress-nginx
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nginx-ingress-proxy-to-service
+      app.kubernetes.io/part-of: ingress-nginx
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: nginx-ingress-proxy-to-service
+        app.kubernetes.io/part-of: ingress-nginx
+    spec:
+      containers:
+        - name: http
+          image: k8s.gcr.io/proxy-to-service:v2
+          args:
+            - tcp
+            - "80"
+            - ingress-nginx
+          ports:
+            - name: http
+              containerPort: 80
+              hostPort: 80
+        - name: https
+          image: k8s.gcr.io/proxy-to-service:v2
+          args:
+            - tcp
+            - "443"
+            - ingress-nginx
+          ports:
+            - name: https
+              containerPort: 443
+              hostPort: 443
+
+---
+

--- a/deploy/static/provider/proxy-to-service/service-clusterip.yaml
+++ b/deploy/static/provider/proxy-to-service/service-clusterip.yaml
@@ -7,8 +7,6 @@ metadata:
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
 spec:
-  externalTrafficPolicy: Local
-  type: LoadBalancer
   selector:
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx

--- a/docs/deploy/index.md
+++ b/docs/deploy/index.md
@@ -10,6 +10,7 @@
     - [GCE - GKE](#gce-gke)
     - [Azure](#azure)
     - [Bare-metal](#bare-metal)
+    - [Proxy-to-Service](#proxy-to-service)
   - [Verify installation](#verify-installation)
   - [Detect installed version](#detect-installed-version)
 - [Using Helm](#using-helm)
@@ -153,7 +154,7 @@ kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/mast
 
 #### Bare-metal
 
-Using [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport):
+Using [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport):
 
 ```console
 kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/baremetal/service-nodeport.yaml
@@ -161,6 +162,15 @@ kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/mast
 
 !!! tip
     For extended notes regarding deployments on bare-metal, see [Bare-metal considerations](./baremetal.md).
+
+#### Proxy-to-Service
+
+Using [Proxy-to-Service](https://github.com/kubernetes-retired/contrib/tree/master/for-demos/proxy-to-service)
+
+```console
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/proxy-to-service/service-clusterip.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/proxy-to-service/daemonset-proxy-to-service.yaml
+```
 
 ### Verify installation
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Refer to https://github.com/kubernetes-retired/contrib/tree/master/for-demos/proxy-to-service, by using `k8s.gcr.io/proxy-to-service:v2` we could proxy both 80/443 with `hostPort` from DaemonSet, to a standard service with `ClusterIP`.

This style could keep our exsting Deployment for Controller as-is, and most likey working for any network architecture, where also keep using the standard port with 80/443.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->



**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
