### PR TITLE
adds hability to use externalIP when controller service is of type NodePort

### DIFF
--- a/internal/ingress/status/status.go
+++ b/internal/ingress/status/status.go
@@ -338,7 +338,13 @@ func statusAddressFromService(service string, kubeClient clientset.Interface) ([
 	case apiv1.ServiceTypeClusterIP:
 		return []string{svc.Spec.ClusterIP}, nil
 	case apiv1.ServiceTypeNodePort:
-		return []string{svc.Spec.ClusterIP}, nil
+		addresses := []string{}
+		if svc.Spec.ExternalIPs != nil {
+			addresses = append(addresses, svc.Spec.ExternalIPs...)
+		} else {
+			addresses = append(addresses, svc.Spec.ClusterIP)
+		}
+		return addresses, nil
 	case apiv1.ServiceTypeLoadBalancer:
 		addresses := []string{}
 		for _, ip := range svc.Status.LoadBalancer.Ingress {


### PR DESCRIPTION
**What this PR does / why we need it**: To enable externalIPs to be addressed to ingresses when controller's service is of type NodePort

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #4699

**Special notes for your reviewer**:
