### PR TITLE
Add support for configmap of headers for auth-url per ingress

### DIFF
--- a/docs/user-guide/nginx-configuration/annotations.md
+++ b/docs/user-guide/nginx-configuration/annotations.md
@@ -30,6 +30,7 @@ You can add these Kubernetes annotations to specific Ingress objects to customiz
 |[nginx.ingress.kubernetes.io/auth-url](#external-authentication)|string|
 |[nginx.ingress.kubernetes.io/auth-cache-key](#external-authentication)|string|
 |[nginx.ingress.kubernetes.io/auth-cache-duration](#external-authentication)|string|
+|[nginx.ingress.kubernetes.io/auth-proxy-set-headers](#external-authentication)|string|
 |[nginx.ingress.kubernetes.io/auth-snippet](#external-authentication)|string|
 |[nginx.ingress.kubernetes.io/enable-global-auth](#external-authentication)|"true" or "false"|
 |[nginx.ingress.kubernetes.io/backend-protocol](#backend-protocol)|string|HTTP,HTTPS,GRPC,GRPCS,AJP|
@@ -414,6 +415,8 @@ Additionally it is possible to set:
   `<SignIn_URL>` to specify the location of the error page.
 * `nginx.ingress.kubernetes.io/auth-response-headers`:
   `<Response_Header_1, ..., Response_Header_n>` to specify headers to pass to backend once authentication request completes.
+* `nginx.ingress.kubernetes.io/auth-proxy-set-headers`:
+  `<ConfigMap>` the name of a ConfigMap that specifies headers to pass to the authentication service
 * `nginx.ingress.kubernetes.io/auth-request-redirect`:
   `<Request_Redirect_URL>`  to specify the X-Auth-Request-Redirect header value.
 * `nginx.ingress.kubernetes.io/auth-cache-key`:

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -645,7 +645,7 @@ func NewDefault() Configuration {
 	defNginxStatusIpv4Whitelist = append(defNginxStatusIpv4Whitelist, "127.0.0.1")
 	defNginxStatusIpv6Whitelist = append(defNginxStatusIpv6Whitelist, "::1")
 	defProxyDeadlineDuration := time.Duration(5) * time.Second
-	defGlobalExternalAuth := GlobalExternalAuth{"", "", "", "", append(defResponseHeaders, ""), "", "", "", []string{}}
+	defGlobalExternalAuth := GlobalExternalAuth{"", "", "", "", append(defResponseHeaders, ""), "", "", "", []string{}, map[string]string{}}
 
 	cfg := Configuration{
 		AllowBackendServerHeader:         false,
@@ -820,12 +820,13 @@ type ListenPorts struct {
 type GlobalExternalAuth struct {
 	URL string `json:"url"`
 	// Host contains the hostname defined in the URL
-	Host              string   `json:"host"`
-	SigninURL         string   `json:"signinUrl"`
-	Method            string   `json:"method"`
-	ResponseHeaders   []string `json:"responseHeaders,omitempty"`
-	RequestRedirect   string   `json:"requestRedirect"`
-	AuthSnippet       string   `json:"authSnippet"`
-	AuthCacheKey      string   `json:"authCacheKey"`
-	AuthCacheDuration []string `json:"authCacheDuration"`
+	Host              string            `json:"host"`
+	SigninURL         string            `json:"signinUrl"`
+	Method            string            `json:"method"`
+	ResponseHeaders   []string          `json:"responseHeaders,omitempty"`
+	RequestRedirect   string            `json:"requestRedirect"`
+	AuthSnippet       string            `json:"authSnippet"`
+	AuthCacheKey      string            `json:"authCacheKey"`
+	AuthCacheDuration []string          `json:"authCacheDuration"`
+	ProxySetHeaders   map[string]string `json:"proxySetHeaders,omitempty"`
 }

--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -141,6 +141,7 @@ var (
 		"buildAuthLocation":               buildAuthLocation,
 		"shouldApplyGlobalAuth":           shouldApplyGlobalAuth,
 		"buildAuthResponseHeaders":        buildAuthResponseHeaders,
+		"buildAuthProxySetHeaders":        buildAuthProxySetHeaders,
 		"buildProxyPass":                  buildProxyPass,
 		"filterRateLimits":                filterRateLimits,
 		"buildRateLimitZones":             buildRateLimitZones,
@@ -459,6 +460,19 @@ func buildAuthResponseHeaders(headers []string) []string {
 		hvar = strings.NewReplacer("-", "_").Replace(hvar)
 		res = append(res, fmt.Sprintf("auth_request_set $authHeader%v $upstream_http_%v;", i, hvar))
 		res = append(res, fmt.Sprintf("proxy_set_header '%v' $authHeader%v;", h, i))
+	}
+	return res
+}
+
+func buildAuthProxySetHeaders(headers map[string]string) []string {
+	res := []string{}
+
+	if len(headers) == 0 {
+		return res
+	}
+
+	for name, value := range headers {
+		res = append(res, fmt.Sprintf("proxy_set_header '%v' '%v';", name, value))
 	}
 	return res
 }

--- a/internal/ingress/controller/template/template_test.go
+++ b/internal/ingress/controller/template/template_test.go
@@ -450,6 +450,23 @@ func TestBuildAuthResponseHeaders(t *testing.T) {
 	}
 }
 
+func TestBuildAuthProxySetHeaders(t *testing.T) {
+	proxySetHeaders := map[string]string{
+		"header1": "value1",
+		"header2": "value2",
+	}
+	expected := []string{
+		"proxy_set_header 'header1' 'value1';",
+		"proxy_set_header 'header2' 'value2';",
+	}
+
+	headers := buildAuthProxySetHeaders(proxySetHeaders)
+
+	if !reflect.DeepEqual(expected, headers) {
+		t.Errorf("Expected \n'%v'\nbut returned \n'%v'", expected, headers)
+	}
+}
+
 func TestTemplateWithData(t *testing.T) {
 	pwd, _ := os.Getwd()
 	f, err := os.Open(path.Join(pwd, "../../../../test/data/config.json"))

--- a/internal/ingress/resolver/mock.go
+++ b/internal/ingress/resolver/mock.go
@@ -17,6 +17,8 @@ limitations under the License.
 package resolver
 
 import (
+	"errors"
+
 	apiv1 "k8s.io/api/core/v1"
 
 	"k8s.io/ingress-nginx/internal/ingress/defaults"
@@ -24,16 +26,12 @@ import (
 
 // Mock implements the Resolver interface
 type Mock struct {
+	ConfigMaps map[string]*apiv1.ConfigMap
 }
 
 // GetDefaultBackend returns the backend that must be used as default
 func (m Mock) GetDefaultBackend() defaults.Backend {
 	return defaults.Backend{}
-}
-
-// GetConfigMap searches for configmap containing the namespace and name usting the character /
-func (m Mock) GetConfigMap(string) (*apiv1.ConfigMap, error) {
-	return nil, nil
 }
 
 // GetSecret searches for secrets contenating the namespace and name using a the character /
@@ -51,4 +49,12 @@ func (m Mock) GetAuthCertificate(string) (*AuthSSLCert, error) {
 // GetService searches for services contenating the namespace and name using a the character /
 func (m Mock) GetService(string) (*apiv1.Service, error) {
 	return nil, nil
+}
+
+// GetConfigMap searches for configMaps contenating the namespace and name using a the character /
+func (m Mock) GetConfigMap(name string) (*apiv1.ConfigMap, error) {
+	if v, ok := m.ConfigMaps[name]; ok {
+		return v, nil
+	}
+	return nil, errors.New("no configmap")
 }

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -935,6 +935,10 @@ stream {
             proxy_set_header ssl-client-issuer-dn   $ssl_client_i_dn;
             {{ end }}
 
+            {{- range $line := buildAuthProxySetHeaders $externalAuth.ProxySetHeaders}}
+            {{ $line }}
+            {{- end }}
+
             {{ if not (empty $externalAuth.AuthSnippet) }}
             {{ $externalAuth.AuthSnippet }}
             {{ end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a new annotation `nginx.ingress.kubernetes.io/auth-proxy-set-headers` which specifies a ConfigMap of `header: value` which are passed to an external authentication service when `nginx.ingress.kubernetes.io/auth-url` is set.

This is valuable to reduce the use of snippets to set headers for each ingress. The ingress validates that the keys and values will produce a valid nginx configuration.