### PR TITLE
Update nginx image and Go to 1.13.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ export E2E_CHECK_LEAKS
 export SLOW_E2E_THRESHOLD
 
 # Set default base image dynamically for each arch
-BASEIMAGE?=quay.io/kubernetes-ingress-controller/nginx-$(ARCH):daf8634acf839708722cffc67a62e9316a2771c6
+BASEIMAGE?=quay.io/kubernetes-ingress-controller/nginx-$(ARCH):d523b4a96eec80324ee04afed74bf8bddcba09cf
 
 ifeq ($(ARCH),arm)
 	QEMUARCH=arm

--- a/build/run-in-docker.sh
+++ b/build/run-in-docker.sh
@@ -30,7 +30,7 @@ function cleanup {
 }
 trap cleanup EXIT
 
-E2E_IMAGE=quay.io/kubernetes-ingress-controller/e2e:v09052019-38b985663
+E2E_IMAGE=quay.io/kubernetes-ingress-controller/e2e:v11272019-7e993dda1
 
 DOCKER_OPTS=${DOCKER_OPTS:-}
 

--- a/images/e2e-prow/Makefile
+++ b/images/e2e-prow/Makefile
@@ -9,9 +9,9 @@ all: docker-build docker-push
 docker-build:
 	$(DOCKER) build \
 		--pull \
-		--build-arg K8S_RELEASE=v1.15.3 \
+		--build-arg K8S_RELEASE=v1.16.3 \
 		--build-arg ETCD_VERSION=v3.3.15 \
-		--build-arg KIND_VERSION=v0.5.1 \
+		--build-arg KIND_VERSION=v0.6.0 \
 		-t $(IMAGE):$(TAG) .
 
 docker-push:

--- a/images/e2e/Dockerfile
+++ b/images/e2e/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM quay.io/kubernetes-ingress-controller/nginx-amd64:0.92
+FROM quay.io/kubernetes-ingress-controller/nginx-amd64:d523b4a96eec80324ee04afed74bf8bddcba09cf
 
 RUN clean-install \
   g++ \
@@ -25,9 +25,9 @@ RUN clean-install \
   parallel \
   pkg-config
 
-ENV GOLANG_VERSION 1.13
+ENV GOLANG_VERSION 1.13.4
 ENV GO_ARCH        linux-amd64
-ENV GOLANG_SHA     68a2297eb099d1a76097905a2ce334e3155004ec08cdea85f24527be3c48e856
+ENV GOLANG_SHA     692d17071736f74be04a72a06dab9cac1cd759377bd85316e52b2227604c004c
 
 RUN set -eux; \
   url="https://golang.org/dl/go${GOLANG_VERSION}.${GO_ARCH}.tar.gz"; \

--- a/test/e2e-image/Dockerfile
+++ b/test/e2e-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/kubernetes-ingress-controller/e2e:v09052019-38b985663 AS BASE
+FROM quay.io/kubernetes-ingress-controller/e2e:v11272019-7e993dda1 AS BASE
 
 FROM quay.io/kubernetes-ingress-controller/debian-base-amd64:0.1
 

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -48,14 +48,13 @@ KIND_CLUSTER_NAME="ingress-nginx-dev"
 kind --version || $(echo "Please install kind before running e2e tests";exit 1)
 
 echo "[dev-env] creating Kubernetes cluster with kind"
-# TODO: replace the custom images after https://github.com/kubernetes-sigs/kind/issues/531
+
+export KUBECONFIG="${HOME}/.kube/kind-config-${KIND_CLUSTER_NAME}"
 kind create cluster \
   --loglevel=${KIND_LOG_LEVEL} \
   --name ${KIND_CLUSTER_NAME} \
   --config ${DIR}/kind.yaml \
   --image "kindest/node:${K8S_VERSION}"
-
-export KUBECONFIG="$(kind get kubeconfig-path --name="${KIND_CLUSTER_NAME}")"
 
 echo "Kubernetes cluster:"
 kubectl get nodes -o wide


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Updates:

- NGINX image to quay.io/kubernetes-ingress-controller/nginx-amd64:d523b4a96eec80324ee04afed74bf8bddcba09cf
- Go to 1.13.4
- Kind to 0.6.0
- Kubectl to v1.16.3

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
