### PR TITLE
Add Example for `ClusterIP` with `alpine/socat:1.0.3`

### DIFF
--- a/deploy/static/provider/aws/service-l4.yaml
+++ b/deploy/static/provider/aws/service-l4.yaml
@@ -1,5 +1,5 @@
-kind: Service
 apiVersion: v1
+kind: Service
 metadata:
   name: ingress-nginx
   namespace: ingress-nginx

--- a/deploy/static/provider/aws/service-l7.yaml
+++ b/deploy/static/provider/aws/service-l7.yaml
@@ -1,5 +1,5 @@
-kind: Service
 apiVersion: v1
+kind: Service
 metadata:
   name: ingress-nginx
   namespace: ingress-nginx
@@ -28,7 +28,7 @@ spec:
       targetPort: http
     - name: https
       port: 443
-      targetPort: http
+      targetPort: https
 
 ---
 

--- a/deploy/static/provider/aws/service-nlb.yaml
+++ b/deploy/static/provider/aws/service-nlb.yaml
@@ -1,5 +1,5 @@
-kind: Service
 apiVersion: v1
+kind: Service
 metadata:
   name: ingress-nginx
   namespace: ingress-nginx

--- a/deploy/static/provider/clusterip/daemonset-proxy.yaml
+++ b/deploy/static/provider/clusterip/daemonset-proxy.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: nginx-ingress-proxy
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: nginx-ingress-proxy
+    app.kubernetes.io/part-of: ingress-nginx
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nginx-ingress-proxy
+      app.kubernetes.io/part-of: ingress-nginx
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: nginx-ingress-proxy
+        app.kubernetes.io/part-of: ingress-nginx
+    spec:
+      containers:
+        - name: http
+          image: alpine/socat:1.0.3
+          args:
+            - tcp-listen:80,fork,reuseaddr
+            - tcp:ingress-nginx:80
+          ports:
+            - name: http
+              containerPort: 80
+              hostPort: 80
+        - name: https
+          image: alpine/socat:1.0.3
+          args:
+            - tcp-listen:443,fork,reuseaddr
+            - tcp:ingress-nginx:443
+          ports:
+            - name: https
+              containerPort: 443
+              hostPort: 443
+
+---
+

--- a/deploy/static/provider/clusterip/service-clusterip.yaml
+++ b/deploy/static/provider/clusterip/service-clusterip.yaml
@@ -7,8 +7,6 @@ metadata:
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
 spec:
-  externalTrafficPolicy: Local
-  type: LoadBalancer
   selector:
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx

--- a/deploy/static/provider/nodeport/service-nodeport.yaml
+++ b/deploy/static/provider/nodeport/service-nodeport.yaml
@@ -8,18 +8,16 @@ metadata:
     app.kubernetes.io/part-of: ingress-nginx
 spec:
   type: NodePort
-  ports:
-    - name: http
-      port: 80
-      targetPort: 80
-      protocol: TCP
-    - name: https
-      port: 443
-      targetPort: 443
-      protocol: TCP
   selector:
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+    - name: https
+      port: 443
+      targetPort: https
 
 ---
 

--- a/docs/deploy/index.md
+++ b/docs/deploy/index.md
@@ -9,7 +9,8 @@
     - [AWS](#aws)
     - [GCE - GKE](#gce-gke)
     - [Azure](#azure)
-    - [Bare-metal](#bare-metal)
+    - [NodePort](#nodeport)
+    - [ClusterIP](#clusterip)
   - [Verify installation](#verify-installation)
   - [Detect installed version](#detect-installed-version)
 - [Using Helm](#using-helm)
@@ -151,16 +152,25 @@ kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/mast
 kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/cloud-generic.yaml
 ```
 
-#### Bare-metal
+#### NodePort
 
-Using [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport):
+Using [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport):
 
 ```console
-kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/baremetal/service-nodeport.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/nodeport/service-nodeport.yaml
 ```
 
 !!! tip
     For extended notes regarding deployments on bare-metal, see [Bare-metal considerations](./baremetal.md).
+
+#### ClusterIP
+
+By using [Socat](https://hub.docker.com/r/alpine/socat) we could expose both 80/443 with `hostPort` from DaemonSet, to a standard service with [ClusterIP](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types).
+
+```console
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/clusterip/service-clusterip.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/clusterip/daemonset-proxy.yaml
+```
 
 ### Verify installation
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Refer to https://hub.docker.com/r/alpine/socat/, by using `alpine/socat:1.0.3` we could expose both 80/443 with `hostPort` from DaemonSet, to a standard service with `ClusterIP`.

This style could keep our exsting Deployment for Controller as-is, and most likey working for any network architecture, where also keep using the standard port with 80/443.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

Close #4181, in favor of using a simple (3M) official socat image from Alpine Linux.

**Special notes for your reviewer**:
