### PR TITLE
Passthrough DD_TRACE_ANALYTICS_ENABLED environment variable

### DIFF
--- a/internal/ingress/controller/template/template_test.go
+++ b/internal/ingress/controller/template/template_test.go
@@ -1135,6 +1135,35 @@ func TestBuildInfluxDB(t *testing.T) {
 	}
 }
 
+func TestBuildGlobalOpenTracing(t *testing.T) {
+	invalidType := &ingress.Ingress{}
+	expected := ""
+	actual := buildOpentracing(invalidType)
+
+	if expected != actual {
+		t.Errorf("Expected '%v' but returned '%v'", expected, actual)
+	}
+
+	cfgEmpty := config.Configuration{}
+	actual = buildGlobalOpentracing(cfgEmpty)
+	expected = ""
+
+	if expected != actual {
+		t.Errorf("Expected '%v' but returned '%v'", expected, actual)
+	}
+
+	cfgDatadog := config.Configuration{
+		EnableOpentracing:    true,
+		DatadogCollectorHost: "datadog-host.com",
+	}
+	actual = buildGlobalOpentracing(cfgDatadog)
+	expected = "env DD_GLOBAL_ANALYTICS_SAMPLE_RATE;\r\n"
+
+	if !strings.Contains(actual, expected) {
+		t.Errorf("Expected '%v' but returned '%v'", expected, actual)
+	}
+}
+
 func TestBuildOpenTracing(t *testing.T) {
 	invalidType := &ingress.Ingress{}
 	expected := ""

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -22,6 +22,7 @@ load_module /etc/nginx/modules/ngx_http_modsecurity_module.so;
 
 {{ if $cfg.EnableOpentracing }}
 load_module /etc/nginx/modules/ngx_http_opentracing_module.so;
+{{ buildGlobalOpentracing $cfg }}
 {{ end }}
 
 daemon off;


### PR DESCRIPTION
**What this PR does / why we need it**:

https://github.com/DataDog/dd-opentracing-cpp supports reading some configuration
from environment variables standard in the Datadog ecosystem, including
DD_TRACE_ANALYTICS_ENABLED. These environment variables could be set on the
ingress-nginx controller pods, but by default nginx removes all environment variables
inherited from its parent process except the TZ variable. The dd-opentracing-cpp
module doesn't see them. See http://nginx.org/en/docs/ngx_core_module.html#env

These configuration options cannot be set via /etc/nginx/opentracing.json today,
as dd-opentracing-cpp doesn't read all possible configuration from its json
configuration file.

When EnableOpentracing=true and DatadogCollectorHost is set, include `env`
directives in the main scope for environment variables which dd-opentracing-cpp
supports. Having these `env` directives present without the corresponding
environment variables defined has no ill-effects.

**Which issue this PR fixes** fixes #4372 

**Special notes for your reviewer**: These configuration options cannot be set via /etc/nginx/opentracing.json today, as `dd-opentracing-cpp` doesn't read all possible configuration from its json configuration file. Maybe that should change, though, instead of this PR as-is.