### PR TITLE
Check and complete intermediate SSL certificates

### DIFF
--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -30,6 +30,13 @@ import (
 	"k8s.io/ingress-nginx/internal/runtime"
 )
 
+var (
+	// EnableSSLChainCompletion Autocomplete SSL certificate chains with missing intermediate CA certificates.
+	EnableSSLChainCompletion = false
+	// EnableDynamicCertificates Dynamically update SSL certificates instead of reloading NGINX
+	EnableDynamicCertificates = true
+)
+
 const (
 	// http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size
 	// Sets the maximum allowed size of the client request body
@@ -755,25 +762,25 @@ func (cfg Configuration) BuildLogFormatUpstream() string {
 
 // TemplateConfig contains the nginx configuration to render the file nginx.conf
 type TemplateConfig struct {
-	ProxySetHeaders            map[string]string
-	AddHeaders                 map[string]string
-	BacklogSize                int
-	Backends                   []*ingress.Backend
-	PassthroughBackends        []*ingress.SSLPassthroughBackend
-	Servers                    []*ingress.Server
-	TCPBackends                []ingress.L4Service
-	UDPBackends                []ingress.L4Service
-	HealthzURI                 string
-	Cfg                        Configuration
-	IsIPV6Enabled              bool
-	IsSSLPassthroughEnabled    bool
-	NginxStatusIpv4Whitelist   []string
-	NginxStatusIpv6Whitelist   []string
-	RedirectServers            interface{}
-	ListenPorts                *ListenPorts
-	PublishService             *apiv1.Service
-	DynamicCertificatesEnabled bool
-	EnableMetrics              bool
+	ProxySetHeaders           map[string]string
+	AddHeaders                map[string]string
+	BacklogSize               int
+	Backends                  []*ingress.Backend
+	PassthroughBackends       []*ingress.SSLPassthroughBackend
+	Servers                   []*ingress.Server
+	TCPBackends               []ingress.L4Service
+	UDPBackends               []ingress.L4Service
+	HealthzURI                string
+	Cfg                       Configuration
+	IsIPV6Enabled             bool
+	IsSSLPassthroughEnabled   bool
+	NginxStatusIpv4Whitelist  []string
+	NginxStatusIpv6Whitelist  []string
+	RedirectServers           interface{}
+	ListenPorts               *ListenPorts
+	PublishService            *apiv1.Service
+	EnableDynamicCertificates bool
+	EnableMetrics             bool
 
 	PID          string
 	StatusSocket string

--- a/internal/ingress/controller/controller_test.go
+++ b/internal/ingress/controller/controller_test.go
@@ -1116,7 +1116,7 @@ func newNGINXController(t *testing.T) *NGINXController {
 		t.Fatalf("error: %v", err)
 	}
 
-	storer := store.New(true,
+	storer := store.New(
 		ns,
 		fmt.Sprintf("%v/config", ns),
 		fmt.Sprintf("%v/tcp", ns),
@@ -1126,7 +1126,6 @@ func newNGINXController(t *testing.T) *NGINXController {
 		clientSet,
 		fs,
 		channels.NewRingChannel(10),
-		false,
 		pod,
 		false)
 

--- a/internal/ingress/controller/nginx.go
+++ b/internal/ingress/controller/nginx.go
@@ -129,7 +129,6 @@ func NewNGINXController(config *Configuration, mc metric.Collector, fs file.File
 	n.podInfo = pod
 
 	n.store = store.New(
-		config.EnableSSLChainCompletion,
 		config.Namespace,
 		config.ConfigMapName,
 		config.TCPConfigMapName,
@@ -139,7 +138,6 @@ func NewNGINXController(config *Configuration, mc metric.Collector, fs file.File
 		config.Client,
 		fs,
 		n.updateCh,
-		config.DynamicCertificatesEnabled,
 		pod,
 		config.DisableCatchAll)
 
@@ -598,24 +596,24 @@ func (n NGINXController) generateTemplate(cfg ngx_config.Configuration, ingressC
 	cfg.SSLDHParam = sslDHParam
 
 	tc := ngx_config.TemplateConfig{
-		ProxySetHeaders:            setHeaders,
-		AddHeaders:                 addHeaders,
-		BacklogSize:                sysctlSomaxconn(),
-		Backends:                   ingressCfg.Backends,
-		PassthroughBackends:        ingressCfg.PassthroughBackends,
-		Servers:                    ingressCfg.Servers,
-		TCPBackends:                ingressCfg.TCPEndpoints,
-		UDPBackends:                ingressCfg.UDPEndpoints,
-		Cfg:                        cfg,
-		IsIPV6Enabled:              n.isIPV6Enabled && !cfg.DisableIpv6,
-		NginxStatusIpv4Whitelist:   cfg.NginxStatusIpv4Whitelist,
-		NginxStatusIpv6Whitelist:   cfg.NginxStatusIpv6Whitelist,
-		RedirectServers:            buildRedirects(ingressCfg.Servers),
-		IsSSLPassthroughEnabled:    n.cfg.EnableSSLPassthrough,
-		ListenPorts:                n.cfg.ListenPorts,
-		PublishService:             n.GetPublishService(),
-		DynamicCertificatesEnabled: n.cfg.DynamicCertificatesEnabled,
-		EnableMetrics:              n.cfg.EnableMetrics,
+		ProxySetHeaders:           setHeaders,
+		AddHeaders:                addHeaders,
+		BacklogSize:               sysctlSomaxconn(),
+		Backends:                  ingressCfg.Backends,
+		PassthroughBackends:       ingressCfg.PassthroughBackends,
+		Servers:                   ingressCfg.Servers,
+		TCPBackends:               ingressCfg.TCPEndpoints,
+		UDPBackends:               ingressCfg.UDPEndpoints,
+		Cfg:                       cfg,
+		IsIPV6Enabled:             n.isIPV6Enabled && !cfg.DisableIpv6,
+		NginxStatusIpv4Whitelist:  cfg.NginxStatusIpv4Whitelist,
+		NginxStatusIpv6Whitelist:  cfg.NginxStatusIpv6Whitelist,
+		RedirectServers:           buildRedirects(ingressCfg.Servers),
+		IsSSLPassthroughEnabled:   n.cfg.EnableSSLPassthrough,
+		ListenPorts:               n.cfg.ListenPorts,
+		PublishService:            n.GetPublishService(),
+		EnableDynamicCertificates: ngx_config.EnableDynamicCertificates,
+		EnableMetrics:             n.cfg.EnableMetrics,
 
 		HealthzURI:   nginx.HealthPath,
 		PID:          nginx.PID,
@@ -851,7 +849,7 @@ func (n *NGINXController) IsDynamicConfigurationEnough(pcfg *ingress.Configurati
 	copyOfRunningConfig.ControllerPodsCount = 0
 	copyOfPcfg.ControllerPodsCount = 0
 
-	if n.cfg.DynamicCertificatesEnabled {
+	if ngx_config.EnableDynamicCertificates {
 		clearCertificates(&copyOfRunningConfig)
 		clearCertificates(&copyOfPcfg)
 	}
@@ -861,7 +859,7 @@ func (n *NGINXController) IsDynamicConfigurationEnough(pcfg *ingress.Configurati
 
 // configureDynamically encodes new Backends in JSON format and POSTs the
 // payload to an internal HTTP endpoint handled by Lua.
-func configureDynamically(pcfg *ingress.Configuration, isDynamicCertificatesEnabled bool) error {
+func configureDynamically(pcfg *ingress.Configuration) error {
 	backends := make([]*ingress.Backend, len(pcfg.Backends))
 
 	for i, backend := range pcfg.Backends {
@@ -949,7 +947,7 @@ func configureDynamically(pcfg *ingress.Configuration, isDynamicCertificatesEnab
 		return fmt.Errorf("unexpected error code: %d", statusCode)
 	}
 
-	if isDynamicCertificatesEnabled {
+	if ngx_config.EnableDynamicCertificates {
 		err = configureCertificates(pcfg)
 		if err != nil {
 			return err

--- a/internal/ingress/controller/store/backend_ssl.go
+++ b/internal/ingress/controller/store/backend_ssl.go
@@ -20,16 +20,14 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/imdario/mergo"
 	"k8s.io/klog"
 
 	apiv1 "k8s.io/api/core/v1"
 	networking "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"k8s.io/ingress-nginx/internal/file"
 	"k8s.io/ingress-nginx/internal/ingress"
-	"k8s.io/ingress-nginx/internal/k8s"
+	ngx_config "k8s.io/ingress-nginx/internal/ingress/controller/config"
 	"k8s.io/ingress-nginx/internal/net/ssl"
 )
 
@@ -103,7 +101,7 @@ func (s *k8sStore) getPemCertificate(secretName string) (*ingress.SSLCert, error
 			return nil, fmt.Errorf("unexpected error creating SSL Cert: %v", err)
 		}
 
-		if !s.isDynamicCertificatesEnabled || len(ca) > 0 {
+		if !ngx_config.EnableDynamicCertificates || len(ca) > 0 {
 			err = ssl.StoreSSLCertOnDisk(s.filesystem, nsSecName, sslCert)
 			if err != nil {
 				return nil, fmt.Errorf("error while storing certificate and key: %v", err)
@@ -150,57 +148,6 @@ func (s *k8sStore) getPemCertificate(secretName string) (*ingress.SSLCert, error
 	sslCert.Namespace = secret.Namespace
 
 	return sslCert, nil
-}
-
-func (s *k8sStore) checkSSLChainIssues() {
-	for _, item := range s.ListLocalSSLCerts() {
-		secrKey := k8s.MetaNamespaceKey(item)
-		secret, err := s.GetLocalSSLCert(secrKey)
-		if err != nil {
-			continue
-		}
-
-		if secret.FullChainPemFileName != "" {
-			// chain already checked
-			continue
-		}
-
-		data, err := ssl.FullChainCert(secret.PemFileName, s.filesystem)
-		if err != nil {
-			klog.Errorf("Error generating CA certificate chain for Secret %q: %v", secrKey, err)
-			continue
-		}
-
-		fullChainPemFileName := fmt.Sprintf("%v/%v-%v-full-chain.pem", file.DefaultSSLDirectory, secret.Namespace, secret.Name)
-
-		file, err := s.filesystem.Create(fullChainPemFileName)
-		if err != nil {
-			klog.Errorf("Error creating SSL certificate file for Secret %q: %v", secrKey, err)
-			continue
-		}
-
-		_, err = file.Write(data)
-		if err != nil {
-			klog.Errorf("Error creating SSL certificate for Secret %q: %v", secrKey, err)
-			continue
-		}
-
-		dst := &ingress.SSLCert{}
-
-		err = mergo.MergeWithOverwrite(dst, secret)
-		if err != nil {
-			klog.Errorf("Error creating SSL certificate for Secret %q: %v", secrKey, err)
-			continue
-		}
-
-		dst.FullChainPemFileName = fullChainPemFileName
-
-		klog.Infof("Updating local copy of SSL certificate %q with missing intermediate CA certs", secrKey)
-		s.sslStore.Update(secrKey, dst)
-		// this update must trigger an update
-		// (like an update event from a change in Ingress)
-		s.sendDummyEvent()
-	}
 }
 
 // sendDummyEvent sends a dummy event to trigger an update

--- a/internal/ingress/controller/store/store_test.go
+++ b/internal/ingress/controller/store/store_test.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/ingress-nginx/internal/file"
 	"k8s.io/ingress-nginx/internal/ingress"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
+	ngx_config "k8s.io/ingress-nginx/internal/ingress/controller/config"
 	"k8s.io/ingress-nginx/internal/k8s"
 	"k8s.io/ingress-nginx/test/e2e/framework"
 )
@@ -87,7 +88,7 @@ func TestStore(t *testing.T) {
 		}(updateCh)
 
 		fs := newFS(t)
-		storer := New(true,
+		storer := New(
 			ns,
 			fmt.Sprintf("%v/config", ns),
 			fmt.Sprintf("%v/tcp", ns),
@@ -97,7 +98,6 @@ func TestStore(t *testing.T) {
 			clientSet,
 			fs,
 			updateCh,
-			false,
 			pod,
 			false)
 
@@ -168,7 +168,7 @@ func TestStore(t *testing.T) {
 		}(updateCh)
 
 		fs := newFS(t)
-		storer := New(true,
+		storer := New(
 			ns,
 			fmt.Sprintf("%v/config", ns),
 			fmt.Sprintf("%v/tcp", ns),
@@ -178,7 +178,6 @@ func TestStore(t *testing.T) {
 			clientSet,
 			fs,
 			updateCh,
-			false,
 			pod,
 			false)
 
@@ -319,7 +318,7 @@ func TestStore(t *testing.T) {
 		}(updateCh)
 
 		fs := newFS(t)
-		storer := New(true,
+		storer := New(
 			ns,
 			fmt.Sprintf("%v/config", ns),
 			fmt.Sprintf("%v/tcp", ns),
@@ -329,7 +328,6 @@ func TestStore(t *testing.T) {
 			clientSet,
 			fs,
 			updateCh,
-			false,
 			pod,
 			false)
 
@@ -426,7 +424,7 @@ func TestStore(t *testing.T) {
 		}(updateCh)
 
 		fs := newFS(t)
-		storer := New(true,
+		storer := New(
 			ns,
 			fmt.Sprintf("%v/config", ns),
 			fmt.Sprintf("%v/tcp", ns),
@@ -436,7 +434,6 @@ func TestStore(t *testing.T) {
 			clientSet,
 			fs,
 			updateCh,
-			false,
 			pod,
 			false)
 
@@ -516,7 +513,7 @@ func TestStore(t *testing.T) {
 		}(updateCh)
 
 		fs := newFS(t)
-		storer := New(true,
+		storer := New(
 			ns,
 			fmt.Sprintf("%v/config", ns),
 			fmt.Sprintf("%v/tcp", ns),
@@ -526,7 +523,6 @@ func TestStore(t *testing.T) {
 			clientSet,
 			fs,
 			updateCh,
-			false,
 			pod,
 			false)
 
@@ -628,7 +624,7 @@ func TestStore(t *testing.T) {
 		}(updateCh)
 
 		fs := newFS(t)
-		storer := New(true,
+		storer := New(
 			ns,
 			fmt.Sprintf("%v/config", ns),
 			fmt.Sprintf("%v/tcp", ns),
@@ -638,7 +634,6 @@ func TestStore(t *testing.T) {
 			clientSet,
 			fs,
 			updateCh,
-			false,
 			pod,
 			false)
 
@@ -708,6 +703,9 @@ func TestStore(t *testing.T) {
 		}
 
 		t.Run("should exists a secret in the local store and filesystem", func(t *testing.T) {
+			ngx_config.EnableDynamicCertificates = false
+			defer func() { ngx_config.EnableDynamicCertificates = true }()
+
 			err := framework.WaitForSecretInNamespace(clientSet, ns, name)
 			if err != nil {
 				t.Errorf("error waiting for secret: %v", err)

--- a/internal/ingress/sslcert.go
+++ b/internal/ingress/sslcert.go
@@ -32,9 +32,6 @@ type SSLCert struct {
 	CAFileName string `json:"caFileName"`
 	// PemFileName contains the path to the file with the certificate and key concatenated
 	PemFileName string `json:"pemFileName"`
-	// FullChainPemFileName contains the path to the file with the certificate and key concatenated
-	// This certificate contains the full chain (ca + intermediates + cert)
-	FullChainPemFileName string `json:"fullChainPemFileName"`
 	// PemSHA contains the sha1 of the pem file.
 	// This is used to detect changes in the secret that contains the certificates
 	PemSHA string `json:"pemSha"`

--- a/internal/ingress/types_equals.go
+++ b/internal/ingress/types_equals.go
@@ -523,9 +523,6 @@ func (s1 *SSLCert) Equal(s2 *SSLCert) bool {
 	if !s1.ExpireTime.Equal(s2.ExpireTime) {
 		return false
 	}
-	if s1.FullChainPemFileName != s2.FullChainPemFileName {
-		return false
-	}
 	if s1.PemCertKey != s2.PemCertKey {
 		return false
 	}

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -96,7 +96,7 @@ http {
         end
         {{ end }}
 
-        {{ if $all.DynamicCertificatesEnabled }}
+        {{ if $all.EnableDynamicCertificates }}
         ok, res = pcall(require, "certificate")
         if not ok then
           error("require failed: " .. tostring(res))
@@ -492,13 +492,8 @@ http {
         # PEM sha: {{ $redirect.SSLCert.PemSHA }}
         ssl_certificate                         {{ $redirect.SSLCert.PemFileName }};
         ssl_certificate_key                     {{ $redirect.SSLCert.PemFileName }};
-        {{ if not (empty $redirect.SSLCert.FullChainPemFileName)}}
-        ssl_trusted_certificate                 {{ $redirect.SSLCert.FullChainPemFileName }};
-        ssl_stapling                            on;
-        ssl_stapling_verify                     on;
-        {{ end }}
 
-        {{ if $all.DynamicCertificatesEnabled}}
+        {{ if $all.EnableDynamicCertificates}}
         ssl_certificate_by_lua_block {
             certificate.call()
         }
@@ -841,13 +836,8 @@ stream {
         # PEM sha: {{ $server.SSLCert.PemSHA }}
         ssl_certificate                         {{ $server.SSLCert.PemFileName }};
         ssl_certificate_key                     {{ $server.SSLCert.PemFileName }};
-        {{ if not (empty $server.SSLCert.FullChainPemFileName)}}
-        ssl_trusted_certificate                 {{ $server.SSLCert.FullChainPemFileName }};
-        ssl_stapling                            on;
-        ssl_stapling_verify                     on;
-        {{ end }}
 
-        {{ if $all.DynamicCertificatesEnabled}}
+        {{ if $all.EnableDynamicCertificates}}
         ssl_certificate_by_lua_block {
             certificate.call()
         }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

In dynamic mode is enabled (flag --enable-dynamic-certificates), if the secret does not contain a complete certificate chain, the SSL connection is rejected. This is not observed if enable-dynamic-certificates=false, where the nginx configuration uses a file to load the certificate.
Enabling --enable-ssl-chain-completion fixes this issue checking completing the chain with the missing intermediate certificates.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
