### PR TITLE
Update socket.go

### DIFF
--- a/internal/ingress/metric/collectors/socket.go
+++ b/internal/ingress/metric/collectors/socket.go
@@ -145,7 +145,7 @@ func NewSocketCollector(pod, namespace, class string, metricsPerHost bool) (*Soc
 		requestTime: prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
 				Name:        "request_duration_seconds",
-				Help:        "The request processing time in milliseconds",
+				Help:        "The total request processing time in milliseconds(Time from first byte read to last byte written)",
 				Namespace:   PrometheusNamespace,
 				ConstLabels: constLabels,
 			},
@@ -186,7 +186,7 @@ func NewSocketCollector(pod, namespace, class string, metricsPerHost bool) (*Soc
 		upstreamLatency: prometheus.NewSummaryVec(
 			prometheus.SummaryOpts{
 				Name:        "ingress_upstream_latency_seconds",
-				Help:        "Upstream service latency per Ingress",
+				Help:        "Upstream service latency per Ingress(time spent on establishing a connection with the upstream server)",
 				Namespace:   PrometheusNamespace,
 				ConstLabels: constLabels,
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:

Add a little more description to these two metrics to make them a bit more clear what they exactly are giving metrics for.

It wasn't quite clear what they were until spending time to uncover what nginx values they were actually using so I copied some of the text from nginx's docs for $upstream_response_time and $request_time