### PR TITLE
Applying proxy-ssl-* directives on locations only

### DIFF
--- a/docs/user-guide/nginx-configuration/configmap.md
+++ b/docs/user-guide/nginx-configuration/configmap.md
@@ -178,6 +178,7 @@ The following table shows a configuration option's name, type, and the default v
 |[block-cidrs](#block-cidrs)|[]string|""|
 |[block-user-agents](#block-user-agents)|[]string|""|
 |[block-referers](#block-referers)|[]string|""|
+|[proxy-ssl-location-only](#proxy-ssl-location-only)|bool|"false"|
 
 ## add-headers
 
@@ -1045,3 +1046,9 @@ It's possible to use here full strings and regular expressions. More details abo
 
 _References:_
 [http://nginx.org/en/docs/http/ngx_http_map_module.html#map](http://nginx.org/en/docs/http/ngx_http_map_module.html#map)
+
+## proxy-ssl-location-only
+
+Set if proxy-ssl parameters should be applied onyl on locations and not on servers.
+_**default:**_ is disabled
+

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -644,6 +644,11 @@ type Configuration struct {
 	// DefaultSSLCertificate holds the default SSL certificate to use in the configuration
 	// It can be the fake certificate or the one behind the flag --default-ssl-certificate
 	DefaultSSLCertificate *ingress.SSLCert `json:"-"`
+
+	// ProxySSLLocationOnly controls whether the proxy-ssl parameters defined in the
+	// proxy-ssl-* annotations are applied on on location level only in the nginx.conf file
+	// Default is that those are applied on server level, too
+	ProxySSLLocationOnly bool `json:"proxy-ssl-location-only"`
 }
 
 // NewDefault returns the default nginx configuration
@@ -786,6 +791,7 @@ func NewDefault() Configuration {
 		NoTLSRedirectLocations:       "/.well-known/acme-challenge",
 		NoAuthLocations:              "/.well-known/acme-challenge",
 		GlobalExternalAuth:           defGlobalExternalAuth,
+		ProxySSLLocationOnly:         false,
 	}
 
 	if klog.V(5) {

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -494,15 +494,17 @@ func (n *NGINXController) getBackendServers(ingresses []*ingress.Ingress) ([]*in
 					server.Hostname, ingKey)
 			}
 
-			if server.ProxySSL.CAFileName == "" {
-				server.ProxySSL = anns.ProxySSL
-				if server.ProxySSL.Secret != "" && server.ProxySSL.CAFileName == "" {
-					klog.V(3).Infof("Secret %q has no 'ca.crt' key, client cert authentication disabled for Ingress %q",
-						server.ProxySSL.Secret, ingKey)
+			if !n.store.GetBackendConfiguration().ProxySSLLocationOnly {
+				if server.ProxySSL.CAFileName == "" {
+					server.ProxySSL = anns.ProxySSL
+					if server.ProxySSL.Secret != "" && server.ProxySSL.CAFileName == "" {
+						klog.V(3).Infof("Secret %q has no 'ca.crt' key, client cert authentication disabled for Ingress %q",
+							server.ProxySSL.Secret, ingKey)
+					}
+				} else {
+					klog.V(3).Infof("Server %q is already configured for client cert authentication (Ingress %q)",
+						server.Hostname, ingKey)
 				}
-			} else {
-				klog.V(3).Infof("Server %q is already configured for client cert authentication (Ingress %q)",
-					server.Hostname, ingKey)
 			}
 
 			if rule.HTTP == nil {


### PR DESCRIPTION
## What this PR does / why we need it:
Currently we can define different proxy-ssl directives for the different locations of the same server if we have different Ingress definitions for those locations. However one of those proxy-ssl directives is also set on the common server level. It has the following problems: 
- it is not possible to have locations with and without proxy-ssl configuration behind the same server. The server level proxy-ssl directives are used on those locations that anyway do not have such configuration in their Ingress definitions.
- the selection of the server level proxy-ssl parameters is a bit "random" when the different locations have different proxy-ssl config: the proxy-ssl-secret parameter first in the alphabetically ordered set of all the proxy-ssl-secrets is selected and configured on server level.
This PR is o further enhance this logic, so it can provide a more user-controlled way of configuring the parameters either on location level, or on both server and location levels.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Which issue/s this PR fixes
This PR implements a solution for the problem drafted in https://github.com/kubernetes/ingress-nginx/issues/4831

## How Has This Been Tested?
Unit tests are added

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
