### PR TITLE
make sure set-cookie is retained from external auth endpoint

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -956,6 +956,8 @@ stream {
         location {{ buildAuthSignURLLocation $location.Path $externalAuth.SigninURL }} {
             internal;
 
+            add_header Set-Cookie $auth_cookie;
+
             return 302 {{ buildAuthSignURL $externalAuth.SigninURL }};
         }
         {{ end }}


### PR DESCRIPTION
**What this PR does / why we need it**:

After the workaround in https://github.com/kubernetes/ingress-nginx/pull/4859, we no longer retain `Set-Cookie` header set by external authentication server. This PR fixes that.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
