### PR TITLE
Add support for annotations to set x-forwarded-proto and x-forwarded-port

### DIFF
--- a/internal/ingress/annotations/annotations.go
+++ b/internal/ingress/annotations/annotations.go
@@ -59,7 +59,9 @@ import (
 	"k8s.io/ingress-nginx/internal/ingress/annotations/sslpassthrough"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/upstreamhashby"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/upstreamvhost"
+	"k8s.io/ingress-nginx/internal/ingress/annotations/xforwardedport"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/xforwardedprefix"
+	"k8s.io/ingress-nginx/internal/ingress/annotations/xforwardedproto"
 	"k8s.io/ingress-nginx/internal/ingress/errors"
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
 )
@@ -101,7 +103,9 @@ type Ingress struct {
 	LoadBalancing      string
 	UpstreamVhost      string
 	Whitelist          ipwhitelist.SourceRange
+	XForwardedPort     string
 	XForwardedPrefix   string
+	XForwardedProto    string
 	SSLCiphers         string
 	Logs               log.Config
 	LuaRestyWAF        luarestywaf.Config
@@ -146,7 +150,9 @@ func NewAnnotationExtractor(cfg resolver.Resolver) Extractor {
 			"LoadBalancing":        loadbalancing.NewParser(cfg),
 			"UpstreamVhost":        upstreamvhost.NewParser(cfg),
 			"Whitelist":            ipwhitelist.NewParser(cfg),
+			"XForwardedPort":       xforwardedport.NewParser(cfg),
 			"XForwardedPrefix":     xforwardedprefix.NewParser(cfg),
+			"XForwardedProto":      xforwardedproto.NewParser(cfg),
 			"SSLCiphers":           sslcipher.NewParser(cfg),
 			"Logs":                 log.NewParser(cfg),
 			"LuaRestyWAF":          luarestywaf.NewParser(cfg),

--- a/internal/ingress/annotations/xforwardedport/main.go
+++ b/internal/ingress/annotations/xforwardedport/main.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package xforwardedport
+
+import (
+	networking "k8s.io/api/networking/v1beta1"
+
+	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
+	"k8s.io/ingress-nginx/internal/ingress/resolver"
+)
+
+type xforwardedport struct {
+	r resolver.Resolver
+}
+
+// NewParser creates a new xforwardedport annotation parser
+func NewParser(r resolver.Resolver) parser.IngressAnnotation {
+	return xforwardedport{r}
+}
+
+// Parse parses the annotations contained in the ingress rule
+// used to add an x-forwarded-port header to the request
+func (cbbs xforwardedport) Parse(ing *networking.Ingress) (interface{}, error) {
+	return parser.GetStringAnnotation("x-forwarded-port", ing)
+}

--- a/internal/ingress/annotations/xforwardedport/main_test.go
+++ b/internal/ingress/annotations/xforwardedport/main_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package xforwardedport
+
+import (
+	"testing"
+
+	api "k8s.io/api/core/v1"
+	networking "k8s.io/api/networking/v1beta1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
+	"k8s.io/ingress-nginx/internal/ingress/resolver"
+)
+
+func TestParse(t *testing.T) {
+	annotation := parser.GetAnnotationWithPrefix("x-forwarded-port")
+	ap := NewParser(&resolver.Mock{})
+	if ap == nil {
+		t.Fatalf("expected a parser.IngressAnnotation but returned nil")
+	}
+
+	testCases := []struct {
+		annotations map[string]string
+		expected    string
+	}{
+		{map[string]string{annotation: "true"}, "true"},
+		{map[string]string{annotation: "1"}, "1"},
+		{map[string]string{annotation: ""}, ""},
+		{map[string]string{}, ""},
+		{nil, ""},
+	}
+
+	ing := &networking.Ingress{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      "foo",
+			Namespace: api.NamespaceDefault,
+		},
+		Spec: networking.IngressSpec{},
+	}
+
+	for _, testCase := range testCases {
+		ing.SetAnnotations(testCase.annotations)
+		result, _ := ap.Parse(ing)
+		if result != testCase.expected {
+			t.Errorf("expected %v but returned %v, annotations: %s", testCase.expected, result, testCase.annotations)
+		}
+	}
+}

--- a/internal/ingress/annotations/xforwardedproto/main.go
+++ b/internal/ingress/annotations/xforwardedproto/main.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package xforwardedproto
+
+import (
+	networking "k8s.io/api/networking/v1beta1"
+
+	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
+	"k8s.io/ingress-nginx/internal/ingress/resolver"
+)
+
+type xforwardedproto struct {
+	r resolver.Resolver
+}
+
+// NewParser creates a new xforwardedproto annotation parser
+func NewParser(r resolver.Resolver) parser.IngressAnnotation {
+	return xforwardedproto{r}
+}
+
+// Parse parses the annotations contained in the ingress rule
+// used to add an x-forwarded-proto header to the request
+func (cbbs xforwardedproto) Parse(ing *networking.Ingress) (interface{}, error) {
+	return parser.GetStringAnnotation("x-forwarded-proto", ing)
+}

--- a/internal/ingress/annotations/xforwardedproto/main_test.go
+++ b/internal/ingress/annotations/xforwardedproto/main_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package xforwardedproto
+
+import (
+	"testing"
+
+	api "k8s.io/api/core/v1"
+	networking "k8s.io/api/networking/v1beta1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
+	"k8s.io/ingress-nginx/internal/ingress/resolver"
+)
+
+func TestParse(t *testing.T) {
+	annotation := parser.GetAnnotationWithPrefix("x-forwarded-proto")
+	ap := NewParser(&resolver.Mock{})
+	if ap == nil {
+		t.Fatalf("expected a parser.IngressAnnotation but returned nil")
+	}
+
+	testCases := []struct {
+		annotations map[string]string
+		expected    string
+	}{
+		{map[string]string{annotation: "true"}, "true"},
+		{map[string]string{annotation: "1"}, "1"},
+		{map[string]string{annotation: ""}, ""},
+		{map[string]string{}, ""},
+		{nil, ""},
+	}
+
+	ing := &networking.Ingress{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      "foo",
+			Namespace: api.NamespaceDefault,
+		},
+		Spec: networking.IngressSpec{},
+	}
+
+	for _, testCase := range testCases {
+		ing.SetAnnotations(testCase.annotations)
+		result, _ := ap.Parse(ing)
+		if result != testCase.expected {
+			t.Errorf("expected %v but returned %v, annotations: %s", testCase.expected, result, testCase.annotations)
+		}
+	}
+}

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -1157,7 +1157,9 @@ func locationApplyAnnotations(loc *ingress.Location, anns *annotations.Ingress) 
 	loc.UpstreamVhost = anns.UpstreamVhost
 	loc.Whitelist = anns.Whitelist
 	loc.Denied = anns.Denied
+	loc.XForwardedPort = anns.XForwardedPort
 	loc.XForwardedPrefix = anns.XForwardedPrefix
+	loc.XForwardedProto = anns.XForwardedProto
 	loc.UsePortInRedirects = anns.UsePortInRedirects
 	loc.Connection = anns.Connection
 	loc.Logs = anns.Logs

--- a/internal/ingress/types.go
+++ b/internal/ingress/types.go
@@ -293,10 +293,18 @@ type Location struct {
 	// DefaultBackendUpstreamName is the upstream-formatted string for the name of
 	// this location's custom default backend
 	DefaultBackendUpstreamName string `json:"defaultBackendUpstreamName,omitempty"`
+	// XForwardedPort allows to add a header X-Forwarded-Port to the request with the
+	// original port.
+	// +optional
+	XForwardedPort string `json:"xForwardedPort,omitempty"`
 	// XForwardedPrefix allows to add a header X-Forwarded-Prefix to the request with the
 	// original location.
 	// +optional
 	XForwardedPrefix string `json:"xForwardedPrefix,omitempty"`
+	// XForwardedProto allows to add a header X-Forwarded-Proto to the request with the
+	// original protocol.
+	// +optional
+	XForwardedProto string `json:"xForwardedProto,omitempty"`
 	// Logs allows to enable or disable the nginx logs
 	// By default access logs are enabled and rewrite logs are disabled
 	Logs log.Config `json:"logs,omitempty"`

--- a/internal/ingress/types_equals.go
+++ b/internal/ingress/types_equals.go
@@ -380,7 +380,13 @@ func (l1 *Location) Equal(l2 *Location) bool {
 	if l1.UpstreamVhost != l2.UpstreamVhost {
 		return false
 	}
+	if l1.XForwardedPort != l2.XForwardedPort {
+		return false
+	}
 	if l1.XForwardedPrefix != l2.XForwardedPrefix {
+		return false
+	}
+	if l1.XForwardedProto != l2.XForwardedProto {
 		return false
 	}
 	if !(&l1.Connection).Equal(&l2.Connection) {

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -1202,8 +1202,16 @@ stream {
             {{ $proxySetHeader }} X-Forwarded-For        $the_real_ip;
             {{ end }}
             {{ $proxySetHeader }} X-Forwarded-Host       $best_http_host;
+            {{ if not (empty $location.XForwardedPort) }}
+            {{ $proxySetHeader }} X-Forwarded-Port       {{ $location.XForwardedPort }};
+            {{ else }}
             {{ $proxySetHeader }} X-Forwarded-Port       $pass_port;
+            {{ end }}
+            {{ if not (empty $location.XForwardedProto) }}
+            {{ $proxySetHeader }} X-Forwarded-Proto      {{ $location.XForwardedProto }};
+            {{ else }}
             {{ $proxySetHeader }} X-Forwarded-Proto      $pass_access_scheme;
+            {{ end }}
             {{ if $all.Cfg.ProxyAddOriginalURIHeader }}
             {{ $proxySetHeader }} X-Original-URI         $request_uri;
             {{ end }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

The use case and configuration is pretty well described in https://github.com/kubernetes/ingress-nginx/issues/2724#issuecomment-444835897 so I won't repeat it here. The linked solution used to rely on passing a map through `http-snippet`, which got broken in 0.24.0 due to #3798.

This PR aims at providing a  solution for this problem.

Ingresses can be annotated with 

```
    nginx.ingress.kubernetes.io/x-forwarded-port: "443"
    nginx.ingress.kubernetes.io/x-forwarded-proto: https
```

and the `nginx-configuration` configmap keeps the redirect on port 8080 as follow

```
 http-snippet: |
    server {
      listen 8080 proxy_protocol;
      return 308 https://$host$request_uri;
    }
```

As a result:
* when accessing the ELB on port 80, it is forwarded to port `8080` on nginx-ingress-controller, which issues a redirect to https
* when accessing the ELB on port 443, it is TLS terminated and unencrypted traffic is forwarded to port `http` on nginx-ingress-controller which serves the content. Headers `x-forwarded-port` and `x-forwarded-proto` are overridden to the values provided in the Ingress configuration.

**Which issue this PR fixes**: fixes #2724 

**Special notes for your reviewer**:
