### PR TITLE
Avoid unnecessary reloads generating lua_shared_dict directives

### DIFF
--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -267,6 +267,8 @@ func buildLuaSharedDictionaries(c interface{}, s interface{}, disableLuaRestyWAF
 		}
 	}
 
+	sort.Strings(out)
+
 	return strings.Join(out, ";\n") + ";\n"
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Running the controller with `--v=2` the lua_shared_dict order changes and forces a reload

```
-	lua_shared_dict configuration_data 20M;
-	lua_shared_dict certificate_data 20M;
-	lua_shared_dict balancer_ewma 10M;
 	lua_shared_dict balancer_ewma_last_touched_at 10M;
 	lua_shared_dict balancer_ewma_locks 1M;
 	lua_shared_dict certificate_servers 5M;
+	lua_shared_dict configuration_data 20M;
+	lua_shared_dict certificate_data 20M;
+	lua_shared_dict balancer_ewma 10M;

```
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #


**Special notes for your reviewer**:
