### PR TITLE
fix bug with new and running configuration comparison

### DIFF
--- a/internal/ingress/controller/nginx.go
+++ b/internal/ingress/controller/nginx.go
@@ -795,9 +795,7 @@ func clearCertificates(config *ingress.Configuration) {
 	var clearedServers []*ingress.Server
 	for _, server := range config.Servers {
 		copyOfServer := *server
-		if copyOfServer.SSLCert != nil {
-			copyOfServer.SSLCert = &ingress.SSLCert{PemFileName: copyOfServer.SSLCert.PemFileName}
-		}
+		copyOfServer.SSLCert = nil
 		clearedServers = append(clearedServers, &copyOfServer)
 	}
 	config.Servers = clearedServers

--- a/test/e2e/lua/dynamic_certificates.go
+++ b/test/e2e/lua/dynamic_certificates.go
@@ -103,8 +103,7 @@ var _ = framework.IngressNginxDescribe("Dynamic Certificate", func() {
 		rc1, err := extractReloadCount(mf)
 		Expect(err).ToNot(HaveOccurred())
 
-		// TODO: This is wrong. We should not require a reload when SSL is configured
-		Expect(rc0).To(BeEquivalentTo(rc1 - 1))
+		Expect(rc0).To(BeEquivalentTo(rc1))
 	})
 
 	Context("given an ingress with TLS correctly configured", func() {
@@ -177,41 +176,37 @@ var _ = framework.IngressNginxDescribe("Dynamic Certificate", func() {
 			Expect(restOfLogs).ToNot(ContainSubstring(logBackendReloadSuccess))
 		})
 
-		// TODO: Fix
-		/*
-			It("falls back to using default certificate when secret gets deleted without reloading", func() {
-				ing, err := f.KubeClientSet.ExtensionsV1beta1().Ingresses(f.Namespace).Get(host, metav1.GetOptions{})
+		It("falls back to using default certificate when secret gets deleted without reloading", func() {
+			ing, err := f.KubeClientSet.ExtensionsV1beta1().Ingresses(f.Namespace).Get(host, metav1.GetOptions{})
 
-				ensureHTTPSRequest(fmt.Sprintf("%s?id=dummy_log_splitter_foo_bar", f.GetURL(framework.HTTPS)), host, host)
+			ensureHTTPSRequest(fmt.Sprintf("%s?id=dummy_log_splitter_foo_bar", f.GetURL(framework.HTTPS)), host, host)
 
-				ip := f.GetNginxPodIP()
-				mf, err := f.GetMetric("nginx_ingress_controller_success", ip[0])
-				Expect(err).ToNot(HaveOccurred())
-				Expect(mf).ToNot(BeNil())
+			ip := f.GetNginxPodIP()
+			mf, err := f.GetMetric("nginx_ingress_controller_success", ip[0])
+			Expect(err).ToNot(HaveOccurred())
+			Expect(mf).ToNot(BeNil())
 
-				rc0, err := extractReloadCount(mf)
-				Expect(err).ToNot(HaveOccurred())
+			rc0, err := extractReloadCount(mf)
+			Expect(err).ToNot(HaveOccurred())
 
-				err = f.KubeClientSet.CoreV1().Secrets(ing.Namespace).Delete(ing.Spec.TLS[0].SecretName, nil)
-				Expect(err).ToNot(HaveOccurred())
+			err = f.KubeClientSet.CoreV1().Secrets(ing.Namespace).Delete(ing.Spec.TLS[0].SecretName, nil)
+			Expect(err).ToNot(HaveOccurred())
 
-				time.Sleep(waitForLuaSync * 2)
+			time.Sleep(waitForLuaSync * 2)
 
-				By("serving the default certificate on HTTPS endpoint")
-				ensureHTTPSRequest(f.GetURL(framework.HTTPS), host, "ingress.local")
+			By("serving the default certificate on HTTPS endpoint")
+			ensureHTTPSRequest(f.GetURL(framework.HTTPS), host, "ingress.local")
 
-				mf, err = f.GetMetric("nginx_ingress_controller_success", ip[0])
-				Expect(err).ToNot(HaveOccurred())
-				Expect(mf).ToNot(BeNil())
+			mf, err = f.GetMetric("nginx_ingress_controller_success", ip[0])
+			Expect(err).ToNot(HaveOccurred())
+			Expect(mf).ToNot(BeNil())
 
-				rc1, err := extractReloadCount(mf)
-				Expect(err).ToNot(HaveOccurred())
+			rc1, err := extractReloadCount(mf)
+			Expect(err).ToNot(HaveOccurred())
 
-				By("skipping Nginx reload")
-				// TODO: This is wrong. We should not require a reload when SSL is configured
-				Expect(rc0).To(BeEquivalentTo(rc1 - 1))
-			})
-		*/
+			By("skipping Nginx reload")
+			Expect(rc0).To(BeEquivalentTo(rc1))
+		})
 
 		It("picks up a non-certificate only change", func() {
 			newHost := "foo2.com"

--- a/test/e2e/lua/dynamic_configuration.go
+++ b/test/e2e/lua/dynamic_configuration.go
@@ -166,37 +166,6 @@ var _ = framework.IngressNginxDescribe("Dynamic Configuration", func() {
 		})
 	})
 
-	It("handles a non backend update", func() {
-		var nginxConfig string
-		f.WaitForNginxConfiguration(func(cfg string) bool {
-			nginxConfig = cfg
-			return true
-		})
-
-		ingress, err := f.KubeClientSet.ExtensionsV1beta1().Ingresses(f.Namespace).Get("foo.com", metav1.GetOptions{})
-		Expect(err).ToNot(HaveOccurred())
-		ingress.Spec.TLS = []extensions.IngressTLS{
-			{
-				Hosts:      []string{"foo.com"},
-				SecretName: "foo.com",
-			},
-		}
-		_, err = framework.CreateIngressTLSSecret(f.KubeClientSet,
-			ingress.Spec.TLS[0].Hosts,
-			ingress.Spec.TLS[0].SecretName,
-			ingress.Namespace)
-		Expect(err).ToNot(HaveOccurred())
-		_, err = f.KubeClientSet.ExtensionsV1beta1().Ingresses(f.Namespace).Update(ingress)
-		Expect(err).ToNot(HaveOccurred())
-
-		var newNginxConfig string
-		f.WaitForNginxConfiguration(func(cfg string) bool {
-			newNginxConfig = cfg
-			return true
-		})
-		Expect(nginxConfig).ShouldNot(Equal(newNginxConfig))
-	})
-
 	It("sets controllerPodsCount in Lua general configuration", func() {
 		// https://github.com/curl/curl/issues/936
 		curlCmd := fmt.Sprintf("curl --fail --silent http://localhost:%v/configuration/general", nginx.StatusPort)


### PR DESCRIPTION
**What this PR does / why we need it**:

With this PR we now have fully dynamic certificate management without requiring any Nginx reload.

In https://github.com/kubernetes/ingress-nginx/pull/4356/files#diff-8492ddd211d3991f5ff17fe064fabbb6L182 we changed `SSLCert` attribute of `Server` type to be a reference. That meant its default value is `nil`. We haven't adjusted `clearCertificates` properly, therefore it was not clearing the certificates correctly and we were always getting diff between running and new configuration when certificate is added or deleted (update was fine).

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
