### PR TITLE
cleanup unused certificates

### DIFF
--- a/internal/ingress/controller/nginx_test.go
+++ b/internal/ingress/controller/nginx_test.go
@@ -205,7 +205,7 @@ func TestConfigureDynamically(t *testing.T) {
 					}
 				case "/configuration/servers":
 					{
-						if !strings.Contains(body, `{"certificates":{},"servers":{}}`) {
+						if !strings.Contains(body, `{"certificates":{},"servers":{"myapp.fake":"-1"}}`) {
 							t.Errorf("controllerPodsCount should be present in JSON content: %v", body)
 						}
 					}
@@ -330,13 +330,18 @@ func TestConfigureCertificates(t *testing.T) {
 	}
 	defer streamListener.Close()
 
-	servers := []*ingress.Server{{
-		Hostname: "myapp.fake",
-		SSLCert: &ingress.SSLCert{
-			PemCertKey: "fake-cert",
-			UID:        "c89a5111-b2e9-4af8-be19-c2a4a924c256",
+	servers := []*ingress.Server{
+		{
+			Hostname: "myapp.fake",
+			SSLCert: &ingress.SSLCert{
+				PemCertKey: "fake-cert",
+				UID:        "c89a5111-b2e9-4af8-be19-c2a4a924c256",
+			},
 		},
-	}}
+		{
+			Hostname: "myapp.nossl",
+		},
+	}
 
 	server := &httptest.Server{
 		Listener: listener,
@@ -363,8 +368,14 @@ func TestConfigureCertificates(t *testing.T) {
 				}
 
 				for _, server := range servers {
-					if server.SSLCert.UID != conf.Servers[server.Hostname] {
-						t.Errorf("Expected servers and posted servers to be equal")
+					if server.SSLCert == nil {
+						if conf.Servers[server.Hostname] != emptyUID {
+							t.Errorf("Expected server %s to have UID of %s but got %s", server.Hostname, emptyUID, conf.Servers[server.Hostname])
+						}
+					} else {
+						if server.SSLCert.UID != conf.Servers[server.Hostname] {
+							t.Errorf("Expected server %s to have UID of %s but got %s", server.Hostname, server.SSLCert.UID, conf.Servers[server.Hostname])
+						}
 					}
 				}
 			}),


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently when TLS section from an ingress is removed we don't cleanup corresponding certificate from Lua shared dict. This PR makes sure we clean them up. Notice that I'm still not cleaning the certificate itself and deleting only server. I can not delete certificate because relationship between certificates and servers is one to many.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
