### PR TITLE
fix modsecurity SecRuleEngine On

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -134,14 +134,15 @@ http {
     {{ if $all.Cfg.EnableModsecurity }}
     modsecurity on;
 
-    modsecurity_rules_file /etc/nginx/modsecurity/modsecurity.conf;
-
     {{ if $all.Cfg.EnableOWASPCoreRules }}
+    modsecurity_rules_file /etc/nginx/modsecurity/modsecurity.conf;
     modsecurity_rules_file /etc/nginx/owasp-modsecurity-crs/nginx-modsecurity.conf;
     {{ else if (not (empty $all.Cfg.ModsecuritySnippet)) }}
     modsecurity_rules '
       {{ $all.Cfg.ModsecuritySnippet }}
     ';
+    {{ else }}  
+    modsecurity_rules_file /etc/nginx/modsecurity/modsecurity.conf;
     {{ end }}
 
     {{ end }}

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -1037,16 +1037,17 @@ stream {
             {{ if (or $location.ModSecurity.Enable $all.Cfg.EnableModsecurity) }}
             {{ if not $all.Cfg.EnableModsecurity }}
             modsecurity on;
-
-            modsecurity_rules_file /etc/nginx/modsecurity/modsecurity.conf;
             {{ end }}
 
-            {{ if $location.ModSecurity.Snippet }}
+            {{ if (and (not $all.Cfg.EnableOWASPCoreRules) ($location.ModSecurity.OWASPRules))}}
+            modsecurity_rules_file /etc/nginx/modsecurity/modsecurity.conf;
+            modsecurity_rules_file /etc/nginx/owasp-modsecurity-crs/nginx-modsecurity.conf;
+            {{ else if $location.ModSecurity.Snippet }}
             modsecurity_rules '
                 {{ $location.ModSecurity.Snippet }}
             ';
-            {{ else if (and (not $all.Cfg.EnableOWASPCoreRules) ($location.ModSecurity.OWASPRules))}}
-            modsecurity_rules_file /etc/nginx/owasp-modsecurity-crs/nginx-modsecurity.conf;
+            {{ else if not $all.Cfg.EnableModsecurity }}
+            modsecurity_rules_file /etc/nginx/modsecurity/modsecurity.conf;
             {{ end }}
 
             {{ if (not (empty $location.ModSecurity.TransactionID)) }}


### PR DESCRIPTION
## What this PR does / why we need it:
Currently it is impossible to run `SecRuleEngine On` because somehow it is not possible to override `modsecurity_rules_file /etc/nginx/modsecurity/modsecurity.conf;` values. By this change we can modify everything again with snippet.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes

fixes #4385


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
