### PR TITLE
Add a forwarded protocol map for included x-forwarded-proto.

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -323,6 +323,12 @@ http {
         ''               "$realip_remote_addr";
         {{ end}}
     }
+
+    map $http_x_forwarded_proto $full_x_forwarded_proto {
+        default $http_x_forwarded_proto;
+        "" $scheme;
+    }
+
     {{ end }}
 
     # Create a variable that contains the literal $ character.
@@ -1132,6 +1138,7 @@ stream {
             {{ $proxySetHeader }} X-Real-IP              $remote_addr;
             {{ if and $all.Cfg.UseForwardedHeaders $all.Cfg.ComputeFullForwardedFor }}
             {{ $proxySetHeader }} X-Forwarded-For        $full_x_forwarded_for;
+            {{ $proxySetHeader }} X-Forwarded-Proto      $full_x_forwarded_proto;
             {{ else }}
             {{ $proxySetHeader }} X-Forwarded-For        $remote_addr;
             {{ end }}


### PR DESCRIPTION
This change adds a new map for including the passed x-forwarded-proto
header in case is provided as an extra header.

## What this PR does / why we need it:

Current the protocol is enforced to pass_access_scheme and the x-forwarded-proto
option gets ignored and not pass to the backend service. 

## Types of changes

- [X ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

## Checklist:
- [X ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
