### PR TITLE
Update python syntax in OAuth2 example

### DIFF
--- a/docs/examples/auth/oauth-external-auth/README.md
+++ b/docs/examples/auth/oauth-external-auth/README.md
@@ -55,7 +55,7 @@ kubectl create -f https://raw.githubusercontent.com/kubernetes/kops/master/addon
 
 - OAUTH2_PROXY_CLIENT_ID with the github `<Client ID>`
 - OAUTH2_PROXY_CLIENT_SECRET with the github `<Client Secret>`
-- OAUTH2_PROXY_COOKIE_SECRET with value of `python -c 'import os,base64; print base64.b64encode(os.urandom(16))'`
+- OAUTH2_PROXY_COOKIE_SECRET with value of `python -c 'import os,base64; print(base64.b64encode(os.urandom(16)).decode("ascii"))'`
 
 4. Customize the contents of the file dashboard-ingress.yaml:
 


### PR DESCRIPTION
Since Python 2.x has been [retired](https://pythonclock.org/), it makes sense to update code examples to the new [Python 3 syntax](https://pythonclock.org/).
    Sidenote: Invoking `print` as a function (instead of using the depreacted Python 2.x built-in) is also backwards compatible to Python 2, so this is by no means a "breaking change".

## What this PR does / why we need it:
Improvement of the documentation

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] None of the above. ;-)
