### PR TITLE
Support Datadog sample rate with global trace sampling from configmap

### DIFF
--- a/docs/user-guide/nginx-configuration/configmap.md
+++ b/docs/user-guide/nginx-configuration/configmap.md
@@ -131,6 +131,12 @@ The following table shows a configuration option's name, type, and the default v
 |[jaeger-debug-header](#jaeger-debug-header)|string|uber-debug-id|
 |[jaeger-baggage-header](#jaeger-baggage-header)|string|jaeger-baggage|
 |[jaeger-trace-baggage-header-prefix](#jaeger-trace-baggage-header-prefix)|string|uberctx-|
+|[datadog-collector-host](#datadog-collector-host)|string|""|
+|[datadog-collector-port](#datadog-collector-port)|int|8126|
+|[datadog-service-name](#datadog-service-name)|service|"nginx"|
+|[datadog-operation-name-override](#datadog-operation-name-override)|service|"nginx.handle"|
+|[datadog-priority-sampling](#datadog-priority-sampling)|bool|"true"|
+|[datadog-sample-rate](#datadog-sample-rate)|float|1.0|
 |[main-snippet](#main-snippet)|string|""|
 |[http-snippet](#http-snippet)|string|""|
 |[server-snippet](#server-snippet)|string|""|
@@ -779,6 +785,32 @@ Specifies the header name used to submit baggage if there is no root span. _**de
 ## jaeger-tracer-baggage-header-prefix
 
 Specifies the header prefix used to propagate baggage. _**default:**_ uberctx-
+
+## datadog-collector-host
+
+Specifies the datadog agent host to use when uploading traces. It must be a valid URL.
+
+## datadog-collector-port
+
+Specifies the port to use when uploading traces. _**default:**_ 8126
+
+## datadog-service-name
+
+Specifies the service name to use for any traces created. _**default:**_ nginx
+
+## datadog-operation-name-override
+
+Overrides the operation naem to use for any traces crated. _**default:**_ nginx.handle
+
+## datadog-priority-sampling
+
+Specifies to use client-side sampling.
+If true disables client-side sampling (thus ignoring `sample_rate`) and enables distributed priority sampling, where traces are sampled based on a combination of user-assigned priorities and configuration from the agent. _**default:**_ true
+
+## datadog-sample-rate
+
+Specifies sample rate for any traces created.
+This is effective only when `datadog-priority-sampling` is `false` _**default:**_ 1.0
 
 ## main-snippet
 

--- a/docs/user-guide/third-party-addons/opentracing.md
+++ b/docs/user-guide/third-party-addons/opentracing.md
@@ -88,6 +88,12 @@ datadog-service-name
 
 # specifies the operation name to use for any traces collected, Default: nginx.handle
 datadog-operation-name-override
+
+# Specifies to use client-side sampling for distributed priority sampling and ignore sample rate, Default: true
+datadog-priority-sampling
+
+# specifies sample rate for any traces created, Default: 1.0
+datadog-sample-rate
 ```
 
 All these options (including host) allow environment variables, such as `$HOSTNAME` or `$HOST_IP`. In the case of Jaeger, if you have a Jaeger agent running on each machine in your cluster, you can use something like `$HOST_IP` (which can be 'mounted' with the `status.hostIP` fieldpath, as described [here](https://kubernetes.io/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/#capabilities-of-the-downward-api)) to make sure traces will be sent to the local agent.

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -552,6 +552,17 @@ type Configuration struct {
 	// Default: nginx.handle
 	DatadogOperationNameOverride string `json:"datadog-operation-name-override"`
 
+	// DatadogPrioritySampling specifies to use client-side sampling
+	// If true disables client-side sampling (thus ignoring sample_rate) and enables distributed
+	// priority sampling, where traces are sampled based on a combination of user-assigned
+	// Default: true
+	DatadogPrioritySampling bool `json:"datadog-priority-sampling"`
+
+	// DatadogSampleRate specifies sample rate for any traces created.
+	// This is effective only when datadog-priority-sampling is false
+	// Default: 1.0
+	DatadogSampleRate float32 `json:"datadog-sample-rate"`
+
 	// MainSnippet adds custom configuration to the main section of the nginx configuration
 	MainSnippet string `json:"main-snippet"`
 
@@ -767,6 +778,8 @@ func NewDefault() Configuration {
 		DatadogServiceName:           "nginx",
 		DatadogCollectorPort:         8126,
 		DatadogOperationNameOverride: "nginx.handle",
+		DatadogSampleRate:            1.0,
+		DatadogPrioritySampling:      true,
 		LimitReqStatusCode:           503,
 		LimitConnStatusCode:          503,
 		SyslogPort:                   514,

--- a/internal/ingress/controller/nginx.go
+++ b/internal/ingress/controller/nginx.go
@@ -1075,7 +1075,9 @@ const datadogTmpl = `{
   "service": "{{ .DatadogServiceName }}",
   "agent_host": "{{ .DatadogCollectorHost }}",
   "agent_port": {{ .DatadogCollectorPort }},
-  "operation_name_override": "{{ .DatadogOperationNameOverride }}"
+  "operation_name_override": "{{ .DatadogOperationNameOverride }}",
+  "sample_rate": {{ .DatadogSampleRate }},
+  "dd.priority.sampling": {{ .DatadogPrioritySampling }}
 }`
 
 func createOpentracingCfg(cfg ngx_config.Configuration) error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
I have been looking for a way to do a Datadog trace sampling in a global level, and ended up filing a PR.

Currently [dd-opentracing-cpp](https://github.com/DataDog/dd-opentracing-cpp) has a capability to disable priority sampling (client-side sampling) and use global sampling rate, however there is no native way for ingress-nginx to support this.
Please see the `Annotated Datadog config JSON` section.
https://github.com/DataDog/dd-opentracing-cpp/blob/7d58654a41a4fa4589988d105f953049f9eeee3c/README.md#guide

In this PR, I added the following:
- support `datadog-priority-sampling` and `datadog-sample-rate` in configmap
- Added missing documentations about datadog configuration options
- Added the docs to `third-party-addons`

I tested the change in my local development.
- Hit an endpoint every 2~3 seconds
- Disable `datadog-priority-sampling` in configmap
- Change the values of `datadog-sample-rate` from configmap and observe the difference
![2020-01-07_11-51-51](https://user-images.githubusercontent.com/3166390/71938376-08105480-3164-11ea-8d55-3bdcb40430da.png)

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
No known open issues that I know of

**Special notes for your reviewer**:
Probably useful to get some eyes of dd-opentracing-cpp maintainer, so cc-ing @cgilmour here as [this issue](https://github.com/DataDog/dd-opentracing-cpp/issues/117) was my starting point of this PR.