### PR TITLE
Add support to define a tag for syslog messages

### DIFF
--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -574,6 +574,8 @@ type Configuration struct {
 	SyslogHost string `json:"syslog-host"`
 	// SyslogPort port
 	SyslogPort int `json:"syslog-port"`
+	// SyslogTag changes the tag of messages, default is nginx
+	SyslogTag string `json:"syslog-tag"`
 
 	// NoTLSRedirectLocations is a comma-separated list of locations
 	// that should not get redirected to TLS

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -277,18 +277,23 @@ http {
         default 1;
     }
 
+    {{ $syslogOptions := "" }}
+    {{ if not (empty $cfg.SyslogTag) }}
+    {{ $syslogOptions = printf ",tag=%s" $cfg.SyslogTag }}
+    {{ end }}
+
     {{ if $cfg.DisableAccessLog }}
     access_log off;
     {{ else }}
     {{ if $cfg.EnableSyslog }}
-    access_log syslog:server={{ $cfg.SyslogHost }}:{{ $cfg.SyslogPort }} upstreaminfo if=$loggable;
+    access_log syslog:server={{ $cfg.SyslogHost }}:{{ $cfg.SyslogPort }}{{ $syslogOptions }} upstreaminfo if=$loggable;
     {{ else }}
     access_log {{ $cfg.AccessLogPath }} upstreaminfo {{ $cfg.AccessLogParams }} if=$loggable;
     {{ end }}
     {{ end }}
 
     {{ if $cfg.EnableSyslog }}
-    error_log syslog:server={{ $cfg.SyslogHost }}:{{ $cfg.SyslogPort }} {{ $cfg.ErrorLogLevel }};
+    error_log syslog:server={{ $cfg.SyslogHost }}:{{ $cfg.SyslogPort }}{{ $syslogOptions }} {{ $cfg.ErrorLogLevel }};
     {{ else }}
     error_log  {{ $cfg.ErrorLogPath }} {{ $cfg.ErrorLogLevel }};
     {{ end }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This PR adds an option for Syslog to be able to use the tag for access/error logs.
It is useful to have tag especially when one Syslog is used by multiple ingress controllers.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
I only added `tag` because I think it is useful to have (in our case we need it because we have few ingress controller) but also I can add options for `severity` and/or `facility`!