### PR TITLE
Fix proxy protocol support for X-Forwarded-Port

### DIFF
--- a/rootfs/etc/nginx/lua/lua_ingress.lua
+++ b/rootfs/etc/nginx/lua/lua_ingress.lua
@@ -105,7 +105,6 @@ end
 -- phases or redirection
 function _M.rewrite(location_config)
   ngx.var.pass_access_scheme = ngx.var.scheme
-  ngx.var.pass_server_port = ngx.var.server_port
   ngx.var.best_http_host = ngx.var.http_host or ngx.var.host
 
   if config.use_forwarded_headers then

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -1032,7 +1032,13 @@ stream {
             set $proxy_upstream_name {{ buildUpstreamName $location | quote }};
             set $proxy_host          $proxy_upstream_name;
             set $pass_access_scheme  $scheme;
+            
+            {{ if $all.Cfg.UseProxyProtocol }}
+            set $pass_server_port    $proxy_protocol_server_port;
+            {{ else }}
             set $pass_server_port    $server_port;
+            {{ end }}
+            
             set $best_http_host      $http_host;
             set $pass_port           $pass_server_port;
 

--- a/test/e2e/settings/proxy_protocol.go
+++ b/test/e2e/settings/proxy_protocol.go
@@ -68,7 +68,7 @@ var _ = framework.IngressNginxDescribe("Proxy Protocol", func() {
 		Expect(err).NotTo(HaveOccurred(), "unexpected error reading connection data")
 		body := string(data)
 		Expect(body).Should(ContainSubstring(fmt.Sprintf("host=%v", "proxy-protocol")))
-		Expect(body).Should(ContainSubstring(fmt.Sprintf("x-forwarded-port=80")))
+		Expect(body).Should(ContainSubstring(fmt.Sprintf("x-forwarded-port=1234")))
 		Expect(body).Should(ContainSubstring(fmt.Sprintf("x-forwarded-for=192.168.0.1")))
 	})
 })


### PR DESCRIPTION
This PR fixes issue #4951 by using the `$proxy_protocol_server_port` value
as `X-Forwarded-Port`, when Proxy Protocol is enabled.

## What this PR does / why we need it:
* The `nginx.tmpl` was changed to assign `$proxy_protocol_server_port` as `pass_server_port`
value when Proxy Protocol is enabled.
* `lua_ingress.lua` had to be adjusted in order not to overwrite `pass_server_port` as it's already set in `nginx.tmpl`.
* The Proxy Protocol E2E test was updated to validate the correct `X-Forwarded-Port`.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
fixes #4951 

## How Has This Been Tested?
Ran the E2E test suite and testet it in our lab environment with Proxy Protocol enabled and disabled.
https was only tested without TLS passthrough on our lab.

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.