### PR TITLE
Switch to nginx again

### DIFF
--- a/images/nginx/Makefile
+++ b/images/nginx/Makefile
@@ -32,9 +32,6 @@ IMGNAME = nginx
 IMAGE = $(REGISTRY)/$(IMGNAME)
 MULTI_ARCH_IMG = $(IMAGE)-$(ARCH)
 
-# Set default base image dynamically for each arch
-BASEIMAGE?=quay.io/kubernetes-ingress-controller/debian-base-$(ARCH):0.1
-
 ifeq ($(ARCH),arm)
 	QEMUARCH=arm
 endif
@@ -62,7 +59,6 @@ all-push: $(addprefix sub-push-,$(ALL_ARCH))
 container: .container-$(ARCH)
 .container-$(ARCH):
 	cp -r ./rootfs/* $(TEMP_DIR)
-	cd $(TEMP_DIR) && $(SED_I) 's|BASEIMAGE|$(BASEIMAGE)|g' Dockerfile
 	cd $(TEMP_DIR) && $(SED_I) "s|ARCH|$(QEMUARCH)|g" Dockerfile
 
 ifeq ($(ARCH),amd64)

--- a/images/nginx/Makefile
+++ b/images/nginx/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # 0.0.0 shouldn't clobber any released builds
-TAG ?= 0.94
+TAG ?= 0.95
 REGISTRY ?= quay.io/kubernetes-ingress-controller
 ARCH ?= $(shell go env GOARCH)
 DOCKER ?= docker
@@ -26,7 +26,7 @@ ifeq ($(GOHOSTOS),darwin)
   SED_I=sed -i ''
 endif
 
-QEMUVERSION=v4.1.0-1
+QEMUVERSION=v4.1.1-1
 
 IMGNAME = nginx
 IMAGE = $(REGISTRY)/$(IMGNAME)

--- a/images/nginx/README.md
+++ b/images/nginx/README.md
@@ -1,6 +1,4 @@
-OpenResty base image using [debian-base](https://quay.io/kubernetes-ingress-controller/debian-base-amd64)
-
-OpenResty® is a dynamic web platform based on NGINX and LuaJIT.
+NGINX base image using [alpine](https://www.alpinelinux.org/)
 
 This custom image contains:
 
@@ -20,7 +18,7 @@ This image provides a default configuration file with no backend servers.
 _Using docker_
 
 ```console
-docker run -v /some/nginx.con:/etc/nginx/nginx.conf:ro quay.io/kubernetes-ingress-controller/nginx:0.90
+docker run -v /some/nginx.con:/etc/nginx/nginx.conf:ro quay.io/kubernetes-ingress-controller/nginx:0.95
 ```
 
 _Creating a replication controller_

--- a/images/nginx/rc.yaml
+++ b/images/nginx/rc.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: nginxsvc
+  name: nginx
   labels:
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
@@ -38,7 +38,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: quay.io/kubernetes-ingress-controller/nginx:0.90
+          image: quay.io/kubernetes-ingress-controller/nginx:0.95
           ports:
             - containerPort: 80
             - containerPort: 443

--- a/images/nginx/rootfs/Dockerfile
+++ b/images/nginx/rootfs/Dockerfile
@@ -13,22 +13,67 @@
 # limitations under the License.
 
 
-FROM BASEIMAGE
+FROM BASEIMAGE as builder
 
 CROSS_BUILD_COPY qemu-ARCH-static /usr/bin/
 
-ENV PATH=$PATH:/usr/local/openresty/luajit/bin:/usr/local/openresty/nginx/sbin:/usr/local/openresty/bin
-
-# Add LuaRocks paths
-# see https://github.com/openresty/docker-openresty/blob/de05cd72594498b83e3a97e2f632da6aa75ec01d/bionic/Dockerfile#L168
-ENV LUA_PATH="/usr/local/openresty/site/lualib/?.ljbc;/usr/local/openresty/site/lualib/?/init.ljbc;/usr/local/openresty/lualib/?.ljbc;/usr/local/openresty/lualib/?/init.ljbc;/usr/local/openresty/site/lualib/?.lua;/usr/local/openresty/site/lualib/?/init.lua;/usr/local/openresty/lualib/?.lua;/usr/local/openresty/lualib/?/init.lua;./?.lua;/usr/local/openresty/luajit/share/luajit-2.1.0-beta3/?.lua;/usr/local/share/lua/5.1/?.lua;/usr/local/share/lua/5.1/?/init.lua;/usr/local/openresty/luajit/share/lua/5.1/?.lua;/usr/local/openresty/luajit/share/lua/5.1/?/init.lua;/usr/local/lib/lua/?.lua"
-ENV LUA_CPATH="/usr/local/openresty/site/lualib/?.so;/usr/local/openresty/lualib/?.so;./?.so;/usr/local/lib/lua/5.1/?.so;/usr/local/openresty/luajit/lib/lua/5.1/?.so;/usr/local/lib/lua/5.1/loadall.so;/usr/local/openresty/luajit/lib/lua/5.1/?.so"
+RUN clean-install bash
 
 COPY . /
 
-RUN clean-install bash
-
 RUN /build.sh
+
+# Use a multi-stage build
+FROM BASEIMAGE
+
+ENV PATH=$PATH:/usr/local/luajit/bin:/usr/local/nginx/sbin:/usr/local/nginx/bin
+
+ENV LUA_PATH="/usr/local/share/luajit-2.1.0-beta3/?.lua;/usr/local/share/lua/5.1/?.lua;/usr/local/lib/lua/?.lua;;"
+ENV LUA_CPATH="/usr/local/lib/lua/?/?.so;/usr/local/lib/lua/?.so;;"
+
+COPY --from=builder /usr/local /usr/local
+COPY --from=builder /opt /opt
+COPY --chown=www-data:www-data --from=builder /etc/nginx /etc/nginx
+
+RUN apt-get update && apt-get dist-upgrade -y \
+  && clean-install \
+    bash \
+    curl ca-certificates \
+    libgeoip1 \
+    patch \
+    libpcre3 \
+    zlib1g \
+    libaio1 \
+    openssl \
+    util-linux \
+    lmdb-utils \
+    libcurl4 \
+    libprotobuf17 \
+    libz3-4 \
+    procps \
+    libxml2 libpcre++0v5 \
+    liblmdb0 \
+    libmaxminddb0 \
+    dumb-init \
+    nano \
+    libyaml-cpp0.6 \
+    libyajl2 \
+  && ln -s /usr/local/nginx/sbin/nginx /sbin/nginx \
+  && ln -s /usr/local/lib/mimalloc-1.2/libmimalloc.so /usr/local/lib/libmimalloc.so \
+  && bash -eu -c ' \
+  writeDirs=( \
+    /var/log/nginx \
+    /var/lib/nginx/body \
+    /var/lib/nginx/fastcgi \
+    /var/lib/nginx/proxy \
+    /var/lib/nginx/scgi \
+    /var/lib/nginx/uwsgi \
+    /var/log/audit \
+  ); \
+  for dir in "${writeDirs[@]}"; do \
+    mkdir -p ${dir}; \
+    chown -R www-data.www-data ${dir}; \
+  done'
 
 EXPOSE 80 443
 

--- a/images/nginx/rootfs/Dockerfile
+++ b/images/nginx/rootfs/Dockerfile
@@ -13,18 +13,17 @@
 # limitations under the License.
 
 
-FROM BASEIMAGE as builder
+FROM alpine:3.11 as builder
 
 CROSS_BUILD_COPY qemu-ARCH-static /usr/bin/
 
-RUN clean-install bash
-
 COPY . /
 
-RUN /build.sh
+RUN apk add -U bash \
+  && /build.sh
 
 # Use a multi-stage build
-FROM BASEIMAGE
+FROM alpine:3.11
 
 ENV PATH=$PATH:/usr/local/luajit/bin:/usr/local/nginx/sbin:/usr/local/nginx/bin
 
@@ -33,33 +32,29 @@ ENV LUA_CPATH="/usr/local/lib/lua/?/?.so;/usr/local/lib/lua/?.so;;"
 
 COPY --from=builder /usr/local /usr/local
 COPY --from=builder /opt /opt
-COPY --chown=www-data:www-data --from=builder /etc/nginx /etc/nginx
+COPY --from=builder /etc/nginx /etc/nginx
 
-RUN apt-get update && apt-get dist-upgrade -y \
-  && clean-install \
+RUN apk add -U --no-cache \
     bash \
-    curl ca-certificates \
-    libgeoip1 \
-    patch \
-    libpcre3 \
-    zlib1g \
-    libaio1 \
     openssl \
-    util-linux \
-    lmdb-utils \
-    libcurl4 \
-    libprotobuf17 \
-    libz3-4 \
-    procps \
-    libxml2 libpcre++0v5 \
-    liblmdb0 \
-    libmaxminddb0 \
+    pcre \
+    zlib \
+    geoip \
+    curl ca-certificates \
+    patch \
+    yajl \
+    lmdb \
+    libxml2 \
+    libmaxminddb \
+    yaml-cpp \
     dumb-init \
     nano \
-    libyaml-cpp0.6 \
-    libyajl2 \
+    tzdata \
   && ln -s /usr/local/nginx/sbin/nginx /sbin/nginx \
   && ln -s /usr/local/lib/mimalloc-1.2/libmimalloc.so /usr/local/lib/libmimalloc.so \
+  && addgroup -Sg 101 www-data \
+  && adduser -S -D -H -u 101 -h /usr/local/nginx \
+    -s /sbin/nologin -G www-data -g www-data www-data \
   && bash -eu -c ' \
   writeDirs=( \
     /var/log/nginx \

--- a/images/nginx/rootfs/build.sh
+++ b/images/nginx/rootfs/build.sh
@@ -67,47 +67,47 @@ get_src()
   rm -rf "$f"
 }
 
-apt-get update && apt-get dist-upgrade -y
+apk update
+apk upgrade
 
 # install required packages to build
-clean-install \
+apk add \
   bash \
-  build-essential \
+  gcc \
+  clang \
+  libc-dev \
+  make \
+  automake \
+  openssl-dev \
+  pcre-dev \
+  zlib-dev \
+  linux-headers \
+  libxslt-dev \
+  gd-dev \
+  geoip-dev \
+  perl-dev \
+  libedit-dev \
+  mercurial \
+  alpine-sdk \
+  findutils \
   curl ca-certificates \
-  libgeoip1 \
-  libgeoip-dev \
+  geoip-dev \
   patch \
-  libpcre3 \
-  libpcre3-dev \
-  libssl-dev \
-  zlib1g \
-  zlib1g-dev \
-  libaio1 \
   libaio-dev \
   openssl \
-  libperl-dev \
   cmake \
   util-linux \
-  lmdb-utils \
+  lmdb-tools \
   wget \
-  libcurl4-openssl-dev \
-  libprotobuf-dev protobuf-compiler \
-  libz-dev \
-  git g++ pkgconf flex bison doxygen libyajl-dev liblmdb-dev libtool dh-autoreconf libxml2 libpcre++-dev libxml2-dev \
+  curl-dev \
+  libprotobuf \
+  git g++ pkgconf flex bison doxygen yajl-dev lmdb-dev libtool autoconf libxml2 pcre-dev libxml2-dev \
   python \
   libmaxminddb-dev \
   bc \
   unzip \
   dos2unix mercurial \
-  libyaml-cpp0.6 \
-  || exit 1
-
-# https://www.mail-archive.com/debian-bugs-dist@lists.debian.org/msg1667178.html
-if [[ ${ARCH} == "armv7l" ]]; then
-  echo "Fixing ca-certificates"
-  touch /etc/ssl/certs/ca-certificates.crt
-  c_rehash
-fi
+  yaml-cpp
 
 mkdir -p /etc/nginx
 
@@ -228,18 +228,6 @@ export LUAJIT_INC=/usr/local/include/luajit-2.1
 cd "$BUILD_PATH/luajit2-$LUAJIT_VERSION"
 make CCDEBUG=-g
 make install
-
-if [[ ${ARCH} == "armv7l" ]]; then
-  export PCRE_DIR=/usr/lib/arm-linux-gnueabihf
-fi
-
-if [[ ${ARCH} == "x86_64" ]]; then
-  export PCRE_DIR=/usr/lib/x86_64-linux-gnu
-fi
-
-if [[ ${ARCH} == "aarch64" ]]; then
-  export PCRE_DIR=/usr/lib/aarch64-linux-gnu
-fi
 
 cd "$BUILD_PATH"
 
@@ -554,7 +542,7 @@ export LUA_INCLUDE_DIR=/usr/local/include/luajit-2.1
 ln -s $LUA_INCLUDE_DIR /usr/include/lua5.1
 
 if [[ ${ARCH} != "armv7l" ]]; then
-  luarocks install lrexlib-pcre 2.7.2-1 PCRE_LIBDIR=${PCRE_DIR}
+  luarocks install lrexlib-pcre 2.7.2-1
 fi
 
 cd "$BUILD_PATH/lua-resty-core-$LUA_RESTY_CORE"
@@ -582,7 +570,6 @@ make install
 
 cd "$BUILD_PATH/lua-resty-string-0.11"
 make install
-
 
 # build Lua bridge tracer
 cd "$BUILD_PATH/lua-bridge-tracer-$LUA_BRIDGE_TRACER_VERSION"
@@ -612,6 +599,9 @@ writeDirs=( \
   /var/log/audit \
   /var/log/nginx \
 );
+
+addgroup -Sg 101 www-data
+adduser -S -D -H -u 101 -h /usr/local/nginx -s /sbin/nologin -G www-data -g www-data www-data
 
 for dir in "${writeDirs[@]}"; do
   mkdir -p ${dir};

--- a/images/nginx/rootfs/patches/nginx-1.17.4-balancer_status_code.patch
+++ b/images/nginx/rootfs/patches/nginx-1.17.4-balancer_status_code.patch
@@ -1,0 +1,72 @@
+diff --git a/src/http/ngx_http_upstream.c b/src/http/ngx_http_upstream.c
+index f8d5707d..6efe0047 100644
+--- a/src/http/ngx_http_upstream.c
++++ b/src/http/ngx_http_upstream.c
+@@ -1515,6 +1515,11 @@ ngx_http_upstream_connect(ngx_http_request_t *r, ngx_http_upstream_t *u)
+         return;
+     }
+ 
++    if (rc >= NGX_HTTP_SPECIAL_RESPONSE) {
++        ngx_http_upstream_finalize_request(r, u, rc);
++        return;
++    }
++
+     u->state->peer = u->peer.name;
+ 
+     if (rc == NGX_BUSY) {
+diff --git a/src/http/ngx_http_upstream.h b/src/http/ngx_http_upstream.h
+index 3e714e5b..dfbb25e0 100644
+--- a/src/http/ngx_http_upstream.h
++++ b/src/http/ngx_http_upstream.h
+@@ -427,4 +427,9 @@ extern ngx_conf_bitmask_t  ngx_http_upstream_cache_method_mask[];
+ extern ngx_conf_bitmask_t  ngx_http_upstream_ignore_headers_masks[];
+ 
+ 
++#ifndef HAVE_BALANCER_STATUS_CODE_PATCH
++#define HAVE_BALANCER_STATUS_CODE_PATCH
++#endif
++
++
+ #endif /* _NGX_HTTP_UPSTREAM_H_INCLUDED_ */
+diff --git a/src/stream/ngx_stream.h b/src/stream/ngx_stream.h
+index 09d24593..d8b4b584 100644
+--- a/src/stream/ngx_stream.h
++++ b/src/stream/ngx_stream.h
+@@ -27,6 +27,7 @@ typedef struct ngx_stream_session_s  ngx_stream_session_t;
+ 
+ 
+ #define NGX_STREAM_OK                        200
++#define NGX_STREAM_SPECIAL_RESPONSE          300
+ #define NGX_STREAM_BAD_REQUEST               400
+ #define NGX_STREAM_FORBIDDEN                 403
+ #define NGX_STREAM_INTERNAL_SERVER_ERROR     500
+diff --git a/src/stream/ngx_stream_proxy_module.c b/src/stream/ngx_stream_proxy_module.c
+index 818d7329..329dcdc6 100644
+--- a/src/stream/ngx_stream_proxy_module.c
++++ b/src/stream/ngx_stream_proxy_module.c
+@@ -691,6 +691,11 @@ ngx_stream_proxy_connect(ngx_stream_session_t *s)
+         return;
+     }
+ 
++    if (rc >= NGX_STREAM_SPECIAL_RESPONSE) {
++        ngx_stream_proxy_finalize(s, rc);
++        return;
++    }
++
+     u->state->peer = u->peer.name;
+ 
+     if (rc == NGX_BUSY) {
+diff --git a/src/stream/ngx_stream_upstream.h b/src/stream/ngx_stream_upstream.h
+index 73947f46..21bc0ad7 100644
+--- a/src/stream/ngx_stream_upstream.h
++++ b/src/stream/ngx_stream_upstream.h
+@@ -151,4 +151,9 @@ ngx_stream_upstream_srv_conf_t *ngx_stream_upstream_add(ngx_conf_t *cf,
+ extern ngx_module_t  ngx_stream_upstream_module;
+ 
+ 
++#ifndef HAVE_BALANCER_STATUS_CODE_PATCH
++#define HAVE_BALANCER_STATUS_CODE_PATCH
++#endif
++
++
+ #endif /* _NGX_STREAM_UPSTREAM_H_INCLUDED_ */

--- a/images/nginx/rootfs/patches/nginx-1.17.4-larger_max_error_str.patch
+++ b/images/nginx/rootfs/patches/nginx-1.17.4-larger_max_error_str.patch
@@ -1,0 +1,13 @@
+--- nginx-1.17.4/src/core/ngx_log.h	2013-10-08 05:07:14.000000000 -0700
++++ nginx-1.17.4-patched/src/core/ngx_log.h	2013-12-05 20:35:35.996236720 -0800
+@@ -64,7 +64,9 @@ struct ngx_log_s {
+ };
+ 
+ 
+-#define NGX_MAX_ERROR_STR   2048
++#ifndef NGX_MAX_ERROR_STR
++#define NGX_MAX_ERROR_STR   4096
++#endif
+ 
+ 
+ /*********************************/

--- a/images/nginx/rootfs/patches/nginx-1.17.4-reuseport_close_unused_fds.patch
+++ b/images/nginx/rootfs/patches/nginx-1.17.4-reuseport_close_unused_fds.patch
@@ -1,0 +1,38 @@
+diff --git a/src/core/ngx_connection.c b/src/core/ngx_connection.c
+--- a/src/core/ngx_connection.c
++++ b/src/core/ngx_connection.c
+@@ -1118,6 +1118,12 @@ ngx_close_listening_sockets(ngx_cycle_t *cycle)
+     ls = cycle->listening.elts;
+     for (i = 0; i < cycle->listening.nelts; i++) {
+ 
++#if (NGX_HAVE_REUSEPORT)
++        if (ls[i].fd == (ngx_socket_t) -1) {
++            continue;
++        }
++#endif
++
+         c = ls[i].connection;
+ 
+         if (c) {
+diff --git a/src/event/ngx_event.c b/src/event/ngx_event.c
+--- a/src/event/ngx_event.c
++++ b/src/event/ngx_event.c
+@@ -775,6 +775,18 @@ ngx_event_process_init(ngx_cycle_t *cycle)
+ 
+ #if (NGX_HAVE_REUSEPORT)
+         if (ls[i].reuseport && ls[i].worker != ngx_worker) {
++            ngx_log_debug2(NGX_LOG_DEBUG_CORE, cycle->log, 0,
++                           "closing unused fd:%d listening on %V",
++                           ls[i].fd, &ls[i].addr_text);
++
++            if (ngx_close_socket(ls[i].fd) == -1) {
++                ngx_log_error(NGX_LOG_EMERG, cycle->log, ngx_socket_errno,
++                              ngx_close_socket_n " %V failed",
++                              &ls[i].addr_text);
++            }
++
++            ls[i].fd = (ngx_socket_t) -1;
++
+             continue;
+         }
+ #endif

--- a/images/nginx/rootfs/patches/nginx-1.17.4-single_process_graceful_exit.patch
+++ b/images/nginx/rootfs/patches/nginx-1.17.4-single_process_graceful_exit.patch
@@ -1,0 +1,53 @@
+diff --git a/src/os/unix/ngx_process_cycle.c b/src/os/unix/ngx_process_cycle.c
+index 1710ea81..b379da9c 100644
+--- a/src/os/unix/ngx_process_cycle.c
++++ b/src/os/unix/ngx_process_cycle.c
+@@ -304,11 +304,26 @@ ngx_single_process_cycle(ngx_cycle_t *cycle)
+     }
+ 
+     for ( ;; ) {
++        if (ngx_exiting) {
++            if (ngx_event_no_timers_left() == NGX_OK) {
++                ngx_log_error(NGX_LOG_NOTICE, cycle->log, 0, "exiting");
++
++                for (i = 0; cycle->modules[i]; i++) {
++                    if (cycle->modules[i]->exit_process) {
++                        cycle->modules[i]->exit_process(cycle);
++                    }
++                }
++
++                ngx_master_process_exit(cycle);
++            }
++        }
++
+         ngx_log_debug0(NGX_LOG_DEBUG_EVENT, cycle->log, 0, "worker cycle");
+ 
+         ngx_process_events_and_timers(cycle);
+ 
+-        if (ngx_terminate || ngx_quit) {
++        if (ngx_terminate) {
++            ngx_log_error(NGX_LOG_NOTICE, cycle->log, 0, "exiting");
+ 
+             for (i = 0; cycle->modules[i]; i++) {
+                 if (cycle->modules[i]->exit_process) {
+@@ -319,6 +334,20 @@ ngx_single_process_cycle(ngx_cycle_t *cycle)
+             ngx_master_process_exit(cycle);
+         }
+ 
++        if (ngx_quit) {
++            ngx_quit = 0;
++            ngx_log_error(NGX_LOG_NOTICE, cycle->log, 0,
++                          "gracefully shutting down");
++            ngx_setproctitle("process is shutting down");
++
++            if (!ngx_exiting) {
++                ngx_exiting = 1;
++                ngx_set_shutdown_timer(cycle);
++                ngx_close_listening_sockets(cycle);
++                ngx_close_idle_connections(cycle);
++            }
++        }
++
+         if (ngx_reconfigure) {
+             ngx_reconfigure = 0;
+             ngx_log_error(NGX_LOG_NOTICE, cycle->log, 0, "reconfiguring");

--- a/images/nginx/rootfs/patches/nginx-1.17.4-ssl_cert_cb_yield.patch
+++ b/images/nginx/rootfs/patches/nginx-1.17.4-ssl_cert_cb_yield.patch
@@ -1,0 +1,64 @@
+# HG changeset patch
+# User Yichun Zhang <agentzh@openresty.org>
+# Date 1451762084 28800
+#      Sat Jan 02 11:14:44 2016 -0800
+# Node ID 449f0461859c16e95bdb18e8be6b94401545d3dd
+# Parent  78b4e10b4367b31367aad3c83c9c3acdd42397c4
+SSL: handled SSL_CTX_set_cert_cb() callback yielding.
+
+OpenSSL 1.0.2+ introduces SSL_CTX_set_cert_cb() to allow custom
+callbacks to serve the SSL certificiates and private keys dynamically
+and lazily. The callbacks may yield for nonblocking I/O or sleeping.
+Here we added support for such usage in NGINX 3rd-party modules
+(like ngx_lua) in NGINX's event handlers for downstream SSL
+connections.
+
+diff -r 78b4e10b4367 -r 449f0461859c src/event/ngx_event_openssl.c
+--- a/src/event/ngx_event_openssl.c Thu Dec 17 16:39:15 2015 +0300
++++ b/src/event/ngx_event_openssl.c Sat Jan 02 11:14:44 2016 -0800
+@@ -1445,6 +1445,23 @@ ngx_ssl_handshake(ngx_connection_t *c)
+         return NGX_AGAIN;
+     }
+ 
++#if OPENSSL_VERSION_NUMBER >= 0x10002000L
++    if (sslerr == SSL_ERROR_WANT_X509_LOOKUP) {
++        c->read->handler = ngx_ssl_handshake_handler;
++        c->write->handler = ngx_ssl_handshake_handler;
++
++        if (ngx_handle_read_event(c->read, 0) != NGX_OK) {
++            return NGX_ERROR;
++        }
++
++        if (ngx_handle_write_event(c->write, 0) != NGX_OK) {
++            return NGX_ERROR;
++        }
++
++        return NGX_AGAIN;
++    }
++#endif
++
+     err = (sslerr == SSL_ERROR_SYSCALL) ? ngx_errno : 0;
+ 
+     c->ssl->no_wait_shutdown = 1;
+@@ -1558,6 +1575,21 @@ ngx_ssl_try_early_data(ngx_connection_t *c)
+         return NGX_AGAIN;
+     }
+ 
++    if (sslerr == SSL_ERROR_WANT_X509_LOOKUP) {
++        c->read->handler = ngx_ssl_handshake_handler;
++        c->write->handler = ngx_ssl_handshake_handler;
++
++        if (ngx_handle_read_event(c->read, 0) != NGX_OK) {
++            return NGX_ERROR;
++        }
++
++        if (ngx_handle_write_event(c->write, 0) != NGX_OK) {
++            return NGX_ERROR;
++        }
++
++        return NGX_AGAIN;
++    }
++
+     err = (sslerr == SSL_ERROR_SYSCALL) ? ngx_errno : 0;
+ 
+     c->ssl->no_wait_shutdown = 1;

--- a/images/nginx/rootfs/patches/nginx-1.17.4-ssl_sess_cb_yield.patch
+++ b/images/nginx/rootfs/patches/nginx-1.17.4-ssl_sess_cb_yield.patch
@@ -1,0 +1,41 @@
+diff --git a/src/event/ngx_event_openssl.c b/src/event/ngx_event_openssl.c
+--- a/src/event/ngx_event_openssl.c
++++ b/src/event/ngx_event_openssl.c
+@@ -1446,7 +1446,12 @@ ngx_ssl_handshake(ngx_connection_t *c)
+     }
+ 
+ #if OPENSSL_VERSION_NUMBER >= 0x10002000L
+-    if (sslerr == SSL_ERROR_WANT_X509_LOOKUP) {
++    if (sslerr == SSL_ERROR_WANT_X509_LOOKUP
++#   ifdef SSL_ERROR_PENDING_SESSION
++        || sslerr == SSL_ERROR_PENDING_SESSION
++#   endif
++       )
++    {
+         c->read->handler = ngx_ssl_handshake_handler;
+         c->write->handler = ngx_ssl_handshake_handler;
+ 
+@@ -1575,6 +1580,23 @@ ngx_ssl_try_early_data(ngx_connection_t *c)
+         return NGX_AGAIN;
+     }
+ 
++#ifdef SSL_ERROR_PENDING_SESSION
++    if (sslerr == SSL_ERROR_PENDING_SESSION) {
++        c->read->handler = ngx_ssl_handshake_handler;
++        c->write->handler = ngx_ssl_handshake_handler;
++
++        if (ngx_handle_read_event(c->read, 0) != NGX_OK) {
++            return NGX_ERROR;
++        }
++
++        if (ngx_handle_write_event(c->write, 0) != NGX_OK) {
++            return NGX_ERROR;
++        }
++
++        return NGX_AGAIN;
++    }
++#endif
++
+     err = (sslerr == SSL_ERROR_SYSCALL) ? ngx_errno : 0;
+ 
+     c->ssl->no_wait_shutdown = 1;

--- a/images/nginx/rootfs/patches/nginx-1.17.4-upstream_timeout_fields.patch
+++ b/images/nginx/rootfs/patches/nginx-1.17.4-upstream_timeout_fields.patch
@@ -1,0 +1,112 @@
+diff --git a/src/http/ngx_http_upstream.c b/src/http/ngx_http_upstream.c
+index 69019417..2265d8f7 100644
+--- a/src/http/ngx_http_upstream.c
++++ b/src/http/ngx_http_upstream.c
+@@ -509,12 +509,19 @@ void
+ ngx_http_upstream_init(ngx_http_request_t *r)
+ {
+     ngx_connection_t     *c;
++    ngx_http_upstream_t  *u;
+ 
+     c = r->connection;
+ 
+     ngx_log_debug1(NGX_LOG_DEBUG_HTTP, c->log, 0,
+                    "http init upstream, client timer: %d", c->read->timer_set);
+ 
++    u = r->upstream;
++
++    u->connect_timeout = u->conf->connect_timeout;
++    u->send_timeout = u->conf->send_timeout;
++    u->read_timeout = u->conf->read_timeout;
++
+ #if (NGX_HTTP_V2)
+     if (r->stream) {
+         ngx_http_upstream_init_request(r);
+@@ -1626,7 +1633,7 @@ ngx_http_upstream_connect(ngx_http_request_t *r, ngx_http_upstream_t *u)
+     u->request_body_blocked = 0;
+ 
+     if (rc == NGX_AGAIN) {
+-        ngx_add_timer(c->write, u->conf->connect_timeout);
++        ngx_add_timer(c->write, u->connect_timeout);
+         return;
+     }
+ 
+@@ -1704,7 +1711,7 @@ ngx_http_upstream_ssl_init_connection(ngx_http_request_t *r,
+     if (rc == NGX_AGAIN) {
+ 
+         if (!c->write->timer_set) {
+-            ngx_add_timer(c->write, u->conf->connect_timeout);
++            ngx_add_timer(c->write, u->connect_timeout);
+         }
+ 
+         c->ssl->handler = ngx_http_upstream_ssl_handshake_handler;
+@@ -2022,7 +2029,7 @@ ngx_http_upstream_send_request(ngx_http_request_t *r, ngx_http_upstream_t *u,
+ 
+     if (rc == NGX_AGAIN) {
+         if (!c->write->ready || u->request_body_blocked) {
+-            ngx_add_timer(c->write, u->conf->send_timeout);
++            ngx_add_timer(c->write, u->send_timeout);
+ 
+         } else if (c->write->timer_set) {
+             ngx_del_timer(c->write);
+@@ -2084,7 +2091,7 @@ ngx_http_upstream_send_request(ngx_http_request_t *r, ngx_http_upstream_t *u,
+             return;
+         }
+ 
+-        ngx_add_timer(c->read, u->conf->read_timeout);
++        ngx_add_timer(c->read, u->read_timeout);
+ 
+         if (c->read->ready) {
+             ngx_http_upstream_process_header(r, u);
+@@ -3213,7 +3220,7 @@ ngx_http_upstream_send_response(ngx_http_request_t *r, ngx_http_upstream_t *u)
+         p->cyclic_temp_file = 0;
+     }
+ 
+-    p->read_timeout = u->conf->read_timeout;
++    p->read_timeout = u->read_timeout;
+     p->send_timeout = clcf->send_timeout;
+     p->send_lowat = clcf->send_lowat;
+ 
+@@ -3458,7 +3465,7 @@ ngx_http_upstream_process_upgraded(ngx_http_request_t *r,
+     }
+ 
+     if (upstream->write->active && !upstream->write->ready) {
+-        ngx_add_timer(upstream->write, u->conf->send_timeout);
++        ngx_add_timer(upstream->write, u->send_timeout);
+ 
+     } else if (upstream->write->timer_set) {
+         ngx_del_timer(upstream->write);
+@@ -3470,7 +3477,7 @@ ngx_http_upstream_process_upgraded(ngx_http_request_t *r,
+     }
+ 
+     if (upstream->read->active && !upstream->read->ready) {
+-        ngx_add_timer(upstream->read, u->conf->read_timeout);
++        ngx_add_timer(upstream->read, u->read_timeout);
+ 
+     } else if (upstream->read->timer_set) {
+         ngx_del_timer(upstream->read);
+@@ -3664,7 +3671,7 @@ ngx_http_upstream_process_non_buffered_request(ngx_http_request_t *r,
+     }
+ 
+     if (upstream->read->active && !upstream->read->ready) {
+-        ngx_add_timer(upstream->read, u->conf->read_timeout);
++        ngx_add_timer(upstream->read, u->read_timeout);
+ 
+     } else if (upstream->read->timer_set) {
+         ngx_del_timer(upstream->read);
+diff --git a/src/http/ngx_http_upstream.h b/src/http/ngx_http_upstream.h
+index c2f4dc0b..b9eef118 100644
+--- a/src/http/ngx_http_upstream.h
++++ b/src/http/ngx_http_upstream.h
+@@ -333,6 +333,11 @@ struct ngx_http_upstream_s {
+     ngx_array_t                     *caches;
+ #endif
+ 
++#define HAVE_NGX_UPSTREAM_TIMEOUT_FIELDS  1
++    ngx_msec_t                       connect_timeout;
++    ngx_msec_t                       send_timeout;
++    ngx_msec_t                       read_timeout;
++
+     ngx_http_upstream_headers_in_t   headers_in;
+ 
+     ngx_http_upstream_resolved_t    *resolved;


### PR DESCRIPTION
**What this PR does / why we need it**:

- The latest release from OpenResty is almost four months old.
- It still uses NGINX 1.15.8.
- There is no clear timeline for the next release or sync with 1.17.7 (security issues with error_page directive)
- Use a multi-stage build to simplify the cleanup process of the source artifacts and packages.
- Why the migration to alpine Linux? Because it removes all vulnerabilities from the image.
- Reduces the size of the docker image in ~90MB
