### PR TITLE
Add canary-by-cookie-value annotation

### DIFF
--- a/docs/user-guide/nginx-configuration/annotations.md
+++ b/docs/user-guide/nginx-configuration/annotations.md
@@ -35,6 +35,7 @@ You can add these Kubernetes annotations to specific Ingress objects to customiz
 |[nginx.ingress.kubernetes.io/canary-by-header](#canary)|string|
 |[nginx.ingress.kubernetes.io/canary-by-header-value](#canary)|string
 |[nginx.ingress.kubernetes.io/canary-by-cookie](#canary)|string|
+|[nginx.ingress.kubernetes.io/canary-by-cookie-value](#canary)|string
 |[nginx.ingress.kubernetes.io/canary-weight](#canary)|number|
 |[nginx.ingress.kubernetes.io/client-body-buffer-size](#client-body-buffer-size)|string|
 |[nginx.ingress.kubernetes.io/configuration-snippet](#configuration-snippet)|string|
@@ -117,6 +118,8 @@ In some cases, you may want to "canary" a new set of changes by sending a small 
 * `nginx.ingress.kubernetes.io/canary-by-header-value`: The header value to match for notifying the Ingress to route the request to the service specified in the Canary Ingress. When the request header is set to this value, it will be routed to the canary. For any other header value, the header will be ignored and the request compared against the other canary rules by precedence. This annotation has to be used together with . The annotation is an extension of the `nginx.ingress.kubernetes.io/canary-by-header` to allow customizing the header value instead of using hardcoded values. It doesn't have any effect if the `nginx.ingress.kubernetes.io/canary-by-header` annotation is not defined.
 
 * `nginx.ingress.kubernetes.io/canary-by-cookie`: The cookie to use for notifying the Ingress to route the request to the service specified in the Canary Ingress. When the cookie value is set to `always`, it will be routed to the canary. When the cookie is set to `never`, it will never be routed to the canary. For any other value, the cookie will be ignored and the request compared against the other canary rules by precedence.
+
+* `nginx.ingress.kubernetes.io/canary-by-cookie-value`: The cookie value (it is [regular expression of Lua](https://www.lua.org/pil/20.2.html)) to match for notifying the Ingress to route the request to the service specified in the Canary Ingress. When the cookie value is set to this value, it will be routed to the canary. If cookie value doesn't match as a regular expression, the cookie will be ignored and the request compared against the other canary rules by precedence. This annotation has to be used together with . The annotation is an extension of the `nginx.ingress.kubernetes.io/canary-by-cookie` to allow customizing the cookie value instead of using hardcoded values. It doesn't have any effect if the `nginx.ingress.kubernetes.io/canary-by-cookie` annotation is not defined.
 
 * `nginx.ingress.kubernetes.io/canary-weight`: The integer based (0 - 100) percent of random requests that should be routed to the service specified in the canary Ingress. A weight of 0 implies that no requests will be sent to the service in the Canary ingress by this canary rule. A weight of 100 means implies all requests will be sent to the alternative service specified in the Ingress.
 

--- a/internal/ingress/annotations/canary/main.go
+++ b/internal/ingress/annotations/canary/main.go
@@ -35,6 +35,7 @@ type Config struct {
 	Header      string
 	HeaderValue string
 	Cookie      string
+	CookieValue string
 }
 
 // NewParser parses the ingress for canary related annotations
@@ -73,7 +74,12 @@ func (c canary) Parse(ing *networking.Ingress) (interface{}, error) {
 		config.Cookie = ""
 	}
 
-	if !config.Enabled && (config.Weight > 0 || len(config.Header) > 0 || len(config.HeaderValue) > 0 || len(config.Cookie) > 0) {
+	config.CookieValue, err = parser.GetStringAnnotation("canary-by-cookie-value", ing)
+	if err != nil {
+		config.CookieValue = ""
+	}
+
+	if !config.Enabled && (config.Weight > 0 || len(config.Header) > 0 || len(config.HeaderValue) > 0 || len(config.Cookie) > 0 || len(config.CookieValue) > 0) {
 		return nil, errors.NewInvalidAnnotationConfiguration("canary", "configured but not enabled")
 	}
 

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -707,6 +707,7 @@ func (n *NGINXController) createUpstreams(data []*ingress.Ingress, du *ingress.B
 					Header:      anns.Canary.Header,
 					HeaderValue: anns.Canary.HeaderValue,
 					Cookie:      anns.Canary.Cookie,
+					CookieValue: anns.Canary.CookieValue,
 				}
 			}
 
@@ -772,6 +773,7 @@ func (n *NGINXController) createUpstreams(data []*ingress.Ingress, du *ingress.B
 						Header:      anns.Canary.Header,
 						HeaderValue: anns.Canary.HeaderValue,
 						Cookie:      anns.Canary.Cookie,
+						CookieValue: anns.Canary.CookieValue,
 					}
 				}
 

--- a/internal/ingress/types.go
+++ b/internal/ingress/types.go
@@ -122,6 +122,8 @@ type TrafficShapingPolicy struct {
 	HeaderValue string `json:"headerValue"`
 	// Cookie on which to redirect requests to this backend
 	Cookie string `json:"cookie"`
+	// CookieValue (regular expression of Lua) on which to redirect requests to this backend
+	CookieValue string `json:"cookieValue"`
 }
 
 // HashInclude defines if a field should be used or not to calculate the hash

--- a/internal/ingress/types_equals.go
+++ b/internal/ingress/types_equals.go
@@ -248,6 +248,9 @@ func (tsp1 TrafficShapingPolicy) Equal(tsp2 TrafficShapingPolicy) bool {
 	if tsp1.Cookie != tsp2.Cookie {
 		return false
 	}
+	if tsp1.CookieValue != tsp2.CookieValue {
+		return false
+	}
 
 	return true
 }

--- a/rootfs/etc/nginx/lua/balancer.lua
+++ b/rootfs/etc/nginx/lua/balancer.lua
@@ -175,7 +175,11 @@ local function route_to_alternative_balancer(balancer)
   local target_cookie = traffic_shaping_policy.cookie
   local cookie = ngx.var["cookie_" .. target_cookie]
   if cookie then
-    if cookie == "always" then
+    if traffic_shaping_policy.cookieValue and #traffic_shaping_policy.cookieValue > 0 then
+      if cookie:find(traffic_shaping_policy.cookieValue) ~= nil then
+        return true
+      end
+    elseif cookie == "always" then
       return true
     elseif cookie == "never" then
       return false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This PR adds new annotation `canary-by-cookie-value` to enable canary release with specific cookie's value. 
It's similar with an existing annotation `canary-by-header-value`, but the difference is that `canary-by-cookie-value` will be used on regular expression matching.
Original motivation to add this annotation is that we'd like to have canary release for web application and want to lock version for each user. If this PR is merged, this can be possible by using session cookie's value.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
N/A

**Special notes for your reviewer**:
I have concern about the naming of annotation. `canary-by-header-value` is not treated as regular expression but `canary-by-cookie-value` is so, even though the name is similar. If it's confusing, it can be different annotation name. Let me hear your opinion.