### PR TITLE
Add support for multi-arch images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,14 @@ push: .push-$(ARCH) ## Publish image for a particular arch.
 .push-$(ARCH):
 	docker push $(REGISTRY)/nginx-ingress-controller-${ARCH}:$(TAG)
 
+.PHONY: push-manifest
+push-manifest:
+	docker manifest create $(REGISTRY)/nginx-ingress-controller:$(TAG) \
+		$(REGISTRY)/nginx-ingress-controller-amd64:$(TAG) \
+		$(REGISTRY)/nginx-ingress-controller-arm:$(TAG) \
+		$(REGISTRY)/nginx-ingress-controller-arm64:$(TAG)
+	docker manifest push --purge $(REGISTRY)/nginx-ingress-controller:$(TAG)
+
 .PHONY: build
 build: check-go-version ## Build ingress controller, debug tool and pre-stop hook.
 ifeq ($(USE_DOCKER), true)

--- a/build/images/ingress-controller/build-ingress-controller.sh
+++ b/build/images/ingress-controller/build-ingress-controller.sh
@@ -93,6 +93,5 @@ ARCH=amd64 make build container push
 ARCH=arm   make build container push
 ARCH=arm64 make build container push
 
-# Requires https://github.com/kubernetes/ingress-nginx/pull/4271
-#echo "Creating multi-arch images..."
-#make push-manifest
+echo "Creating multi-arch images..."
+make push-manifest


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

This allows users to just pull the image `quay.io/kubernetes-ingress-controller/nginx-ingress-controller:X.XX.X` independently of the arch (amd64, arm or arm64)

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
