### PR TITLE
Correctly format ipv6 resolver config for lua

### DIFF
--- a/rootfs/etc/nginx/lua/util/resolv_conf.lua
+++ b/rootfs/etc/nginx/lua/util/resolv_conf.lua
@@ -51,6 +51,9 @@ local function parse_line(line)
   local keyword, value = parts[1], parts[2]
 
   if keyword == "nameserver" then
+    if not value:match("^%d+.%d+.%d+.%d+$") then
+      value = string.format("[%s]", value)
+    end
     nameservers[#nameservers + 1] = value
   elseif keyword == "search" then
     set_search(parts)


### PR DESCRIPTION
It seems that when support was added for parsing resolv_conf directly a regression was introduced which effectively breaks anyone with ipv6 resolvers.

Regression of #3895