### PR TITLE
Ignore default certificate during server initialization

### DIFF
--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -1090,8 +1090,8 @@ func (n *NGINXController) createServers(data []*ingress.Ingress,
 				servers[host].SSLCiphers = anns.SSLCiphers
 			}
 
-			// only add a certificate if the server does not have one previously configured
-			if servers[host].SSLCert != nil {
+			// only add a certificate if the server does not have one previously configured that is not the default
+			if servers[host].SSLCert != nil && servers[host].SSLCert.PemFileName != n.cfg.DefaultSSLCertificate && servers[host].SSLCert != n.cfg.FakeCertificate {
 				continue
 			}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Recreation of #2279. When the oldest Ingress for a domain contains a TLS section, but no secret, the default certificate will always be used, even though a newer Ingress may contain a valid secret.

This PR tries to change the behavior from ignoring all further certificates if any certificate is present to ignoring all further certificates if any non-default certificate is present

**Special notes for your reviewer**: See the old PR for examples
