### PR TITLE
Fix X-Forwarded-Proto based on proxy-protocol server port

### DIFF
--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -275,6 +275,7 @@ func configForLua(input interface{}) string {
 
 	return fmt.Sprintf(`{
 		use_forwarded_headers = %t,
+		use_proxy_protocol = %t,
 		is_ssl_passthrough_enabled = %t,
 		http_redirect_code = %v,
 		listen_ports = { ssl_proxy = "%v", https = "%v" },
@@ -285,6 +286,7 @@ func configForLua(input interface{}) string {
 		hsts_preload = %t,
 	}`,
 		all.Cfg.UseForwardedHeaders,
+		all.Cfg.UseProxyProtocol,
 		all.IsSSLPassthroughEnabled,
 		all.Cfg.HTTPRedirectCode,
 		all.ListenPorts.SSLProxy,

--- a/rootfs/etc/nginx/lua/lua_ingress.lua
+++ b/rootfs/etc/nginx/lua/lua_ingress.lua
@@ -123,6 +123,12 @@ function _M.rewrite(location_config)
     end
   end
 
+  if config.use_proxy_protocol then
+    if ngx.var.proxy_protocol_server_port == "443" then
+      ngx.var.pass_access_scheme = "https"
+    end
+  end
+
   ngx.var.pass_port = ngx.var.pass_server_port
   if config.is_ssl_passthrough_enabled then
     if ngx.var.pass_server_port == config.listen_ports.ssl_proxy then


### PR DESCRIPTION
This PR resolves the problem described on https://github.com/kubernetes/ingress-nginx/issues/2724 and some other issues.

## What this PR does / why we need it:

- The internal/ingress/controller/template/template.go was changed to add all.Cfg.UseProxyProtocol as use_proxy_protocol in func configForLua()
- Added expression to set ngx.var.pass_access_scheme as https if proxy_protocol_server_port = 443

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran the E2E test suite and tested it in our lab environment on AWS with Proxy Protocol enabled and disabled (based on Amazon ELB).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
