### PR TITLE
Show current reloads count, not total

### DIFF
--- a/deploy/grafana/dashboards/nginx.json
+++ b/deploy/grafana/dashboards/nginx.json
@@ -372,9 +372,9 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "avg(nginx_ingress_controller_success{controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$namespace\"})",
+          "expr": "avg(irate(nginx_ingress_controller_success{controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$namespace\"}[1m])) * 60",
           "format": "time_series",
-          "instant": true,
+          "instant": false,
           "intervalFactor": 1,
           "refId": "A",
           "step": 4
@@ -392,7 +392,7 @@
           "value": "null"
         }
       ],
-      "valueName": "avg"
+      "valueName": "total"
     },
     {
       "cacheTimeout": null,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: This PR improves the Grafana dashboard by displaying the reloads count related to the currently selected period rather than an overall cumulative total which doesn't really help.

**Special notes for your reviewer**:

It changes this:

![Previous graph version](https://i.imgur.com/DsFK0K9.png)

Into this:

![Proposed graph version](https://i.imgur.com/aK2phrm.png)