### PR TITLE
dev-env.sh: fix for parsing `minikube status` output of newer versions, fix shellcheck lints

### DIFF
--- a/build/dev-env.sh
+++ b/build/dev-env.sh
@@ -37,11 +37,12 @@ test $(minikube status | grep -c Running) -ge 2 && $(minikube status | grep -q '
     --extra-config=kubelet.sync-frequency=1s \
     --extra-config=apiserver.authorization-mode=RBAC
 
+# shellcheck disable=SC2046
 eval $(minikube docker-env --shell bash)
 
 echo "[dev-env] building container"
 make build container
-docker tag "${REGISTRY}/nginx-ingress-controller-${ARCH}:${TAG}" ${DEV_IMAGE}
+docker tag "${REGISTRY}/nginx-ingress-controller-${ARCH}:${TAG}" "${DEV_IMAGE}"
 
 # kubectl >= 1.14 includes Kustomize via "apply -k". Makes it easier to use on Linux as well, assuming kubectl installed
 KUBE_CLIENT_VERSION=$(kubectl version --client --short | awk '{print $3}' | cut -d. -f2) || true
@@ -56,7 +57,7 @@ if ! kubectl get namespace "${NAMESPACE}"; then
   kubectl create namespace "${NAMESPACE}"
 fi
 
-kubectl get deploy nginx-ingress-controller -n ${NAMESPACE} && kubectl delete deploy nginx-ingress-controller -n ${NAMESPACE}
+kubectl get deploy nginx-ingress-controller -n "${NAMESPACE}" && kubectl delete deploy nginx-ingress-controller -n "${NAMESPACE}"
 
 ROOT=./deploy/minikube
 

--- a/build/dev-env.sh
+++ b/build/dev-env.sh
@@ -33,7 +33,8 @@ export REGISTRY=${REGISTRY:-ingress-controller}
 
 DEV_IMAGE=${REGISTRY}/nginx-ingress-controller:${TAG}
 
-test $(minikube status | grep -c Running) -ge 2 && $(minikube status | grep -q 'Correctly Configured') || minikube start \
+{ [ "$(minikube status | grep -c Running)" -ge 2 ] && minikube status | grep -qE ': Configured$|Correctly Configured'; } \
+  || minikube start \
     --extra-config=kubelet.sync-frequency=1s \
     --extra-config=apiserver.authorization-mode=RBAC
 


### PR DESCRIPTION
**What this PR does / why we need it**:

I have `minikube version: v1.5.0`, and they changed the `minikube status` output with https://github.com/kubernetes/minikube/commit/ca7d378aaaef66ef69c4f88303e2ec29e10f47b3. This patch supports both old and new format, and includes some lint fixes so shellcheck is quiet about the script.