### PR TITLE
ConfigMap option: Allow real_ip_recursive to be set on/off outside of proxy-protocol

### DIFF
--- a/docs/user-guide/nginx-configuration/configmap.md
+++ b/docs/user-guide/nginx-configuration/configmap.md
@@ -112,6 +112,7 @@ The following table shows a configuration option's name, type, and the default v
 |[use-forwarded-headers](#use-forwarded-headers)|bool|"false"|
 |[forwarded-for-header](#forwarded-for-header)|string|"X-Forwarded-For"|
 |[compute-full-forwarded-for](#compute-full-forwarded-for)|bool|"false"|
+|[real-ip-recursive-search](#real-ip-recursive-search)|bool|"false"|
 |[proxy-add-original-uri-header](#proxy-add-original-uri-header)|bool|"false"|
 |[generate-request-id](#generate-request-id)|bool|"true"|
 |[enable-opentracing](#enable-opentracing)|bool|"false"|
@@ -694,6 +695,10 @@ Sets the header field for identifying the originating IP address of a client. _*
 ## compute-full-forwarded-for
 
 Append the remote address to the X-Forwarded-For header instead of replacing it. When this option is enabled, the upstream application is responsible for extracting the client IP based on its own list of trusted proxies.
+
+## real-ip-recursive-search
+
+By default, the original client address that matches one of the trusted addresses is replaced by the last address sent in the request header field defined by the real_ip_header directive. If recursive search is enabled, the original client address that matches one of the trusted addresses is replaced by the last non-trusted address instead. `real_ip_recursive` is enabled if Proxy-Protocol is enabled.
 
 ## proxy-add-original-uri-header
 

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -461,6 +461,16 @@ type Configuration struct {
 	// Default: false
 	ComputeFullForwardedFor bool `json:"compute-full-forwarded-for,omitempty"`
 
+	// If recursive search is disabled, the original client address that matches one
+	// of the trusted addresses is replaced by the last address sent in the request
+	// header field defined by the real_ip_header directive.
+	// If recursive search is enabled, the original client address that matches one of
+	// the trusted addresses is replaced by the last non-trusted address sent in the
+	// request header field.
+	// This is enabled if Proxy-Protocol is enabled.
+	// Default: false
+	RealIPRecursiveSearch bool `json:"real-ip-recursive-search,omitempty"`
+
 	// If the request does not have a request-id, should we generate a random value?
 	// Default: true
 	GenerateRequestID bool `json:"generate-request-id,omitempty"`
@@ -671,6 +681,7 @@ func NewDefault() Configuration {
 		UseForwardedHeaders:              false,
 		ForwardedForHeader:               "X-Forwarded-For",
 		ComputeFullForwardedFor:          false,
+		RealIPRecursiveSearch:            false,
 		ProxyAddOriginalURIHeader:        false,
 		GenerateRequestID:                true,
 		HTTP2MaxFieldSize:                "4k",

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -131,9 +131,9 @@ http {
     {{ end }}
 
     {{ if or $cfg.RealIPRecursiveSearch $cfg.UseProxyProtocol }}
-    real_ip_recursive   on;
+    real_ip_recursive on;
     {{ else }}
-    real_ip_recursive   off;
+    real_ip_recursive off;
     {{ end }}
 
     {{ range $trusted_ip := $cfg.ProxyRealIPCIDR }}

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -130,7 +130,12 @@ http {
     real_ip_header      {{ $cfg.ForwardedForHeader }};
     {{ end }}
 
+    {{ if or $cfg.RealIPRecursiveSearch $cfg.UseProxyProtocol }}
     real_ip_recursive   on;
+    {{ else }}
+    real_ip_recursive   off;
+    {{ end }}
+
     {{ range $trusted_ip := $cfg.ProxyRealIPCIDR }}
     set_real_ip_from    {{ $trusted_ip }};
     {{ end }}

--- a/test/e2e/settings/real_ip_recursive_search.go
+++ b/test/e2e/settings/real_ip_recursive_search.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package settings
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/parnurzeal/gorequest"
+
+	"k8s.io/ingress-nginx/test/e2e/framework"
+)
+
+var _ = framework.IngressNginxDescribe("Real IP Recursive Search", func() {
+	f := framework.NewDefaultFramework("real-ip-recursive-search")
+
+	setting := "real-ip-recursive-search"
+
+	BeforeEach(func() {
+		f.NewEchoDeployment()
+		f.UpdateNginxConfigMapData("use-forwarded-headers", "true")
+		f.UpdateNginxConfigMapData(setting, "false")
+	})
+
+	AfterEach(func() {
+	})
+
+	It("should include real_ip_recursive=off if turned off", func() {
+		host := "real-ip-recursive-search"
+		expectedConfig := "real_ip_recursive off;"
+
+		f.UpdateNginxConfigMapData(setting, "false")
+
+		f.EnsureIngress(framework.NewSingleIngress(host, "/", host, f.Namespace, framework.EchoService, 80, nil))
+
+		f.WaitForNginxConfiguration(
+			func(cfg string) bool {
+				return strings.Contains(cfg, expectedConfig)
+			})
+
+		By("ensuring x-forwarded-for values are parsed correctly")
+		resp, body, errs := gorequest.New().
+			Get(f.GetURL(framework.HTTP)).
+			Set("Host", host).
+			Set("X-Forwarded-For", "10.0.0.1,1.2.3.4").
+			End()
+
+		Expect(errs).Should(BeEmpty())
+		Expect(resp.StatusCode).Should(Equal(http.StatusOK))
+		Expect(body).Should(ContainSubstring(fmt.Sprintf("host=%s", host)))
+		Expect(body).Should(ContainSubstring(fmt.Sprintf("x-forwarded-for=1.2.3.4")))
+	})
+
+	It("should include real_ip_recursive=on if turned on", func() {
+		host := "real-ip-recursive-search"
+		expectedConfig := "real_ip_recursive on;"
+
+		f.UpdateNginxConfigMapData(setting, "true")
+
+		f.EnsureIngress(framework.NewSingleIngress(host, "/", host, f.Namespace, framework.EchoService, 80, nil))
+
+		f.WaitForNginxConfiguration(
+			func(cfg string) bool {
+				return strings.Contains(cfg, expectedConfig)
+			})
+
+		By("ensuring x-forwarded-for values are parsed correctly")
+		resp, body, errs := gorequest.New().
+			Get(f.GetURL(framework.HTTP)).
+			Set("Host", host).
+			Set("X-Forwarded-For", "10.0.0.1,1.2.3.4").
+			End()
+
+		Expect(errs).Should(BeEmpty())
+		Expect(resp.StatusCode).Should(Equal(http.StatusOK))
+		Expect(body).Should(ContainSubstring(fmt.Sprintf("host=%s", host)))
+		Expect(body).Should(ContainSubstring(fmt.Sprintf("x-forwarded-for=10.0.0.1")))
+	})
+
+	It("should include real_ip_recursive=on if proxy-protocol is on", func() {
+		host := "real-ip-recursive-search"
+		expectedConfig := "real_ip_recursive on;"
+
+		f.UpdateNginxConfigMapData("proxy-protocol", "true")
+
+		f.EnsureIngress(framework.NewSingleIngress(host, "/", host, f.Namespace, framework.EchoService, 80, nil))
+
+		f.WaitForNginxConfiguration(
+			func(cfg string) bool {
+				return strings.Contains(cfg, expectedConfig)
+			})
+
+		f.WaitForNginxServer(host,
+			func(server string) bool {
+				return strings.Contains(server, "server_name real-ip-recursive-search") &&
+					strings.Contains(server, "listen 80 proxy_protocol")
+			})
+
+		ip := f.GetNginxIP()
+
+		conn, err := net.Dial("tcp", net.JoinHostPort(ip, "80"))
+		Expect(err).NotTo(HaveOccurred(), "unexpected error creating connection to %s:80", ip)
+		defer conn.Close()
+
+		header := "PROXY TCP4 192.168.0.1 192.168.0.11 56324 1234\r\n"
+		conn.Write([]byte(header))
+		conn.Write([]byte("GET / HTTP/1.1\r\nHost: real-ip-recursive-search\r\nX-Forwarded-For: 192.168.0.1,10.0.0.1\r\n\r\n"))
+
+		data, err := ioutil.ReadAll(conn)
+		Expect(err).NotTo(HaveOccurred(), "unexpected error reading connection data")
+		body := string(data)
+		Expect(body).Should(ContainSubstring(fmt.Sprintf("host=%s", host)))
+		Expect(body).Should(ContainSubstring(fmt.Sprintf("x-forwarded-port=80")))
+		Expect(body).Should(ContainSubstring(fmt.Sprintf("x-forwarded-for=192.168.0.1")))
+	})
+})

--- a/test/e2e/settings/real_ip_recursive_search.go
+++ b/test/e2e/settings/real_ip_recursive_search.go
@@ -100,7 +100,7 @@ var _ = framework.IngressNginxDescribe("Real IP Recursive Search", func() {
 		host := "real-ip-recursive-search"
 		expectedConfig := "real_ip_recursive on;"
 
-		f.UpdateNginxConfigMapData("proxy-protocol", "true")
+		f.UpdateNginxConfigMapData("use-proxy-protocol", "true")
 
 		f.EnsureIngress(framework.NewSingleIngress(host, "/", host, f.Namespace, framework.EchoService, 80, nil))
 


### PR DESCRIPTION
**What this PR does / why we need it**: This PR introduces a new configmap setting, `real-ip-recursive-search`, which takes a boolean `"true"` or `"false"` value. Based on this value, the  `real_ip_recursive` setting within the nginx template is set to `off`/`on`.

As a result, this fixes an issue in the case where we are using a Layer 7 proxy in front of nginx-ingress, but nginx-ingress is resolving X-Forwarded-For to the wrong IP if the L7 proxy (or an ALB) inserts an entry in addition to what may already be in `X-Forwarded-For`. 

From the issue linked below - we end up facing the following undesirable behaviour if we simulate the client sitting behind a proxy/ELB:

`> curl -H 'X-Forwarded-For: 10.1.1.1' -v https://example.com/ip`

This request leads to the ELB sending the following X-Forwarded-For header where `34.230.47.162` is my real IP:

```
X-Forwarded-For: 10.1.1.1, 34.230.47.162
```

The X-Forwarded-For header at the current state in time is what we would expect. We would also expect that nginx determines `34.230.47.162` as the real client IP.

However, the values in `X-Forwarded-For` do get replaced such that we end up with the following resulting headers:

```
X-Forwarded-For: 10.1.1.1
X-Original-Forwarded-For: 10.1.1.1, 34.230.47.162
X-Real-IP: 10.1.1.1
```

**Which issue this PR fixes** https://github.com/kubernetes/ingress-nginx/issues/4073

**Special notes for your reviewer**: I've kept the `real_ip_recursive` value to `on` in the case where proxy-protocol is enabled to not break any existing deployments. 

--- 

TODO: Need to update docs
TODO: Update E2E tests
