### PR TITLE
point users to kubectl ingress-nginx plugin

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -408,6 +408,17 @@ http {
     {{ end }}
 
     upstream upstream_balancer {
+        ### Attention!!!
+        #
+        # We no longer create "upstream" section for every backend.
+        # Backends are handled dynamically using Lua. If you would like to debug
+        # and see what backends ingress-nginx has in its memory you can
+        # install our kubectl plugin https://kubernetes.github.io/ingress-nginx/kubectl-plugin.
+        # Once you have the plugin you can use "kubectl ingress-nginx backends" command to
+        # inspect current backends.
+        #
+        ###
+
         server 0.0.0.1; # placeholder
 
         balancer_by_lua_block {


### PR DESCRIPTION
**What this PR does / why we need it**:

I noticed people still inspect Nginx configuration to look for upstream definitions. Hopefully this message will point them to the right direction.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
