### PR TITLE
Modified sticky-session management to fix wrong routing when scaling …

### DIFF
--- a/rootfs/etc/nginx/lua/balancer/sticky.lua
+++ b/rootfs/etc/nginx/lua/balancer/sticky.lua
@@ -1,9 +1,7 @@
 local balancer_resty = require("balancer.resty")
-local resty_chash = require("resty.chash")
 local util_nodemap = require("util.nodemap")
 local util = require("util")
 local ck = require("resty.cookie")
-local math = require("math")
 local ngx_balancer = require("ngx.balancer")
 local split = require("util.split")
 

--- a/rootfs/etc/nginx/lua/test/util/nodemap_test.lua
+++ b/rootfs/etc/nginx/lua/test/util/nodemap_test.lua
@@ -1,0 +1,167 @@
+local util = require("util")
+local nodemap = require("util.nodemap")
+
+local function get_test_backend_single()
+  return {
+    name = "access-router-production-web-80",
+    endpoints = {
+      { address = "10.184.7.40", port = "8080", maxFails = 0, failTimeout = 0 }
+    }
+  }
+end
+
+local function get_test_backend_multi()
+  return {
+    name = "access-router-production-web-80",
+    endpoints = {
+      { address = "10.184.7.40", port = "8080", maxFails = 0, failTimeout = 0 },
+      { address = "10.184.7.41", port = "8080", maxFails = 0, failTimeout = 0 }
+    }
+  }
+end
+
+local function get_test_nodes_ignore(endpoint)
+  local ignore = {}
+  ignore[endpoint] = true
+  return ignore
+end
+
+describe("Node Map", function()
+
+  local test_backend_single = get_test_backend_single()
+  local test_backend_multi = get_test_backend_multi()
+  local test_salt = test_backend_single.name
+  local test_nodes_single = util.get_nodes(test_backend_single.endpoints)
+  local test_nodes_multi = util.get_nodes(test_backend_multi.endpoints)
+  local test_endpoint1 = test_backend_multi.endpoints[1].address .. ":" .. test_backend_multi.endpoints[1].port
+  local test_endpoint2 = test_backend_multi.endpoints[2].address .. ":" .. test_backend_multi.endpoints[2].port
+  local test_nodes_ignore = get_test_nodes_ignore(test_endpoint1)
+
+  describe("new()", function()
+    context("when no salt has been provided", function()
+      it("random() returns an unsalted key", function()
+        local nodemap_instance = nodemap:new(test_nodes_single, nil)
+        local expected_endpoint = test_endpoint1
+        local expected_hash_key = ngx.md5(expected_endpoint)
+        local actual_endpoint
+        local actual_hash_key
+
+        actual_endpoint, actual_hash_key = nodemap_instance:random()
+
+        assert.equal(actual_endpoint, expected_endpoint)
+        assert.equal(expected_hash_key, actual_hash_key)
+      end)
+    end)
+
+    context("when a salt has been provided", function()
+      it("random() returns a salted key", function()
+        local nodemap_instance = nodemap:new(test_nodes_single, test_salt)
+        local expected_endpoint = test_endpoint1
+        local expected_hash_key = ngx.md5(test_salt .. expected_endpoint)
+        local actual_endpoint
+        local actual_hash_key
+
+        actual_endpoint, actual_hash_key = nodemap_instance:random()
+
+        assert.equal(actual_endpoint, expected_endpoint)
+        assert.equal(expected_hash_key, actual_hash_key)
+      end)
+    end)
+
+    context("when no nodes have been provided", function()
+      it("random() returns nil", function()
+        local nodemap_instance = nodemap:new({}, test_salt)
+        local actual_endpoint
+        local actual_hash_key
+
+        actual_endpoint, actual_hash_key = nodemap_instance:random()
+
+        assert.equal(actual_endpoint, nil)
+        assert.equal(expected_hash_key, nil)
+      end)
+    end)
+  end)
+
+  describe("find()", function()
+    before_each(function()
+      package.loaded["util.nodemap"] = nil
+      nodemap = require("util.nodemap")
+    end)
+
+    context("when a hash key is valid", function()
+      it("find() returns the correct endpoint", function()
+        local nodemap_instance = nodemap:new(test_nodes_single, test_salt)
+        local test_hash_key
+        local expected_endpoint
+        local actual_endpoint
+
+        expected_endpoint, test_hash_key = nodemap_instance:random()
+        assert.not_equal(expected_endpoint, nil)
+        assert.not_equal(test_hash_key, nil)
+
+        actual_endpoint = nodemap_instance:find(test_hash_key)
+        assert.equal(actual_endpoint, expected_endpoint)
+      end)
+    end)
+
+    context("when a hash key is invalid", function()
+      it("find() returns nil", function()
+        local nodemap_instance = nodemap:new(test_nodes_single, test_salt)
+        local test_hash_key = "invalid or nonexistent hash key"
+        local actual_endpoint
+
+        actual_endpoint = nodemap_instance:find(test_hash_key)
+
+        assert.equal(actual_endpoint, nil)
+      end)
+    end)
+  end)
+
+
+  describe("random_except()", function()
+    before_each(function()
+      package.loaded["util.nodemap"] = nil
+      nodemap = require("util.nodemap")
+    end)
+
+    context("when nothing has been excluded", function()
+      it("random_except() returns the correct endpoint", function()
+        local nodemap_instance = nodemap:new(test_nodes_single, test_salt)
+        local expected_endpoint = test_endpoint1
+        local test_hash_key
+        local actual_endpoint
+
+        actual_endpoint, test_hash_key = nodemap_instance:random_except({})
+        assert.equal(expected_endpoint, actual_endpoint)
+        assert.not_equal(test_hash_key, nil)
+      end)
+    end)
+
+    context("when everything has been excluded", function()
+      it("random_except() returns nil", function()
+        local nodemap_instance = nodemap:new(test_nodes_single, test_salt)
+        local actual_hash_key
+        local actual_endpoint
+
+        actual_endpoint, actual_hash_key = nodemap_instance:random_except(test_nodes_ignore)
+
+        assert.equal(actual_endpoint, nil)
+        assert.equal(actual_hash_key, nil)
+      end)
+    end)
+
+    context("when an endpoint has been excluded", function()
+      it("random_except() does not return it", function()
+        local nodemap_instance = nodemap:new(test_nodes_multi, test_salt)
+        local expected_endpoint = test_endpoint2
+        local actual_endpoint
+        local test_hash_key
+
+        actual_endpoint, test_hash_key = nodemap_instance:random_except(test_nodes_ignore)
+
+        assert.equal(actual_endpoint, expected_endpoint)
+        assert.not_equal(test_hash_key, nil)
+      end)
+    end)
+  end)
+end)

--- a/rootfs/etc/nginx/lua/util/nodemap.lua
+++ b/rootfs/etc/nginx/lua/util/nodemap.lua
@@ -1,0 +1,120 @@
+local math = require("math")
+local util = require("util")
+
+local _M = {}
+
+--- create_map generates the node hash table
+-- @tparam {[string]=number} nodes A table with the node as a key and its weight as a value.
+-- @tparam string salt A salt that will be used to generate salted hash keys.
+local function create_map(nodes, salt)
+  local hash_map = {}
+
+  for endpoint, _ in pairs(nodes) do
+    -- obfuscate the endpoint with a shared key to prevent brute force
+    -- and rainbow table attacks which could reveal internal endpoints
+    local key = salt .. endpoint
+    local hash_key = ngx.md5(key)
+    hash_map[hash_key] = endpoint
+  end
+
+  return hash_map
+end
+
+--- get_random_node picks a random node from the given map.
+-- @tparam {[string], ...} map A key to node hash table.
+-- @treturn string,string The node and its key
+local function get_random_node(map)
+  local size = util.tablelength(map)
+
+  if size < 1 then
+    return nil, nil
+  end
+
+  local index = math.random(1, size)
+  local count = 1
+
+  for key, endpoint in pairs(map) do
+      if count == index then
+        return endpoint, key
+      end
+
+      count = count + 1
+  end
+
+  ngx.log(ngx.ERR, string.format("Failed to find element number %d in a map of size %d! This is a bug, please report!", index, size))
+
+  return nil, nil
+end
+
+--- new constructs a new instance of the node map
+--
+-- The map uses MD5 to create hash keys for a given node. For security reasons it supports
+-- salted hash keys, to prevent attackers from using rainbow tables or brute forcing
+-- the node endpoints, which would reveal cluster internal network information.
+--
+-- To make sure hash keys are reproducible on different ingress controller instances the salt
+-- needs to be shared and therefore is not simply generated randomly.
+--
+-- @tparam {[string]=number} endpoints A table with the node endpoint as a key and its weight as a value.
+-- @tparam[opt] string hash_salt A optional hash salt that will be used to obfuscate the hash key.
+function _M.new(self, endpoints, hash_salt)
+
+  if hash_salt == nil then
+    hash_salt = ''
+  end
+
+  -- the endpoints have to be saved as 'nodes' to keep compatibility to balancer.resty
+  local o = {
+    salt = hash_salt,
+    nodes = endpoints,
+    map = create_map(endpoints, hash_salt)
+  }
+
+  setmetatable(o, self)
+  self.__index = self
+  return o
+end
+
+--- reinit reinitializes the node map reusing the original salt
+-- @tparam {[string]=number} nodes A table with the node as a key and its weight as a value.
+function _M.reinit(self, nodes)
+  self.nodes = nodes
+  self.map = create_map(nodes, self.salt)
+end
+
+--- find looks up a node by hash key.
+-- @tparam string key The hash key.
+-- @treturn string The node.
+function _M.find(self, key)
+  return self.map[key]
+end
+
+--- random picks a random node from the hashmap.
+-- @treturn string,string A random node and its key or both nil.
+function _M.random(self)
+  return get_random_node(self.map)
+end
+
+--- random_except picks a random node from the hashmap, ignoring the nodes in the given table
+-- @tparam {string, } ignore_nodes A table of nodes to ignore, the node needs to be the key, the value needs to be set to true
+-- @treturn string,string A random node and its key or both nil.
+function _M.random_except(self, ignore_nodes)
+  local valid_nodes = {}
+  local ignore_nodes_size = util.tablelength(ignore_nodes)
+
+  -- avoid generating the map if no ignores where provided
+  if ignore_nodes_size == 0 then
+    return get_random_node(self.map)
+  end
+
+  -- generate valid endpoints
+  for key, endpoint in pairs(self.map) do
+      if not ignore_nodes[endpoint] then
+        valid_nodes[key] = endpoint
+      end
+  end
+
+  return get_random_node(valid_nodes)
+end
+
+return _M

--- a/rootfs/etc/nginx/lua/util/nodemap.lua
+++ b/rootfs/etc/nginx/lua/util/nodemap.lua
@@ -41,7 +41,7 @@ local function get_random_node(map)
       count = count + 1
   end
 
-  ngx.log(ngx.ERR, string.format("Failed to find element number %d in a map of size %d! This is a bug, please report!", index, size))
+  ngx.log(ngx.ERR, string.format("Failed to find node %d of %d! This is a bug, please report!", index, size))
 
   return nil, nil
 end
@@ -96,14 +96,14 @@ function _M.random(self)
 end
 
 --- random_except picks a random node from the hashmap, ignoring the nodes in the given table
--- @tparam {string, } ignore_nodes A table of nodes to ignore, the node needs to be the key, the value needs to be set to true
+-- @tparam {string, } ignore_nodes A table of nodes to ignore, the node needs to be the key,
+--                                 the value needs to be set to true
 -- @treturn string,string A random node and its key or both nil.
 function _M.random_except(self, ignore_nodes)
   local valid_nodes = {}
-  local ignore_nodes_size = util.tablelength(ignore_nodes)
 
   -- avoid generating the map if no ignores where provided
-  if ignore_nodes_size == 0 then
+  if ignore_nodes == nil or util.tablelength(ignore_nodes) == 0 then
     return get_random_node(self.map)
   end
 


### PR DESCRIPTION
…or restarting pods

**What this PR does / why we need it**:
It fixes a bug where users lose their sessions when deployments are scaled or when pods are restarted.

**Which issue this PR fixes**: fixes kubernetes/ingress-nginx#4475

**Special notes for your reviewer**:
The new implementation uses a hash of the endpoint as routing cookie. The hash is salted for security reasons to prevent brute force or rainbow table attacks which could reveal information about the cluster internal network.

Each ingress controller generates a hash map of all endpoints to resolve incoming routing cookies. This way only users of dead pods will lose their session.

