### PR TITLE
WIP: Added support of every http2 option

### DIFF
--- a/docs/user-guide/nginx-configuration/configmap.md
+++ b/docs/user-guide/nginx-configuration/configmap.md
@@ -48,9 +48,18 @@ The following table shows a configuration option's name, type, and the default v
 |[ignore-invalid-headers](#ignore-invalid-headers)|bool|true|
 |[retry-non-idempotent](#retry-non-idempotent)|bool|"false"|
 |[error-log-level](#error-log-level)|string|"notice"|
+|[http2-body-preread-size](#http2-body-preread-size)|string|"64k"|
+|[http2-chunk-size](#http2-chunk-size)|string|"8k"|
+|[http2-idle-timeout](#http2-idle-timeout)|string|"3m"|
+|[http2-max-concurrent-pushes](#http2-max-concurrent-pushes)|int|10|
+|[http2-max-concurrent-streams](#http2-max-concurrent-streams)|int|128|
 |[http2-max-field-size](#http2-max-field-size)|string|"4k"|
 |[http2-max-header-size](#http2-max-header-size)|string|"16k"|
 |[http2-max-requests](#http2-max-requests)|int|1000|
+|[http2-push](#http2-push)|string|"off"|
+|[http2-push-preload](#http2-push-preload)|bool|"false"|
+|[http2-recv-buffer-size](#http2-recv-buffer-size)|string|"256k"|
+|[http2-recv-timeout](#http2-recv-timeout)|string|"30s"|
 |[hsts](#hsts)|bool|"true"|
 |[hsts-include-subdomains](#hsts-include-subdomains)|bool|"true"|
 |[hsts-max-age](#hsts-max-age)|string|"15724800"|
@@ -287,6 +296,41 @@ Configures the logging level of errors. Log levels above are listed in the order
 _References:_
 [http://nginx.org/en/docs/ngx_core_module.html#error_log](http://nginx.org/en/docs/ngx_core_module.html#error_log)
 
+# http2-body-preread-size
+
+Sets the size of the buffer per each request.
+
+_References:_
+[http://nginx.org/en/docs/http/ngx_http_v2_module.html#http2_body_preread_size](http://nginx.org/en/docs/http/ngx_http_v2_module.html#http2_body_preread_size)
+
+# http2-chunk-size
+
+HTTP2ChunkSize Sets the maximum size of chunks into which the response body is sliced.
+
+_References:_
+[http://nginx.org/en/docs/http/ngx_http_v2_module.html#http2_chunk_size](http://nginx.org/en/docs/http/ngx_http_v2_module.html#http2_chunk_size)
+
+# http2-idle-timeout
+
+Sets the timeout of inactivity after which the connection is closed.
+
+_References:_
+[http://nginx.org/en/docs/http/ngx_http_v2_module.html#http2_idle_timeout](http://nginx.org/en/docs/http/ngx_http_v2_module.html#http2_idle_timeout)
+
+# http2-max-concurrent-pushes
+
+Limits the maximum number of concurrent push requests in a connection.
+
+_References:_
+[http://nginx.org/en/docs/http/ngx_http_v2_module.html#http2_max_concurrent_pushes](http://nginx.org/en/docs/http/ngx_http_v2_module.html#http2_max_concurrent_pushes)
+
+# http2-max-concurrent-streams
+
+Sets the maximum number of concurrent HTTP/2 streams in a connection.
+
+_References:_
+[http://nginx.org/en/docs/http/ngx_http_v2_module.html#http2_max_concurrent_streams](http://nginx.org/en/docs/http/ngx_http_v2_module.html#http2_max_concurrent_streams)
+
 ## http2-max-field-size
 
 Limits the maximum size of an HPACK-compressed request header field.
@@ -307,6 +351,34 @@ Sets the maximum number of requests (including push requests) that can be served
 
 _References:_
 [http://nginx.org/en/docs/http/ngx_http_v2_module.html#http2_max_requests](http://nginx.org/en/docs/http/ngx_http_v2_module.html#http2_max_requests)
+
+# http2-push
+
+Pre-emptively sends (pushes) a request to the specified uri along with the response to the original request.
+
+_References:_
+[http://nginx.org/en/docs/http/ngx_http_v2_module.html#http2_push](http://nginx.org/en/docs/http/ngx_http_v2_module.html#http2_push)
+
+# http2-push-preload
+
+Enables automatic conversion of preload links specified in the “Link” response header fields into push requests.
+
+_References:_
+[http://nginx.org/en/docs/http/ngx_http_v2_module.html#http2_push_preload](http://nginx.org/en/docs/http/ngx_http_v2_module.html#http2_push_preload)
+
+# http2-recv-buffer-size
+
+Sets the size of the per worker input buffer.
+
+_References:_
+[http://nginx.org/en/docs/http/ngx_http_v2_module.html#http2_recv_buffer_size](http://nginx.org/en/docs/http/ngx_http_v2_module.html#http2_recv_buffer_size)
+
+# http2-recv-timeout
+
+Sets the timeout for expecting more data from the client, after which the connection is closed.
+
+_References:_
+[http://nginx.org/en/docs/http/ngx_http_v2_module.html#http2_recv_timeout](http://nginx.org/en/docs/http/ngx_http_v2_module.html#http2_recv_timeout)
 
 ## hsts
 

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -183,6 +183,26 @@ type Configuration struct {
 	// Log levels above are listed in the order of increasing severity
 	ErrorLogLevel string `json:"error-log-level,omitempty"`
 
+	// http://nginx.org/en/docs/http/ngx_http_v2_module.html#http2_body_preread_size
+	// HTTP2BodyPrereadSize Sets the size of the buffer per each request
+	HTTP2BodyPrereadSize string `json:"http2-body-preread-size,omitempty"`
+
+	// http://nginx.org/en/docs/http/ngx_http_v2_module.html#http2_chunk_size
+	// HTTP2ChunkSize Sets the maximum size of chunks into which the response body is sliced
+	HTTP2ChunkSize string `json:"http2-chunk-size,omitempty"`
+
+	// http://nginx.org/en/docs/http/ngx_http_v2_module.html#http2_idle_timeout
+	// HTTP2IdleTimeout Sets the timeout of inactivity after which the connection is closed
+	HTTP2IdleTimeout string `json:"http2-idle-timeout,omitempty"`
+
+	// http://nginx.org/en/docs/http/ngx_http_v2_module.html#http2_max_concurrent_pushes
+	// HTTP2MaxConcurrentPushes Limits the maximum number of concurrent push requests in a connection
+	HTTP2MaxConcurrentPushes int `json:"http2-max-concurrent-pushes,omitempty"`
+
+	// http://nginx.org/en/docs/http/ngx_http_v2_module.html#http2_max_concurrent_streams
+	// HTTP2MaxConcurrentStreams Sets the maximum number of concurrent HTTP/2 streams in a connection
+	HTTP2MaxConcurrentStreams int `json:"http2-max-concurrent-streams,omitempty"`
+
 	// https://nginx.org/en/docs/http/ngx_http_v2_module.html#http2_max_field_size
 	// HTTP2MaxFieldSize Limits the maximum size of an HPACK-compressed request header field
 	HTTP2MaxFieldSize string `json:"http2-max-field-size,omitempty"`
@@ -196,6 +216,25 @@ type Configuration struct {
 	// through one HTTP/2 connection, after which the next client request will lead to connection closing
 	// and the need of establishing a new connection.
 	HTTP2MaxRequests int `json:"http2-max-requests,omitempty"`
+
+	// http://nginx.org/en/docs/http/ngx_http_v2_module.html#http2_push
+	// HTTP2Push Pre-emptively sends (pushes) a request to the specified uri along with the response
+	// to the original request
+	HTTP2Push string `json:"http2-push,omitempty"`
+
+	// http://nginx.org/en/docs/http/ngx_http_v2_module.html#http2_push_preload
+	// HTTP2PushPreload Enables automatic conversion of preload links specified in the “Link” response
+	// header fields into push requests
+	HTTP2PushPreload bool `json:"http2-push-preload,omitempty"`
+
+	// http://nginx.org/en/docs/http/ngx_http_v2_module.html#http2_recv_buffer_size
+	// HTTP2RecvBufferSize Sets the size of the per worker input buffer
+	HTTP2RecvBufferSize string `json:"http2-recv-buffer-size,omitempty"`
+
+	// http://nginx.org/en/docs/http/ngx_http_v2_module.html#http2_recv_timeout
+	// HTTP2RecvTimeout Sets the timeout for expecting more data from the client, after which the connection
+	// is closed
+	HTTP2RecvTimeout string `json:"http2-recv-timeout,omitempty"`
 
 	// Enables or disables the header HSTS in servers running SSL
 	HSTS bool `json:"hsts,omitempty"`
@@ -648,9 +687,18 @@ func NewDefault() Configuration {
 		ComputeFullForwardedFor:          false,
 		ProxyAddOriginalURIHeader:        true,
 		GenerateRequestID:                true,
+		HTTP2BodyPrereadSize:             "64k",
+		HTTP2ChunkSize:                   "8k",
+		HTTP2IdleTimeout:                 "3m",
+		HTTP2MaxConcurrentPushes:         10,
+		HTTP2MaxConcurrentStreams:        128,
 		HTTP2MaxFieldSize:                "4k",
 		HTTP2MaxHeaderSize:               "16k",
 		HTTP2MaxRequests:                 1000,
+		HTTP2Push:                        "off",
+		HTTP2PushPreload:                 false,
+		HTTP2RecvBufferSize:              "256k",
+		HTTP2RecvTimeout:                 "30s",
 		HTTPRedirectCode:                 308,
 		HSTS:                             true,
 		HSTSIncludeSubdomains:            true,

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -205,9 +205,18 @@ http {
     client_body_buffer_size         {{ $cfg.ClientBodyBufferSize }};
     client_body_timeout             {{ $cfg.ClientBodyTimeout }}s;
 
+    http2_body_preread_size         {{ $cfg.HTTP2BodyPrereadSize }};
+    http2_chunk_size                {{ $cfg.HTTP2ChunkSize }};
+    http2_idle_timeout              {{ $cfg.HTTP2IdleTimeout }};
+    http2_max_concurrent_pushes     {{ $cfg.HTTP2MaxConcurrentPushes }};
+    http2_max_concurrent_streams    {{ $cfg.HTTP2MaxConcurrentStreams }};
     http2_max_field_size            {{ $cfg.HTTP2MaxFieldSize }};
     http2_max_header_size           {{ $cfg.HTTP2MaxHeaderSize }};
     http2_max_requests              {{ $cfg.HTTP2MaxRequests }};
+    http2_push                      {{ $cfg.HTTP2Push }};
+    http2_push_preload              {{ if $cfg.HTTP2PushPreload }}on{{ else }}off{{ end }};
+    http2_recv_buffer_size          {{ $cfg.HTTP2RecvBufferSize }};
+    http2_recv_timeout              {{ $cfg.HTTP2RecvTimeout }};
 
     types_hash_max_size             2048;
     server_names_hash_max_size      {{ $cfg.ServerNameHashMaxSize }};


### PR DESCRIPTION
This PR adds support of all http2 related options: http://nginx.org/en/docs/http/ngx_http_v2_module.html#http2_max_requests

Fixes #4353 

This is Work In Progress. Ingress options support is coming next.