### PR TITLE
Update references to oauth2_proxy

### DIFF
--- a/docs/examples/auth/oauth-external-auth/README.md
+++ b/docs/examples/auth/oauth-external-auth/README.md
@@ -31,7 +31,7 @@ metadata:
 
 ### Example: OAuth2 Proxy + Kubernetes-Dashboard
 
-This example will show you how to deploy [`oauth2_proxy`](https://github.com/bitly/oauth2_proxy)
+This example will show you how to deploy [`oauth2_proxy`](https://github.com/pusher/oauth2_proxy)
 into a Kubernetes cluster and use it to protect the Kubernetes Dashboard using github as oAuth2 provider
 
 #### Prepare
@@ -55,7 +55,7 @@ kubectl create -f https://raw.githubusercontent.com/kubernetes/kops/master/addon
 
 - OAUTH2_PROXY_CLIENT_ID with the github `<Client ID>`
 - OAUTH2_PROXY_CLIENT_SECRET with the github `<Client Secret>`
-- OAUTH2_PROXY_COOKIE_SECRET with value of `python -c 'import os,base64; print base64.b64encode(os.urandom(16))'`      
+- OAUTH2_PROXY_COOKIE_SECRET with value of `python -c 'import os,base64; print base64.b64encode(os.urandom(16))'`
 
 4. Customize the contents of the file dashboard-ingress.yaml:
 

--- a/docs/examples/auth/oauth-external-auth/oauth2-proxy.yaml
+++ b/docs/examples/auth/oauth-external-auth/oauth2-proxy.yaml
@@ -31,7 +31,7 @@ spec:
         # docker run -ti --rm python:3-alpine python -c 'import secrets,base64; print(base64.b64encode(base64.b64encode(secrets.token_bytes(16))));'
         - name: OAUTH2_PROXY_COOKIE_SECRET
           value: SECRET
-        image: docker.io/colemickens/oauth2_proxy:latest
+        image: quay.io/pusher/oauth2_proxy:latest
         imagePullPolicy: Always
         name: oauth2-proxy
         ports:


### PR DESCRIPTION
**What this PR does / why we need it**:

The custodian of the project has been shifted from [bitly] to [pusher].
So this diff updates these references.

[bitly]: https://github.com/bitly/oauth2_proxy
[pusher]: https://github.com/pusher/oauth2_proxy

**Which issue this PR fixes**
None, didn't open an issue as it's a small docs change.

**Special notes for your reviewer**:
