### PR TITLE
Add a lua plugin forcing headers when behind an ELB terminating TLS

### DIFF
--- a/rootfs/etc/nginx/lua/plugins/force_tls_headers/main.lua
+++ b/rootfs/etc/nginx/lua/plugins/force_tls_headers/main.lua
@@ -1,0 +1,9 @@
+local _M = {}
+
+-- To be used behind an ELB terminating TLS
+function _M.rewrite()
+  ngx.var.pass_access_scheme = "https"
+  ngx.var.pass_port = 443
+end
+
+return _M


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This provides a simple lua plugin to be used when nginx-ingress-controller is set up behind an AWS ELB terminating TLS.
This use case, and corresponding configuration is well documented on https://github.com/kubernetes/ingress-nginx/issues/2724#issuecomment-444835897. It used to rely on defining maps in the `http-snippet` field of the `nginx-configuration` configmap. Due to #3798, this doesn't work anymore. This plugin provides a functional replacement.

Until #3967 is merged, this requires to patch `/etc/nginx/template/nginx.tmpl` as follow

```
diff --git a/rootfs/etc/nginx/template/nginx.tmpl b/rootfs/etc/nginx/template/nginx.tmpl
index 619ca4a7f..6764fafad 100755
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -112,7 +112,7 @@ http {
           plugins = res
         end
         -- load all plugins that'll be used here
-        plugins.init({})
+        plugins.init({"force_tls_headers"})
     }

     init_worker_by_lua_block {
```
