### PR TITLE
Disable access log in stream section for configuration socket

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -681,6 +681,8 @@ stream {
     server {
         listen unix:{{ .StreamSocket }};
 
+        access_log off;
+        
         content_by_lua_block {
           tcp_udp_configuration.call()
         }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Removes `[10/Jul/2019:17:37:18 +0000]TCP200000.000` from the output each time the controller updates the tcp/udp feature

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
