### PR TITLE
Always set headers with add-headers option

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -251,7 +251,7 @@ http {
 
     # Custom headers for response
     {{ range $k, $v := $addHeaders }}
-    add_header {{ $k }}            {{ $v | quote }};
+    more_set_headers {{ printf "%s: %s" $k $v | quote }};
     {{ end }}
 
     server_tokens {{ if $cfg.ShowServerTokens }}on{{ else }}off{{ end }};


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
With `nginx-custom-headers` configmap and `add-headers` option.
```yaml
apiVersion: v1
data:
  X-Request-Id: $req_id
kind: ConfigMap
metadata:
  name: nginx-custom-headers
  namespace: default
```

```yaml
apiVersion: v1
data:
  add-headers: default/nginx-custom-headers
kind: ConfigMap
metadata:
  name: nginx-configuration
  namespace: default
```

It should set `X-Request-Id` header to response all the time, but failed at following scenarios because of limits with `add_header` directive.

From the documentation on [add_header](https://nginx.org/en/docs/http/ngx_http_headers_module.html#add_header)

1. when response code is 40x or 50x.
By default, `add_header` adds the specified field to a response header provided only when the response code equals 200, 201 (1.3.10), 204, 206, 301, 302, 303, 304, 307 (1.1.16, 1.0.13), or 308 (1.13.0).

1. when `add_header` used in location block
These directives are inherited from the previous level **if and only if** there are no `add_header` directives defined on the current level.
If an ingress has`nginx.ingress.kubernetes.io/auth-url` annotation, it will not set `X-Request-Id` to the response, because the `add_header Set-Cookie $auth_cookie;` already exists in location.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
fixes #4359

**Special notes for your reviewer**:
None