### PR TITLE
tls user guide --default-ssl-certificate clarification

### DIFF
--- a/docs/user-guide/tls.md
+++ b/docs/user-guide/tls.md
@@ -34,6 +34,9 @@ If this flag is not provided NGINX will use a self-signed certificate.
 For instance, if you have a TLS secret `foo-tls` in the `default` namespace,
 add `--default-ssl-certificate=default/foo-tls` in the `nginx-controller` deployment.
 
+The default certificate will also be used for ingress `tls:` sections that do not
+have a `secretName` option.
+
 ## SSL Passthrough
 
 The [`--enable-ssl-passthrough`](cli-arguments/) flag enables the SSL Passthrough feature, which is disabled by


### PR DESCRIPTION
Evidently the `--default-ssl-certificate` option is used not only for the catch-all server, but also for all ingress `tls:` sections that don't have a `secretName` option. This doesn't seem to be documented anywhere, hence this change.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
