### PR TITLE
fix POD_NAME environment variable

### DIFF
--- a/docs/deploy/index.md
+++ b/docs/deploy/index.md
@@ -202,6 +202,6 @@ helm install stable/nginx-ingress --name my-nginx --set rbac.create=true
 Detect installed version:
 
 ```console
-POD_NAME=$(kubectl get pods -l app.kubernetes.io/name=ingress-nginx -o jsonpath='{.items[0].metadata.name}')
+POD_NAME=$(kubectl get pods -l app=nginx-ingress,component=controller -o jsonpath='{.items[0].metadata.name}')
 kubectl exec -it $POD_NAME -- /nginx-ingress-controller --version
 ```


### PR DESCRIPTION
A small fix in the deploy index.md.
POD_NAME environment variable does not work as it is, so I have fix it.