### PR TITLE
Remove invalid log "Failed to executing diff command: exit status 1"

### DIFF
--- a/internal/ingress/controller/nginx.go
+++ b/internal/ingress/controller/nginx.go
@@ -698,7 +698,12 @@ func (n *NGINXController) OnUpdate(ingressCfg ingress.Configuration) error {
 
 			diffOutput, err := exec.Command("diff", "-u", cfgPath, tmpfile.Name()).CombinedOutput()
 			if err != nil {
-				klog.Warningf("Failed to executing diff command: %v", err)
+				if exitError, ok := err.(*exec.ExitError); ok {
+					ws := exitError.Sys().(syscall.WaitStatus)
+					if ws.ExitStatus() == 2 {
+						klog.Warningf("Failed to executing diff command: %v", err)
+					}
+				}
 			}
 
 			klog.Infof("NGINX configuration diff:\n%v", string(diffOutput))


### PR DESCRIPTION
**What this PR does / why we need it**:

From http://man7.org/linux/man-pages/man1/diff.1.html Exit status is 0 if inputs are the same, 1 if different, 2 if trouble.

This is interpreted as "error" but this is true only when the exit code is 2
