### PR TITLE
Fixes https://github.com/kubernetes/ingress-nginx/issues/5120

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -856,8 +856,10 @@ stream {
         location = {{ $authPath }} {
             internal;
 
+						{{ if $all.Cfg.EnableOpentracing }}
             opentracing on; 
             opentracing_propagate_context;
+            {{ end }}
 
             {{ if $externalAuth.AuthCacheKey }}
             set $tmp_cache_key '{{ $server.Hostname }}{{ $authPath }}{{ $externalAuth.AuthCacheKey }}';

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -856,6 +856,9 @@ stream {
         location = {{ $authPath }} {
             internal;
 
+            opentracing on; 
+            opentracing_propagate_context;
+
             {{ if $externalAuth.AuthCacheKey }}
             set $tmp_cache_key '{{ $server.Hostname }}{{ $authPath }}{{ $externalAuth.AuthCacheKey }}';
             set $cache_key '';


### PR DESCRIPTION
This fixes the opentracing context not being passed in auth requests. 

Tested and has reduced our nginx errors significantly:

<img width="1213" alt="Screenshot 2020-02-20 at 14 01 28" src="https://user-images.githubusercontent.com/1486729/74940843-f7e9c700-53e9-11ea-8aa1-a62b37ea1f48.png">
