### PR TITLE
Rollback change of ModSecurity setting SecAuditLog

### DIFF
--- a/docs/user-guide/third-party-addons/modsecurity.md
+++ b/docs/user-guide/third-party-addons/modsecurity.md
@@ -8,8 +8,8 @@ The default ModSecurity configuration file is located in `/etc/nginx/modsecurity
 To enable the ModSecurity feature we need to specify `enable-modsecurity: "true"` in the configuration configmap.
 
 >__Note:__ the default configuration use detection only, because that minimizes the chances of post-installation disruption.
-The file `/var/log/modsec_audit.log` contains the log of ModSecurity.
-
+Due to the value of the setting [SecAuditLogType=Concurrent](https://github.com/SpiderLabs/ModSecurity/wiki/Reference-Manual-(v2.x)#secauditlogtype) the ModSecurity log is stored in multiple files inside the directory `/var/log/audit`.
+The default `Serial` value in SecAuditLogType can impact performance.
 
 The OWASP ModSecurity Core Rule Set (CRS) is a set of generic attack detection rules for use with ModSecurity or compatible web application firewalls. The CRS aims to protect web applications from a wide range of attacks, including the OWASP Top Ten, with a minimum of false alerts.
 The directory `/etc/nginx/owasp-modsecurity-crs` contains the [owasp-modsecurity-crs repository](https://github.com/SpiderLabs/owasp-modsecurity-crs).

--- a/images/nginx/rootfs/build.sh
+++ b/images/nginx/rootfs/build.sh
@@ -332,8 +332,8 @@ cp unicode.mapping /etc/nginx/modsecurity/unicode.mapping
 # Replace serial logging with concurrent
 sed -i 's|SecAuditLogType Serial|SecAuditLogType Concurrent|g' /etc/nginx/modsecurity/modsecurity.conf
 
-# Use stdout for modsecurity logs
-sed -i 's|SecAuditLog /var/log/modsec_audit.log|SecAuditLog /dev/stdout|g' /etc/nginx/modsecurity/modsecurity.conf
+# Concurrent logging implies the log is stored in several files
+echo "SecAuditLogStorageDir /var/log/audit/" >> /etc/nginx/modsecurity/modsecurity.conf
 
 # Download owasp modsecurity crs
 cd /etc/nginx/
@@ -576,6 +576,7 @@ writeDirs=( \
   /opt/modsecurity/var/log \
   /opt/modsecurity/var/upload \
   /opt/modsecurity/var/audit \
+  /var/log/audit \
 );
 
 for dir in "${writeDirs[@]}"; do


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

The last update of the image changed the default file to stdout, something that is too verbose and also with a format not compatible with nginx.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
