### PR TITLE
Remove extraneous back-tick in redirects example

### DIFF
--- a/docs/deploy/baremetal.md
+++ b/docs/deploy/baremetal.md
@@ -245,7 +245,7 @@ for generating redirect URLs that take into account the URL used by external cli
     NodePort:
 
     ```console
-    $ curl -D- http://myapp.example.com:30100`
+    $ curl -D- http://myapp.example.com:30100
     HTTP/1.1 308 Permanent Redirect
     Server: nginx/1.15.2
     Location: https://myapp.example.com/  #-> missing NodePort in HTTPS redirect


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Removes unneeded character. Attention to detail matters.