### PR TITLE
Server-only authentication of backends and per-location SSL config

### DIFF
--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -491,6 +491,17 @@ func (n *NGINXController) getBackendServers(ingresses []*ingress.Ingress) ([]*in
 					server.Hostname, ingKey)
 			}
 
+			if server.ProxySSL.CAFileName == "" {
+				server.ProxySSL = anns.ProxySSL
+				if server.ProxySSL.Secret != "" && server.ProxySSL.CAFileName == "" {
+					klog.V(3).Infof("Secret %q has no 'ca.crt' key, client cert authentication disabled for Ingress %q",
+						server.ProxySSL.Secret, ingKey)
+				}
+			} else {
+				klog.V(3).Infof("Server %q is already configured for client cert authentication (Ingress %q)",
+					server.Hostname, ingKey)
+			}
+
 			if rule.HTTP == nil {
 				klog.V(3).Infof("Ingress %q does not contain any HTTP rule, using default backend", ingKey)
 				continue

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -491,17 +491,6 @@ func (n *NGINXController) getBackendServers(ingresses []*ingress.Ingress) ([]*in
 					server.Hostname, ingKey)
 			}
 
-			if server.ProxySSL.CAFileName == "" {
-				server.ProxySSL = anns.ProxySSL
-				if server.ProxySSL.Secret != "" && server.ProxySSL.CAFileName == "" {
-					klog.V(3).Infof("Secret %q has no 'ca.crt' key, client cert authentication disabled for Ingress %q",
-						server.ProxySSL.Secret, ingKey)
-				}
-			} else {
-				klog.V(3).Infof("Server %q is already configured for client cert authentication (Ingress %q)",
-					server.Hostname, ingKey)
-			}
-
 			if rule.HTTP == nil {
 				klog.V(3).Infof("Ingress %q does not contain any HTTP rule, using default backend", ingKey)
 				continue
@@ -1170,6 +1159,7 @@ func locationApplyAnnotations(loc *ingress.Location, anns *annotations.Ingress) 
 	loc.EnableGlobalAuth = anns.EnableGlobalAuth
 	loc.HTTP2PushPreload = anns.HTTP2PushPreload
 	loc.Proxy = anns.Proxy
+	loc.ProxySSL = anns.ProxySSL
 	loc.RateLimit = anns.RateLimit
 	loc.Redirect = anns.Redirect
 	loc.Rewrite = anns.Rewrite

--- a/internal/ingress/controller/store/backend_ssl.go
+++ b/internal/ingress/controller/store/backend_ssl.go
@@ -104,19 +104,18 @@ func (s *k8sStore) getPemCertificate(secretName string) (*ingress.SSLCert, error
 			return nil, fmt.Errorf("unexpected error creating SSL Cert: %v", err)
 		}
 
-		path, err := ssl.StoreSSLCertOnDisk(nsSecName, sslCert)
-		if err != nil {
-			return nil, fmt.Errorf("error while storing certificate and key: %v", err)
-		}
-
-		sslCert.PemFileName = path
-
 		if len(ca) > 0 {
 			caCert, err := ssl.CheckCACert(ca)
 			if err != nil {
 				return nil, fmt.Errorf("parsing CA certificate: %v", err)
 			}
 
+			path, err := ssl.StoreSSLCertOnDisk(nsSecName, sslCert)
+			if err != nil {
+				return nil, fmt.Errorf("error while storing certificate and key: %v", err)
+			}
+
+			sslCert.PemFileName = path
 			sslCert.CACertificate = caCert
 			sslCert.CAFileName = path
 			sslCert.CASHA = file.SHA1(path)

--- a/internal/ingress/controller/store/backend_ssl.go
+++ b/internal/ingress/controller/store/backend_ssl.go
@@ -104,15 +104,17 @@ func (s *k8sStore) getPemCertificate(secretName string) (*ingress.SSLCert, error
 			return nil, fmt.Errorf("unexpected error creating SSL Cert: %v", err)
 		}
 
+		path, err := ssl.StoreSSLCertOnDisk(nsSecName, sslCert)
+		if err != nil {
+			return nil, fmt.Errorf("error while storing certificate and key: %v", err)
+		}
+
+		sslCert.PemFileName = path
+
 		if len(ca) > 0 {
 			caCert, err := ssl.CheckCACert(ca)
 			if err != nil {
 				return nil, fmt.Errorf("parsing CA certificate: %v", err)
-			}
-
-			path, err := ssl.StoreSSLCertOnDisk(nsSecName, sslCert)
-			if err != nil {
-				return nil, fmt.Errorf("error while storing certificate and key: %v", err)
 			}
 
 			sslCert.CACertificate = caCert

--- a/internal/ingress/controller/store/store.go
+++ b/internal/ingress/controller/store/store.go
@@ -843,6 +843,7 @@ func (s *k8sStore) GetAuthCertificate(name string) (*resolver.AuthSSLCert, error
 		CASHA:       cert.CASHA,
 		CRLFileName: cert.CRLFileName,
 		CRLSHA:      cert.CRLSHA,
+		PemFileName: cert.PemFileName,
 	}, nil
 }
 

--- a/internal/ingress/resolver/main.go
+++ b/internal/ingress/resolver/main.go
@@ -56,6 +56,8 @@ type AuthSSLCert struct {
 	CRLFileName string `json:"crlFileName"`
 	// CRLSHA contains the SHA1 hash of the 'ca.crl' file
 	CRLSHA string `json:"crlSha"`
+	// PemFileName contains the path to the secrets 'tls.crt' and 'tls.key'
+	PemFileName string `json:"pemFilename"`
 }
 
 // Equal tests for equality between two AuthSSLCert types

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -825,8 +825,8 @@ stream {
         {{ end }}
 
         {{ if not (empty $server.ProxySSL.PemFileName) }}
-        proxy_ssl_certificate                   {{ $server.ProxySSL.CAFileName }};
-        proxy_ssl_certificate_key               {{ $server.ProxySSL.CAFileName }};
+        proxy_ssl_certificate                   {{ $server.ProxySSL.PemFileName }};
+        proxy_ssl_certificate_key               {{ $server.ProxySSL.PemFileName }};
         {{ end }}
 
         {{ if not (empty $server.SSLCiphers) }}
@@ -1299,8 +1299,8 @@ stream {
             {{ end }}
 
             {{ if not (empty $location.ProxySSL.PemFileName) }}
-            proxy_ssl_certificate                   {{ $location.ProxySSL.CAFileName }};
-            proxy_ssl_certificate_key               {{ $location.ProxySSL.CAFileName }};
+            proxy_ssl_certificate                   {{ $location.ProxySSL.PemFileName }};
+            proxy_ssl_certificate_key               {{ $location.ProxySSL.PemFileName }};
             {{ end }}
         }
         {{ end }}

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -817,13 +817,16 @@ stream {
 
         {{ if not (empty $server.ProxySSL.CAFileName) }}
         # PEM sha: {{ $server.ProxySSL.CASHA }}
-        proxy_ssl_certificate                   {{ $server.ProxySSL.CAFileName }};
-        proxy_ssl_certificate_key               {{ $server.ProxySSL.CAFileName }};
         proxy_ssl_trusted_certificate           {{ $server.ProxySSL.CAFileName }};
         proxy_ssl_ciphers                       {{ $server.ProxySSL.Ciphers }};
         proxy_ssl_protocols                     {{ $server.ProxySSL.Protocols }};
         proxy_ssl_verify                        {{ $server.ProxySSL.Verify }};
         proxy_ssl_verify_depth                  {{ $server.ProxySSL.VerifyDepth }};
+        {{ end }}
+
+        {{ if not (empty $server.ProxySSL.PemFileName) }}
+        proxy_ssl_certificate                   {{ $server.ProxySSL.CAFileName }};
+        proxy_ssl_certificate_key               {{ $server.ProxySSL.CAFileName }};
         {{ end }}
 
         {{ if not (empty $server.SSLCiphers) }}
@@ -1285,6 +1288,19 @@ stream {
             {{ else }}
             # Location denied. Reason: {{ $location.Denied | quote }}
             return 503;
+            {{ end }}
+            {{ if not (empty $location.ProxySSL.CAFileName) }}
+            # PEM sha: {{ $location.ProxySSL.CASHA }}
+            proxy_ssl_trusted_certificate           {{ $location.ProxySSL.CAFileName }};
+            proxy_ssl_ciphers                       {{ $location.ProxySSL.Ciphers }};
+            proxy_ssl_protocols                     {{ $location.ProxySSL.Protocols }};
+            proxy_ssl_verify                        {{ $location.ProxySSL.Verify }};
+            proxy_ssl_verify_depth                  {{ $location.ProxySSL.VerifyDepth }};
+            {{ end }}
+
+            {{ if not (empty $location.ProxySSL.PemFileName) }}
+            proxy_ssl_certificate                   {{ $location.ProxySSL.CAFileName }};
+            proxy_ssl_certificate_key               {{ $location.ProxySSL.CAFileName }};
             {{ end }}
         }
         {{ end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
1. It enables the one-way authentication of backends based on the ca.crt configured in the annotation proxy-ssl-secret. 
2. It enables the configuration of different proxy-ssl-secrets for the different locations of the same server

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #4688 #4503 

**Special notes for your reviewer**:
