### PR TITLE
Remove limits from configuration endpoint

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -574,6 +574,9 @@ http {
 
         access_log off;
 
+        # always send the request body into a file.
+        client_body_in_file_only clean;
+
         {{ if $cfg.EnableOpentracing }}
         opentracing off;
         {{ end }}
@@ -602,8 +605,7 @@ http {
 
         location /configuration {
             # this should be equals to configuration_data dict
-            client_max_body_size                    10m;
-            client_body_buffer_size                 10m;
+            client_max_body_size                    0;
             proxy_buffering                         off;
 
             content_by_lua_block {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Remove limits from configuration endpoint and always generate a temporal file with the request
This is required in scenarios with lots of SSL certificates that generate a JSON of more than 10MB

https://kubernetes.slack.com/archives/CANQGM8BA/p1562956612084700?thread_ts=1562952715.077500&cid=CANQGM8BA

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
