### PR TITLE
proxy_ssl_name support

### DIFF
--- a/docs/user-guide/nginx-configuration/annotations.md
+++ b/docs/user-guide/nginx-configuration/annotations.md
@@ -73,6 +73,7 @@ You can add these Kubernetes annotations to specific Ingress objects to customiz
 |[nginx.ingress.kubernetes.io/proxy-http-version](#proxy-http-version)|"1.0" or "1.1"|
 |[nginx.ingress.kubernetes.io/proxy-ssl-secret](#backend-certificate-authentication)|string|
 |[nginx.ingress.kubernetes.io/proxy-ssl-ciphers](#backend-certificate-authentication)|string|
+|[nginx.ingress.kubernetes.io/proxy-ssl-name](#backend-certificate-authentication)|string|
 |[nginx.ingress.kubernetes.io/proxy-ssl-protocols](#backend-certificate-authentication)|string|
 |[nginx.ingress.kubernetes.io/proxy-ssl-verify](#backend-certificate-authentication)|string|
 |[nginx.ingress.kubernetes.io/proxy-ssl-verify-depth](#backend-certificate-authentication)|number|
@@ -274,6 +275,8 @@ It is possible to authenticate to a proxied HTTPS backend with certificate using
   Sets the verification depth in the proxied HTTPS server certificates chain. (default: 1)
 * `nginx.ingress.kubernetes.io/proxy-ssl-ciphers`:
   Specifies the enabled [ciphers](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_ssl_ciphers) for requests to a proxied HTTPS server. The ciphers are specified in the format understood by the OpenSSL library.
+* `nginx.ingress.kubernetes.io/proxy-ssl-name`:
+  Allows to set [proxy_ssl_name](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_ssl_name). This allows overriding the server name used to verify the certificate of the proxied HTTPS server. This value is also passed through SNI when a connection is established to the proxied HTTPS server.
 * `nginx.ingress.kubernetes.io/proxy-ssl-protocols`:
   Enables the specified [protocols](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_ssl_protocols) for requests to a proxied HTTPS server.
 

--- a/internal/ingress/annotations/proxyssl/main.go
+++ b/internal/ingress/annotations/proxyssl/main.go
@@ -45,11 +45,11 @@ var (
 // and the configured VerifyDepth
 type Config struct {
 	resolver.AuthSSLCert
-	Ciphers                   string `json:"ciphers"`
-	Protocols                 string `json:"protocols"`
-	ProxySSLName              string `json:"proxySSLName"`
-	Verify                    string `json:"verify"`
-	VerifyDepth               int    `json:"verifyDepth"`
+	Ciphers      string `json:"ciphers"`
+	Protocols    string `json:"protocols"`
+	ProxySSLName string `json:"proxySSLName"`
+	Verify       string `json:"verify"`
+	VerifyDepth  int    `json:"verifyDepth"`
 }
 
 // Equal tests for equality between two Config types
@@ -146,8 +146,7 @@ func (p proxySSL) Parse(ing *networking.Ingress) (interface{}, error) {
 
 	config.ProxySSLName, err = parser.GetStringAnnotation("proxy-ssl-name", ing)
 	if err != nil {
-		e := errors.Wrap(err, "error obtaining proxy-ssl-name")
-		return &Config{}, ing_errors.LocationDenied{Reason: e}
+		config.ProxySSLName = ""
 	}
 
 	config.Verify, err = parser.GetStringAnnotation("proxy-ssl-verify", ing)

--- a/internal/ingress/annotations/proxyssl/main.go
+++ b/internal/ingress/annotations/proxyssl/main.go
@@ -45,10 +45,11 @@ var (
 // and the configured VerifyDepth
 type Config struct {
 	resolver.AuthSSLCert
-	Ciphers     string `json:"ciphers"`
-	Protocols   string `json:"protocols"`
-	Verify      string `json:"verify"`
-	VerifyDepth int    `json:"verifyDepth"`
+	Ciphers                   string `json:"ciphers"`
+	Protocols                 string `json:"protocols"`
+	ProxySSLName              string `json:"proxySSLName"`
+	Verify                    string `json:"verify"`
+	VerifyDepth               int    `json:"verifyDepth"`
 }
 
 // Equal tests for equality between two Config types
@@ -141,6 +142,12 @@ func (p proxySSL) Parse(ing *networking.Ingress) (interface{}, error) {
 		config.Protocols = defaultProxySSLProtocols
 	} else {
 		config.Protocols = sortProtocols(config.Protocols)
+	}
+
+	config.ProxySSLName, err = parser.GetStringAnnotation("proxy-ssl-name", ing)
+	if err != nil {
+		e := errors.Wrap(err, "error obtaining proxy-ssl-name")
+		return &Config{}, ing_errors.LocationDenied{Reason: e}
 	}
 
 	config.Verify, err = parser.GetStringAnnotation("proxy-ssl-verify", ing)

--- a/internal/ingress/annotations/proxyssl/main_test.go
+++ b/internal/ingress/annotations/proxyssl/main_test.go
@@ -94,6 +94,7 @@ func TestAnnotations(t *testing.T) {
 	data[parser.GetAnnotationWithPrefix("proxy-ssl-session-reuse")] = "off"
 	data[parser.GetAnnotationWithPrefix("proxy-ssl-verify")] = "on"
 	data[parser.GetAnnotationWithPrefix("proxy-ssl-verify-depth")] = "3"
+	data[parser.GetAnnotationWithPrefix("proxy-ssl-name")] = "testname.namespace"
 
 	ing.SetAnnotations(data)
 
@@ -128,6 +129,10 @@ func TestAnnotations(t *testing.T) {
 	if u.VerifyDepth != 3 {
 		t.Errorf("expected %v but got %v", 3, u.VerifyDepth)
 	}
+	if u.ProxySSLName != "testname.namespace" {
+		t.Errorf("expected %v but got %v", "testname.namespace", u.ProxySSLName)
+	}
+
 }
 
 func TestInvalidAnnotations(t *testing.T) {

--- a/internal/ingress/annotations/proxyssl/main_test.go
+++ b/internal/ingress/annotations/proxyssl/main_test.go
@@ -94,7 +94,6 @@ func TestAnnotations(t *testing.T) {
 	data[parser.GetAnnotationWithPrefix("proxy-ssl-session-reuse")] = "off"
 	data[parser.GetAnnotationWithPrefix("proxy-ssl-verify")] = "on"
 	data[parser.GetAnnotationWithPrefix("proxy-ssl-verify-depth")] = "3"
-	data[parser.GetAnnotationWithPrefix("proxy-ssl-name")] = "testname.namespace"
 
 	ing.SetAnnotations(data)
 
@@ -129,8 +128,8 @@ func TestAnnotations(t *testing.T) {
 	if u.VerifyDepth != 3 {
 		t.Errorf("expected %v but got %v", 3, u.VerifyDepth)
 	}
-	if u.ProxySSLName != "testname.namespace" {
-		t.Errorf("expected %v but got %v", "testname.namespace", u.ProxySSLName)
+	if u.ProxySSLName != "$host" {
+		t.Errorf("expected %v but got %v", "$host", u.ProxySSLName)
 	}
 
 }

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -813,6 +813,9 @@ stream {
         proxy_ssl_protocols                     {{ $server.ProxySSL.Protocols }};
         proxy_ssl_verify                        {{ $server.ProxySSL.Verify }};
         proxy_ssl_verify_depth                  {{ $server.ProxySSL.VerifyDepth }};
+        {{ if not (empty $server.ProxySSL.ProxySSLName) }}
+        proxy_ssl_name                           {{ $server.ProxySSL.ProxySSLName }};
+        {{ end }}        
         {{ end }}
 
         {{ if not (empty $server.ProxySSL.PemFileName) }}

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -1237,6 +1237,10 @@ stream {
             proxy_ssl_verify_depth                  {{ $location.ProxySSL.VerifyDepth }};
             {{ end }}
 
+            {{ if not (empty $location.ProxySSL.ProxySSLName) }}
+            proxy_ssl_name                           {{ $location.ProxySSL.ProxySSLName }};
+            {{ end }}
+
             {{ if not (empty $location.ProxySSL.PemFileName) }}
             proxy_ssl_certificate                   {{ $location.ProxySSL.PemFileName }};
             proxy_ssl_certificate_key               {{ $location.ProxySSL.PemFileName }};


### PR DESCRIPTION
## What this PR does / why we need it:
It implements the support of `proxy_ssl_name` on server and location levels.

Credit goes to the original PR #4639 , this is only a continuation of that, with the additional location level support requested in that PR.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes

## How Has This Been Tested?
Unit test

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
