### PR TITLE
Add timezone value into $geoip2_time_zone variable

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -172,6 +172,7 @@ http {
         $geoip2_dma_code source=$the_real_ip location metro_code;
         $geoip2_latitude source=$the_real_ip location latitude;
         $geoip2_longitude source=$the_real_ip location longitude;
+        $geoip2_time_zone source=$the_real_ip location time_zone;
         $geoip2_region_code source=$the_real_ip subdivisions 0 iso_code;
         $geoip2_region_name source=$the_real_ip subdivisions 0 names en;
     }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a timezone geoip2 variable `$geoip2_time_zone` according to a source ip. Applications looking for user timezone may get this value from nginx controller directly instead of using another geoip2 request.

