### PR TITLE
improve logging for custom-error-pages image

### DIFF
--- a/images/custom-error-pages/main.go
+++ b/images/custom-error-pages/main.go
@@ -66,6 +66,10 @@ const (
 
 func main() {
 	klog.InitFlags(nil)
+
+	// increase log level to get old logging behavior
+	flag.Set("v", "3")
+
 	flag.Parse()
 
 	errFilesPath := "/www"

--- a/images/custom-error-pages/main.go
+++ b/images/custom-error-pages/main.go
@@ -124,7 +124,6 @@ func errorHandler(path string) func(http.ResponseWriter, *http.Request) {
 			code = 404
 			klog.V(3).Infof("unexpected error reading return code: %v. Using %v", err, code)
 		}
-		w.WriteHeader(code)
 
 		if !strings.HasPrefix(ext, ".") {
 			ext = "." + ext
@@ -148,6 +147,7 @@ func errorHandler(path string) func(http.ResponseWriter, *http.Request) {
 		}
 		defer f.Close()
 		klog.Errorf("serving custom error response for code %v and format %v from file %v", code, format, file)
+		w.WriteHeader(code)
 		io.Copy(w, f)
 
 		duration := time.Now().Sub(start).Seconds()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
If you use the image `custom-error-pages` as the default backend (--default-backend-service) and a request goes to the default server, the container throws this error:
```
format not specified. Using text/html
unexpected error reading return code: strconv.Atoi: parsing "": invalid syntax. Using 404
```
Because the HTTP headers `X-Format` and `X-Code` are not set by the default server.

With this PR, the image `customer error page` uses klog instead of log and it is possible to lower the log level.
