### PR TITLE
sort ingress by namespace and name when ingress.CreationTimestamp identical

### DIFF
--- a/internal/ingress/controller/store/store.go
+++ b/internal/ingress/controller/store/store.go
@@ -778,6 +778,12 @@ func (s *k8sStore) ListIngresses(filter IngressFilterFunc) []*ingress.Ingress {
 	sort.SliceStable(ingresses, func(i, j int) bool {
 		ir := ingresses[i].CreationTimestamp
 		jr := ingresses[j].CreationTimestamp
+		if ir.Equal(&jr) {
+			in := fmt.Sprintf("%v/%v", ingresses[i].Namespace, ingresses[i].Name)
+			jn := fmt.Sprintf("%v/%v", ingresses[j].Namespace, ingresses[j].Name)
+			klog.Warningf("Ingress %v and %v have identical CreationTimestamp", in, jn)
+			return in > jn
+		}
 		return ir.Before(&jr)
 	})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:  
Because `store.ListIngresses()` sort Ingresses using the CreationTimestamp field and `s.listers.IngressWithAnnotation.List() ` use `map` as backend cache , So when the list contains more than one Ingress with the same creationTimestamp, the sorting results are unstable.
```
// ListIngresses returns the list of Ingresses
func (s *k8sStore) ListIngresses(filter IngressFilterFunc) []*ingress.Ingress {
	for _, item := range s.listers.IngressWithAnnotation.List() {
                //Irrelevant logic ignored
		ingresses = append(ingresses, ing)
	}

	// sort Ingresses using the CreationTimestamp field
	sort.SliceStable(ingresses, func(i, j int) bool {
		ir := ingresses[i].CreationTimestamp
		jr := ingresses[j].CreationTimestamp
		return ir.Before(&jr)
	})

	return ingresses
}
```

For the reasons mentioned above, the output of `Server.rootLocation` logic will be equally unstable, resulting in slight differences in `nginx.conf` generated each time, triggering repeated meaningless nginx reload.
`Server.rootLocation`  generate in `controller.createServers()` 
```
for _, ing := range data {
         anns := ing.ParsedAnnotations
	for _, rule := range ing.Spec.Rules {
		if _, ok := servers[host]; ok {
			// server already configured
			continue
		}
		loc := &ingress.Location{
			Path:         rootLocation,
			IsDefBackend: true
		}

                //Because of the unstable order, anns may point to  different ingress.annotaions
		locationApplyAnnotations(loc, anns) 

		servers[host] = &ingress.Server{
			Locations: []*ingress.Location{
				loc,
			}
		}
	}
}
```



**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
