### PR TITLE
Testing now can be done on Kubernetes cluster with private registry.

### DIFF
--- a/images/echo/Makefile
+++ b/images/echo/Makefile
@@ -29,5 +29,8 @@ container:
 		--platform linux/amd64 \
 		-t $(IMAGE):$(TAG) .
 
+push:
+	$(DOCKER) push ${IMAGE}:${TAG}
+
 clean:
 	$(DOCKER) rmi -f $(IMAGE):$(TAG) || true

--- a/images/fastcgi-helloserver/Makefile
+++ b/images/fastcgi-helloserver/Makefile
@@ -31,6 +31,9 @@ container: clean build
 		--platform linux/amd64 \
 		-t $(IMAGE):$(TAG) rootfs
 
+push:
+	$(DOCKER) push ${IMAGE}:${TAG}
+
 build: clean
 	CGO_ENABLED=0 go build -a -installsuffix cgo \
 		-ldflags "-s -w" \

--- a/images/httpbin/Makefile
+++ b/images/httpbin/Makefile
@@ -29,5 +29,8 @@ container:
 		--platform linux/amd64 \
 		-t $(IMAGE):$(TAG) rootfs
 
+push:
+	$(DOCKER) push ${IMAGE}:${TAG}
+
 clean:
 	$(DOCKER) rmi -f $(IMAGE):$(TAG) || true

--- a/test/e2e-image/Makefile
+++ b/test/e2e-image/Makefile
@@ -24,13 +24,32 @@ endif
 	cp ../e2e/wait-for-nginx.sh .
 	cp -r ../../deploy/cloud-generic .
 	cp -r ../../deploy/cluster-wide .
+ifdef CUSTOM_REGISTRY
+	@docker buildx build \
+                --load \
+                --progress plain \
+                --tag ${REGISTRY}/nginx-ingress-controller:e2e .
+else
+	@docker buildx build \
+                --load \
+                --progress plain \
+                --tag nginx-ingress-controller:e2e .
+endif
 
-	docker buildx build \
-		--load \
-		--progress plain \
-		--tag nginx-ingress-controller:e2e .
+.PHONY: push
+push:
+ifdef CUSTOM_REGISTRY
+	@docker push ${REGISTRY}/nginx-ingress-controller:e2e
+else
+	@echo "REGISTRY environment variable is not set."
+endif
 
 .PHONY: clean
 clean:
 	rm -rf _cache e2e.test kubectl cluster ginkgo
-	docker rmi -f nginx-ingress-controller:e2e || true
+ifdef CUSTOM_REGISTRY
+	@docker rmi -f ${REGISTRY}/nginx-ingress-controller:e2e || true
+else
+	@docker rmi -f nginx-ingress-controller:e2e || true
+endif
+	

--- a/test/e2e-image/overlay/kustomization.yaml
+++ b/test/e2e-image/overlay/kustomization.yaml
@@ -28,7 +28,3 @@ patchesJson6902:
     kind: Role
     name: nginx-ingress-role
     version: v1beta1
-images:
-- name: quay.io/kubernetes-ingress-controller/nginx-ingress-controller
-  newName: ingress-controller/nginx-ingress-controller
-  newTag: dev

--- a/test/e2e/cluster-run.sh
+++ b/test/e2e/cluster-run.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+export TAG=dev
+export ARCH=amd64
+export DOCKER_CLI_EXPERIMENTAL=enabled
+export CUSTOM_REGISTRY=true
+
+echo "Build and push e2e test images"
+echo "
+make -C ${DIR}/../../ build container push
+make -C ${DIR}/../../ e2e-test-binary
+make -C ${DIR}/../../test/e2e-image container push
+make -C ${DIR}/../../images/echo/ container push
+make -C ${DIR}/../../images/fastcgi-helloserver/ GO111MODULE="on" build container push
+make -C ${DIR}/../../images/httpbin/ container push
+" | parallel --joblog /tmp/log {} || cat /tmp/log
+
+echo "Start e2e test suite"
+make -C ${DIR}/../../ e2e-test

--- a/test/e2e/framework/exec.go
+++ b/test/e2e/framework/exec.go
@@ -115,6 +115,7 @@ func (f *Framework) NamespaceContent() (string, error) {
 
 // newIngressController deploys a new NGINX Ingress controller in a namespace
 func (f *Framework) newIngressController(namespace string, namespaceOverlay string) error {
+	f.DistributePrivateRegistrySecretToNamespace(namespace)
 	// Creates an nginx deployment
 	cmd := exec.Command("./wait-for-nginx.sh", namespace, namespaceOverlay)
 	out, err := cmd.CombinedOutput()

--- a/test/e2e/framework/fastcgi_helloserver.go
+++ b/test/e2e/framework/fastcgi_helloserver.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"os"
 )
 
 // NewFastCGIHelloServerDeployment creates a new single replica
@@ -35,6 +36,8 @@ func (f *Framework) NewFastCGIHelloServerDeployment() {
 // NewNewFastCGIHelloServerDeploymentWithReplicas creates a new deployment of the
 // fortune teller image in a particular namespace. Number of replicas is configurable
 func (f *Framework) NewNewFastCGIHelloServerDeploymentWithReplicas(replicas int32) {
+	imageName := os.Getenv("REGISTRY") + "/fastcgi-helloserver:dev"
+
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "fastcgi-helloserver",
@@ -57,9 +60,10 @@ func (f *Framework) NewNewFastCGIHelloServerDeploymentWithReplicas(replicas int3
 					TerminationGracePeriodSeconds: NewInt64(0),
 					Containers: []corev1.Container{
 						{
-							Name:  "fastcgi-helloserver",
-							Image: "ingress-controller/fastcgi-helloserver:dev",
-							Env:   []corev1.EnvVar{},
+							Name:            "fastcgi-helloserver",
+							Image:           imageName,
+							ImagePullPolicy: f.GetImagePullPolicy(),
+							Env:             []corev1.EnvVar{},
 							Ports: []corev1.ContainerPort{
 								{
 									Name:          "fastcgi",

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -15,6 +15,7 @@ package framework
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -184,6 +185,16 @@ func (f *Framework) GetNginxPodIP() []string {
 func (f *Framework) GetURL(scheme RequestScheme) string {
 	ip := f.GetNginxIP()
 	return fmt.Sprintf("%v://%v", scheme, ip)
+}
+
+// GetImagePullPolicy should return:
+// - PullIfNotPresent on local cluster e.g.:Minicube and Kind.
+// - PullAlways if it deploys on an existing (not local) Kubernetes cluster (refresh local docker images)
+func (f *Framework) GetImagePullPolicy() v1.PullPolicy {
+	if os.Getenv("IMAGE_PULL_POLICY") == "Always" {
+		return v1.PullAlways
+	}
+	return v1.PullIfNotPresent
 }
 
 // WaitForNginxServer waits until the nginx configuration contains a particular server section


### PR DESCRIPTION
- Added new target inside main Makefile
  1. Users will be able to run the e2e tests in their Kubernetes cluster (set KUBECONFIG env variable)
  2. The built images are uploaded to targeted private registy (login via docker to your private registry and set REGISRTY env. variable to your registry)
  3. Private registry username and password handling are handeld as existing (default namespaced) kube secret on your Kubernetes cluster (PRIVATE_DOCKER_REGISTRY_SECRET_NAME)
- Added imagepullpolicy to deployments.
  1. Now updated images from the registry could repulled from private registry to run on the existing cluster.
  2. Local enviroment testing (Minicube, kind) when REGISTRY is set to 'ingress-controller' is the same default behaviour
- Moved the image override from the overlay/kustomization.yml to wati_for_nginx.sh
- Added push target for httpbin and fastcgi Makefile so images cloud be pushed to private docker  registry.
- Changed BASE_IMAGE push may not suitable for everyone. eg.: testing ingress image with existing cluster and private docker registry
- Added go .cache folder cleanup to make clean (linking issue on rerun)

## What this PR does / why we need it:
Extends e2e testing possibilities for users how own Kubernetes clusters. (Faster development and testing) If you don't need to run your local cluster.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
None

## How Has This Been Tested?
make KUBECONFIG=/path/to/my/kubeconfig.yml PRIVATE_DOCKER_REGISTRY_SECRET_NAME=my-private-docker-registry-secret REGISTRY=my.docker.registry.com/my-regsitry-namespace  cluster-e2e-test

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
