### PR TITLE
Use docker to run makefile tasks

### DIFF
--- a/build/test.sh
+++ b/build/test.sh
@@ -34,5 +34,5 @@ export GODEBUG=netdns=cgo+2
 # use vendor directory instead of go modules https://github.com/golang/go/wiki/Modules
 export GO111MODULE=off
 
-go test -v -race \
+go test -v \
   $(go list "${PKG}/..." | grep -v vendor | grep -v '/test/e2e' | grep -v images | grep -v "docs/examples")

--- a/images/httpbin/Makefile
+++ b/images/httpbin/Makefile
@@ -20,7 +20,7 @@ ARCH ?= $(shell go env GOARCH)
 GOARCH = ${ARCH}
 
 # Set default base image dynamically for each arch
-BASEIMAGE?=quay.io/kubernetes-ingress-controller/debian-base-$(ARCH):0.1
+BASEIMAGE=quay.io/kubernetes-ingress-controller/debian-base-$(ARCH):0.1
 
 ALL_ARCH = amd64 arm arm64
 

--- a/test/e2e-image/Dockerfile
+++ b/test/e2e-image/Dockerfile
@@ -7,6 +7,7 @@ RUN apk add -U --no-cache \
     bash \
     curl \
     tzdata \
+    libc6-compat \
     openssl
 
 COPY --from=BASE /go/bin/ginkgo /usr/local/bin/

--- a/test/e2e-image/Makefile
+++ b/test/e2e-image/Makefile
@@ -3,9 +3,22 @@ all: container
 
 DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+# Use docker to run makefile tasks
+USE_DOCKER ?= true
+
+# Disable run docker tasks if running in prow.
+# only checks the existence of the variable, not the value.
+ifdef DIND_TASKS
+USE_DOCKER=false
+endif
+
 .PHONY: container
 container:
-	${DIR}/../../build/run-in-docker.sh make e2e-test-binary
+ifeq ($(USE_DOCKER), true)
+	@${DIR}/../../build/run-in-docker.sh make e2e-test-binary
+else
+	@make -C ${DIR}/../../ e2e-test-binary
+endif
 
 	cp ../e2e/e2e.test .
 	cp ../e2e/wait-for-nginx.sh .


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: documents makefile tasks, add a new help task and uses docker to run several tasks

```
make

Usage:
  make <target>
  help             Display this help
  all-container    Build image for amd64, arm and arm64.
  all-push         Publish images for amd64, arm and arm64.
  container        Build image for a particular arch.
  clean-container  Removes local image
  register-qemu    Register /usr/bin/qemu-ARCH-static as the handler for binaries in multiple platforms
  push             Publish image for a particular arch.
  build            Build ingress controller, debug tool and pre-stop hook.
  build-plugin     Build ingress-nginx krew plugin.
  clean            Remove .gocache directory.
  static-check     Run verification script for boilerplate, codegen, gofmt, golint and lualint.
  test             Run go unit tests.
  lua-test         Run lua unit tests.
  cover            Run go coverage unit tests.
  release          Build and publish images of the ingress controller.
  check_dead_links  Check if the documentation contains dead links.
  dep-ensure       Update and vendo go dependencies.
  dev-env          Starts a local Kubernetes cluster using minikube, building and deploying the ingress controller.
  live-docs        Build and launch a local copy of the documentation website in http://localhost:3000
  build-docs       Build documentation (output in ./site directory).
  misspell         Check for spelling errors.
  run-ingress-controller  Run the ingress controller locally using a kubectl proxy connection.

```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
