### PR TITLE
Resolve #4106, add check for empty certificate in get_pem_cert_key

### DIFF
--- a/rootfs/etc/nginx/lua/certificate.lua
+++ b/rootfs/etc/nginx/lua/certificate.lua
@@ -30,7 +30,7 @@ end
 
 local function get_pem_cert_key(hostname)
   local pem_cert_key = configuration.get_pem_cert_key(hostname)
-  if pem_cert_key then
+  if pem_cert_key and pem_cert_key ~= '' then
     return pem_cert_key
   end
 


### PR DESCRIPTION
What this PR does / why we need it:
This PR fixes kubernetes#4106

Special notes for your reviewer:
The original author's expectation might be that configuration.get_pem_cert_key(hostname) returns nil for the hostname when no tls section is defined for the corresponding ingress resource. But it seems to be returning empty string and this causes ssl.cert_pem_to_der(pem_cert_key) to fail later. This check fixes this issue.