### PR TITLE
avoid warning during lua unit test

### DIFF
--- a/rootfs/etc/nginx/lua/test/run.lua
+++ b/rootfs/etc/nginx/lua/test/run.lua
@@ -1,3 +1,39 @@
+local busted_runner
+do 
+  -- avoid warning during test runs caused by
+  -- https://github.com/openresty/lua-nginx-module/blob/2524330e59f0a385a9c77d4d1b957476dce7cb33/src/ngx_http_lua_util.c#L810
+
+  local traceback = require "debug".traceback
+
+  setmetatable(_G, { __newindex = function(table, key, value) rawset(table, key, value) end })
+  busted_runner = require "busted.runner"
+
+  -- if there's more constants need to be whitelisted for test runs, add here.
+  local GLOBALS_ALLOWED_IN_TEST = {
+    _TEST = true,
+  }
+  local newindex = function(table, key, value)
+    rawset(table, key, value)
+
+    local phase = ngx.get_phase()
+    if phase == "init_worker" or phase == "init" then
+      return
+    end
+
+    -- we check only timer phase because resty-cli runs everything in timer phase
+    if phase == "timer" and GLOBALS_ALLOWED_IN_TEST[key] then
+      return
+    end
+
+    local message = "writing a global lua variable " .. key ..
+      " which may lead to race conditions between concurrent requests, so prefer the use of 'local' variables " .. traceback('', 2)
+    -- it's important to do print here because ngx.log is mocked below
+    print(message)
+  end
+  setmetatable(_G, { __newindex = newindex })
+end
+
+
 local ffi = require("ffi")
 local lua_ingress = require("lua_ingress")
 
@@ -35,4 +71,4 @@ ngx.print = function(...) end
 
 lua_ingress.init_worker()
 
-require "busted.runner"({ standalone = false })
+busted_runner({ standalone = false })


### PR DESCRIPTION
**What this PR does / why we need it**:
This is to avoid warning messages during Lua test runs such as:

```
2019/07/11 22:22:31 [warn] 118#118: *2 [lua] _G write guard:12: __newindex(): writing a global lua variable ('_TEST') which may lead to race conditions between concurrent requests, so prefer the use of 'local' variables
stack traceback:
	./rootfs/etc/nginx/lua/test/balancer_test.lua:1: in main chunk
	[C]: in function 'xpcall'
	/usr/local/openresty/luajit/share/lua/5.1/busted/core.lua:178: in function 'safe'
	/usr/local/openresty/luajit/share/lua/5.1/busted/block.lua:146: in function 'execute'
	/usr/local/openresty/luajit/share/lua/5.1/busted/init.lua:7: in function 'executor'
	/usr/local/openresty/luajit/share/lua/5.1/busted/core.lua:312: in function </usr/local/openresty/luajit/share/lua/5.1/busted/core.lua:312>
	[C]: in function 'xpcall'
	/usr/local/openresty/luajit/share/lua/5.1/busted/core.lua:178: in function 'safe'
	/usr/local/openresty/luajit/share/lua/5.1/busted/core.lua:312: in function 'execute'
	.../local/openresty/luajit/share/lua/5.1/busted/execute.lua:58: in function 'execute'
	/usr/local/openresty/luajit/share/lua/5.1/busted/runner.lua:197: in function </usr/local/openresty/luajit/share/lua/5.1/busted/runner.lua:11>
	./rootfs/etc/nginx/lua/test/run.lua:38: in function 'file_gen'
	init_worker_by_lua:58: in function <init_worker_by_lua:56>
	[C]: in function 'xpcall'
	init_worker_by_lua:65: in function <init_worker_by_lua:63>, context: ngx.timer
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
