### PR TITLE
[docs] Add info about x-forwarded-prefix breaking change

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -365,6 +365,10 @@ _New Features:_
 
 - NGINX 1.15.10
 
+_Breaking changes:_
+
+- `x-forwarded-prefix` annotation changed from a boolean to a string, see [#3786](https://github.com/kubernetes/ingress-nginx/pull/3786)
+
 _Changes:_
 
 - [X] [#3743](https://github.com/kubernetes/ingress-nginx/pull/3743) Remove session-cookie-hash annotation


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
#3786 changed the way the `x-forwarded-prefix` annotation worked. Informing users in release notes helps with to take appropriate action when upgrading.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

I am using the `x-forwarded-prefix: true` annotation and ran into problems when upgrading from v0.21 to v0.26.

I am not sure about the appropriate mitigation, so far the following worked for me:

### v0.21
```
apiVersion: networking.k8s.io/v1beta1
kind: Ingress
metadata:
  name: test-ingress
  annotations:
    nginx.ingress.kubernetes.io/rewrite-target: /
    nginx.ingress.kubernetes.io/x-forwarded-prefix: "true"
spec:
  rules:
  - http:
      paths:
      - path: /testpath/
        backend:
          serviceName: test
          servicePort: 80
```
### v0.26
```
apiVersion: networking.k8s.io/v1beta1
kind: Ingress
metadata:
  name: test-ingress
  annotations:
    nginx.ingress.kubernetes.io/rewrite-target: /
    nginx.ingress.kubernetes.io/x-forwarded-prefix: "/testpath/"
spec:
  rules:
  - http:
      paths:
      - path: /testpath/
        backend:
          serviceName: test
          servicePort: 80
```