### PR TITLE
use http2 in http server to support grpc without tls fix #4630

### DIFF
--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -1251,6 +1251,11 @@ func httpListener(addresses []string, co string, tc config.TemplateConfig) []str
 		}
 
 		l = append(l, co)
+
+		if tc.Cfg.UseHTTP2 {
+			l = append(l, "http2")
+		}
+
 		l = append(l, ";")
 		out = append(out, strings.Join(l, " "))
 	}


### PR DESCRIPTION
**What this PR does / why we need it**: to handle grpc without tls

**Which issue this PR fixes** : fixes #4630

**Special notes for your reviewer**:
