### PR TITLE
Attempt AAAA before A

### DIFF
--- a/rootfs/etc/nginx/lua/util/dns.lua
+++ b/rootfs/etc/nginx/lua/util/dns.lua
@@ -15,7 +15,7 @@ local _M = {}
 local CACHE_SIZE = 10000
 local MAXIMUM_TTL_VALUE = 2147483647 -- maximum value according to https://tools.ietf.org/html/rfc2181
 -- for every host we will try two queries for the following types with the order set here
-local QTYPES_TO_CHECK = { resolver.TYPE_A, resolver.TYPE_AAAA }
+local QTYPES_TO_CHECK = { resolver.TYPE_AAAA, resolver.TYPE_A }
 
 local cache
 do


### PR DESCRIPTION
This is common-practice for systems. Generally if a domain has ipv6 it also has ipv4, so if we query ipv4 always we effectively never use ipv6.

Ideally this would be (1) configurable or (2) smart enough to know if we have a ipv6 capability