### PR TITLE
Add case for when user agent is nil

### DIFF
--- a/rootfs/etc/nginx/lua/test/util/same_site_test.lua
+++ b/rootfs/etc/nginx/lua/test/util/same_site_test.lua
@@ -1,4 +1,8 @@
 describe("same_site_compatible_test", function()
+  it("returns true for nil user agent", function()
+    local same_site = require("util.same_site")
+    assert.True(same_site.same_site_none_compatible(nil))
+  end)
   it("returns false for chrome 4", function()
     local same_site = require("util.same_site")
     assert.False(same_site.same_site_none_compatible("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2704.103 Safari/537.36"))

--- a/rootfs/etc/nginx/lua/util/same_site.lua
+++ b/rootfs/etc/nginx/lua/util/same_site.lua
@@ -13,7 +13,9 @@ local _M = {}
 -- browsers which will reject SameSite=None cookies.
 -- reference: https://www.chromium.org/updates/same-site/incompatible-clients
 function _M.same_site_none_compatible(user_agent)
-  if string.match(user_agent, "Chrome/4") then
+  if not user_agent then
+    return true
+  elseif string.match(user_agent, "Chrome/4") then
     return false
   elseif string.match(user_agent, "Chrome/5") then
     return false


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
This PR simply adds a check to protect against a nil user agent in the same site tests, as pointed out [here](https://github.com/kubernetes/ingress-nginx/pull/4949#discussion_r378988432).

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
