### PR TITLE
Fix logic issue in template - (and ((not false) false)) = true

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -1041,7 +1041,7 @@ stream {
             modsecurity_rules '
                 {{ $location.ModSecurity.Snippet }}
             ';
-            {{ else if (and ((not $all.Cfg.EnableOWASPCoreRules) $location.ModSecurity.OWASPRules))}}
+            {{ else if (and (not $all.Cfg.EnableOWASPCoreRules) ($location.ModSecurity.OWASPRules))}}
             modsecurity_rules_file /etc/nginx/owasp-modsecurity-crs/nginx-modsecurity.conf;
             {{ end }}
 


### PR DESCRIPTION
somehow, this is weird but true. Previously, either owasp was disabled globally and rendered in all locations, or it was enabled globally. This commit fixes the logic issue by fixing the and-clause in the if-statement. This reduces baseline global modsecurity-enabled resource usage.

**What this PR does / why we need it**:
The current logic in the template dictates that when you enable modsecurity globally, you either also enable the owasp rule sets globally, or the owasp rulesets are rendered into each location, increasing memory usage per-location without a way to turn this off.

**Which issue this PR fixes** fixes #4629

**Special notes for your reviewer**: If possible, please backport to 0.26.x
