### PR TITLE
Add a datasource variable $DS_PROMETHEUS

### DIFF
--- a/deploy/grafana/dashboards/nginx.json
+++ b/deploy/grafana/dashboards/nginx.json
@@ -1323,6 +1323,16 @@
   "templating": {
     "list": [
       {
+        "hide": 0,
+        "label": "datasource",
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
         "allValue": ".*",
         "current": {
           "text": "All",


### PR DESCRIPTION
**What this PR does / why we need it**: Current grafana dashboard does not work with dashboard provisioning (e.g. the default prometheus-operator setup) due to missing `$DS_PROMETHEUS` datasource.

**Which issue this PR fixes**: fixes #4190 

**Special notes for your reviewer**:
