### PR TITLE
Fix ports collision when hostNetwork=true

### DIFF
--- a/cmd/nginx/flags.go
+++ b/cmd/nginx/flags.go
@@ -149,9 +149,9 @@ Requires the update-status parameter.`)
 		metricsPerHost = flags.Bool("metrics-per-host", true,
 			`Export metrics per-host`)
 
-		httpPort      = flags.Int("http-port", 80, `Port to use for servicing HTTP traffic.`)
-		httpsPort     = flags.Int("https-port", 443, `Port to use for servicing HTTPS traffic.`)
-		_             = flags.Int("status-port", 18080, `Port to use for exposing NGINX status pages.`)
+		httpPort  = flags.Int("http-port", 80, `Port to use for servicing HTTP traffic.`)
+		httpsPort = flags.Int("https-port", 443, `Port to use for servicing HTTPS traffic.`)
+
 		sslProxyPort  = flags.Int("ssl-passthrough-proxy-port", 442, `Port to use internally for SSL Passthrough.`)
 		defServerPort = flags.Int("default-server-port", 8181, `Port to use for exposing the default server (catch-all).`)
 		healthzPort   = flags.Int("healthz-port", 10254, "Port to use for the healthz endpoint.")
@@ -166,9 +166,13 @@ Takes the form "<host>:port". If not provided, no admission controller is starte
 			`The path of the validating webhook certificate PEM.`)
 		validationWebhookKey = flags.String("validating-webhook-key", "",
 			`The path of the validating webhook key PEM.`)
+
+		statusPort = flags.Int("status-port", 10246, `Port to use for the lua HTTP endpoint configuration.`)
+		streamPort = flags.Int("stream-port", 10247, "Port to use for the lua TCP/UDP endpoint configuration.")
+
+		profilerPort = flags.Int("profiler-port", 10245, "Port to use for expose the ingress controller Go profiler when it is enabled.")
 	)
 
-	flags.MarkDeprecated("status-port", `The status port is a unix socket now.`)
 	flags.MarkDeprecated("force-namespace-isolation", `This flag doesn't do anything.`)
 
 	flags.MarkDeprecated("enable-dynamic-certificates", `Only dynamic mode is supported`)
@@ -214,6 +218,22 @@ Takes the form "<host>:port". If not provided, no admission controller is starte
 	if !ing_net.IsPortAvailable(*defServerPort) {
 		return false, nil, fmt.Errorf("port %v is already in use. Please check the flag --default-server-port", *defServerPort)
 	}
+
+	if !ing_net.IsPortAvailable(*statusPort) {
+		return false, nil, fmt.Errorf("port %v is already in use. Please check the flag --status-port", *statusPort)
+	}
+
+	if !ing_net.IsPortAvailable(*streamPort) {
+		return false, nil, fmt.Errorf("port %v is already in use. Please check the flag --stream-port", *streamPort)
+	}
+
+	if !ing_net.IsPortAvailable(*profilerPort) {
+		return false, nil, fmt.Errorf("port %v is already in use. Please check the flag --profiler-port", *profilerPort)
+	}
+
+	nginx.StatusPort = *statusPort
+	nginx.StreamPort = *streamPort
+	nginx.ProfilerPort = *profilerPort
 
 	if *enableSSLPassthrough && !ing_net.IsPortAvailable(*sslProxyPort) {
 		return false, nil, fmt.Errorf("port %v is already in use. Please check the flag --ssl-passthrough-proxy-port", *sslProxyPort)

--- a/cmd/nginx/main.go
+++ b/cmd/nginx/main.go
@@ -44,6 +44,7 @@ import (
 	"k8s.io/ingress-nginx/internal/ingress/metric"
 	"k8s.io/ingress-nginx/internal/k8s"
 	"k8s.io/ingress-nginx/internal/net/ssl"
+	"k8s.io/ingress-nginx/internal/nginx"
 	"k8s.io/ingress-nginx/version"
 )
 
@@ -280,7 +281,7 @@ func registerProfiler() {
 	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
 
 	server := &http.Server{
-		Addr:    fmt.Sprintf(":10255"),
+		Addr:    fmt.Sprintf("127.0.0.1:%v", nginx.ProfilerPort),
 		Handler: mux,
 	}
 	klog.Fatal(server.ListenAndServe())

--- a/docs/user-guide/cli-arguments.md
+++ b/docs/user-guide/cli-arguments.md
@@ -23,6 +23,8 @@ They are set in the container spec of the `nginx-ingress-controller` Deployment 
 | `--healthz-port int`              | Port to use for the healthz endpoint. (default 10254) |
 | `--http-port int`                 | Port to use for servicing HTTP traffic. (default 80) |
 | `--https-port int`                | Port to use for servicing HTTPS traffic. (default 443) |
+| `--status-port int`                | Port to use for the lua HTTP endpoint configuration. (default 10246) |
+| `--stream-port int`                | Port to use for the lua TCP/UDP endpoint configuration. (default 10247) |
 | `--ingress-class string`          | Name of the ingress class this controller satisfies. The class of an Ingress object is set using the annotation "kubernetes.io/ingress.class". All ingress classes are satisfied if this parameter is left empty. |
 | `--kubeconfig string`             | Path to a kubeconfig file containing authorization and API server information. |
 | `--log_backtrace_at traceLocation` | when logging hits line file:N, emit a stack trace (default :0) |

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -261,17 +261,21 @@ func (n *NGINXController) getStreamServices(configmapName string, proto apiv1.Pr
 		klog.Errorf("Error getting ConfigMap %q: %v", configmapName, err)
 		return []ingress.L4Service{}
 	}
+
 	var svcs []ingress.L4Service
 	var svcProxyProtocol ingress.ProxyProtocol
+
 	rp := []int{
 		n.cfg.ListenPorts.HTTP,
 		n.cfg.ListenPorts.HTTPS,
 		n.cfg.ListenPorts.SSLProxy,
 		n.cfg.ListenPorts.Health,
 		n.cfg.ListenPorts.Default,
-		10255, // profiling port
+		nginx.ProfilerPort,
 		nginx.StatusPort,
+		nginx.StreamPort,
 	}
+
 	reserverdPorts := sets.NewInt(rp...)
 	// svcRef format: <(str)namespace>/<(str)service>:<(intstr)port>[:<("PROXY")decode>:<("PROXY")encode>]
 	for port, svcRef := range configmap.Data {

--- a/internal/nginx/main.go
+++ b/internal/nginx/main.go
@@ -31,6 +31,11 @@ import (
 	"k8s.io/klog"
 )
 
+// TODO: Check https://github.com/kubernetes/kubernetes/blob/master/pkg/master/ports/ports.go for ports already being used
+
+// ProfilerPort port used by the ingress controller to expose the Go Profiler when it is enabled.
+var ProfilerPort = 10245
+
 // TemplatePath path of the NGINX template
 var TemplatePath = "/etc/nginx/template/nginx.tmpl"
 
@@ -38,7 +43,7 @@ var TemplatePath = "/etc/nginx/template/nginx.tmpl"
 var PID = "/tmp/nginx.pid"
 
 // StatusPort port used by NGINX for the status server
-var StatusPort = 10256
+var StatusPort = 10246
 
 // HealthPath defines the path used to define the health check location in NGINX
 var HealthPath = "/healthz"
@@ -51,7 +56,7 @@ var HealthCheckTimeout = 10 * time.Second
 var StatusPath = "/nginx_status"
 
 // StreamPort defines the port used by NGINX for the NGINX stream configuration socket
-var StreamPort = 10257
+var StreamPort = 10247
 
 // NewGetStatusRequest creates a new GET request to the internal NGINX status server
 func NewGetStatusRequest(path string) (int, []byte, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

The ports for the lua configuration of HTTP and TCP/UDP should not use ports already defined in Kubernetes. This PR also introduces two flags to allow different port values.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #4616

**Special notes for your reviewer**:
