### PR TITLE
Overwrite method for default backend request

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -764,6 +764,7 @@ stream {
             proxy_set_header       X-Request-ID       $req_id;
             proxy_set_header       Host               $best_http_host;
 
+            proxy_method GET;
             set $proxy_upstream_name {{ $upstreamName }};
 
             rewrite                (.*) / break;


### PR DESCRIPTION
Overwrite method (Get) for default backend in case of CUSTOM_ERRORS

**What this PR does / why we need it**:
default backend crushes when request sent to default backend with no http request method


