### PR TITLE
Initialize nginx process error channel

### DIFF
--- a/internal/ingress/controller/nginx.go
+++ b/internal/ingress/controller/nginx.go
@@ -101,6 +101,8 @@ func NewNGINXController(config *Configuration, mc metric.Collector, fs file.File
 		stopCh:   make(chan struct{}),
 		updateCh: channels.NewRingChannel(1024),
 
+		ngxErrCh: make(chan error),
+
 		stopLock: &sync.Mutex{},
 
 		fileSystem: fs,


### PR DESCRIPTION
**What this PR does / why we need it**:

The goroutine created by `(*NGINXController) start()` remains asleep forever without that necessary initialization. As a result, the [`<-n.ngxErrCh`](https://github.com/kubernetes/ingress-nginx/blob/d1feb65ff9afe8d15db26ff45c3845bbdd8d8a7f/internal/ingress/controller/nginx.go#L311-L332) select case is never visited, and the main `nginx` process isn't respawned after it returns.

Leftover from #2164

/kind bug