### PR TITLE
oauth-external-auth: README.md: Link to oauth2-proxy, dashboard-ingress.yaml

### DIFF
--- a/docs/examples/auth/oauth-external-auth/README.md
+++ b/docs/examples/auth/oauth-external-auth/README.md
@@ -51,13 +51,13 @@ kubectl create -f https://raw.githubusercontent.com/kubernetes/kops/master/addon
 
 ![Register OAuth2 Application](images/register-oauth-app-2.png)
 
-3. Configure oauth2_proxy values in the file oauth2-proxy.yaml with the values:
+3. Configure oauth2_proxy values in the file [`oauth2-proxy.yaml`](https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/docs/examples/auth/oauth-external-auth/oauth2-proxy.yaml) with the values:
 
 - OAUTH2_PROXY_CLIENT_ID with the github `<Client ID>`
 - OAUTH2_PROXY_CLIENT_SECRET with the github `<Client Secret>`
 - OAUTH2_PROXY_COOKIE_SECRET with value of `python -c 'import os,base64; print(base64.b64encode(os.urandom(16)).decode("ascii"))'`
 
-4. Customize the contents of the file dashboard-ingress.yaml:
+4. Customize the contents of the file [`dashboard-ingress.yaml`](https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/docs/examples/auth/oauth-external-auth/dashboard-ingress.yaml):
 
 Replace `__INGRESS_HOST__` with a valid FQDN and `__INGRESS_SECRET__` with a Secret with a valid SSL certificate.
 


### PR DESCRIPTION
## What this PR does / why we need it:
At the moment the content in this README.md refers to the two files oauth2-proxy.yaml
and dashboard-ingress.yaml without linking to them, which is confusing for the reader
actually trying to apply the documentation (especially when reading it in the rendered
form on https://kubernetes.github.io/)

This PR simply adds hypertext links to their source (raw on github).

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
(None)

## How Has This Been Tested?
Documentation has been rendered locally

## Checklist:
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
