### PR TITLE
Only set mirror source when a target is configured

### DIFF
--- a/internal/ingress/annotations/mirror/main.go
+++ b/internal/ingress/annotations/mirror/main.go
@@ -82,6 +82,7 @@ func (a mirror) Parse(ing *networking.Ingress) (interface{}, error) {
 	config.Target, err = parser.GetStringAnnotation("mirror-target", ing)
 	if err != nil {
 		config.Target = ""
+		config.Source = ""
 	}
 
 	return config, nil

--- a/internal/ingress/annotations/mirror/main_test.go
+++ b/internal/ingress/annotations/mirror/main_test.go
@@ -47,7 +47,7 @@ func TestParse(t *testing.T) {
 			Target:      "https://test.env.com/$request_uri",
 		}},
 		{map[string]string{requestBody: "off"}, &Config{
-			Source:      ngxURI,
+			Source:      "",
 			RequestBody: "off",
 			Target:      "",
 		}},

--- a/test/e2e/annotations/mirror.go
+++ b/test/e2e/annotations/mirror.go
@@ -69,7 +69,7 @@ var _ = framework.IngressNginxDescribe("Annotations - Mirror", func() {
 
 	It("should disable mirror-request-body", func() {
 		annotations := map[string]string{
-			"nginx.ingress.kubernetes.io/mirror-uri":          "http://localhost/mirror",
+			"nginx.ingress.kubernetes.io/mirror-target":       "http://localhost/mirror",
 			"nginx.ingress.kubernetes.io/mirror-request-body": "off",
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:

mirror locations should be defined only when the annotation is used and contains a valid target.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
