### PR TITLE
Add annotation to skip certificate hostname verification (allow using certificates with mismatching CN/SAN)

### DIFF
--- a/docs/user-guide/nginx-configuration/annotations.md
+++ b/docs/user-guide/nginx-configuration/annotations.md
@@ -117,6 +117,7 @@ You can add these Kubernetes annotations to specific Ingress objects to customiz
 |[nginx.ingress.kubernetes.io/modsecurity-snippet](#modsecurity)|string|
 |[nginx.ingress.kubernetes.io/mirror-uri](#mirror)|string|
 |[nginx.ingress.kubernetes.io/mirror-request-body](#mirror)|string|
+|[nginx.ingress.kubernetes.io/use-certificate-without-hostname-verification](#use-certificate-without-hostname-verification)|"true" or "false"|
 
 ### Canary
 
@@ -875,3 +876,15 @@ nginx.ingress.kubernetes.io/mirror-request-body: "off"
 The request sent to the mirror is linked to the orignial request. If you have a slow mirror backend, then the orignial request will throttle.
 
 For more information on the mirror module see https://nginx.org/en/docs/http/ngx_http_mirror_module.html
+
+### Use certificate without hostname verification
+
+By default, a TLS certificate is only used if its Common Name (CN) or Subject Alternative Name (SAN) matches the hostname of your ingress.
+
+If you want to explicitly force use of a mismatching certificate and skip the hostname check, use:
+
+```yaml
+nginx.ingress.kubernetes.io/use-certificate-without-hostname-verification: "true"
+```
+
+This can make sense in rare application scenarios where a 3rd party makes requests and checks the certificate against a custom CA without verifying the server name.

--- a/internal/ingress/annotations/annotations.go
+++ b/internal/ingress/annotations/annotations.go
@@ -19,6 +19,7 @@ package annotations
 import (
 	"github.com/imdario/mergo"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/canary"
+	"k8s.io/ingress-nginx/internal/ingress/annotations/certificatewithouthostnameverification"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/modsecurity"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/proxyssl"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/sslcipher"
@@ -85,34 +86,35 @@ type Ingress struct {
 	CustomHTTPErrors     []int
 	DefaultBackend       *apiv1.Service
 	//TODO: Change this back into an error when https://github.com/imdario/mergo/issues/100 is resolved
-	FastCGI            fastcgi.Config
-	Denied             *string
-	ExternalAuth       authreq.Config
-	EnableGlobalAuth   bool
-	HTTP2PushPreload   bool
-	Proxy              proxy.Config
-	ProxySSL           proxyssl.Config
-	RateLimit          ratelimit.Config
-	Redirect           redirect.Config
-	Rewrite            rewrite.Config
-	Satisfy            string
-	SecureUpstream     secureupstream.Config
-	ServerSnippet      string
-	ServiceUpstream    bool
-	SessionAffinity    sessionaffinity.Config
-	SSLPassthrough     bool
-	UsePortInRedirects bool
-	UpstreamHashBy     upstreamhashby.Config
-	LoadBalancing      string
-	UpstreamVhost      string
-	Whitelist          ipwhitelist.SourceRange
-	XForwardedPrefix   string
-	SSLCiphers         string
-	Logs               log.Config
-	LuaRestyWAF        luarestywaf.Config
-	InfluxDB           influxdb.Config
-	ModSecurity        modsecurity.Config
-	Mirror             mirror.Config
+	FastCGI                                   fastcgi.Config
+	Denied                                    *string
+	ExternalAuth                              authreq.Config
+	EnableGlobalAuth                          bool
+	HTTP2PushPreload                          bool
+	Proxy                                     proxy.Config
+	ProxySSL                                  proxyssl.Config
+	RateLimit                                 ratelimit.Config
+	Redirect                                  redirect.Config
+	Rewrite                                   rewrite.Config
+	Satisfy                                   string
+	SecureUpstream                            secureupstream.Config
+	ServerSnippet                             string
+	ServiceUpstream                           bool
+	SessionAffinity                           sessionaffinity.Config
+	SSLPassthrough                            bool
+	UsePortInRedirects                        bool
+	UpstreamHashBy                            upstreamhashby.Config
+	LoadBalancing                             string
+	UpstreamVhost                             string
+	Whitelist                                 ipwhitelist.SourceRange
+	XForwardedPrefix                          string
+	SSLCiphers                                string
+	Logs                                      log.Config
+	LuaRestyWAF                               luarestywaf.Config
+	InfluxDB                                  influxdb.Config
+	ModSecurity                               modsecurity.Config
+	Mirror                                    mirror.Config
+	UseCertificateWithoutHostnameVerification bool
 }
 
 // Extractor defines the annotation parsers to be used in the extraction of annotations
@@ -162,6 +164,7 @@ func NewAnnotationExtractor(cfg resolver.Resolver) Extractor {
 			"BackendProtocol":      backendprotocol.NewParser(cfg),
 			"ModSecurity":          modsecurity.NewParser(cfg),
 			"Mirror":               mirror.NewParser(cfg),
+			"UseCertificateWithoutHostnameVerification": certificatewithouthostnameverification.NewParser(cfg),
 		},
 	}
 }

--- a/internal/ingress/annotations/certificatewithouthostnameverification/main.go
+++ b/internal/ingress/annotations/certificatewithouthostnameverification/main.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certificatewithouthostnameverification
+
+import (
+	networking "k8s.io/api/networking/v1beta1"
+
+	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
+	"k8s.io/ingress-nginx/internal/ingress/resolver"
+)
+
+type certificateWithoutHostnameVerification struct {
+	r resolver.Resolver
+}
+
+// NewParser creates an annotation parser
+func NewParser(r resolver.Resolver) parser.IngressAnnotation {
+	return certificateWithoutHostnameVerification{r}
+}
+
+// Parse parses the annotations contained in the ingress
+// rule used to indicate if the redirects must
+func (a certificateWithoutHostnameVerification) Parse(ing *networking.Ingress) (interface{}, error) {
+	// Default to false in case of no/empty value, since previous default behavior was to verify hostname
+	value, err := parser.GetBoolAnnotation("use-certificate-without-hostname-verification", ing)
+	if err != nil {
+		return false, nil
+	}
+	return value, nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, ingress-nginx would deny use of certificates whose CN/SAN doesn't have a hostname matching the ingress object. It falls back to the default certificate in that case.

Outside regular WWW use cases, there are companies and entities using TLS differently... In my case, we purchased a simulation tool which ships with a fixed test certificate. That tool makes requests to an endpoint which we develop (defined by an `Ingress` object that uses the fixed test certificate file!), and accepts exactly their provided server certificate / CA. The domain name of our endpoint is of course different (e.g. per-developer, per-environment) since the test certificate is the same for all customers of that tool. No CA private key is provided, so I can't create custom certificates for this environment (and why should I do that...).

Also, for regular use cases, it's always a pain to debug why ingress-nginx delivers the default certificate (read old logs, etc.). Using the certificate specified in the `Ingress` object, even if mismatching, might be a saner default for many people, since the developer/admin knows which certificate was specified. This annotation allows switching to that as default (mind that I didn't implement `if (!annotation on ingress) return default backend annotation`, but that can be added if desired).

**Special notes for your reviewer**:

This should of course have unit tests. I just couldn't find quickly how to create fake certificates in `controller_test.go` which can be found by the local store. And also, I wouldn't be able to run those tests nicely on macOS (see #4762).

Also I don't know what the existing warning `Validating certificate against DNS names. This will be deprecated in a future version` means exactly – for instance, it might mean that the hostname check might be removed altogether?!