### PR TITLE
Fixed incorrect documentation of cli flag --default-backend-service

### DIFF
--- a/docs/examples/customization/custom-errors/README.md
+++ b/docs/examples/customization/custom-errors/README.md
@@ -28,7 +28,7 @@ service/nginx-errors   ClusterIP   10.0.0.12   <none>        80/TCP    10s
 If you do not already have an instance of the NGINX Ingress controller running, deploy it according to the
 [deployment guide][deploy], then follow these steps:
 
-1. Edit the `nginx-ingress-controller` Deployment and set the value of the `--default-backend` flag to the name of the
+1. Edit the `nginx-ingress-controller` Deployment and set the value of the `--default-backend-service` flag to the name of the
    newly created error backend.
 
 2. Edit the `nginx-configuration` ConfigMap and create the key `custom-http-errors` with a value of `404,503`.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The flag stated in the example readme is `--default-backend` but passing that (or looking at --help`) for the ingress controller shows:

```
unknown flag: --default-backend
...
      --default-backend-service string          Service used to serve HTTP requests not matching any known server name (catch-all).
                                                Takes the form "namespace/name". The controller configures NGINX to forward
                                                requests to the first port of this Service.
```

The flag is also stated in the source as:
ref: https://github.com/kubernetes/ingress-nginx/blob/master/cmd/nginx/flags.go#L55

After switching to `--default-backend-service` the documentation's example errors work correctly.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
Incorrect documentation flag causes the example deployment of a custom nginx ingress error controller to fail due to missing command line flag.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I attempted to follow the documentation to deploy a custom nginx backend, it didn't work so I dove in and found out it was just the incorrect command line flag. Tested by correcting the flag in my deployment and re-running.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
