### PR TITLE
Fix security issues: bump alpine to 3.10

### DIFF
--- a/images/custom-error-pages/Makefile
+++ b/images/custom-error-pages/Makefile
@@ -25,7 +25,7 @@ endif
 ARCH ?= $(shell go env GOARCH)
 GOARCH = ${ARCH}
 
-BASEIMAGE?=alpine:3.9
+BASEIMAGE?=alpine:3.10
 
 ALL_ARCH = amd64 arm arm64 ppc64le
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix security issues, using newest alpine3.10 version.

```
clair-scanner --ip=192.168.1.199 quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.25.0
2019/07/29 23:02:39 [INFO] ▶ Start clair-scanner
2019/07/29 23:02:44 [INFO] ▶ Server listening on port 9279
2019/07/29 23:02:44 [INFO] ▶ Analyzing 4d6d914ae983e297d22bcd8d4d5096b391a0c7d2bbcae22b05605e86ef835fe4
2019/07/29 23:02:44 [INFO] ▶ Analyzing f3eb4c991f233423ec5d03899defb2f746feca56bf8352f30ca5de0112ed414c
2019/07/29 23:02:44 [INFO] ▶ Analyzing 516de404d5a1fa617cd376bee534f60ad0cf27870054f211b95185a8594213ee
2019/07/29 23:02:44 [INFO] ▶ Analyzing 609305983fbb15035f2a7be497f382df0e2471e75e9b793b93fd7ca4df447aee
2019/07/29 23:02:44 [INFO] ▶ Analyzing 694d5274f021ef3912aefe50a4c4abbceced8663744d581b773869d73aec29e7
2019/07/29 23:02:44 [INFO] ▶ Analyzing 21019689adfec4276e6deaf99802635af29ba9eff90ddf43bbaed69cf2b8d400
2019/07/29 23:02:44 [INFO] ▶ Analyzing 6bed41ff1b7a3adcc68c4828058e88a180500b1fe334995f5bf01d167db785aa
2019/07/29 23:02:44 [INFO] ▶ Analyzing 04bac2dc1c464c69d57b9a1abccef6b3a38043b66b3a6e0a2083036ee8573905
2019/07/29 23:02:44 [INFO] ▶ Analyzing 7a495c518748c1efdb283a1a1eaf6d6ee60ba2ba0196aeba62e72ca6d1472746
2019/07/29 23:02:44 [INFO] ▶ Analyzing 0a24d7820dfde10b9bec6ad9ff0132c207b1c90c75ed1c515f6fc3b141c5f5ba
2019/07/29 23:02:44 [INFO] ▶ Analyzing 2d94fd68c27938e9f4f3ec6b7c674c2cf31882b9855c80cd5ab53043de321f1d
2019/07/29 23:02:44 [INFO] ▶ Analyzing 165a83c57c30d9b42bb0156c3316cbf0ef78f242d524fb567d8d600a6e95a8ce
2019/07/29 23:02:44 [WARN] ▶ Image [quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.25.0] contains 68 total vulnerabilities
2019/07/29 23:02:44 [ERRO] ▶ Image [quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.25.0] contains 68 unapproved vulnerabilities
```


<details>

```
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| STATUS     | CVE SEVERITY                | PACKAGE NAME | PACKAGE VERSION | CVE DESCRIPTION                                              |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | High CVE-2019-12900         | bzip2        | 1.0.6-9         | BZ2_decompress in decompress.c in bzip2 through 1.0.6 has    |
|            |                             |              |                 | an out-of-bounds write when there are many selectors.        |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2019-12900   |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | High CVE-2014-8501          | gdb          | 8.2.1-2         | The _bfd_XXi_swap_aouthdr_in function in                     |
|            |                             |              |                 | bfd/peXXigen.c in GNU binutils 2.24 and earlier              |
|            |                             |              |                 | allows remote attackers to cause a denial of service         |
|            |                             |              |                 | (out-of-bounds write) and possibly have other                |
|            |                             |              |                 | unspecified impact via a crafted NumberOfRvaAndSizes         |
|            |                             |              |                 | field in the AOUT header in a PE executable.                 |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2014-8501    |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | High CVE-2018-20843         | expat        | 2.2.6-1         | In libexpat in Expat before 2.2.7, XML input                 |
|            |                             |              |                 | including XML names that contain a large number              |
|            |                             |              |                 | of colons could make the XML parser consume a high           |
|            |                             |              |                 | amount of RAM and CPU resources while processing             |
|            |                             |              |                 | (enough to be usable for denial-of-service attacks).         |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2018-20843   |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Medium CVE-2016-9318        | libxml2      | 2.9.4+dfsg1-7   | libxml2 2.9.4 and earlier, as used in XMLSec 1.2.23          |
|            |                             |              |                 | and earlier and other products, does not offer a             |
|            |                             |              |                 | flag directly indicating that the current document           |
|            |                             |              |                 | may be read but other files may not be opened, which         |
|            |                             |              |                 | makes it easier for remote attackers to conduct XML          |
|            |                             |              |                 | External Entity (XXE) attacks via a crafted document.        |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2016-9318    |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Medium CVE-2019-13232       | unzip        | 6.0-23          | Info-ZIP UnZip 6.0 mishandles the overlapping of files       |
|            |                             |              |                 | inside a ZIP container, leading to denial of service         |
|            |                             |              |                 | (resource consumption), aka a "better zip bomb" issue.       |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2019-13232   |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Medium CVE-2018-12886       | gcc-8        | 8.3.0-6         | stack_protect_prologue in cfgexpand.c and                    |
|            |                             |              |                 | stack_protect_epilogue in function.c in GNU Compiler         |
|            |                             |              |                 | Collection (GCC) 4.1 through 8 (under certain                |
|            |                             |              |                 | circumstances) generate instruction sequences when           |
|            |                             |              |                 | targeting ARM targets that spill the address of              |
|            |                             |              |                 | the stack protector guard, which allows an attacker          |
|            |                             |              |                 | to bypass the protection of -fstack-protector,               |
|            |                             |              |                 | -fstack-protector-all, -fstack-protector-strong, and         |
|            |                             |              |                 | -fstack-protector-explicit against stack overflow by         |
|            |                             |              |                 | controlling what the stack canary is compared against.       |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2018-12886   |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Medium CVE-2019-13012       | glib2.0      | 2.58.3-2        | The keyfile settings backend in GNOME GLib (aka              |
|            |                             |              |                 | glib2.0) before 2.59.1 creates directories using             |
|            |                             |              |                 | g_file_make_directory_with_parents (kfsb->dir,               |
|            |                             |              |                 | NULL, NULL) and files using g_file_replace_contents          |
|            |                             |              |                 | (kfsb->file, contents, length, NULL, FALSE,                  |
|            |                             |              |                 | G_FILE_CREATE_REPLACE_DESTINATION, NULL, NULL, NULL).        |
|            |                             |              |                 | Consequently, it does not properly restrict directory        |
|            |                             |              |                 | (and file) permissions. Instead, for directories,            |
|            |                             |              |                 | 0777 permissions are used; for files, default file           |
|            |                             |              |                 | permissions are used. This is similar to CVE-2019-12450.     |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2019-13012   |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Medium CVE-2019-12904       | libgcrypt20  | 1.8.4-5         | In Libgcrypt 1.8.4, the C implementation                     |
|            |                             |              |                 | of AES is vulnerable to a flush-and-reload                   |
|            |                             |              |                 | side-channel attack because physical addresses               |
|            |                             |              |                 | are available to other processes. (The C                     |
|            |                             |              |                 | implementation is used on platforms where an                 |
|            |                             |              |                 | assembly-language implementation is unavailable.)            |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2019-12904   |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Medium CVE-2019-9947        | python3.7    | 3.7.3-2         | An issue was discovered in urllib2 in Python 2.x             |
|            |                             |              |                 | through 2.7.16 and urllib in Python 3.x through 3.7.3.       |
|            |                             |              |                 | CRLF injection is possible if the attacker controls a        |
|            |                             |              |                 | url parameter, as demonstrated by the first argument         |
|            |                             |              |                 | to urllib.request.urlopen with \r\n (specifically in         |
|            |                             |              |                 | the path component of a URL that lacks a ? character)        |
|            |                             |              |                 | followed by an HTTP header or a Redis command. This          |
|            |                             |              |                 | is similar to the CVE-2019-9740 query string issue.          |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2019-9947    |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Medium CVE-2011-3389        | gnutls28     | 3.6.7-4         | The SSL protocol, as used in certain configurations          |
|            |                             |              |                 | in Microsoft Windows and Microsoft Internet Explorer,        |
|            |                             |              |                 | Mozilla Firefox, Google Chrome, Opera, and other             |
|            |                             |              |                 | products, encrypts data by using CBC mode with chained       |
|            |                             |              |                 | initialization vectors, which allows man-in-the-middle       |
|            |                             |              |                 | attackers to obtain plaintext HTTP headers via a blockwise   |
|            |                             |              |                 | chosen-boundary attack (BCBA) on an HTTPS session, in        |
|            |                             |              |                 | conjunction with JavaScript code that uses (1) the HTML5     |
|            |                             |              |                 | WebSocket API, (2) the Java URLConnection API, or (3)        |
|            |                             |              |                 | the Silverlight WebClient API, aka a "BEAST" attack.         |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2011-3389    |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Medium CVE-2019-13115       | libssh2      | 1.8.0-2.1       | In libssh2 before 1.9.0,                                     |
|            |                             |              |                 | kex_method_diffie_hellman_group_exchange_sha256_key_exchange |
|            |                             |              |                 | in kex.c has an integer overflow that could lead to an       |
|            |                             |              |                 | out-of-bounds read in the way packets are read from the      |
|            |                             |              |                 | server. A remote attacker who compromises a SSH server       |
|            |                             |              |                 | may be able to disclose sensitive information or cause       |
|            |                             |              |                 | a denial of service condition on the client system when      |
|            |                             |              |                 | a user connects to the server. This is related to an         |
|            |                             |              |                 | _libssh2_check_length mistake, and is different from the     |
|            |                             |              |                 | various issues fixed in 1.8.1, such as CVE-2019-3855.        |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2019-13115   |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Medium CVE-2018-14404       | libxml2      | 2.9.4+dfsg1-7   | A NULL pointer dereference vulnerability exists in           |
|            |                             |              |                 | the xpath.c:xmlXPathCompOpEval() function of libxml2         |
|            |                             |              |                 | through 2.9.8 when parsing an invalid XPath expression       |
|            |                             |              |                 | in the XPATH_OP_AND or XPATH_OP_OR case. Applications        |
|            |                             |              |                 | processing untrusted XSL format inputs with the use          |
|            |                             |              |                 | of the libxml2 library may be vulnerable to a denial         |
|            |                             |              |                 | of service attack due to a crash of the application.         |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2018-14404   |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Medium CVE-2019-3843        | systemd      | 241-5           | It was discovered that a systemd service that uses           |
|            |                             |              |                 | DynamicUser property can create a SUID/SGID binary           |
|            |                             |              |                 | that would be allowed to run as the transient service        |
|            |                             |              |                 | UID/GID even after the service is terminated. A local        |
|            |                             |              |                 | attacker may use this flaw to access resources that          |
|            |                             |              |                 | will be owned by a potentially different service             |
|            |                             |              |                 | in the future, when the UID/GID will be recycled.            |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2019-3843    |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Medium CVE-2019-3844        | systemd      | 241-5           | It was discovered that a systemd service that uses           |
|            |                             |              |                 | DynamicUser property can get new privileges through the      |
|            |                             |              |                 | execution of SUID binaries, which would allow to create      |
|            |                             |              |                 | binaries owned by the service transient group with the       |
|            |                             |              |                 | setgid bit set. A local attacker may use this flaw to access |
|            |                             |              |                 | resources that will be owned by a potentially different      |
|            |                             |              |                 | service in the future, when the GID will be recycled.        |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2019-3844    |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Medium CVE-2018-20839       | systemd      | 241-5           | systemd 242 changes the VT1 mode upon a logout, which        |
|            |                             |              |                 | allows attackers to read cleartext passwords in certain      |
|            |                             |              |                 | circumstances, such as watching a shutdown, or using         |
|            |                             |              |                 | Ctrl-Alt-F1 and Ctrl-Alt-F2. This occurs because the         |
|            |                             |              |                 | KDGKBMODE (aka current keyboard mode) check is mishandled.   |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2018-20839   |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Medium CVE-2019-10160       | python2.7    | 2.7.16-2        | A security regression of CVE-2019-9636 was discovered in     |
|            |                             |              |                 | python since commit d537ab0ff9767ef024f26246899728f0116b1ec3 |
|            |                             |              |                 | affecting versions 2.7, 3.5, 3.6, 3.7 and from v3.8.0a4      |
|            |                             |              |                 | through v3.8.0b1, which still allows an attacker to exploit  |
|            |                             |              |                 | CVE-2019-9636 by abusing the user and password parts of      |
|            |                             |              |                 | a URL. When an application parses user-supplied URLs to      |
|            |                             |              |                 | store cookies, authentication credentials, or other kind     |
|            |                             |              |                 | of information, it is possible for an attacker to provide    |
|            |                             |              |                 | specially crafted URLs to make the application locate        |
|            |                             |              |                 | host-related information (e.g. cookies, authentication       |
|            |                             |              |                 | data) and send them to a different host than where it        |
|            |                             |              |                 | should, unlike if the URLs had been correctly parsed. The    |
|            |                             |              |                 | result of an attack may vary based on the application.       |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2019-10160   |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Medium CVE-2019-9740        | python2.7    | 2.7.16-2        | An issue was discovered in urllib2 in Python 2.x             |
|            |                             |              |                 | through 2.7.16 and urllib in Python 3.x through              |
|            |                             |              |                 | 3.7.3. CRLF injection is possible if the attacker            |
|            |                             |              |                 | controls a url parameter, as demonstrated by the             |
|            |                             |              |                 | first argument to urllib.request.urlopen with \r\n           |
|            |                             |              |                 | (specifically in the query string after a ? character)       |
|            |                             |              |                 | followed by an HTTP header or a Redis command.               |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2019-9740    |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Medium CVE-2019-9948        | python3.7    | 3.7.3-2         | urllib in Python 2.x through 2.7.16 supports the             |
|            |                             |              |                 | local_file: scheme, which makes it easier for remote         |
|            |                             |              |                 | attackers to bypass protection mechanisms that               |
|            |                             |              |                 | blacklist file: URIs, as demonstrated by triggering          |
|            |                             |              |                 | a urllib.urlopen('local_file:///etc/passwd') call.           |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2019-9948    |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Medium CVE-2019-9740        | python3.7    | 3.7.3-2         | An issue was discovered in urllib2 in Python 2.x             |
|            |                             |              |                 | through 2.7.16 and urllib in Python 3.x through              |
|            |                             |              |                 | 3.7.3. CRLF injection is possible if the attacker            |
|            |                             |              |                 | controls a url parameter, as demonstrated by the             |
|            |                             |              |                 | first argument to urllib.request.urlopen with \r\n           |
|            |                             |              |                 | (specifically in the query string after a ? character)       |
|            |                             |              |                 | followed by an HTTP header or a Redis command.               |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2019-9740    |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Medium CVE-2018-20852       | python2.7    | 2.7.16-2        | http.cookiejar.DefaultPolicy.domain_return_ok in             |
|            |                             |              |                 | Lib/http/cookiejar.py in Python before 3.7.3 does not        |
|            |                             |              |                 | correctly validate the domain: it can be tricked into        |
|            |                             |              |                 | sending existing cookies to the wrong server. An attacker    |
|            |                             |              |                 | may abuse this flaw by using a server with a hostname        |
|            |                             |              |                 | that has another valid hostname as a suffix (e.g.,           |
|            |                             |              |                 | pythonicexample.com to steal cookies for example.com).       |
|            |                             |              |                 | When a program uses http.cookiejar.DefaultPolicy and         |
|            |                             |              |                 | tries to do an HTTP connection to an attacker-controlled     |
|            |                             |              |                 | server, existing cookies can be leaked to the attacker.      |
|            |                             |              |                 | This affects 2.x through 2.7.16, 3.x before 3.4.10, 3.5.x    |
|            |                             |              |                 | before 3.5.7, 3.6.x before 3.6.9, and 3.7.x before 3.7.3.    |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2018-20852   |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Medium CVE-2018-14567       | libxml2      | 2.9.4+dfsg1-7   | libxml2 2.9.8, if --with-lzma is used, allows                |
|            |                             |              |                 | remote attackers to cause a denial of service                |
|            |                             |              |                 | (infinite loop) via a crafted XML file that triggers         |
|            |                             |              |                 | LZMA_MEMLIMIT_ERROR, as demonstrated by xmllint, a different |
|            |                             |              |                 | vulnerability than CVE-2015-8035 and CVE-2018-9251.          |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2018-14567   |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Medium CVE-2019-9947        | python2.7    | 2.7.16-2        | An issue was discovered in urllib2 in Python 2.x             |
|            |                             |              |                 | through 2.7.16 and urllib in Python 3.x through 3.7.3.       |
|            |                             |              |                 | CRLF injection is possible if the attacker controls a        |
|            |                             |              |                 | url parameter, as demonstrated by the first argument         |
|            |                             |              |                 | to urllib.request.urlopen with \r\n (specifically in         |
|            |                             |              |                 | the path component of a URL that lacks a ? character)        |
|            |                             |              |                 | followed by an HTTP header or a Redis command. This          |
|            |                             |              |                 | is similar to the CVE-2019-9740 query string issue.          |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2019-9947    |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Medium CVE-2019-10160       | python3.7    | 3.7.3-2         | A security regression of CVE-2019-9636 was discovered in     |
|            |                             |              |                 | python since commit d537ab0ff9767ef024f26246899728f0116b1ec3 |
|            |                             |              |                 | affecting versions 2.7, 3.5, 3.6, 3.7 and from v3.8.0a4      |
|            |                             |              |                 | through v3.8.0b1, which still allows an attacker to exploit  |
|            |                             |              |                 | CVE-2019-9636 by abusing the user and password parts of      |
|            |                             |              |                 | a URL. When an application parses user-supplied URLs to      |
|            |                             |              |                 | store cookies, authentication credentials, or other kind     |
|            |                             |              |                 | of information, it is possible for an attacker to provide    |
|            |                             |              |                 | specially crafted URLs to make the application locate        |
|            |                             |              |                 | host-related information (e.g. cookies, authentication       |
|            |                             |              |                 | data) and send them to a different host than where it        |
|            |                             |              |                 | should, unlike if the URLs had been correctly parsed. The    |
|            |                             |              |                 | result of an attack may vary based on the application.       |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2019-10160   |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Medium CVE-2017-18258       | libxml2      | 2.9.4+dfsg1-7   | The xz_head function in xzlib.c in libxml2 before 2.9.6      |
|            |                             |              |                 | allows remote attackers to cause a denial of service         |
|            |                             |              |                 | (memory consumption) via a crafted LZMA file, because        |
|            |                             |              |                 | the decoder functionality does not restrict memory           |
|            |                             |              |                 | usage to what is required for a legitimate file.             |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2017-18258   |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Medium CVE-2017-16932       | libxml2      | 2.9.4+dfsg1-7   | parser.c in libxml2 before 2.9.5 does not prevent            |
|            |                             |              |                 | infinite recursion in parameter entities.                    |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2017-16932   |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Low CVE-2016-2781           | coreutils    | 8.30-3          | chroot in GNU coreutils, when used with --userspec,          |
|            |                             |              |                 | allows local users to escape to the parent session           |
|            |                             |              |                 | via a crafted TIOCSTI ioctl call, which pushes               |
|            |                             |              |                 | characters to the terminal's input buffer.                   |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2016-2781    |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Low CVE-2018-7169           | shadow       | 1:4.5-1.1       | An issue was discovered in shadow 4.5. newgidmap (in         |
|            |                             |              |                 | shadow-utils) is setuid and allows an unprivileged user      |
|            |                             |              |                 | to be placed in a user namespace where setgroups(2) is       |
|            |                             |              |                 | permitted. This allows an attacker to remove themselves      |
|            |                             |              |                 | from a supplementary group, which may allow access to        |
|            |                             |              |                 | certain filesystem paths if the administrator has used       |
|            |                             |              |                 | "group blacklisting" (e.g., chmod g-rwx) to restrict access  |
|            |                             |              |                 | to paths. This flaw effectively reverts a security feature   |
|            |                             |              |                 | in the kernel (in particular, the /proc/self/setgroups       |
|            |                             |              |                 | knob) to prevent this sort of privilege escalation.          |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2018-7169    |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Low CVE-2019-13565          | openldap     | 2.4.47+dfsg-3   | An issue was discovered in OpenLDAP 2.x before 2.4.48.       |
|            |                             |              |                 | When using SASL authentication and session encryption,       |
|            |                             |              |                 | and relying on the SASL security layers in slapd access      |
|            |                             |              |                 | controls, it is possible to obtain access that would         |
|            |                             |              |                 | otherwise be denied via a simple bind for any identity       |
|            |                             |              |                 | covered in those ACLs. After the first SASL bind is          |
|            |                             |              |                 | completed, the sasl_ssf value is retained for all new        |
|            |                             |              |                 | non-SASL connections. Depending on the ACL configuration,    |
|            |                             |              |                 | this can affect different types of operations (searches,     |
|            |                             |              |                 | modifications, etc.). In other words, a successful           |
|            |                             |              |                 | authorization step completed by one user affects             |
|            |                             |              |                 | the authorization requirement for a different user.          |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2019-13565   |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Low CVE-2019-13057          | openldap     | 2.4.47+dfsg-3   | An issue was discovered in the server in OpenLDAP before     |
|            |                             |              |                 | 2.4.48. When the server administrator delegates rootDN       |
|            |                             |              |                 | (database admin) privileges for certain databases but        |
|            |                             |              |                 | wants to maintain isolation (e.g., for multi-tenant          |
|            |                             |              |                 | deployments), slapd does not properly stop a rootDN from     |
|            |                             |              |                 | requesting authorization as an identity from another         |
|            |                             |              |                 | database during a SASL bind or with a proxyAuthz (RFC        |
|            |                             |              |                 | 4370) control. (It is not a common configuration to          |
|            |                             |              |                 | deploy a system where the server administrator and a         |
|            |                             |              |                 | DB administrator enjoy different levels of trust.)           |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2019-13057   |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Low CVE-2016-10228          | glibc        | 2.28-10         | The iconv program in the GNU C Library (aka glibc or         |
|            |                             |              |                 | libc6) 2.25 and earlier, when invoked with the -c option,    |
|            |                             |              |                 | enters an infinite loop when processing invalid multi-byte   |
|            |                             |              |                 | input sequences, leading to a denial of service.             |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2016-10228   |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Negligible CVE-2019-9923    | tar          | 1.30+dfsg-6     | pax_decode_header in sparse.c in GNU Tar before 1.32         |
|            |                             |              |                 | had a NULL pointer dereference when parsing certain          |
|            |                             |              |                 | archives that have malformed extended headers.               |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2019-9923    |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Negligible CVE-2013-0340    | expat        | 2.2.6-1         | expat 2.1.0 and earlier does not properly handle             |
|            |                             |              |                 | entities expansion unless an application developer uses      |
|            |                             |              |                 | the XML_SetEntityDeclHandler function, which allows          |
|            |                             |              |                 | remote attackers to cause a denial of service (resource      |
|            |                             |              |                 | consumption), send HTTP requests to intranet servers,        |
|            |                             |              |                 | or read arbitrary files via a crafted XML document, aka      |
|            |                             |              |                 | an XML External Entity (XXE) issue.  NOTE: it could be       |
|            |                             |              |                 | argued that because expat already provides the ability to    |
|            |                             |              |                 | disable external entity expansion, the responsibility for    |
|            |                             |              |                 | resolving this issue lies with application developers;       |
|            |                             |              |                 | according to this argument, this entry should be REJECTed,   |
|            |                             |              |                 | and each affected application would need its own CVE.        |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2013-0340    |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Negligible CVE-2018-1000654 | libtasn1-6   | 4.13-3          | GNU Libtasn1-4.13 libtasn1-4.13 version libtasn1-4.13,       |
|            |                             |              |                 | libtasn1-4.12 contains a DoS, specifically CPU usage         |
|            |                             |              |                 | will reach 100% when running asn1Paser against the POC       |
|            |                             |              |                 | due to an issue in _asn1_expand_object_id(p_tree), after     |
|            |                             |              |                 | a long time, the program will be killed. This attack         |
|            |                             |              |                 | appears to be exploitable via parsing a crafted file.        |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2018-1000654 |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Negligible CVE-2017-9778    | gdb          | 8.2.1-2         | GNU Debugger (GDB) 8.0 and earlier fails to detect           |
|            |                             |              |                 | a negative length field in a DWARF section. A                |
|            |                             |              |                 | malformed section in an ELF binary or a core file            |
|            |                             |              |                 | can cause GDB to repeatedly allocate memory until            |
|            |                             |              |                 | a process limit is reached. This can, for example,           |
|            |                             |              |                 | impede efforts to analyze malware with GDB.                  |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2017-9778    |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Negligible CVE-2013-7040    | python2.7    | 2.7.16-2        | Python 2.7 before 3.4 only uses the last eight bits of       |
|            |                             |              |                 | the prefix to randomize hash values, which causes it to      |
|            |                             |              |                 | compute hash values without restricting the ability to       |
|            |                             |              |                 | trigger hash collisions predictably and makes it easier for  |
|            |                             |              |                 | context-dependent attackers to cause a denial of service     |
|            |                             |              |                 | (CPU consumption) via crafted input to an application        |
|            |                             |              |                 | that maintains a hash table.  NOTE: this vulnerability       |
|            |                             |              |                 | exists because of an incomplete fix for CVE-2012-1150.       |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2013-7040    |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Negligible CVE-2017-17522   | python3.7    | 3.7.3-2         | ** DISPUTED ** Lib/webbrowser.py in Python through 3.6.3     |
|            |                             |              |                 | does not validate strings before launching the program       |
|            |                             |              |                 | specified by the BROWSER environment variable, which might   |
|            |                             |              |                 | allow remote attackers to conduct argument-injection attacks |
|            |                             |              |                 | via a crafted URL. NOTE: a software maintainer indicates     |
|            |                             |              |                 | that exploitation is impossible because the code relies      |
|            |                             |              |                 | on subprocess.Popen and the default shell=False setting.     |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2017-17522   |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Negligible CVE-2019-9893    | libseccomp   | 2.3.3-4         | libseccomp before 2.4.0 did not correctly generate 64-bit    |
|            |                             |              |                 | syscall argument comparisons using the arithmetic operators  |
|            |                             |              |                 | (LT, GT, LE, GE), which might able to lead to bypassing      |
|            |                             |              |                 | seccomp filters and potential privilege escalations.         |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2019-9893    |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Negligible CVE-2017-17522   | python2.7    | 2.7.16-2        | ** DISPUTED ** Lib/webbrowser.py in Python through 3.6.3     |
|            |                             |              |                 | does not validate strings before launching the program       |
|            |                             |              |                 | specified by the BROWSER environment variable, which might   |
|            |                             |              |                 | allow remote attackers to conduct argument-injection attacks |
|            |                             |              |                 | via a crafted URL. NOTE: a software maintainer indicates     |
|            |                             |              |                 | that exploitation is impossible because the code relies      |
|            |                             |              |                 | on subprocess.Popen and the default shell=False setting.     |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2017-17522   |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Negligible CVE-2017-16231   | pcre3        | 2:8.39-12       | ** DISPUTED ** In PCRE 8.41, after compiling, a pcretest     |
|            |                             |              |                 | load test PoC produces a crash overflow in the function      |
|            |                             |              |                 | match() in pcre_exec.c because of a self-recursive           |
|            |                             |              |                 | call. NOTE: third parties dispute the relevance of           |
|            |                             |              |                 | this report, noting that there are options that can          |
|            |                             |              |                 | be used to limit the amount of stack that is used.           |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2017-16231   |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Negligible CVE-2017-11164   | pcre3        | 2:8.39-12       | In PCRE 8.41, the OP_KETRMAX feature in the match function   |
|            |                             |              |                 | in pcre_exec.c allows stack exhaustion (uncontrolled         |
|            |                             |              |                 | recursion) when processing a crafted regular expression.     |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2017-11164   |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Negligible CVE-2017-7245    | pcre3        | 2:8.39-12       | Stack-based buffer overflow in the pcre32_copy_substring     |
|            |                             |              |                 | function in pcre_get.c in libpcre1 in PCRE                   |
|            |                             |              |                 | 8.40 allows remote attackers to cause a denial               |
|            |                             |              |                 | of service (WRITE of size 4) or possibly have                |
|            |                             |              |                 | unspecified other impact via a crafted file.                 |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2017-7245    |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Negligible CVE-2013-4392    | systemd      | 241-5           | systemd, when updating file permissions, allows local users  |
|            |                             |              |                 | to change the permissions and SELinux security contexts for  |
|            |                             |              |                 | arbitrary files via a symlink attack on unspecified files.   |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2013-4392    |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Negligible CVE-2017-14159   | openldap     | 2.4.47+dfsg-3   | slapd in OpenLDAP 2.4.45 and earlier creates a PID file      |
|            |                             |              |                 | after dropping privileges to a non-root account, which       |
|            |                             |              |                 | might allow local users to kill arbitrary processes by       |
|            |                             |              |                 | leveraging access to this non-root account for PID file      |
|            |                             |              |                 | modification before a root script executes a "kill `cat      |
|            |                             |              |                 | /pathname`" command, as demonstrated by openldap-initscript. |
|            |                             |              |                 |  https://security-tracker.debian.org/tracker/CVE-2017-14159  |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Negligible CVE-2018-5709    | krb5         | 1.17-3          | An issue was discovered in MIT Kerberos 5 (aka krb5)         |
|            |                             |              |                 | through 1.16. There is a variable "dbentry->n_key_data"      |
|            |                             |              |                 | in kadmin/dbutil/dump.c that can store 16-bit                |
|            |                             |              |                 | data but unknowingly the developer has assigned              |
|            |                             |              |                 | a "u4" variable to it, which is for 32-bit data.             |
|            |                             |              |                 | An attacker can use this vulnerability to affect             |
|            |                             |              |                 | other artifacts of the database as we know that a            |
|            |                             |              |                 | Kerberos database dump file contains trusted data.           |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2018-5709    |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Negligible CVE-2004-0971    | krb5         | 1.17-3          | The krb5-send-pr script in the kerberos5 (krb5) package      |
|            |                             |              |                 | in Trustix Secure Linux 1.5 through 2.1, and possibly        |
|            |                             |              |                 | other operating systems, allows local users to overwrite     |
|            |                             |              |                 | files via a symlink attack on temporary files.               |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2004-0971    |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Negligible CVE-2010-4051    | glibc        | 2.28-10         | The regcomp implementation in the GNU C Library (aka         |
|            |                             |              |                 | glibc or libc6) through 2.11.3, and 2.12.x through 2.12.2,   |
|            |                             |              |                 | allows context-dependent attackers to cause a denial         |
|            |                             |              |                 | of service (application crash) via a regular expression      |
|            |                             |              |                 | containing adjacent bounded repetitions that bypass the      |
|            |                             |              |                 | intended RE_DUP_MAX limitation, as demonstrated by a         |
|            |                             |              |                 | {10,}{10,}{10,}{10,}{10,} sequence in the proftpd.gnu.c      |
|            |                             |              |                 | exploit for ProFTPD, related to a "RE_DUP_MAX overflow."     |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2010-4051    |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Negligible CVE-2019-9192    | glibc        | 2.28-10         | ** DISPUTED ** In the GNU C Library (aka glibc or            |
|            |                             |              |                 | libc6) through 2.29, check_dst_limits_calc_pos_1             |
|            |                             |              |                 | in posix/regexec.c has Uncontrolled Recursion, as            |
|            |                             |              |                 | demonstrated by '(|)(\\1\\1)*' in grep, a different          |
|            |                             |              |                 | issue than CVE-2018-20796. NOTE: the software                |
|            |                             |              |                 | maintainer disputes that this is a vulnerability because     |
|            |                             |              |                 | the behavior occurs only with a crafted pattern.             |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2019-9192    |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Negligible CVE-2019-1010023 | glibc        | 2.28-10         | GNU Libc current is affected by: Re-mapping current loaded   |
|            |                             |              |                 | libray with malicious ELF file. The impact is: In worst      |
|            |                             |              |                 | case attacker may evaluate privileges. The component is:     |
|            |                             |              |                 | libld. The attack vector is: Attacker sends 2 ELF files      |
|            |                             |              |                 | to victim and asks to run ldd on it. ldd execute code.       |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2019-1010023 |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Negligible CVE-2010-4052    | glibc        | 2.28-10         | Stack consumption vulnerability in the regcomp               |
|            |                             |              |                 | implementation in the GNU C Library (aka glibc or            |
|            |                             |              |                 | libc6) through 2.11.3, and 2.12.x through 2.12.2,            |
|            |                             |              |                 | allows context-dependent attackers to cause a                |
|            |                             |              |                 | denial of service (resource exhaustion) via a                |
|            |                             |              |                 | regular expression containing adjacent repetition            |
|            |                             |              |                 | operators, as demonstrated by a {10,}{10,}{10,}{10,}         |
|            |                             |              |                 | sequence in the proftpd.gnu.c exploit for ProFTPD.           |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2010-4052    |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Negligible CVE-2017-7246    | pcre3        | 2:8.39-12       | Stack-based buffer overflow in the pcre32_copy_substring     |
|            |                             |              |                 | function in pcre_get.c in libpcre1 in PCRE 8.40              |
|            |                             |              |                 | allows remote attackers to cause a denial of                 |
|            |                             |              |                 | service (WRITE of size 268) or possibly have                 |
|            |                             |              |                 | unspecified other impact via a crafted file.                 |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2017-7246    |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Negligible CVE-2018-20796   | glibc        | 2.28-10         | In the GNU C Library (aka glibc or libc6) through            |
|            |                             |              |                 | 2.29, check_dst_limits_calc_pos_1 in posix/regexec.c         |
|            |                             |              |                 | has Uncontrolled Recursion, as demonstrated                  |
|            |                             |              |                 | by '(\227|)(\\1\\1|t1|\\\2537)+' in grep.                    |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2018-20796   |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Negligible CVE-2019-1010022 | glibc        | 2.28-10         | GNU Libc current is affected by: Mitigation bypass.          |
|            |                             |              |                 | The impact is: Attacker may bypass stack guard               |
|            |                             |              |                 | protection. The component is: nptl. The attack vector        |
|            |                             |              |                 | is: Exploit stack buffer overflow vulnerability and          |
|            |                             |              |                 | use this bypass vulnerability to bypass stack guard.         |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2019-1010022 |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Negligible CVE-2010-4756    | glibc        | 2.28-10         | The glob implementation in the GNU C Library (aka glibc      |
|            |                             |              |                 | or libc6) allows remote authenticated users to cause a       |
|            |                             |              |                 | denial of service (CPU and memory consumption) via crafted   |
|            |                             |              |                 | glob expressions that do not match any pathnames, as         |
|            |                             |              |                 | demonstrated by glob expressions in STAT commands to an      |
|            |                             |              |                 | FTP daemon, a different vulnerability than CVE-2010-2632.    |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2010-4756    |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Negligible CVE-2019-1010025 | glibc        | 2.28-10         | GNU Libc current is affected by: Mitigation bypass.          |
|            |                             |              |                 | The impact is: Attacker may guess the heap addresses         |
|            |                             |              |                 | of pthread_created thread. The component is: glibc.          |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2019-1010025 |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Negligible CVE-2019-1010024 | glibc        | 2.28-10         | GNU Libc current is affected by: Mitigation bypass.          |
|            |                             |              |                 | The impact is: Attacker may bypass ASLR using cache          |
|            |                             |              |                 | of thread stack and heap. The component is: glibc.           |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2019-1010024 |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Negligible CVE-2017-18018   | coreutils    | 8.30-3          | In GNU Coreutils through 8.29, chown-core.c in chown         |
|            |                             |              |                 | and chgrp does not prevent replacement of a plain file       |
|            |                             |              |                 | with a symlink during use of the POSIX "-R -L" options,      |
|            |                             |              |                 | which allows local users to modify the ownership             |
|            |                             |              |                 | of arbitrary files by leveraging a race condition.           |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2017-18018   |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Negligible CVE-2018-6829    | libgcrypt20  | 1.8.4-5         | cipher/elgamal.c in Libgcrypt through 1.8.2, when            |
|            |                             |              |                 | used to encrypt messages directly, improperly encodes        |
|            |                             |              |                 | plaintexts, which allows attackers to obtain sensitive       |
|            |                             |              |                 | information by reading ciphertext data (i.e., it does        |
|            |                             |              |                 | not have semantic security in face of a ciphertext-only      |
|            |                             |              |                 | attack). The Decisional Diffie-Hellman (DDH) assumption      |
|            |                             |              |                 | does not hold for Libgcrypt's ElGamal implementation.        |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2018-6829    |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Negligible CVE-2005-2541    | tar          | 1.30+dfsg-6     | Tar 1.15.1 does not properly warn the user when              |
|            |                             |              |                 | extracting setuid or setgid files, which may allow           |
|            |                             |              |                 | local users or remote attackers to gain privileges.          |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2005-2541    |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Negligible CVE-2011-3374    | apt          | 1.8.2           |   https://security-tracker.debian.org/tracker/CVE-2011-3374  |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Negligible CVE-2010-0928    | openssl      | 1.1.1c-1        | OpenSSL 0.9.8i on the Gaisler Research LEON3 SoC on the      |
|            |                             |              |                 | Xilinx Virtex-II Pro FPGA uses a Fixed Width Exponentiation  |
|            |                             |              |                 | (FWE) algorithm for certain signature calculations, and does |
|            |                             |              |                 | not verify the signature before providing it to a caller,    |
|            |                             |              |                 | which makes it easier for physically proximate attackers     |
|            |                             |              |                 | to determine the private key via a modified supply voltage   |
|            |                             |              |                 | for the microprocessor, related to a "fault-based attack."   |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2010-0928    |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Negligible CVE-2011-4116    | perl         | 5.28.1-6        |   https://security-tracker.debian.org/tracker/CVE-2011-4116  |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Negligible CVE-2007-6755    | openssl      | 1.1.1c-1        | The NIST SP 800-90A default statement of the Dual Elliptic   |
|            |                             |              |                 | Curve Deterministic Random Bit Generation (Dual_EC_DRBG)     |
|            |                             |              |                 | algorithm contains point Q constants with a possible         |
|            |                             |              |                 | relationship to certain "skeleton key" values, which         |
|            |                             |              |                 | might allow context-dependent attackers to defeat            |
|            |                             |              |                 | cryptographic protection mechanisms by leveraging knowledge  |
|            |                             |              |                 | of those values.  NOTE: this is a preliminary CVE for        |
|            |                             |              |                 | Dual_EC_DRBG; future research may provide additional         |
|            |                             |              |                 | details about point Q and associated attacks, and could      |
|            |                             |              |                 | potentially lead to a RECAST or REJECT of this CVE.          |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2007-6755    |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Negligible CVE-2007-5686    | shadow       | 1:4.5-1.1       | initscripts in rPath Linux 1 sets insecure permissions for   |
|            |                             |              |                 | the /var/log/btmp file, which allows local users to obtain   |
|            |                             |              |                 | sensitive information regarding authentication attempts.     |
|            |                             |              |                 |  NOTE: because sshd detects the insecure permissions and     |
|            |                             |              |                 | does not log certain events, this also prevents sshd from    |
|            |                             |              |                 | logging failed authentication attempts by remote attackers.  |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2007-5686    |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Negligible CVE-2015-3276    | openldap     | 2.4.47+dfsg-3   | The nss_parse_ciphers function in libraries/libldap/tls_m.c  |
|            |                             |              |                 | in OpenLDAP does not properly parse OpenSSL-style            |
|            |                             |              |                 | multi-keyword mode cipher strings, which might cause a       |
|            |                             |              |                 | weaker than intended cipher to be used and allow remote      |
|            |                             |              |                 | attackers to have unspecified impact via unknown vectors.    |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2015-3276    |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Negligible CVE-2017-17740   | openldap     | 2.4.47+dfsg-3   | contrib/slapd-modules/nops/nops.c in OpenLDAP through        |
|            |                             |              |                 | 2.4.45, when both the nops module and the memberof overlay   |
|            |                             |              |                 | are enabled, attempts to free a buffer that was allocated on |
|            |                             |              |                 | the stack, which allows remote attackers to cause a denial   |
|            |                             |              |                 | of service (slapd crash) via a member MODDN operation.       |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2017-17740   |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Negligible CVE-2013-4235    | shadow       | 1:4.5-1.1       |   https://security-tracker.debian.org/tracker/CVE-2013-4235  |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Negligible CVE-2012-0039    | glib2.0      | 2.58.3-2        | ** DISPUTED ** GLib 2.31.8 and earlier, when the g_str_hash  |
|            |                             |              |                 | function is used, computes hash values without restricting   |
|            |                             |              |                 | the ability to trigger hash collisions predictably,          |
|            |                             |              |                 | which allows context-dependent attackers to cause a          |
|            |                             |              |                 | denial of service (CPU consumption) via crafted input        |
|            |                             |              |                 | to an application that maintains a hash table.  NOTE:        |
|            |                             |              |                 | this issue may be disputed by the vendor; the existence      |
|            |                             |              |                 | of the g_str_hash function is not a vulnerability in         |
|            |                             |              |                 | the library, because callers of g_hash_table_new and         |
|            |                             |              |                 | g_hash_table_new_full can specify an arbitrary hash          |
|            |                             |              |                 | function that is appropriate for the application.            |
|            |                             |              |                 | https://security-tracker.debian.org/tracker/CVE-2012-0039    |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
| Unapproved | Unknown CVE-2019-9619       | systemd      | 241-5           |   https://security-tracker.debian.org/tracker/CVE-2019-9619  |
+------------+-----------------------------+--------------+-----------------+--------------------------------------------------------------+
```

</details>