### PR TITLE
introduce ngx.var.balancer_ewma_score

### DIFF
--- a/rootfs/etc/nginx/lua/balancer/ewma.lua
+++ b/rootfs/etc/nginx/lua/balancer/ewma.lua
@@ -73,18 +73,20 @@ local function pick_and_score(self, peers, k)
       lowest_score_index, lowest_score = i, new_score
     end
   end
-  return peers[lowest_score_index]
+  return peers[lowest_score_index], lowest_score
 end
 
 function _M.balance(self)
   local peers = self.peers
-  local endpoint = peers[1]
+  local endpoint, score = peers[1], -1
 
   if #peers > 1 then
     local k = (#peers < PICK_SET_SIZE) and #peers or PICK_SET_SIZE
     local peer_copy = util.deepcopy(peers)
-    endpoint = pick_and_score(self, peer_copy, k)
+    endpoint, score = pick_and_score(self, peer_copy, k)
   end
+
+  ngx.var.balancer_ewma_score = score
 
   -- TODO(elvinefendi) move this processing to _M.sync
   return endpoint.address .. ":" .. endpoint.port

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -1090,6 +1090,7 @@ stream {
 
             port_in_redirect {{ if $location.UsePortInRedirects }}on{{ else }}off{{ end }};
 
+            set $balancer_ewma_score -1;
             set $proxy_upstream_name    "{{ buildUpstreamName $location }}";
             set $proxy_host             $proxy_upstream_name;
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This is to aid debugging when using EWMA. I'm not including it in the default access log because EWMA is not default LB algorithm. One can include it using following configmap setting:

```
log-format-upstream: '[$the_real_ip] - $remote_user [$time_local] "$request" $status
    $body_bytes_sent "$http_referer" "$http_user_agent" $request_length $request_time
    [$proxy_upstream_name] $upstream_addr $upstream_response_length $upstream_response_time
    $upstream_status [$balancer_ewma_score] $req_id'
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
