### PR TITLE
Allow custom log_format per Ingress

### DIFF
--- a/docs/user-guide/nginx-configuration/annotations.md
+++ b/docs/user-guide/nginx-configuration/annotations.md
@@ -120,6 +120,8 @@ You can add these Kubernetes annotations to specific Ingress objects to customiz
 |[nginx.ingress.kubernetes.io/modsecurity-snippet](#modsecurity)|string|
 |[nginx.ingress.kubernetes.io/mirror-request-body](#mirror)|string|
 |[nginx.ingress.kubernetes.io/mirror-target](#mirror)|string|
+|[nginx.ingress.kubernetes.io/log-format-upstream](#log-format-upstream)|string|
+|[nginx.ingress.kubernetes.io/log-format-escape-json](#log-format-escape-json)|string|
 
 ### Canary
 
@@ -886,3 +888,23 @@ nginx.ingress.kubernetes.io/mirror-request-body: "off"
 The request sent to the mirror is linked to the orignial request. If you have a slow mirror backend, then the orignial request will throttle.
 
 For more information on the mirror module see https://nginx.org/en/docs/http/ngx_http_mirror_module.html
+
+
+### log-format-upstream
+
+Overrdes the nginx [log format](http://nginx.org/en/docs/http/ngx_http_log_module.html#log_format) for a given Ingress.
+Example for json output:
+
+```json
+
+log-format-upstream: '{"time": "$time_iso8601", "remote_addr": "$proxy_protocol_addr", "x-forward-for": "$proxy_add_x_forwarded_for", "request_id": "$req_id",
+  "remote_user": "$remote_user", "bytes_sent": $bytes_sent, "request_time": $request_time, "status":$status, "vhost": "$host", "request_proto": "$server_protocol",
+  "path": "$uri", "request_query": "$args", "request_length": $request_length, "duration": $request_time,"method": "$request_method", "http_referrer": "$http_referer",
+  "http_user_agent": "$http_user_agent" }'
+```
+
+Please check the [log-format](log-format.md) for definition of each field.
+
+### log-format-escape-json
+
+Sets if the escape parameter allows JSON ("true") or default characters escaping in variables ("false") for the Ingress [log format](http://nginx.org/en/docs/http/ngx_http_log_module.html#log_format).

--- a/internal/ingress/annotations/log/main.go
+++ b/internal/ingress/annotations/log/main.go
@@ -29,8 +29,10 @@ type log struct {
 
 // Config contains the configuration to be used in the Ingress
 type Config struct {
-	Access  bool `json:"accessLog"`
-	Rewrite bool `json:"rewriteLog"`
+	Access              bool   `json:"accessLog"`
+	Rewrite             bool   `json:"rewriteLog"`
+	LogFormatUpstream   string `json:"logFormatUpstream,omitempty"`
+	LogFormatEscapeJSON bool   `json:"logFormatEscapeJSON,omitempty"`
 }
 
 // Equal tests for equality between two Config types
@@ -40,6 +42,14 @@ func (bd1 *Config) Equal(bd2 *Config) bool {
 	}
 
 	if bd1.Rewrite != bd2.Rewrite {
+		return false
+	}
+
+	if bd1.LogFormatUpstream != bd2.LogFormatUpstream {
+		return false
+	}
+
+	if bd1.LogFormatEscapeJSON != bd2.LogFormatEscapeJSON {
 		return false
 	}
 
@@ -65,6 +75,16 @@ func (l log) Parse(ing *networking.Ingress) (interface{}, error) {
 	config.Rewrite, err = parser.GetBoolAnnotation("enable-rewrite-log", ing)
 	if err != nil {
 		config.Rewrite = false
+	}
+
+	config.LogFormatUpstream, err = parser.GetStringAnnotation("log-format-upstream", ing)
+	if err != nil {
+		config.LogFormatUpstream = ""
+	}
+
+	config.LogFormatEscapeJSON, err = parser.GetBoolAnnotation("log-format-escape-json", ing)
+	if err != nil {
+		config.LogFormatEscapeJSON = false
 	}
 
 	return config, nil

--- a/internal/ingress/annotations/log/main_test.go
+++ b/internal/ingress/annotations/log/main_test.go
@@ -97,3 +97,41 @@ func TestIngressRewriteLogConfig(t *testing.T) {
 		t.Errorf("expected rewrite log to be enabled but it is disabled")
 	}
 }
+
+func TestIngressLogFormatUpstreamLogConfig(t *testing.T) {
+	ing := buildIngress()
+
+	const logFormat = `{"request": "$request"}`
+
+	data := map[string]string{}
+	data[parser.GetAnnotationWithPrefix("log-format-upstream")] = logFormat
+	ing.SetAnnotations(data)
+
+	log, _ := NewParser(&resolver.Mock{}).Parse(ing)
+	nginxLogs, ok := log.(*Config)
+	if !ok {
+		t.Errorf("expected a Config type")
+	}
+
+	if nginxLogs.LogFormatUpstream != logFormat {
+		t.Errorf("expected log-format-upstream to be '%s', but got '%s'", logFormat, nginxLogs.LogFormatUpstream)
+	}
+}
+
+func TestIngressLogFormatEscapeJSONLogConfig(t *testing.T) {
+	ing := buildIngress()
+
+	data := map[string]string{}
+	data[parser.GetAnnotationWithPrefix("log-format-escape-json")] = "true"
+	ing.SetAnnotations(data)
+
+	log, _ := NewParser(&resolver.Mock{}).Parse(ing)
+	nginxLogs, ok := log.(*Config)
+	if !ok {
+		t.Errorf("expected a Config type")
+	}
+
+	if !nginxLogs.LogFormatEscapeJSON {
+		t.Errorf("expected log-format-escape-json to be enabled but it is disabled")
+	}
+}

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -984,12 +984,13 @@ func (n *NGINXController) createServers(data []*ingress.Ingress,
 				Backend:      du.Name,
 				Proxy:        ngxProxy,
 				Service:      du.Service,
-				Logs: log.Config{
-					Access:  n.store.GetBackendConfiguration().EnableAccessLogForDefaultBackend,
-					Rewrite: false,
-				},
 			},
-		}}
+		},
+		Logs: log.Config{
+			Access:  n.store.GetBackendConfiguration().EnableAccessLogForDefaultBackend,
+			Rewrite: false,
+		},
+	}
 
 	// initialize all other servers
 	for _, ing := range data {
@@ -1061,6 +1062,7 @@ func (n *NGINXController) createServers(data []*ingress.Ingress,
 				},
 				SSLPassthrough: anns.SSLPassthrough,
 				SSLCiphers:     anns.SSLCiphers,
+				Logs:           anns.Logs,
 			}
 		}
 	}
@@ -1201,7 +1203,6 @@ func locationApplyAnnotations(loc *ingress.Location, anns *annotations.Ingress) 
 	loc.XForwardedPrefix = anns.XForwardedPrefix
 	loc.UsePortInRedirects = anns.UsePortInRedirects
 	loc.Connection = anns.Connection
-	loc.Logs = anns.Logs
 	loc.InfluxDB = anns.InfluxDB
 	loc.DefaultBackend = anns.DefaultBackend
 	loc.BackendProtocol = anns.BackendProtocol

--- a/internal/ingress/types.go
+++ b/internal/ingress/types.go
@@ -200,6 +200,9 @@ type Server struct {
 	SSLCiphers string `json:"sslCiphers,omitempty"`
 	// AuthTLSError contains the reason why the access to a server should be denied
 	AuthTLSError string `json:"authTLSError,omitempty"`
+	// Logs allows to enable or disable the nginx logs
+	// By default access logs are enabled and rewrite logs are disabled
+	Logs log.Config `json:"logs,omitempty"`
 }
 
 // Location describes an URI inside a server.
@@ -306,9 +309,6 @@ type Location struct {
 	// original location.
 	// +optional
 	XForwardedPrefix string `json:"xForwardedPrefix,omitempty"`
-	// Logs allows to enable or disable the nginx logs
-	// By default access logs are enabled and rewrite logs are disabled
-	Logs log.Config `json:"logs,omitempty"`
 	// InfluxDB allows to monitor the incoming request by sending them to an influxdb database
 	// +optional
 	InfluxDB influxdb.Config `json:"influxDB,omitempty"`

--- a/internal/ingress/types_equals.go
+++ b/internal/ingress/types_equals.go
@@ -308,6 +308,9 @@ func (s1 *Server) Equal(s2 *Server) bool {
 	if s1.AuthTLSError != s2.AuthTLSError {
 		return false
 	}
+	if !(&s1.Logs).Equal(&s2.Logs) {
+		return false
+	}
 
 	if len(s1.Locations) != len(s2.Locations) {
 		return false
@@ -405,9 +408,6 @@ func (l1 *Location) Equal(l2 *Location) bool {
 		return false
 	}
 	if !(&l1.Connection).Equal(&l2.Connection) {
-		return false
-	}
-	if !(&l1.Logs).Equal(&l2.Logs) {
 		return false
 	}
 

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -265,6 +265,12 @@ http {
     # $service_port
     log_format upstreaminfo {{ if $cfg.LogFormatEscapeJSON }}escape=json {{ end }}'{{ $cfg.LogFormatUpstream }}';
 
+    {{ range $server := $servers }}
+        {{ if not (empty $server.Logs.LogFormatUpstream) }}
+        log_format upstreaminfo-{{ $server.Hostname }} {{ if $server.Logs.LogFormatEscapeJSON }}escape=json {{ end }}'{{ $server.Logs.LogFormatUpstream }}';
+        {{ end }}
+    {{ end }}
+
     {{/* map urls that should not appear in access.log */}}
     {{/* http://nginx.org/en/docs/http/ngx_http_log_module.html#access_log */}}
     map $request_uri $loggable {
@@ -828,6 +834,18 @@ stream {
         {{ $server.ServerSnippet }}
         {{ end }}
 
+        {{ if not $server.Logs.Access }}
+        access_log off;
+        {{ else }}
+            {{ if not (empty $server.Logs.LogFormatUpstream) }}
+            access_log {{ $all.Cfg.AccessLogPath }} upstreaminfo-{{ $server.Hostname }} {{ $all.Cfg.AccessLogParams }} if=$loggable;
+            {{ end }}
+        {{ end }}
+
+        {{ if $server.Logs.Rewrite }}
+        rewrite_log on;
+        {{ end }}
+
         {{ range $errorLocation := (buildCustomErrorLocationsPerServer $server) }}
         {{ template "CUSTOM_ERRORS" (buildCustomErrorDeps $errorLocation.UpstreamName $errorLocation.Codes $all.EnableMetrics) }}
         {{ end }}
@@ -999,14 +1017,6 @@ stream {
 
                 plugins.run()
             }
-
-            {{ if not $location.Logs.Access }}
-            access_log off;
-            {{ end }}
-
-            {{ if $location.Logs.Rewrite }}
-            rewrite_log on;
-            {{ end }}
 
             {{ if $location.HTTP2PushPreload }}
             http2_push_preload on;


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR introduces 2 new annotations,
* `nginx.ingress.kubernetes.io/log-format-upstream`
* `nginx.ingress.kubernetes.io/log-format-escape-json`

Like their ConfigMap counterpart, they allow to configuration a different log_format for a given server.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

I'm not 100% if this should be done at the `server` block level or `location`.

Cc @jmreid