### PR TITLE
Simplify initialization function of bytes.Buffer

### DIFF
--- a/internal/ingress/controller/template/buffer_pool.go
+++ b/internal/ingress/controller/template/buffer_pool.go
@@ -31,8 +31,7 @@ func NewBufferPool(s int) *BufferPool {
 	return &BufferPool{
 		Pool: sync.Pool{
 			New: func() interface{} {
-				b := bytes.NewBuffer(make([]byte, s))
-				b.Reset()
+				b := bytes.NewBuffer(make([]byte, 0, s))
 				return b
 			},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:

Simplifies some code; just better style and slightly faster.