### PR TITLE
Fix: fillout missing health check timeout on health check.

### DIFF
--- a/cmd/nginx/flags.go
+++ b/cmd/nginx/flags.go
@@ -20,6 +20,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/spf13/pflag"
 
@@ -97,7 +98,7 @@ Takes the form "namespace/name".`)
 Configured inside the NGINX status server. All requests received on the port
 defined by the healthz-port parameter are forwarded internally to this path.`)
 
-		healthCheckTimeout = flags.Duration("health-check-timeout", 10, `Time limit, in seconds, for a probe to health-check-path to succeed.`)
+		defHealthCheckTimeout = flags.Int("health-check-timeout", 10, `Time limit, in seconds, for a probe to health-check-path to succeed.`)
 
 		updateStatus = flags.Bool("update-status", true,
 			`Update the load-balancer status of Ingress objects this controller satisfies.
@@ -232,6 +233,10 @@ Takes the form "<host>:port". If not provided, no admission controller is starte
 
 	nginx.HealthPath = *defHealthzURL
 
+	if *defHealthCheckTimeout > 0 {
+		nginx.HealthCheckTimeout = time.Duration(*defHealthCheckTimeout) * time.Second
+	}
+
 	config := &controller.Configuration{
 		APIServerHost:              *apiserverHost,
 		KubeConfigFile:             *kubeConfigFile,
@@ -249,7 +254,6 @@ Takes the form "<host>:port". If not provided, no admission controller is starte
 		TCPConfigMapName:           *tcpConfigMapName,
 		UDPConfigMapName:           *udpConfigMapName,
 		DefaultSSLCertificate:      *defSSLCertificate,
-		HealthCheckTimeout:         *healthCheckTimeout,
 		PublishService:             *publishSvc,
 		PublishStatusAddress:       *publishStatusAddress,
 		UpdateStatusOnShutdown:     *updateStatusOnShutdown,

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -64,7 +64,6 @@ type Configuration struct {
 	// +optional
 	UDPConfigMapName string
 
-	HealthCheckTimeout    time.Duration
 	DefaultSSLCertificate string
 
 	// +optional


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes the missing flag argument HealthCheckTimeout which is removed in [this commit](https://github.com/kubernetes/ingress-nginx/commit/34b05802258b21e44de663bfb303719ceebc832f#diff-2ba8760e8fa4ab430df5f1adde0dbf29L41) by mistake, and keeps the default timeout settings ( 10s ) where it's NOT health check related calls.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
