### PR TITLE
sort auth proxy headers from configmap

### DIFF
--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -474,6 +474,7 @@ func buildAuthProxySetHeaders(headers map[string]string) []string {
 	for name, value := range headers {
 		res = append(res, fmt.Sprintf("proxy_set_header '%v' '%v';", name, value))
 	}
+	sort.Strings(res)
 	return res
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixing flaky order dependent test introduced in https://github.com/kubernetes/ingress-nginx/pull/4550:

```
--- FAIL: TestBuildAuthProxySetHeaders (0.00s)
    template_test.go:466: Expected 
        '[proxy_set_header 'header1' 'value1'; proxy_set_header 'header2' 'value2';]'
        but returned 
        '[proxy_set_header 'header2' 'value2'; proxy_set_header 'header1' 'value1';]'
W0924 19:02:38.196548   22128 template.go:120] unexpected error cleaning template: fork/exec /ingress-controller/clean-nginx-conf.sh: no such file or directory
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
