### PR TITLE
Issue 4244

### DIFF
--- a/cmd/nginx/main.go
+++ b/cmd/nginx/main.go
@@ -135,7 +135,7 @@ func main() {
 		go registerProfiler()
 	}
 
-	registerHealthz(ngx, mux)
+	registerHealthz(nginx.HealthPath, ngx, mux)
 	registerMetrics(reg, mux)
 	registerHandlers(mux)
 
@@ -247,9 +247,10 @@ func registerHandlers(mux *http.ServeMux) {
 	})
 }
 
-func registerHealthz(ic *controller.NGINXController, mux *http.ServeMux) {
+func registerHealthz(healthPath string, ic *controller.NGINXController, mux *http.ServeMux) {
 	// expose health check endpoint (/healthz)
-	healthz.InstallHandler(mux,
+	healthz.InstallPathHandler(mux,
+		healthPath,
 		healthz.PingHealthz,
 		ic,
 	)

--- a/internal/ingress/controller/checker_test.go
+++ b/internal/ingress/controller/checker_test.go
@@ -33,84 +33,97 @@ import (
 )
 
 func TestNginxCheck(t *testing.T) {
-	mux := http.NewServeMux()
-
-	listener, err := net.Listen("tcp", fmt.Sprintf(":%v", nginx.StatusPort))
-	if err != nil {
-		t.Fatalf("crating tcp listener: %s", err)
-	}
-	defer listener.Close()
-
-	server := &httptest.Server{
-		Listener: listener,
-		Config: &http.Server{
-			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(http.StatusOK)
-				fmt.Fprintf(w, "ok")
-			}),
-		},
-	}
-	defer server.Close()
-	server.Start()
-
-	n := &NGINXController{
-		cfg: &Configuration{
-			ListenPorts: &ngx_config.ListenPorts{},
-		},
+	var tests = []struct {
+		healthzPath string
+	}{
+		{"/healthz"},
+		{"/not-healthz"},
 	}
 
-	t.Run("no pid or process", func(t *testing.T) {
-		if err := callHealthz(true, mux); err == nil {
-			t.Error("expected an error but none returned")
-		}
-	})
+	for _, tt := range tests {
+		testName := fmt.Sprintf("health path: %s", tt.healthzPath)
+		t.Run(testName, func(t *testing.T) {
 
-	// create pid file
-	os.MkdirAll("/tmp", file.ReadWriteByUser)
-	pidFile, err := os.Create(nginx.PID)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+			mux := http.NewServeMux()
+
+			listener, err := net.Listen("tcp", fmt.Sprintf(":%v", nginx.StatusPort))
+			if err != nil {
+				t.Fatalf("crating tcp listener: %s", err)
+			}
+			defer listener.Close()
+
+			server := &httptest.Server{
+				Listener: listener,
+				Config: &http.Server{
+					Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						w.WriteHeader(http.StatusOK)
+						fmt.Fprintf(w, "ok")
+					}),
+				},
+			}
+			defer server.Close()
+			server.Start()
+
+			n := &NGINXController{
+				cfg: &Configuration{
+					ListenPorts: &ngx_config.ListenPorts{},
+				},
+			}
+
+			t.Run("no pid or process", func(t *testing.T) {
+				if err := callHealthz(true, tt.healthzPath, mux); err == nil {
+					t.Error("expected an error but none returned")
+				}
+			})
+
+			// create pid file
+			os.MkdirAll("/tmp", file.ReadWriteByUser)
+			pidFile, err := os.Create(nginx.PID)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			t.Run("no process", func(t *testing.T) {
+				if err := callHealthz(true, tt.healthzPath, mux); err == nil {
+					t.Error("expected an error but none returned")
+				}
+			})
+
+			// start dummy process to use the PID
+			cmd := exec.Command("sleep", "3600")
+			cmd.Start()
+			pid := cmd.Process.Pid
+			defer cmd.Process.Kill()
+			go func() {
+				cmd.Wait()
+			}()
+
+			pidFile.Write([]byte(fmt.Sprintf("%v", pid)))
+			pidFile.Close()
+
+			healthz.InstallPathHandler(mux, tt.healthzPath, n)
+
+			t.Run("valid request", func(t *testing.T) {
+				if err := callHealthz(false, tt.healthzPath, mux); err != nil {
+					t.Error(err)
+				}
+			})
+
+			// pollute pid file
+			pidFile.Write([]byte(fmt.Sprint("999999")))
+			pidFile.Close()
+
+			t.Run("bad pid", func(t *testing.T) {
+				if err := callHealthz(true, tt.healthzPath, mux); err == nil {
+					t.Error("expected an error but none returned")
+				}
+			})
+		})
 	}
-
-	t.Run("no process", func(t *testing.T) {
-		if err := callHealthz(true, mux); err == nil {
-			t.Error("expected an error but none returned")
-		}
-	})
-
-	// start dummy process to use the PID
-	cmd := exec.Command("sleep", "3600")
-	cmd.Start()
-	pid := cmd.Process.Pid
-	defer cmd.Process.Kill()
-	go func() {
-		cmd.Wait()
-	}()
-
-	pidFile.Write([]byte(fmt.Sprintf("%v", pid)))
-	pidFile.Close()
-
-	healthz.InstallHandler(mux, n)
-
-	t.Run("valid request", func(t *testing.T) {
-		if err := callHealthz(false, mux); err != nil {
-			t.Error(err)
-		}
-	})
-
-	// pollute pid file
-	pidFile.Write([]byte(fmt.Sprint("999999")))
-	pidFile.Close()
-
-	t.Run("bad pid", func(t *testing.T) {
-		if err := callHealthz(true, mux); err == nil {
-			t.Error("expected an error but none returned")
-		}
-	})
 }
 
-func callHealthz(expErr bool, mux *http.ServeMux) error {
-	req, err := http.NewRequest("GET", "/healthz", nil)
+func callHealthz(expErr bool, healthzPath string, mux *http.ServeMux) error {
+	req, err := http.NewRequest("GET", healthzPath, nil)
 	if err != nil {
 		return fmt.Errorf("healthz error: %v", err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
`--health-check-path` param is broken, only default `healthz` value is working.
Needed for integration with custom ingress controllers that need hardcoded health check path (like https://github.com/zalando-incubator/kube-ingress-aws-controller)

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
fixes #4244 

**Special notes for your reviewer**:
I added one test case in internal/ingress/controller/checker_test.go:35 (`TestNginxCheck`), not so useful and maybe an e2e test would be rather needed, but I'd need some guidance to add one of this