### PR TITLE
Need to quote expansion of `$cfg.LogFormatStream` in `log_stream` access log

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -642,7 +642,7 @@ stream {
 
     lua_add_variable $proxy_upstream_name;
 
-    log_format log_stream {{ $cfg.LogFormatStream }};
+    log_format log_stream '{{ $cfg.LogFormatStream }}';
 
     {{ if $cfg.DisableAccessLog }}
     access_log off;


### PR DESCRIPTION
format in `nginx.tmpl` otherwise individual variables are just glued together
without separating spaces so that you would get these in access logs:
```
[10/Oct/2019:05:03:30 +0000]TCP200000.003
[10/Oct/2019:05:03:30 +0000]TCP200000.000
[10/Oct/2019:05:05:04 +0000]TCP200000.000
```
which supposed to be someting like these:
```
[10/Oct/2019:05:03:30 +0000] TCP 200 0 0 0.003
[10/Oct/2019:05:03:30 +0000] TCP 200 0 0 0.000
[10/Oct/2019:05:05:04 +0000] TCP 200 0 0 0.000
```