### PR TITLE
Enable publish-service for ClusterIP type service. fixes #4461

### DIFF
--- a/internal/ingress/status/status.go
+++ b/internal/ingress/status/status.go
@@ -185,6 +185,10 @@ func (s *statusSync) runningAddresses() ([]string, error) {
 			return addrs, nil
 		}
 
+		if svc.Spec.Type == apiv1.ServiceTypeClusterIP {
+			addrs = append(addrs, svc.Spec.ClusterIP)
+		}
+
 		for _, ip := range svc.Status.LoadBalancer.Ingress {
 			if ip.IP == "" {
 				addrs = append(addrs, ip.Hostname)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

This pull request enables publishing the `ClusterIP` for `nginx-ingress-controller` service when the service's type is `ClusterIP`.

**Which issue this PR fixes**
fixes #4461 
