### PR TITLE
ingress-path-matching: doc typo

### DIFF
--- a/docs/user-guide/ingress-path-matching.md
+++ b/docs/user-guide/ingress-path-matching.md
@@ -158,4 +158,4 @@ location ~* "^/foo/bar/bar" {
 }
 ```
 
-A request to `test.com/foo/bar/bar` would match the `^/foo/[A-Z0-9]{3}` location block instead of the longest EXACT matching path.
+A request to `test.com/foo/bar/bar` would match the `^/foo/bar/[A-Z0-9]{3}` location block instead of the longest EXACT matching path.


### PR DESCRIPTION
A small typo in the README describing the path matching.

## What this PR does / why we need it:
Small documentation typo

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Just documentation change.

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
