### PR TITLE
refactor ssl handling in preparation of OCSP stapling

### DIFF
--- a/rootfs/etc/nginx/lua/configuration.lua
+++ b/rootfs/etc/nginx/lua/configuration.lua
@@ -37,7 +37,7 @@ local function fetch_request_body()
   return body
 end
 
-function _M.get_pem_cert_key(hostname)
+local function get_pem_cert(hostname)
   local uid = certificate_servers:get(hostname)
   if not uid then
     return nil
@@ -143,7 +143,7 @@ local function handle_certs()
     return
   end
 
-  local key = _M.get_pem_cert_key(query["hostname"])
+  local key = get_pem_cert(query["hostname"])
   if key then
     ngx.status = ngx.HTTP_OK
     ngx.print(key)


### PR DESCRIPTION
## What this PR does / why we need it:

- expose DER encoded version of certificate in certificate.call
- expose uid of certificate in certificate.call

In order to extract OCSP responder URL and generate OCSP request DER encoded version of a certificate is needed: https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/ocsp.md.

UID will be used to check whether OCSP stapling should be done for the given certificate.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
