### PR TITLE
feat: auth-req caching

### DIFF
--- a/docs/user-guide/nginx-configuration/annotations.md
+++ b/docs/user-guide/nginx-configuration/annotations.md
@@ -26,6 +26,8 @@ You can add these Kubernetes annotations to specific Ingress objects to customiz
 |[nginx.ingress.kubernetes.io/auth-tls-error-page](#client-certificate-authentication)|string|
 |[nginx.ingress.kubernetes.io/auth-tls-pass-certificate-to-upstream](#client-certificate-authentication)|"true" or "false"|
 |[nginx.ingress.kubernetes.io/auth-url](#external-authentication)|string|
+|[nginx.ingress.kubernetes.io/auth-cache-key](#external-authentication)|string|
+|[nginx.ingress.kubernetes.io/auth-cache-duration](#external-authentication)|string|
 |[nginx.ingress.kubernetes.io/auth-snippet](#external-authentication)|string|
 |[nginx.ingress.kubernetes.io/enable-global-auth](#external-authentication)|"true" or "false"|
 |[nginx.ingress.kubernetes.io/backend-protocol](#backend-protocol)|string|HTTP,HTTPS,GRPC,GRPCS,AJP|
@@ -113,18 +115,18 @@ In some cases, you may want to "canary" a new set of changes by sending a small 
 
 * `nginx.ingress.kubernetes.io/canary-by-header-value`: The header value to match for notifying the Ingress to route the request to the service specified in the Canary Ingress. When the request header is set to this value, it will be routed to the canary. For any other header value, the header will be ignored and the request compared against the other canary rules by precedence. This annotation has to be used together with . The annotation is an extension of the `nginx.ingress.kubernetes.io/canary-by-header` to allow customizing the header value instead of using hardcoded values. It doesn't have any effect if the `nginx.ingress.kubernetes.io/canary-by-header` annotation is not defined.
 
-* `nginx.ingress.kubernetes.io/canary-by-cookie`: The cookie to use for notifying the Ingress to route the request to the service specified in the Canary Ingress. When the cookie value is set to `always`, it will be routed to the canary. When the cookie is set to `never`, it will never be routed to the canary. For any other value, the cookie will be ignored and the request compared against the other canary rules by precedence. 
+* `nginx.ingress.kubernetes.io/canary-by-cookie`: The cookie to use for notifying the Ingress to route the request to the service specified in the Canary Ingress. When the cookie value is set to `always`, it will be routed to the canary. When the cookie is set to `never`, it will never be routed to the canary. For any other value, the cookie will be ignored and the request compared against the other canary rules by precedence.
 
-* `nginx.ingress.kubernetes.io/canary-weight`: The integer based (0 - 100) percent of random requests that should be routed to the service specified in the canary Ingress. A weight of 0 implies that no requests will be sent to the service in the Canary ingress by this canary rule. A weight of 100 means implies all requests will be sent to the alternative service specified in the Ingress.   
+* `nginx.ingress.kubernetes.io/canary-weight`: The integer based (0 - 100) percent of random requests that should be routed to the service specified in the canary Ingress. A weight of 0 implies that no requests will be sent to the service in the Canary ingress by this canary rule. A weight of 100 means implies all requests will be sent to the alternative service specified in the Ingress.
 
-Canary rules are evaluated in order of precedence. Precedence is as follows: 
-`canary-by-header -> canary-by-cookie -> canary-weight` 
+Canary rules are evaluated in order of precedence. Precedence is as follows:
+`canary-by-header -> canary-by-cookie -> canary-weight`
 
 **Note** that when you mark an ingress as canary, then all the other non-canary annotations will be ignored (inherited from the corresponding main ingress) except `nginx.ingress.kubernetes.io/load-balance` and `nginx.ingress.kubernetes.io/upstream-hash-by`.
 
 **Known Limitations**
 
-Currently a maximum of one canary ingress can be applied per Ingress rule. 
+Currently a maximum of one canary ingress can be applied per Ingress rule.
 
 ### Rewrite
 
@@ -142,7 +144,7 @@ The annotation `nginx.ingress.kubernetes.io/affinity` enables and sets the affin
 The only affinity type available for NGINX is `cookie`.
 
 !!! attention
-    If more than one Ingress is defined for a host and at least one Ingress uses `nginx.ingress.kubernetes.io/affinity: cookie`, then only paths on the Ingress using `nginx.ingress.kubernetes.io/affinity` will use session cookie affinity. All paths defined on other Ingresses for the host will be load balanced through the random selection of a backend server. 
+    If more than one Ingress is defined for a host and at least one Ingress uses `nginx.ingress.kubernetes.io/affinity: cookie`, then only paths on the Ingress using `nginx.ingress.kubernetes.io/affinity` will use session cookie affinity. All paths defined on other Ingresses for the host will be load balanced through the random selection of a backend server.
 
 !!! example
     Please check the [affinity](../../examples/affinity/cookie/README.md) example.
@@ -151,7 +153,7 @@ The only affinity type available for NGINX is `cookie`.
 
 If you use the ``cookie`` affinity type you can also specify the name of the cookie that will be used to route the requests with the annotation `nginx.ingress.kubernetes.io/session-cookie-name`. The default is to create a cookie named 'INGRESSCOOKIE'.
 
-The NGINX annotation `nginx.ingress.kubernetes.io/session-cookie-path` defines the path that will be set on the cookie. This is optional unless the annotation `nginx.ingress.kubernetes.io/use-regex` is set to true; Session cookie paths do not support regex.  
+The NGINX annotation `nginx.ingress.kubernetes.io/session-cookie-path` defines the path that will be set on the cookie. This is optional unless the annotation `nginx.ingress.kubernetes.io/use-regex` is set to true; Session cookie paths do not support regex.
 
 
 ### Authentication
@@ -294,7 +296,7 @@ CORS can be controlled with the following annotations:
   Example: `nginx.ingress.kubernetes.io/cors-max-age: 600`
 
 !!! note
-    For more information please see [https://enable-cors.org](https://enable-cors.org/server_nginx.html) 
+    For more information please see [https://enable-cors.org](https://enable-cors.org/server_nginx.html)
 
 ### HTTP2 Push Preload.
 
@@ -327,11 +329,11 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/server-snippet: |
         set $agentflag 0;
-        
+
         if ($http_user_agent ~* "(Mobile)" ){
           set $agentflag 1;
         }
-        
+
         if ( $agentflag = 1 ) {
           return 301 https://m.example.com;
         }
@@ -378,6 +380,10 @@ Additionally it is possible to set:
   `<Response_Header_1, ..., Response_Header_n>` to specify headers to pass to backend once authentication request completes.
 * `nginx.ingress.kubernetes.io/auth-request-redirect`:
   `<Request_Redirect_URL>`  to specify the X-Auth-Request-Redirect header value.
+* `nginx.ingress.kubernetes.io/auth-cache-key`:
+  `<Cache_Key>` this enables caching for auth requests. specify a lookup key for auth responses. e.g. `$remote_user$http_authorization`. Each server and location has it's own keyspace. Hence a cached response is only valid on a per-server and per-location basis.
+* `nginx.ingress.kubernetes.io/auth-cache-duration`:
+  `<Cache_duration>` to specify a caching time for auth responses based on their response codes, e.g. `200 202 30m`. See [proxy_cache_valid](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_cache_valid) for details. You may specify multiple, comma-separated values: `200 202 10m, 401 5m`. defaults to `200 202 401 5m`.
 * `nginx.ingress.kubernetes.io/auth-snippet`:
   `<Auth_Snippet>` to specify a custom snippet to use with external authentication, e.g.
 
@@ -681,7 +687,7 @@ of ingress locations. The ModSecurity module must first be enabled by enabling M
 [ConfigMap](./configmap.md#enable-modsecurity). Note this will enable ModSecurity for all paths, and each path
 must be disabled manually.
 
-It can be enabled using the following annotation: 
+It can be enabled using the following annotation:
 ```yaml
 nginx.ingress.kubernetes.io/enable-modsecurity: "true"
 ```
@@ -706,7 +712,7 @@ SecDebugLog /tmp/modsec_debug.log
 ```
 
 Note: If you use both `enable-owasp-core-rules` and `modsecurity-snippet` annotations together, only the
-`modsecurity-snippet` will take effect. If you wish to include the [OWASP Core Rule Set](https://www.modsecurity.org/CRS/Documentation/) or 
+`modsecurity-snippet` will take effect. If you wish to include the [OWASP Core Rule Set](https://www.modsecurity.org/CRS/Documentation/) or
 [recommended configuration](https://github.com/SpiderLabs/ModSecurity/blob/v3/master/modsecurity.conf-recommended) simply use the include
 statement:
 ```yaml
@@ -730,7 +736,7 @@ nginx.ingress.kubernetes.io/influxdb-server-name: "nginx-ingress"
 
 For the `influxdb-host` parameter you have two options:
 
-- Use an InfluxDB server configured with the  [UDP protocol](https://docs.influxdata.com/influxdb/v1.5/supported_protocols/udp/) enabled. 
+- Use an InfluxDB server configured with the  [UDP protocol](https://docs.influxdata.com/influxdb/v1.5/supported_protocols/udp/) enabled.
 - Deploy Telegraf as a sidecar proxy to the Ingress controller configured to listen UDP with the [socket listener input](https://github.com/influxdata/telegraf/tree/release-1.6/plugins/inputs/socket_listener) and to write using
 anyone of the [outputs plugins](https://github.com/influxdata/telegraf/tree/release-1.7/plugins/outputs) like InfluxDB, Apache Kafka,
 Prometheus, etc.. (recommended)
@@ -754,7 +760,7 @@ nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
 ### Use Regex
 
 !!! attention
-When using this annotation with the NGINX annotation `nginx.ingress.kubernetes.io/affinity` of type `cookie`,  `nginx.ingress.kubernetes.io/session-cookie-path` must be also set; Session cookie paths do not support regex.  
+When using this annotation with the NGINX annotation `nginx.ingress.kubernetes.io/affinity` of type `cookie`,  `nginx.ingress.kubernetes.io/session-cookie-path` must be also set; Session cookie paths do not support regex.
 
 Using the `nginx.ingress.kubernetes.io/use-regex` annotation will indicate whether or not the paths defined on an Ingress use regular expressions.  The default value is `false`.
 
@@ -770,9 +776,9 @@ nginx.ingress.kubernetes.io/use-regex: "false"
 
 When this annotation is set to `true`, the case insensitive regular expression [location modifier](https://nginx.org/en/docs/http/ngx_http_core_module.html#location) will be enforced on ALL paths for a given host regardless of what Ingress they are defined on.
 
-Additionally, if the [`rewrite-target` annotation](#rewrite) is used on any Ingress for a given host, then the case insensitive regular expression [location modifier](https://nginx.org/en/docs/http/ngx_http_core_module.html#location) will be enforced on ALL paths for a given host regardless of what Ingress they are defined on.  
+Additionally, if the [`rewrite-target` annotation](#rewrite) is used on any Ingress for a given host, then the case insensitive regular expression [location modifier](https://nginx.org/en/docs/http/ngx_http_core_module.html#location) will be enforced on ALL paths for a given host regardless of what Ingress they are defined on.
 
-Please read about [ingress path matching](../ingress-path-matching.md) before using this modifier. 
+Please read about [ingress path matching](../ingress-path-matching.md) before using this modifier.
 
 ### Satisfy
 

--- a/docs/user-guide/nginx-configuration/configmap.md
+++ b/docs/user-guide/nginx-configuration/configmap.md
@@ -160,6 +160,8 @@ The following table shows a configuration option's name, type, and the default v
 |[global-auth-response-headers](#global-auth-response-headers)|string|""|
 |[global-auth-request-redirect](#global-auth-request-redirect)|string|""|
 |[global-auth-snippet](#global-auth-snippet)|string|""|
+|[global-auth-cache-key](#global-auth-cache-key)|string|""|
+|[global-auth-cache-duration](#global-auth-cache-duration)|string|"200 202 401 5m"|
 |[no-auth-locations](#no-auth-locations)|string|"/.well-known/acme-challenge"|
 |[block-cidrs](#block-cidrs)|[]string|""|
 |[block-user-agents](#block-user-agents)|[]string|""|
@@ -196,7 +198,7 @@ __Note:__ the file `/var/log/nginx/access.log` is a symlink to `/dev/stdout`
 
 ## enable-access-log-for-default-backend
 
-Enables logging access to default backend. _**default:**_ is disabled. 
+Enables logging access to default backend. _**default:**_ is disabled.
 
 ## error-log-path
 
@@ -439,7 +441,7 @@ _References:_
 Instructs NGINX to create an individual listening socket for each worker process (using the SO_REUSEPORT socket option), allowing a kernel to distribute incoming connections between worker processes
 _**default:**_ true
 
-## proxy-headers-hash-bucket-size 
+## proxy-headers-hash-bucket-size
 
 Sets the size of the bucket for the proxy headers hash tables.
 
@@ -503,7 +505,7 @@ Enables or disables session resumption through [TLS session tickets](http://ngin
 Sets the secret key used to encrypt and decrypt TLS session tickets. The value must be a valid base64 string.
 To create a ticket: `openssl rand 80 | openssl enc -A -base64`
 
-[TLS session ticket-key](http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_tickets), by default, a randomly generated key is used. 
+[TLS session ticket-key](http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_tickets), by default, a randomly generated key is used.
 
 ## ssl-session-timeout
 
@@ -622,7 +624,7 @@ _References:_
 
 Activates the cache for connections to upstream servers. The connections parameter sets the maximum number of idle
 keepalive connections to upstream servers that are preserved in the cache of each worker process. When this number is
-exceeded, the least recently used connections are closed. 
+exceeded, the least recently used connections are closed.
 _**default:**_ 32
 
 _References:_
@@ -643,7 +645,7 @@ _References:_
 Sets the maximum number of requests that can be served through one keepalive connection. After the maximum number of
 requests is made, the connection is closed.
 _**default:**_ 100
-	
+
 
 _References:_
 [http://nginx.org/en/docs/http/ngx_http_upstream_module.html#keepalive_requests](http://nginx.org/en/docs/http/ngx_http_upstream_module.html#keepalive_requests)
@@ -921,6 +923,14 @@ _**default:**_ ""
 Sets a custom snippet to use with external authentication. Applied to all the locations.
 Similar to the Ingress rule annotation `nginx.ingress.kubernetes.io/auth-request-redirect`.
 _**default:**_ ""
+
+## global-auth-cache-key
+
+Enables caching for global auth requests. Specify a lookup key for auth responses, e.g. `$remote_user$http_authorization`.
+
+## global-auth-cache-duration
+
+Set a caching time for auth responses based on their response codes, e.g. `200 202 30m`. See [proxy_cache_valid](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_cache_valid) for details. You may specify multiple, comma-separated values: `200 202 10m, 401 5m`. defaults to `200 202 401 5m`.
 
 ## no-auth-locations
 

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -618,7 +618,7 @@ func NewDefault() Configuration {
 	defNginxStatusIpv4Whitelist = append(defNginxStatusIpv4Whitelist, "127.0.0.1")
 	defNginxStatusIpv6Whitelist = append(defNginxStatusIpv6Whitelist, "::1")
 	defProxyDeadlineDuration := time.Duration(5) * time.Second
-	defGlobalExternalAuth := GlobalExternalAuth{"", "", "", "", append(defResponseHeaders, ""), "", ""}
+	defGlobalExternalAuth := GlobalExternalAuth{"", "", "", "", append(defResponseHeaders, ""), "", "", "", []string{}}
 
 	cfg := Configuration{
 		AllowBackendServerHeader:         false,
@@ -803,10 +803,12 @@ type ListenPorts struct {
 type GlobalExternalAuth struct {
 	URL string `json:"url"`
 	// Host contains the hostname defined in the URL
-	Host            string   `json:"host"`
-	SigninURL       string   `json:"signinUrl"`
-	Method          string   `json:"method"`
-	ResponseHeaders []string `json:"responseHeaders,omitempty"`
-	RequestRedirect string   `json:"requestRedirect"`
-	AuthSnippet     string   `json:"authSnippet"`
+	Host              string   `json:"host"`
+	SigninURL         string   `json:"signinUrl"`
+	Method            string   `json:"method"`
+	ResponseHeaders   []string `json:"responseHeaders,omitempty"`
+	RequestRedirect   string   `json:"requestRedirect"`
+	AuthSnippet       string   `json:"authSnippet"`
+	AuthCacheKey      string   `json:"authCacheKey"`
+	AuthCacheDuration []string `json:"authCacheDuration"`
 }

--- a/internal/ingress/controller/template/configmap.go
+++ b/internal/ingress/controller/template/configmap.go
@@ -57,6 +57,8 @@ const (
 	globalAuthResponseHeaders = "global-auth-response-headers"
 	globalAuthRequestRedirect = "global-auth-request-redirect"
 	globalAuthSnippet         = "global-auth-snippet"
+	globalAuthCacheKey        = "global-auth-cache-key"
+	globalAuthCacheDuration   = "global-auth-cache-duration"
 )
 
 var (
@@ -224,6 +226,23 @@ func ReadConfig(src map[string]string) config.Configuration {
 		delete(conf, globalAuthSnippet)
 
 		to.GlobalExternalAuth.AuthSnippet = val
+	}
+
+	if val, ok := conf[globalAuthCacheKey]; ok {
+		delete(conf, globalAuthCacheKey)
+
+		to.GlobalExternalAuth.AuthCacheKey = val
+	}
+
+	// Verify that the configured global external authorization cache duration is valid
+	if val, ok := conf[globalAuthCacheDuration]; ok {
+		delete(conf, globalAuthCacheDuration)
+
+		cacheDurations, err := authreq.ParseStringToCacheDurations(val)
+		if err != nil {
+			klog.Warningf("Global auth location denied - %s", err)
+		}
+		to.GlobalExternalAuth.AuthCacheDuration = cacheDurations
 	}
 
 	// Verify that the configured timeout is parsable as a duration. if not, set the default value

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -443,6 +443,9 @@ http {
     {{ $zone }}
     {{ end }}
 
+    # Cache for internal auth checks
+    proxy_cache_path /tmp/nginx-cache-auth levels=1:2 keys_zone=auth_cache:10m max_size=128m inactive=30m use_temp_path=off;
+
     # Global filters
     {{ range $ip := $cfg.BlockCIDRs }}deny {{ trimSpace $ip }};
     {{ end }}
@@ -894,6 +897,23 @@ stream {
         location = {{ $authPath }} {
             internal;
 
+            {{ if $externalAuth.AuthCacheKey }}
+            set $tmp_cache_key '{{ $server.Hostname }}{{ $authPath }}{{ $externalAuth.AuthCacheKey }}';
+            set $cache_key '';
+
+            rewrite_by_lua_block {
+                ngx.var.cache_key = ngx.encode_base64(ngx.sha1_bin(ngx.var.tmp_cache_key))
+            }
+
+            proxy_cache auth_cache;
+
+            {{- range $dur := $externalAuth.AuthCacheDuration }}
+            proxy_cache_valid {{ $dur }};
+            {{- end }}
+
+            proxy_cache_key "$cache_key";
+            {{ end }}
+
             # ngx_auth_request module overrides variables in the parent request,
             # therefore we have to explicitly set this variable again so that when the parent request
             # resumes it has the correct value set for this variable so that Lua can pick backend correctly
@@ -926,7 +946,11 @@ stream {
             proxy_set_header            X-Auth-Request-Redirect $request_uri;
             {{ end }}
 
+            {{ if $externalAuth.AuthCacheKey }}
+            proxy_buffering                         "on";
+            {{ else }}
             proxy_buffering                         {{ $location.Proxy.ProxyBuffering }};
+            {{ end }}
             proxy_buffer_size                       {{ $location.Proxy.BufferSize }};
             proxy_buffers                           {{ $location.Proxy.BuffersNumber }} {{ $location.Proxy.BufferSize }};
             proxy_request_buffering                 {{ $location.Proxy.RequestBuffering }};

--- a/test/e2e/framework/k8s.go
+++ b/test/e2e/framework/k8s.go
@@ -143,6 +143,21 @@ func WaitForPodsReady(kubeClientSet kubernetes.Interface, timeout time.Duration,
 	})
 }
 
+// WaitForPodsDeleted waits for a given amount of time until a group of Pods are deleted in the given namespace.
+func WaitForPodsDeleted(kubeClientSet kubernetes.Interface, timeout time.Duration, namespace string, opts metav1.ListOptions) error {
+	return wait.Poll(2*time.Second, timeout, func() (bool, error) {
+		pl, err := kubeClientSet.CoreV1().Pods(namespace).List(opts)
+		if err != nil {
+			return false, nil
+		}
+
+		if len(pl.Items) == 0 {
+			return true, nil
+		}
+		return false, nil
+	})
+}
+
 // WaitForEndpoints waits for a given amount of time until an endpoint contains.
 func WaitForEndpoints(kubeClientSet kubernetes.Interface, timeout time.Duration, name, ns string, expectedEndpoints int) error {
 	if expectedEndpoints == 0 {

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -288,6 +288,14 @@ func podRunning(c kubernetes.Interface, podName, namespace string) wait.Conditio
 	}
 }
 
+func labelSelectorToString(labels map[string]string) string {
+	var str string
+	for k, v := range labels {
+		str += fmt.Sprintf("%s=%s,", k, v)
+	}
+	return str[:len(str)-1]
+}
+
 // NewInt32 converts int32 to a pointer
 func NewInt32(val int32) *int32 {
 	p := new(int32)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a way to configure the `proxy_cache_*` ([docs](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_cache_key)) directive for external authentication.

It adds these annotations, as proposed by @Stono in #2862 :
* `nginx.ingress.kubernetes.io/auth-cache-key`
* `nginx.ingress.kubernetes.io/auth-cache-duration`

The first one sets the `proxy_cache_key` (e.g. `$uri$cookie__auth_proxy`) and enables the feature. The latter sets the cache duration (defaults to `10m`)

**Note:**
The user-defined `cache_key` may contain sensitive information (e.g. `Authorization` header). That's why we want to store *only* a hash of that key, not the key itself on disk.


fixes #2862