### PR TITLE
Change default for proxy-add-original-uri-header

### DIFF
--- a/docs/user-guide/nginx-configuration/configmap.md
+++ b/docs/user-guide/nginx-configuration/configmap.md
@@ -111,7 +111,7 @@ The following table shows a configuration option's name, type, and the default v
 |[use-forwarded-headers](#use-forwarded-headers)|bool|"false"|
 |[forwarded-for-header](#forwarded-for-header)|string|"X-Forwarded-For"|
 |[compute-full-forwarded-for](#compute-full-forwarded-for)|bool|"false"|
-|[proxy-add-original-uri-header](#proxy-add-original-uri-header)|bool|"true"|
+|[proxy-add-original-uri-header](#proxy-add-original-uri-header)|bool|"false"|
 |[generate-request-id](#generate-request-id)|bool|"true"|
 |[enable-opentracing](#enable-opentracing)|bool|"false"|
 |[zipkin-collector-host](#zipkin-collector-host)|string|""|

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -668,7 +668,7 @@ func NewDefault() Configuration {
 		UseForwardedHeaders:              false,
 		ForwardedForHeader:               "X-Forwarded-For",
 		ComputeFullForwardedFor:          false,
-		ProxyAddOriginalURIHeader:        true,
+		ProxyAddOriginalURIHeader:        false,
 		GenerateRequestID:                true,
 		HTTP2MaxFieldSize:                "4k",
 		HTTP2MaxHeaderSize:               "16k",

--- a/test/e2e/annotations/grpc.go
+++ b/test/e2e/annotations/grpc.go
@@ -117,7 +117,6 @@ var _ = framework.IngressNginxDescribe("Annotations - GRPC", func() {
 		Expect(err).Should(BeNil())
 
 		metadata := res.GetMetadata()
-		Expect(metadata["x-original-uri"].Values[0]).Should(Equal("/grpcbin.GRPCBin/HeadersUnary"))
 		Expect(metadata["content-type"].Values[0]).Should(Equal("application/grpc"))
 	})
 
@@ -179,7 +178,6 @@ var _ = framework.IngressNginxDescribe("Annotations - GRPC", func() {
 		Expect(err).Should(BeNil())
 
 		metadata := res.GetMetadata()
-		Expect(metadata["x-original-uri"].Values[0]).Should(Equal("/grpcbin.GRPCBin/HeadersUnary"))
 		Expect(metadata["content-type"].Values[0]).Should(Equal("application/grpc"))
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Change the default value for `proxy-add-original-uri-header` from true to false, introduced in #2353. This default adds a header that can trigger an error `HTTP/1.1 431 Request Header Fields Too Large`.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #4593

**Special notes for your reviewer**:
