### PR TITLE
memoize balancer for a request

### DIFF
--- a/rootfs/etc/nginx/lua/balancer.lua
+++ b/rootfs/etc/nginx/lua/balancer.lua
@@ -190,6 +190,10 @@ local function route_to_alternative_balancer(balancer)
 end
 
 local function get_balancer()
+  if ngx.ctx.balancer then
+    return ngx.ctx.balancer
+  end
+
   local backend_name = ngx.var.proxy_upstream_name
 
   local balancer = balancers[backend_name]
@@ -201,8 +205,10 @@ local function get_balancer()
     local alternative_backend_name = balancer.alternative_backends[1]
     ngx.var.proxy_alternative_upstream_name = alternative_backend_name
 
-    return balancers[alternative_backend_name]
+    balancer = balancers[alternative_backend_name]
   end
+  
+  ngx.ctx.balancer = balancer
 
   return balancer
 end

--- a/rootfs/etc/nginx/lua/balancer.lua
+++ b/rootfs/etc/nginx/lua/balancer.lua
@@ -207,7 +207,7 @@ local function get_balancer()
 
     balancer = balancers[alternative_backend_name]
   end
-  
+
   ngx.ctx.balancer = balancer
 
   return balancer
@@ -266,6 +266,7 @@ if _TEST then
   _M.get_implementation = get_implementation
   _M.sync_backend = sync_backend
   _M.route_to_alternative_balancer = route_to_alternative_balancer
+  _M.get_balancer = get_balancer
 end
 
 return _M


### PR DESCRIPTION
**What this PR does / why we need it**:

This is to make sure for a given request context `get_balancer` always returns the same balancer.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes https://github.com/kubernetes/ingress-nginx/issues/4364

**Special notes for your reviewer**:
