### PR TITLE
Lua OCSP stapling

### DIFF
--- a/internal/ingress/controller/template/configmap.go
+++ b/internal/ingress/controller/template/configmap.go
@@ -73,6 +73,7 @@ var (
 		"balancer_ewma_last_touched_at": 10,
 		"balancer_ewma_locks":           1,
 		"certificate_servers":           5,
+		"ocsp_response_cache":           5, // keep this same as certificate_servers
 	}
 )
 

--- a/rootfs/etc/nginx/lua/test/certificate_test.lua
+++ b/rootfs/etc/nginx/lua/test/certificate_test.lua
@@ -128,6 +128,34 @@ describe("Certificate", function()
       refute_certificate_is_set()
       assert.spy(ngx.log).was_called_with(ngx.ERR, "failed to convert certificate chain from PEM to DER: PEM_read_bio_X509_AUX() failed")
     end)
+
+    describe("OCSP stapling", function()
+      before_each(function()
+        certificate.is_ocsp_stapling_enabled = true
+      end)
+
+      after_each(function()
+        certificate.is_ocsp_stapling_enabled = false
+      end)
+
+      it("fetches and caches OCSP response when there is no cached response", function()
+      end)
+
+      it("fetches and caches OCSP response when cached response is stale", function()
+      end)
+
+      it("staples using cached OCSP response", function()
+      end)
+
+      it("staples using cached stale OCSP response", function()
+      end)
+
+      it("does negative caching when OCSP response URL extraction fails", function()
+      end)
+
+      it("does negative caching when the request to OCSP responder fails", function()
+      end)
+    end)
   end)
 
   describe("configured_for_current_request", function()

--- a/rootfs/etc/nginx/lua/test/util/dns_test.lua
+++ b/rootfs/etc/nginx/lua/test/util/dns_test.lua
@@ -5,6 +5,8 @@ search ingress-nginx.svc.cluster.local svc.cluster.local cluster.local
 options ndots:5
 ]===]
 
+package.loaded["util.resolv_conf"] = nil
+
 helpers.with_resolv_conf(conf, function()
   require("util.resolv_conf")
 end)

--- a/rootfs/etc/nginx/lua/test/util/resolv_conf_test.lua
+++ b/rootfs/etc/nginx/lua/test/util/resolv_conf_test.lua
@@ -1,7 +1,7 @@
 local original_io_open = io.open
 
 describe("resolv_conf", function()
-  after_each(function()
+  before_each(function()
     package.loaded["util.resolv_conf"] = nil
     io.open = original_io_open
   end)

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -94,6 +94,8 @@ http {
           error("require failed: " .. tostring(res))
         else
           certificate = res
+          -- TODO: get this from the configmap
+          certificate.is_ocsp_stapling_enabled = false
         end
 
         ok, res = pcall(require, "plugins")


### PR DESCRIPTION
For https://github.com/kubernetes/ingress-nginx/issues/4758

In order to avoid Nginx reload we have moved to dynamically handling TLS certificate serving using Lua a while ago. That also meant things like `ssl_stapling` directives became useless. This PR implements alternative to Nginx's `ssl_stapling` using Lua.

This is bare minimum implementation, expect a lot of rough edges.

The implementation tries to follow advice from https://gist.github.com/sleevi/5efe9ef98961ecfb4da8, but it is not even close to all the best practices mentioned there.

Another important shortcoming of this implementation to keep in mind is that [Lua OCSP API does not provide API for `thisUpdate` and `nextUpdate`](https://github.com/openresty/lua-resty-core/issues/75), therefore we are just caching responses for 3 days. This might and might not be acceptable by some users.

With all these in consideration, give it a try and let us know what can be improved, even better improve it yourself - patches are always welcome.