### PR TITLE
Docker image: Add source code reference label

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,7 @@ container: clean-container .container-$(ARCH)
 	cp -RP ./* $(TEMP_DIR)
 	$(SED_I) "s|BASEIMAGE|$(BASEIMAGE)|g" $(DOCKERFILE)
 	$(SED_I) "s|QEMUARCH|$(QEMUARCH)|g" $(DOCKERFILE)
+	$(SED_I) "s|VERSION|$(TAG)|g" $(DOCKERFILE)
 
 ifeq ($(ARCH),amd64)
 	# When building "normally" for amd64, remove the whole line, it has no part in the amd64 image

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -14,6 +14,8 @@
 
 FROM BASEIMAGE
 
+LABEL org.opencontainers.image.source="https://github.com/kubernetes/ingress-nginx"
+
 CROSS_BUILD_COPY qemu-QEMUARCH-static /usr/bin/
 
 WORKDIR  /etc/nginx

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -14,7 +14,12 @@
 
 FROM BASEIMAGE
 
+LABEL org.opencontainers.image.title='NGINX Ingress Controller for Kubernetes'
+LABEL org.opencontainers.image.documentation='https://kubernetes.github.io/ingress-nginx/'
 LABEL org.opencontainers.image.source="https://github.com/kubernetes/ingress-nginx"
+LABEL org.opencontainers.image.vendor='The Kubernetes Authors'
+LABEL org.opencontainers.image.licenses='Apache-2.0'
+LABEL org.opencontainers.image.version='VERSION'
 
 CROSS_BUILD_COPY qemu-QEMUARCH-static /usr/bin/
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Add a [opencontainers-standardized label](https://github.com/opencontainers/image-spec/blob/master/annotations.md#pre-defined-annotation-keys) (source) to the Docker image, referencing the ingress-nginx GitHub repository.

This allows tools that automate component updates (in our case [Renovate Bot](https://github.com/renovatebot/renovate)) to automatically find the source repository for the Docker image and extract release notes from there. Renovate Bot can include the relevant release notes automatically in a merge request changing the component version.

In https://github.com/renovatebot/renovate/pull/3753, Renovate added the label for their own Docker image.
