### PR TITLE
Add nginx ssl_early_data option support

### DIFF
--- a/docs/user-guide/nginx-configuration/configmap.md
+++ b/docs/user-guide/nginx-configuration/configmap.md
@@ -488,6 +488,14 @@ Sets the [SSL protocols](http://nginx.org/en/docs/http/ngx_http_ssl_module.html#
 
 Please check the result of the configuration using `https://ssllabs.com/ssltest/analyze.html` or `https://testssl.sh`.
 
+## ssl-early-data
+
+Enables or disables TLS 1.3 [early data](https://tools.ietf.org/html/rfc8446#section-2.3)
+
+This requires `ssl-protocols` to have `TLSv1.3` enabled.
+
+[ssl_early_data](http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_early_data). The default is: `false`.
+
 ## ssl-session-cache
 
 Enables or disables the use of shared [SSL cache](http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_cache) among worker processes.

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -75,6 +75,10 @@ const (
 	// http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_protocols
 	sslProtocols = "TLSv1.2"
 
+	// Disable TLS 1.3 early data
+	// http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_early_data
+	sslEarlyData = false
+
 	// Time during which a client may reuse the session parameters stored in a cache.
 	// http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_timeout
 	sslSessionTimeout = "10m"
@@ -316,6 +320,10 @@ type Configuration struct {
 	// SSL enabled protocols to use
 	// http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_protocols
 	SSLProtocols string `json:"ssl-protocols,omitempty"`
+
+	// Enables or disable TLS 1.3 early data.
+	// http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_early_data
+	SSLEarlyData bool `json:"ssl-early-data,omitempty"`
 
 	// Enables or disables the use of shared SSL cache among worker processes.
 	// http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_cache
@@ -683,6 +691,7 @@ func NewDefault() Configuration {
 		SSLCiphers:                       sslCiphers,
 		SSLECDHCurve:                     "auto",
 		SSLProtocols:                     sslProtocols,
+		SSLEarlyData:                     sslEarlyData,
 		SSLSessionCache:                  true,
 		SSLSessionCacheSize:              sslSessionCacheSize,
 		SSLSessionTickets:                true,

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -353,6 +353,8 @@ http {
 
     ssl_protocols {{ $cfg.SSLProtocols }};
 
+    ssl_early_data {{ if $cfg.SSLEarlyData }}on{{ else }}off{{ end }};
+
     # turn on session caching to drastically improve performance
     {{ if $cfg.SSLSessionCache }}
     ssl_session_cache builtin:1000 shared:SSL:{{ $cfg.SSLSessionCacheSize }};


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds support for nginx [ssl_early_data](http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_early_data) configuration in ingress-nginx ConfigMap.

[early_data](https://tools.ietf.org/html/rfc8446#section-2.3) is a TLSv1.3 option that allows reducing connection establishment RTT by 1. But it introduces a replay attack vector.
Nginx provides `ssl_early_data` option to turn on/off that feature.

Default value is `off`.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
