### PR TITLE
Fix relative links

### DIFF
--- a/docs/user-guide/nginx-configuration/annotations.md
+++ b/docs/user-guide/nginx-configuration/annotations.md
@@ -443,7 +443,7 @@ If you specify multiple annotations in a single Ingress rule, limits are applied
 
 To configure settings globally for all Ingress rules, the `limit-rate-after` and `limit-rate` values may be set in the [NGINX ConfigMap](./configmap.md#limit-rate).  The value set in an Ingress annotation will override the global setting.
 
-The client IP address will be set based on the use of [PROXY protocol](./configmap/#use-proxy-protocol) or from the `X-Forwarded-For` header value when [use-forwarded-headers](configmap/#use-forwarded-headers) is enabled.
+The client IP address will be set based on the use of [PROXY protocol](./configmap.md#use-proxy-protocol) or from the `X-Forwarded-For` header value when [use-forwarded-headers](./configmap.md#use-forwarded-headers) is enabled.
 
 ### Permanent Redirect
 


### PR DESCRIPTION
The links in the last paragraph of https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#rate-limiting don't work as intended. I took over the format from a working link, not totally sure if that is the right way. Feel free to adjust or discard this pull request.