### PR TITLE
allow to configure jaeger header names

### DIFF
--- a/docs/user-guide/nginx-configuration/configmap.md
+++ b/docs/user-guide/nginx-configuration/configmap.md
@@ -125,6 +125,10 @@ The following table shows a configuration option's name, type, and the default v
 |[jaeger-sampler-param](#jaeger-sampler-param)|string|"1"|
 |[jaeger-sampler-host](#jaeger-sampler-host)|string|"http://127.0.0.1"|
 |[jaeger-sampler-port](#jaeger-sampler-port)|int|5778|
+|[jaeger-trace-context-header-name](#jaeger-trace-context-header-name)|string|uber-trace-id|
+|[jaeger-debug-header](#jaeger-debug-header)|string|uber-debug-id|
+|[jaeger-baggage-header](#jaeger-baggage-header)|string|jaeger-baggage|
+|[jaeger-trace-baggage-header-prefix](#jaeger-trace-baggage-header-prefix)|string|uberctx-|
 |[main-snippet](#main-snippet)|string|""|
 |[http-snippet](#http-snippet)|string|""|
 |[server-snippet](#server-snippet)|string|""|
@@ -746,6 +750,22 @@ Leave blank to use default value (localhost). _**default:**_ http://127.0.0.1
 ## jaeger-sampler-port
 
 Specifies the custom remote sampler port to be passed to the sampler constructor. Must be a number. _**default:**_ 5778
+
+## jaeger-trace-context-header-name
+
+Specifies the header name used for passing trace context. _**default:**_ uber-trace-id
+
+## jaeger-debug-header
+
+Specifies the header name used for force sampling. _**default:**_ jaeger-debug-id
+
+## jaeger-baggage-header
+
+Specifies the header name used to submit baggage if there is no root span. _**default:**_ jaeger-baggage
+
+## jaeger-tracer-baggage-header-prefix
+
+Specifies the header prefix used to propagate baggage. _**default:**_ uberctx-
 
 ## main-snippet
 

--- a/docs/user-guide/third-party-addons/opentracing.md
+++ b/docs/user-guide/third-party-addons/opentracing.md
@@ -59,6 +59,18 @@ jaeger-sampler-host
 # Specifies the custom remote sampler port to be passed to the sampler constructor. Must be a number. Default: 5778
 jaeger-sampler-port
 
+# Specifies the header name used for passing trace context. Must be a string. Default: uber-trace-id
+jaeger-trace-context-header-name
+
+# Specifies the header name used for force sampling. Must be a string. Default: jaeger-debug-id
+jaeger-debug-header
+
+# Specifies the header name used to submit baggage if there is no root span. Must be a string. Default: jaeger-baggage
+jaeger-baggage-header
+
+# Specifies the header prefix used to propagate baggage. Must be a string. Default: uberctx-
+jaeger-tracer-baggage-header-prefix
+
 # specifies the port to use when uploading traces, Default 8126
 datadog-collector-port
 

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -515,6 +515,22 @@ type Configuration struct {
 	// Default: 5778
 	JaegerSamplerPort int `json:"jaeger-sampler-port"`
 
+	// JaegerTraceContextHeaderName specifies the header name used for passing trace context
+	// Default: uber-trace-id
+	JaegerTraceContextHeaderName string `json:"jaeger-trace-context-header-name"`
+
+	// JaegerDebugHeader specifies the header name used for force sampling
+	// Default: jaeger-debug-id
+	JaegerDebugHeader string `json:"jaeger-debug-header"`
+
+	// JaegerBaggageHeader specifies the header name used to submit baggage if there is no root span
+	// Default: jaeger-baggage
+	JaegerBaggageHeader string `json:"jaeger-baggage-header"`
+
+	// TraceBaggageHeaderPrefix specifies the header prefix used to propagate baggage
+	// Default: uberctx-
+	JaegerTraceBaggageHeaderPrefix string `json:"jaeger-tracer-baggage-header-prefix"`
+
 	// DatadogCollectorHost specifies the datadog agent host to use when uploading traces
 	DatadogCollectorHost string `json:"datadog-collector-host"`
 

--- a/internal/ingress/controller/nginx.go
+++ b/internal/ingress/controller/nginx.go
@@ -1067,7 +1067,13 @@ const jaegerTmpl = `{
   },
   "reporter": {
 	"localAgentHostPort": "{{ .JaegerCollectorHost }}:{{ .JaegerCollectorPort }}"
-  }
+  },
+  "headers": {
+	"TraceContextHeaderName": "{{ .JaegerTraceContextHeaderName }}",
+	"jaegerDebugHeader": "{{ .JaegerDebugHeader }}",
+	"jaegerBaggageHeader": "{{ .JaegerBaggageHeader }}",
+	"traceBaggageHeaderPrefix": "{{ .JaegerTraceBaggageHeaderPrefix }}"
+  },
 }`
 
 const datadogTmpl = `{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

This PR allows to configure jaeger header names as mentioned in [https://github.com/opentracing-contrib/nginx-opentracing#getting-started](url)


