### PR TITLE
introduce proxy_alternative_upstream_name Nginx var

### DIFF
--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -50,7 +50,7 @@ const (
 
 	brotliTypes = "application/xml+rss application/atom+xml application/javascript application/x-javascript application/json application/rss+xml application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/svg+xml image/x-icon text/css text/javascript text/plain text/x-component"
 
-	logFormatUpstream = `%v - [$the_real_ip] - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" $request_length $request_time [$proxy_upstream_name] $upstream_addr $upstream_response_length $upstream_response_time $upstream_status $req_id`
+	logFormatUpstream = `%v - [$the_real_ip] - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" $request_length $request_time [$proxy_upstream_name] [$proxy_alternative_upstream_name] $upstream_addr $upstream_response_length $upstream_response_time $upstream_status $req_id`
 
 	logFormatStream = `[$time_local] $protocol $status $bytes_sent $bytes_received $session_time`
 

--- a/rootfs/etc/nginx/lua/balancer.lua
+++ b/rootfs/etc/nginx/lua/balancer.lua
@@ -198,8 +198,10 @@ local function get_balancer()
   end
 
   if route_to_alternative_balancer(balancer) then
-    local alternative_balancer = balancers[balancer.alternative_backends[1]]
-    return alternative_balancer
+    local alternative_backend_name = balancer.alternative_backends[1]
+    ngx.var.proxy_alternative_upstream_name = alternative_backend_name
+
+    return balancers[alternative_backend_name]
   end
 
   return balancer

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -1094,6 +1094,8 @@ stream {
             set $proxy_upstream_name    "{{ buildUpstreamName $location }}";
             set $proxy_host             $proxy_upstream_name;
 
+            set $proxy_alternative_upstream_name "";
+
             {{ if (or $location.ModSecurity.Enable $all.Cfg.EnableModsecurity) }}
             {{ if not $all.Cfg.EnableModsecurity }}
             modsecurity on;


### PR DESCRIPTION
**What this PR does / why we need it**:

With this PR one now can look at $proxy_alternative_upstream_name to detect whether request hit canary endpoint.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
