### PR TITLE
Adds chown to basic auth configuration file

### DIFF
--- a/internal/ingress/annotations/auth/main.go
+++ b/internal/ingress/annotations/auth/main.go
@@ -19,6 +19,7 @@ package auth
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"regexp"
 
 	"github.com/pkg/errors"
@@ -160,6 +161,14 @@ func dumpSecret(filename string, secret *api.Secret) error {
 	if err != nil {
 		return ing_errors.LocationDenied{
 			Reason: errors.Wrap(err, "unexpected error creating password file"),
+		}
+	}
+
+	// Ensure the nginx process can read our authentication configuration
+	err = os.Chown(filename, -1, 33)
+	if err != nil {
+		return ing_errors.LocationDenied{
+			Reason: errors.Wrap(err, "Unexpected error fixing permissions for password file"),
 		}
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Seems like there's a bug that get's triggered when using basic auth in the nginx ingress. On staging, I'm using this controller with basic auth enabled.
I'm getting the following error regularly:

```
nginx-ingress-controller-6cd5444f6-d6g4m nginx-ingress-controller 2019/07/29 09:35:41 [crit] 84#84: *1145 open() "/etc/ingress-controller/auth/staging-nginx.passwd" failed (13: Permission denied), client: <ip>, server: adoring-perlman.staging-001.company.com, request: "GET /favicon.ico HTTP/2.0", host: "adoring-perlman.staging-001.company.com", referrer: "https://adoring-perlman.staging-001.company.com/admin/firms"
```
To me it looks like this error message is generated by the nginx process, not the controller. After a closer look (and if my previous assumption is correct), the permissions on that file are indeed incorrect:

```
 File: /etc/ingress-controller/auth/staging-nginx.passwd
  Size: 56              Blocks: 8          IO Block: 4096   regular file
Device: 100088h/1048712d        Inode: 1474338     Links: 1
Access: (0640/-rw-r-----)  Uid: (    0/    root)   Gid: (    0/    root)
Access: 2019-07-29 09:30:59.153429882 +0000
Modify: 2019-07-29 09:30:59.153429882 +0000
Change: 2019-07-29 09:30:59.153429882 +0000
 Birth: -
```

process with groupid `33` would not be able to read this. This results in `500` errors when trying to visit the vhosts behind that ingress.


My change is to ensure that group "www-data" can read the config file...

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

User permissions are not altered.