### PR TITLE
Add unit test cases for balancer lua module

### DIFF
--- a/rootfs/etc/nginx/lua/balancer.lua
+++ b/rootfs/etc/nginx/lua/balancer.lua
@@ -257,6 +257,7 @@ end
 if _TEST then
   _M.get_implementation = get_implementation
   _M.sync_backend = sync_backend
+  _M.route_to_alternative_balancer = route_to_alternative_balancer
 end
 
 return _M

--- a/rootfs/etc/nginx/lua/test/balancer_test.lua
+++ b/rootfs/etc/nginx/lua/test/balancer_test.lua
@@ -131,6 +131,48 @@ describe("Balancer", function()
         assert.equal(false, balancer.route_to_alternative_balancer(_balancer))
       end)
     end)
+
+    context("canary by cookie", function()
+      it("returns correct result for given cookies", function()
+        backend.trafficShapingPolicy.cookie = "canaryCookie"
+        balancer.sync_backend(backend)
+        local test_patterns = {
+          {
+            case_title = "cookie_value is 'always'",
+            request_cookie_name = "canaryCookie",
+            request_cookie_value = "always",
+            expected_result = true,
+          },
+          {
+            case_title = "cookie_value is 'never'",
+            request_cookie_name = "canaryCookie",
+            request_cookie_value = "never",
+            expected_result = false,
+          },
+          {
+            case_title = "cookie_value is undefined",
+            request_cookie_name = "canaryCookie",
+            request_cookie_value = "foo",
+            expected_result = false,
+          },
+          {
+            case_title = "cookie_name is undefined",
+            request_cookie_name = "foo",
+            request_cookie_value = "always",
+            expected_result = false
+          },
+        }
+        for _, test_pattern in pairs(test_patterns) do
+          mock_ngx({ var = {
+            ["cookie_" .. test_pattern.request_cookie_name] = test_pattern.request_cookie_value,
+            request_uri = "/"
+          }})
+          assert.message("\nTest data pattern: " .. test_pattern.case_title)
+            .equal(test_pattern.expected_result, balancer.route_to_alternative_balancer(_balancer))
+          reset_ngx()
+        end
+      end)
+    end)
   end)
 
   describe("sync_backend()", function()

--- a/rootfs/etc/nginx/lua/test/balancer_test.lua
+++ b/rootfs/etc/nginx/lua/test/balancer_test.lua
@@ -117,6 +117,20 @@ describe("Balancer", function()
       _balancer.alternative_backends[1] = "nonExistingBackend"
       assert.equal(false, balancer.route_to_alternative_balancer(_balancer))
     end)
+
+    context("canary by weight", function()
+      it("returns true when weight is 100", function()
+        backend.trafficShapingPolicy.weight = 100
+        balancer.sync_backend(backend)
+        assert.equal(true, balancer.route_to_alternative_balancer(_balancer))
+      end)
+
+      it("returns false when weight is 0", function()
+        backend.trafficShapingPolicy.weight = 0
+        balancer.sync_backend(backend)
+        assert.equal(false, balancer.route_to_alternative_balancer(_balancer))
+      end)
+    end)
   end)
 
   describe("sync_backend()", function()

--- a/rootfs/etc/nginx/lua/test/balancer_test.lua
+++ b/rootfs/etc/nginx/lua/test/balancer_test.lua
@@ -1,6 +1,17 @@
 _G._TEST = true
 
 local balancer, expected_implementations, backends
+local original_ngx = ngx
+
+local function reset_ngx()
+  _G.ngx = original_ngx
+end
+
+local function mock_ngx(mock)
+  local _ngx = mock
+  setmetatable(_ngx, { __index = ngx })
+  _G.ngx = _ngx
+end
 
 local function reset_balancer()
   package.loaded["balancer"] = nil
@@ -30,6 +41,12 @@ local function reset_backends()
         { address = "10.184.98.239", port = "8080", maxFails = 0, failTimeout = 0 },
       },
       sessionAffinityConfig = { name = "", cookieSessionAffinity = { name = "" } },
+      trafficShapingPolicy = {
+        weight = 0,
+        header = "",
+        headerValue = "",
+        cookie = ""
+      },
     },
     { name = "my-dummy-app-1", ["load-balance"] = "round_robin", },
     { 
@@ -55,6 +72,10 @@ describe("Balancer", function()
     reset_backends()
   end)
 
+  after_each(function()
+    reset_ngx()
+  end)
+
   describe("get_implementation()", function()
     it("returns correct implementation for given backend", function()
       for _, backend in pairs(backends) do
@@ -62,6 +83,39 @@ describe("Balancer", function()
         local implementation = balancer.get_implementation(backend)
         assert.equal(expected_implementation, balancer.get_implementation(backend))
       end
+    end)
+  end)
+
+  describe("route_to_alternative_balancer()", function()
+    local backend, _balancer
+
+    before_each(function()
+      backend = backends[1]
+      _balancer = {
+        alternative_backends = {
+          backend.name,
+        }
+      }
+      mock_ngx({ var = { request_uri = "/" } })
+    end)
+
+    it("returns false when no trafficShapingPolicy is set", function()
+      balancer.sync_backend(backend)
+      assert.equal(false, balancer.route_to_alternative_balancer(_balancer))
+    end)
+
+    it("returns false when no alternative backends is set", function()
+      backend.trafficShapingPolicy.weight = 100
+      balancer.sync_backend(backend)
+      _balancer.alternative_backends = nil
+      assert.equal(false, balancer.route_to_alternative_balancer(_balancer))
+    end)
+
+    it("returns false when alternative backends name does not match", function()
+      backend.trafficShapingPolicy.weight = 100
+      balancer.sync_backend(backend)
+      _balancer.alternative_backends[1] = "nonExistingBackend"
+      assert.equal(false, balancer.route_to_alternative_balancer(_balancer))
     end)
   end)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds unit test cases for balancer.lua's route_to_alternative_balancer() function.
Since I'm planning to fix #4028 and add more test cases for the change, I added test cases for existing logic of target function.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` Related with #4028 (but not fix it)

**Special notes for your reviewer**:
N/A