### PR TITLE
Discontinue use of a single DNS query to validate an endpoint name

### DIFF
--- a/internal/ingress/controller/endpoints.go
+++ b/internal/ingress/controller/endpoints.go
@@ -22,6 +22,7 @@ import (
 	"reflect"
 	"strconv"
 
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/klog"
 
 	corev1 "k8s.io/api/core/v1"
@@ -58,9 +59,8 @@ func getEndpoints(s *corev1.Service, port *corev1.ServicePort, proto corev1.Prot
 
 		// if the externalName is not an IP address we need to validate is a valid FQDN
 		if net.ParseIP(s.Spec.ExternalName) == nil {
-			_, err := net.LookupHost(s.Spec.ExternalName)
-			if err != nil {
-				klog.Errorf("Error resolving host %q: %v", s.Spec.ExternalName, err)
+			if errs := validation.IsDNS1123Subdomain(s.Spec.ExternalName); len(errs) > 0 {
+				klog.Errorf("Invalid DNS name %s: %v", s.Spec.ExternalName, errs)
 				return upsServers
 			}
 		}

--- a/internal/ingress/controller/endpoints_test.go
+++ b/internal/ingress/controller/endpoints_test.go
@@ -112,7 +112,7 @@ func TestGetEndpoints(t *testing.T) {
 			&corev1.Service{
 				Spec: corev1.ServiceSpec{
 					Type:         corev1.ServiceTypeExternalName,
-					ExternalName: "foo.bar",
+					ExternalName: "1#invalid.hostname",
 					Ports: []corev1.ServicePort{
 						{
 							Name:       "default",

--- a/test/e2e/servicebackend/service_externalname.go
+++ b/test/e2e/servicebackend/service_externalname.go
@@ -146,7 +146,7 @@ var _ = framework.IngressNginxDescribe("Service Type ExternalName", func() {
 		Expect(resp.StatusCode).Should(Equal(200))
 	})
 
-	It("should return status 503 for service type=ExternalName with an invalid host", func() {
+	It("should return status 502 for service type=ExternalName with an invalid host", func() {
 		host := "echo"
 
 		svc := &core.Service{
@@ -175,7 +175,7 @@ var _ = framework.IngressNginxDescribe("Service Type ExternalName", func() {
 			Set("Host", host).
 			End()
 		Expect(errs).Should(BeEmpty())
-		Expect(resp.StatusCode).Should(Equal(503))
+		Expect(resp.StatusCode).Should(Equal(502))
 	})
 
 	It("should return 200 for service type=ExternalName using a port name", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:

This resolves issue #4670 by not using a single DNS query to determine the validity of a configured DNS name.

Fixes #4670

**Special notes for your reviewer**: I have created a test build of this (https://quay.io/repository/jacksontj/ingress-nginx?namespace=jacksontj) and am running it without issue, and can confirm the fix. With this fix it does leave those "broken" services spamming the logs, which is why I have included an addition to the lua log lines to clarify the situation.
