### PR TITLE
Move canary information from ingress.Backend to ingress.Location

### DIFF
--- a/internal/ingress/controller/controller_test.go
+++ b/internal/ingress/controller/controller_test.go
@@ -293,6 +293,15 @@ func TestMergeAlternativeBackends(t *testing.T) {
 						},
 					},
 				},
+				ParsedAnnotations: &annotations.Ingress{
+					Canary: canary.Config{
+						Enabled:     true,
+						Weight:      20,
+						Header:      "canaryByHeader",
+						HeaderValue: "customHeaderValue",
+						Cookie:      "canaryByCookie",
+					},
+				},
 			},
 			map[string]*ingress.Backend{
 				"example-http-svc-80": {
@@ -302,9 +311,6 @@ func TestMergeAlternativeBackends(t *testing.T) {
 				"example-http-svc-canary-80": {
 					Name:     "example-http-svc-canary-80",
 					NoServer: true,
-					TrafficShapingPolicy: ingress.TrafficShapingPolicy{
-						Weight: 20,
-					},
 				},
 			},
 			map[string]*ingress.Server{
@@ -320,16 +326,12 @@ func TestMergeAlternativeBackends(t *testing.T) {
 			},
 			map[string]*ingress.Backend{
 				"example-http-svc-80": {
-					Name:                "example-http-svc-80",
-					NoServer:            false,
-					AlternativeBackends: []string{"example-http-svc-canary-80"},
+					Name:     "example-http-svc-80",
+					NoServer: false,
 				},
 				"example-http-svc-canary-80": {
 					Name:     "example-http-svc-canary-80",
 					NoServer: true,
-					TrafficShapingPolicy: ingress.TrafficShapingPolicy{
-						Weight: 20,
-					},
 				},
 			},
 			map[string]*ingress.Server{
@@ -337,8 +339,15 @@ func TestMergeAlternativeBackends(t *testing.T) {
 					Hostname: "example.com",
 					Locations: []*ingress.Location{
 						{
-							Path:    "/",
-							Backend: "example-http-svc-80",
+							Path:                   "/",
+							Backend:                "example-http-svc-80",
+							AlternativeBackendName: "example-http-svc-canary-80",
+							TrafficShapingPolicy: ingress.TrafficShapingPolicy{
+								Weight:      20,
+								Header:      "canaryByHeader",
+								HeaderValue: "customHeaderValue",
+								Cookie:      "canaryByCookie",
+							},
 						},
 					},
 				},
@@ -393,6 +402,11 @@ func TestMergeAlternativeBackends(t *testing.T) {
 						},
 					},
 				},
+				ParsedAnnotations: &annotations.Ingress{
+					Canary: canary.Config{
+						Enabled: true,
+					},
+				},
 			},
 			map[string]*ingress.Backend{
 				"example-foo-http-svc-80": {
@@ -402,21 +416,14 @@ func TestMergeAlternativeBackends(t *testing.T) {
 				"example-foo-http-svc-canary-80": {
 					Name:     "example-foo-http-svc-canary-80",
 					NoServer: true,
-					TrafficShapingPolicy: ingress.TrafficShapingPolicy{
-						Weight: 20,
-					},
 				},
 				"example-http-svc-80": {
-					Name:                "example-http-svc-80",
-					NoServer:            false,
-					AlternativeBackends: []string{"example-http-svc-canary-80"},
+					Name:     "example-http-svc-80",
+					NoServer: false,
 				},
 				"example-http-svc-canary-80": {
 					Name:     "example-http-svc-canary-80",
 					NoServer: true,
-					TrafficShapingPolicy: ingress.TrafficShapingPolicy{
-						Weight: 20,
-					},
 				},
 			},
 			map[string]*ingress.Server{
@@ -433,45 +440,49 @@ func TestMergeAlternativeBackends(t *testing.T) {
 					Hostname: "example.com",
 					Locations: []*ingress.Location{
 						{
-							Path:    "/",
-							Backend: "example-http-svc-80",
+							Path:                   "/",
+							Backend:                "example-http-svc-80",
+							AlternativeBackendName: "example-http-svc-canary-80",
 						},
 					},
 				},
 			},
 			map[string]*ingress.Backend{
 				"example-foo-http-svc-80": {
-					Name:                "example-foo-http-svc-80",
-					NoServer:            false,
-					AlternativeBackends: []string{"example-foo-http-svc-canary-80"},
+					Name:     "example-foo-http-svc-80",
+					NoServer: false,
 				},
 				"example-foo-http-svc-canary-80": {
 					Name:     "example-foo-http-svc-canary-80",
 					NoServer: true,
-					TrafficShapingPolicy: ingress.TrafficShapingPolicy{
-						Weight: 20,
-					},
 				},
 				"example-http-svc-80": {
-					Name:                "example-http-svc-80",
-					NoServer:            false,
-					AlternativeBackends: []string{"example-http-svc-canary-80"},
+					Name:     "example-http-svc-80",
+					NoServer: false,
 				},
 				"example-http-svc-canary-80": {
 					Name:     "example-http-svc-canary-80",
 					NoServer: true,
-					TrafficShapingPolicy: ingress.TrafficShapingPolicy{
-						Weight: 20,
-					},
 				},
 			},
 			map[string]*ingress.Server{
+				"foo.bar": {
+					Hostname: "foo.bar",
+					Locations: []*ingress.Location{
+						{
+							Path:                   "/",
+							Backend:                "example-foo-http-svc-80",
+							AlternativeBackendName: "example-foo-http-svc-canary-80",
+						},
+					},
+				},
 				"example.com": {
 					Hostname: "example.com",
 					Locations: []*ingress.Location{
 						{
-							Path:    "/",
-							Backend: "example-http-svc-80",
+							Path:                   "/",
+							Backend:                "example-http-svc-80",
+							AlternativeBackendName: "example-http-svc-canary-80",
 						},
 					},
 				},
@@ -507,14 +518,16 @@ func TestMergeAlternativeBackends(t *testing.T) {
 						},
 					},
 				},
+				ParsedAnnotations: &annotations.Ingress{
+					Canary: canary.Config{
+						Enabled: true,
+					},
+				},
 			},
 			map[string]*ingress.Backend{
 				"example-http-svc-canary-80": {
 					Name:     "example-http-svc-canary-80",
 					NoServer: true,
-					TrafficShapingPolicy: ingress.TrafficShapingPolicy{
-						Weight: 20,
-					},
 				},
 			},
 			map[string]*ingress.Server{},
@@ -536,6 +549,11 @@ func TestMergeAlternativeBackends(t *testing.T) {
 						},
 					},
 				},
+				ParsedAnnotations: &annotations.Ingress{
+					Canary: canary.Config{
+						Enabled: true,
+					},
+				},
 			},
 			map[string]*ingress.Backend{
 				"example-http-svc-80": {
@@ -545,9 +563,6 @@ func TestMergeAlternativeBackends(t *testing.T) {
 				"example-http-svc-canary-80": {
 					Name:     "example-http-svc-canary-80",
 					NoServer: true,
-					TrafficShapingPolicy: ingress.TrafficShapingPolicy{
-						Weight: 20,
-					},
 				},
 			},
 			map[string]*ingress.Server{
@@ -563,16 +578,12 @@ func TestMergeAlternativeBackends(t *testing.T) {
 			},
 			map[string]*ingress.Backend{
 				"example-http-svc-80": {
-					Name:                "example-http-svc-80",
-					NoServer:            false,
-					AlternativeBackends: []string{"example-http-svc-canary-80"},
+					Name:     "example-http-svc-80",
+					NoServer: false,
 				},
 				"example-http-svc-canary-80": {
 					Name:     "example-http-svc-canary-80",
 					NoServer: true,
-					TrafficShapingPolicy: ingress.TrafficShapingPolicy{
-						Weight: 20,
-					},
 				},
 			},
 			map[string]*ingress.Server{
@@ -580,8 +591,9 @@ func TestMergeAlternativeBackends(t *testing.T) {
 					Hostname: "_",
 					Locations: []*ingress.Location{
 						{
-							Path:    "/",
-							Backend: "example-http-svc-80",
+							Path:                   "/",
+							Backend:                "example-http-svc-80",
+							AlternativeBackendName: "example-http-svc-canary-80",
 						},
 					},
 				},
@@ -602,6 +614,11 @@ func TestMergeAlternativeBackends(t *testing.T) {
 						},
 					},
 				},
+				ParsedAnnotations: &annotations.Ingress{
+					Canary: canary.Config{
+						Enabled: true,
+					},
+				},
 			},
 			map[string]*ingress.Backend{
 				"upstream-default-backend": {
@@ -611,9 +628,6 @@ func TestMergeAlternativeBackends(t *testing.T) {
 				"example-http-svc-canary-80": {
 					Name:     "example-http-svc-canary-80",
 					NoServer: true,
-					TrafficShapingPolicy: ingress.TrafficShapingPolicy{
-						Weight: 20,
-					},
 				},
 			},
 			map[string]*ingress.Server{
@@ -653,8 +667,8 @@ func TestMergeAlternativeBackends(t *testing.T) {
 				}
 
 				if !actualUpstream.Equal(expUpstream) {
-					t.Logf("actual upstream %s alternative backends: %s", actualUpstream.Name, actualUpstream.AlternativeBackends)
-					t.Logf("expected upstream %s alternative backends: %s", expUpstream.Name, expUpstream.AlternativeBackends)
+					t.Logf("actual upstream %s", actualUpstream.Name)
+					t.Logf("expected upstream %s", expUpstream.Name)
 					t.Errorf("upstream %s was not equal to what was expected: ", upsName)
 				}
 			}
@@ -1330,6 +1344,10 @@ func TestGetBackendServers(t *testing.T) {
 					t.Errorf("all location backend should be 'example-http-svc-1-80'")
 				}
 
+				if s.Locations[0].AlternativeBackendName != "example-http-svc-2-80" || s.Locations[1].AlternativeBackendName != "" || s.Locations[2].AlternativeBackendName != "example-http-svc-2-80" {
+					t.Errorf("example-http-svc-2-80 should be alternative upstream for 'example-http-svc-1-80'")
+				}
+
 				if len(upstreams) != 3 {
 					t.Errorf("upstreams count should be 3, got %d", len(upstreams))
 					return
@@ -1341,9 +1359,6 @@ func TestGetBackendServers(t *testing.T) {
 				}
 				if upstreams[0].NoServer {
 					t.Errorf("'example-http-svc-1-80' should be primary upstream, got as alternative upstream")
-				}
-				if len(upstreams[0].AlternativeBackends) != 1 || upstreams[0].AlternativeBackends[0] != "example-http-svc-2-80" {
-					t.Errorf("example-http-svc-2-80 should be alternative upstream for 'example-http-svc-1-80'")
 				}
 			},
 		},

--- a/internal/ingress/controller/nginx.go
+++ b/internal/ingress/controller/nginx.go
@@ -954,16 +954,14 @@ func configureBackends(rawBackends []*ingress.Backend) error {
 			service = &apiv1.Service{Spec: backend.Service.Spec}
 		}
 		luaBackend := &ingress.Backend{
-			Name:                 backend.Name,
-			Port:                 backend.Port,
-			SSLPassthrough:       backend.SSLPassthrough,
-			SessionAffinity:      backend.SessionAffinity,
-			UpstreamHashBy:       backend.UpstreamHashBy,
-			LoadBalancing:        backend.LoadBalancing,
-			Service:              service,
-			NoServer:             backend.NoServer,
-			TrafficShapingPolicy: backend.TrafficShapingPolicy,
-			AlternativeBackends:  backend.AlternativeBackends,
+			Name:            backend.Name,
+			Port:            backend.Port,
+			SSLPassthrough:  backend.SSLPassthrough,
+			SessionAffinity: backend.SessionAffinity,
+			UpstreamHashBy:  backend.UpstreamHashBy,
+			LoadBalancing:   backend.LoadBalancing,
+			Service:         service,
+			NoServer:        backend.NoServer,
 		}
 
 		var endpoints []ingress.Endpoint

--- a/internal/ingress/types.go
+++ b/internal/ingress/types.go
@@ -103,12 +103,6 @@ type Backend struct {
 	// alternative backend.
 	// This can be used to share multiple upstreams in the sam nginx server block.
 	NoServer bool `json:"noServer"`
-	// Policies to describe the characteristics of an alternative backend.
-	// +optional
-	TrafficShapingPolicy TrafficShapingPolicy `json:"trafficShapingPolicy,omitempty"`
-	// Contains a list of backends without servers that are associated with this backend.
-	// +optional
-	AlternativeBackends []string `json:"alternativeBackends,omitempty"`
 }
 
 // TrafficShapingPolicy describes the policies to put in place when a backend has no server and is used as an
@@ -333,6 +327,12 @@ type Location struct {
 	// Mirror allows you to mirror traffic to a "test" backend
 	// +optional
 	Mirror mirror.Config `json:"mirror,omitempty"`
+	// Policies to describe the characteristics of an alternative backend.
+	// +optional
+	TrafficShapingPolicy TrafficShapingPolicy `json:"trafficShapingPolicy,omitempty"`
+	// Alternative backend name for this location in "Canary" feature
+	// +optional
+	AlternativeBackendName string `json:"alternative-backend-name"`
 }
 
 // SSLPassthroughBackend describes a SSL upstream server configured

--- a/internal/ingress/types_equals.go
+++ b/internal/ingress/types_equals.go
@@ -134,11 +134,7 @@ func (b1 *Backend) Equal(b2 *Backend) bool {
 		return false
 	}
 
-	if !b1.TrafficShapingPolicy.Equal(b2.TrafficShapingPolicy) {
-		return false
-	}
-
-	return sets.StringElementsMatch(b1.AlternativeBackends, b2.AlternativeBackends)
+	return true
 }
 
 // Equal tests for equality between two SessionAffinityConfig types
@@ -445,6 +441,14 @@ func (l1 *Location) Equal(l2 *Location) bool {
 	}
 
 	if l1.Mirror.RequestBody != l2.Mirror.RequestBody {
+		return false
+	}
+
+	if l1.AlternativeBackendName != l2.AlternativeBackendName {
+		return false
+	}
+
+	if !l1.TrafficShapingPolicy.Equal(l2.TrafficShapingPolicy) {
 		return false
 	}
 

--- a/internal/ingress/zz_generated.deepcopy.go
+++ b/internal/ingress/zz_generated.deepcopy.go
@@ -43,12 +43,6 @@ func (in *Backend) DeepCopyInto(out *Backend) {
 	}
 	in.SessionAffinity.DeepCopyInto(&out.SessionAffinity)
 	out.UpstreamHashBy = in.UpstreamHashBy
-	out.TrafficShapingPolicy = in.TrafficShapingPolicy
-	if in.AlternativeBackends != nil {
-		in, out := &in.AlternativeBackends, &out.AlternativeBackends
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	}
 	return
 }
 

--- a/rootfs/etc/nginx/lua/balancer/chash.lua
+++ b/rootfs/etc/nginx/lua/balancer/chash.lua
@@ -9,8 +9,6 @@ function _M.new(self, backend)
   local o = {
     instance = self.factory:new(nodes),
     hash_by = backend["upstreamHashByConfig"]["upstream-hash-by"],
-    traffic_shaping_policy = backend.trafficShapingPolicy,
-    alternative_backends = backend.alternativeBackends,
   }
   setmetatable(o, self)
   self.__index = self

--- a/rootfs/etc/nginx/lua/balancer/ewma.lua
+++ b/rootfs/etc/nginx/lua/balancer/ewma.lua
@@ -194,8 +194,6 @@ function _M.sync(self, backend)
 
   ngx_log(INFO, string_format("[%s] peers have changed for backend %s", self.name, backend.name))
 
-  self.traffic_shaping_policy = backend.trafficShapingPolicy
-  self.alternative_backends = backend.alternativeBackends
   self.peers = backend.endpoints
 
   for _, endpoint_string in ipairs(normalized_endpoints_removed) do
@@ -215,8 +213,6 @@ end
 function _M.new(self, backend)
   local o = {
     peers = backend.endpoints,
-    traffic_shaping_policy = backend.trafficShapingPolicy,
-    alternative_backends = backend.alternativeBackends,
   }
   setmetatable(o, self)
   self.__index = self

--- a/rootfs/etc/nginx/lua/balancer/resty.lua
+++ b/rootfs/etc/nginx/lua/balancer/resty.lua
@@ -14,9 +14,6 @@ function _M.new(self, o)
 end
 
 function _M.sync(self, backend)
-  self.traffic_shaping_policy = backend.trafficShapingPolicy
-  self.alternative_backends = backend.alternativeBackends
-
   local nodes = util.get_nodes(backend.endpoints)
   local changed = not util.deep_compare(self.instance.nodes, nodes)
   if not changed then

--- a/rootfs/etc/nginx/lua/balancer/round_robin.lua
+++ b/rootfs/etc/nginx/lua/balancer/round_robin.lua
@@ -8,8 +8,6 @@ function _M.new(self, backend)
   local nodes = util.get_nodes(backend.endpoints)
   local o = {
     instance = self.factory:new(nodes),
-    traffic_shaping_policy = backend.trafficShapingPolicy,
-    alternative_backends = backend.alternativeBackends,
   }
   setmetatable(o, self)
   self.__index = self

--- a/rootfs/etc/nginx/lua/balancer/sticky.lua
+++ b/rootfs/etc/nginx/lua/balancer/sticky.lua
@@ -12,9 +12,7 @@ end
 
 function _M.new(self)
   local o = {
-    alternative_backends = nil,
     cookie_session_affinity = nil,
-    traffic_shaping_policy = nil
   }
 
   setmetatable(o, self)
@@ -138,8 +136,6 @@ function _M.sync(self, backend)
   -- reload balancer nodes
   balancer_resty.sync(self, backend)
 
-  self.traffic_shaping_policy = backend.trafficShapingPolicy
-  self.alternative_backends = backend.alternativeBackends
   self.cookie_session_affinity = backend.sessionAffinityConfig.cookieSessionAffinity
 end
 

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -960,6 +960,12 @@ stream {
             set $service_name   {{ $ing.Service | quote }};
             set $service_port   {{ $ing.ServicePort | quote }};
             set $location_path  {{ $location.Path | escapeLiteralDollar | quote }};
+            set $alternative_backend_name  {{ $location.AlternativeBackendName | quote }};
+
+            set $traffic_shaping_policy_weight {{ $location.TrafficShapingPolicy.Weight | quote }};
+            set $traffic_shaping_policy_header {{ $location.TrafficShapingPolicy.Header | quote }};
+            set $traffic_shaping_policy_header_value {{ $location.TrafficShapingPolicy.HeaderValue | quote }};
+            set $traffic_shaping_policy_cookie {{ $location.TrafficShapingPolicy.Cookie | quote }};
 
             {{ if $all.Cfg.EnableOpentracing }}
             {{ opentracingPropagateContext $location }};


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR moves canary information (`TrafficShapingPolicy` & `AlternativeBackends`) from `ingress.Backend` to `ingress.Location`. This change tries to resolve **fundamental issue in canary feature** (https://github.com/kubernetes/ingress-nginx/issues/4368#issuecomment-515574775).

Currently there are some bugs/limitation on Canary feature (like #4028, #4667, #4368).
As @ElvinEfendi says on the comment above, this is due to difference between "how to configure" and "how implemented" for Canary information. 

To remove this difference, I suggest to move canary information from `ingress.Backend` to `ingress.Location`.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

fixes #4028 , fixes #4667 

**Special notes for your reviewer**:
N/A