### PR TITLE
Add support for psp

### DIFF
--- a/docs/examples/psp/README.md
+++ b/docs/examples/psp/README.md
@@ -1,0 +1,23 @@
+# Pod Security Policy (PSP)
+
+In most clusters today, by default, all resources (e.g. Deployments and ReplicatSets)
+have permissions to create pods.
+Kubernetes however provides a more fine-grained authorization policy called 
+[Pod Security Policy (PSP)](https://kubernetes.io/docs/concepts/policy/pod-security-policy/).
+
+PSP allows the cluster owner to define the permission of each object, for example creating a pod.
+If you have PSP enabled on the cluster, and you deploy ingress-nginx,
+you will need to provide the Deployment with the permissions to create pods.
+
+Before applying any objects, first apply the PSP permissions by running:
+```console
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/docs/examples/psp/psp.yaml
+```
+
+Now that the pod security policy is applied, we can continue as usual by applying the
+[mandatory.yaml](../../../deploy/static/mandatory.yaml)
+according to the [Installation Guide](../../deploy/index.md). 
+
+Note: PSP permissions must be granted before to the creation of the Deployment and the ReplicaSet.
+If the Deployment or ReplicaSet already exist, they will receive the PSP permissions
+only after deleting them and reapplying mandatory.yaml.

--- a/docs/examples/psp/psp.yaml
+++ b/docs/examples/psp/psp.yaml
@@ -1,0 +1,87 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ingress-nginx
+
+---
+
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    # Assumes apparmor available
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
+    apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
+  name: ingress-nginx
+spec:
+  allowedCapabilities:
+  - NET_BIND_SERVICE
+  allowPrivilegeEscalation: true
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+    - min: 1
+      max: 65535
+  hostIPC: false
+  hostNetwork: false
+  hostPID: false
+  hostPorts:
+  - min: 80
+    max: 65535
+  privileged: false
+  readOnlyRootFilesystem: false
+  runAsUser:
+    rule: 'MustRunAsNonRoot'
+    ranges:
+    - min: 33
+      max: 65535
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+    # Forbid adding the root group.
+    - min: 1
+      max: 65535
+  volumes:
+  - 'configMap'
+  - 'downwardAPI'
+  - 'emptyDir'
+  - 'projected'
+  - 'secret'
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ingress-nginx-psp
+  namespace: ingress-nginx
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - ingress-nginx
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ingress-nginx-psp
+  namespace: ingress-nginx
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ingress-nginx-psp
+subjects:
+- kind: ServiceAccount
+  name: default
+- kind: ServiceAccount
+  name: nginx-ingress-serviceaccount

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,3 +87,4 @@ nav:
       - Rewrite: "examples/rewrite/README.md"
       - Static IPs: "examples/static-ip/README.md"
       - TLS termination: "examples/tls-termination/README.md"
+      - Pod Security Policy (PSP): "examples/psp/README.md"


### PR DESCRIPTION
This PR adds the yaml file needed for running nginx when port security policy (PSP) is enabled on the Kubernetes cluster. Me and my colleagues struggled with it somewhat, and felt it would be nice to have it together with the rest of nginx.