### PR TITLE
fix doc/example/grpc typo

### DIFF
--- a/docs/examples/grpc/README.md
+++ b/docs/examples/grpc/README.md
@@ -48,7 +48,7 @@ inside the cluster and arrive "insecure").
 
 For your own application you may or may not want to do this.  If you prefer to
 forward encrypted traffic to your POD and terminate TLS at the gRPC server
-itself, add the ingress annotation `nginx.ingress.kubernetes.io/backend-protocol: "GRPCS"`.
+itself, add the ingress annotation `nginx.ingress.kubernetes.io/backend-protocol: "GRPC"`.
 
 ### Step 2: the kubernetes `Service`
 


### PR DESCRIPTION
**What this PR does / why we need it**:
fix doc/example/grpc typo
