### PR TITLE
Expose GeoIP2 Organization as variable $geoip2_org

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -179,6 +179,7 @@ http {
 
     geoip2 /etc/nginx/geoip/GeoLite2-ASN.mmdb {
         $geoip2_asn source=$remote_addr autonomous_system_number;
+        $geoip2_org source=$remote_addr autonomous_system_organization;
     }
     {{ end }}
 


### PR DESCRIPTION
**What this PR does / why we need it**: Add support for logging the client IP's organization from GeoIP2 database.  Mirrors existing $geoip_org that is populated from the now-deprecated GeoIP database.

**Which issue this PR fixes**: not a big enough problem to raise an issue?

**Special notes for your reviewer**: