### PR TITLE
Improve the time to run e2e tests

### DIFF
--- a/build/run-in-docker.sh
+++ b/build/run-in-docker.sh
@@ -30,7 +30,7 @@ function cleanup {
 }
 trap cleanup EXIT
 
-E2E_IMAGE=quay.io/kubernetes-ingress-controller/e2e:v09042019-11ed7fc84
+E2E_IMAGE=quay.io/kubernetes-ingress-controller/e2e:v09052019-38b985663
 
 DOCKER_OPTS=${DOCKER_OPTS:-}
 

--- a/images/e2e/Dockerfile
+++ b/images/e2e/Dockerfile
@@ -22,6 +22,7 @@ RUN clean-install \
   make \
   wget \
   python \
+  parallel \
   pkg-config
 
 ENV GOLANG_VERSION 1.13

--- a/test/e2e-image/Dockerfile
+++ b/test/e2e-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/kubernetes-ingress-controller/e2e:v09042019-11ed7fc84 AS BASE
+FROM quay.io/kubernetes-ingress-controller/e2e:v09052019-38b985663 AS BASE
 
 FROM quay.io/kubernetes-ingress-controller/debian-base-amd64:0.1
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

This change reduces the setup time of the e2e tests by half, decreasing the total time from ~24 to ~18 minutes.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
