### PR TITLE
Fix dev-env image name

### DIFF
--- a/build/dev-env.sh
+++ b/build/dev-env.sh
@@ -32,7 +32,7 @@ export TAG=dev
 export ARCH=amd64
 export REGISTRY=${REGISTRY:-ingress-controller}
 
-DEV_IMAGE=${REGISTRY}/nginx-ingress-controller:${TAG}
+DEV_IMAGE=${REGISTRY}/nginx-ingress-controller-${ARCH}:${TAG}
 
 if [ -z "${SKIP_MINIKUBE_START}" ]; then
     test "$(minikube status | grep -c Running) -ge 2 && $(minikube status | grep -q 'Correctly Configured')" || minikube start \

--- a/deploy/minikube/kustomization.yaml
+++ b/deploy/minikube/kustomization.yaml
@@ -1,10 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: ingress-nginx
-bases:
-- ../baremetal
-- ../cluster-wide
 images:
 - name: quay.io/kubernetes-ingress-controller/nginx-ingress-controller
-  newName: ingress-controller/nginx-ingress-controller
+  newName: ingress-controller/nginx-ingress-controller-amd64
   newTag: dev
+resources:
+- ../baremetal
+- ../cluster-wide


### PR DESCRIPTION
**What this PR does / why we need it**:

This fixes a mismatch between Makefile `MULTI_ARCH_IMAGE` and `DEV_IMAGE` used in `dev-env.sh`

While running `build/dev-env.sh`, it builds the appropriate container using https://github.com/kubernetes/ingress-nginx/blob/master/build/dev-env.sh#L46

Then, it replaces the image name in deployment files https://github.com/kubernetes/ingress-nginx/blob/master/build/dev-env.sh#L68

But currently, `DEV_IMAGE` does not depend on `ARCH`.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

I'm a bit confused about why this hasn't been seen sooner.

Cc @ElvinEfendi 