### PR TITLE
Adding annotations support to helm chart configmaps

### DIFF
--- a/charts/ingress-nginx/README.md
+++ b/charts/ingress-nginx/README.md
@@ -58,6 +58,7 @@ Parameter | Description | Default
 `controller.containerPort.http` | The port that the controller container listens on for http connections. | `80`
 `controller.containerPort.https` | The port that the controller container listens on for https connections. | `443`
 `controller.config` | nginx [ConfigMap](https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/configmap.md) entries | none
+`controller.configAnnotations` | annotations to be added to controller custom configuration configmap | `{}`
 `controller.hostNetwork` | If the nginx deployment / daemonset should run on the host's network namespace. Do not set this when `controller.service.externalIPs` is set and `kube-proxy` is used as there will be a port-conflict for port `80` | false
 `controller.defaultBackendService` | default 404 backend service; needed only if `defaultBackend.enabled = false` and version < 0.21.0| `""`
 `controller.dnsPolicy` | If using `hostNetwork=true`, change to `ClusterFirstWithHostNet`. See [pod's dns policy](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy) for details | `ClusterFirst`
@@ -179,7 +180,9 @@ Parameter | Description | Default
 `controller.updateStrategy` | allows setting of RollingUpdate strategy | `{}`
 `controller.configMapNamespace` | The nginx-configmap namespace name | `""`
 `controller.tcp.configMapNamespace` | The tcp-services-configmap namespace name | `""`
+`controller.tcp.annotations` | annotations to be added to tcp configmap | `{}`
 `controller.udp.configMapNamespace` | The udp-services-configmap namespace name | `""`
+`controller.udp.annotations` | annotations to be added to udp configmap | `{}`
 `defaultBackend.enabled` | Use default backend component | `true`
 `defaultBackend.name` | name of the default backend component | `default-backend`
 `defaultBackend.image.repository` | default backend container image repository | `k8s.gcr.io/defaultbackend-amd64`

--- a/charts/ingress-nginx/templates/controller-configmap.yaml
+++ b/charts/ingress-nginx/templates/controller-configmap.yaml
@@ -8,6 +8,8 @@ metadata:
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+  annotations:
+{{ toYaml .Values.controller.configAnnotations | indent 4}}
   name: {{ template "nginx-ingress.controller.fullname" . }}
 data:
 {{- if .Values.controller.addHeaders }}

--- a/charts/ingress-nginx/templates/tcp-configmap.yaml
+++ b/charts/ingress-nginx/templates/tcp-configmap.yaml
@@ -8,6 +8,8 @@ metadata:
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+  annotations:
+{{ toYaml .Values.controller.tcp.annotations | indent 4}}
   name: {{ template "nginx-ingress.fullname" . }}-tcp
 data:
 {{ tpl (toYaml .Values.tcp) . | indent 2 }}

--- a/charts/ingress-nginx/templates/udp-configmap.yaml
+++ b/charts/ingress-nginx/templates/udp-configmap.yaml
@@ -8,6 +8,8 @@ metadata:
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+  annotations:
+{{ toYaml .Values.controller.udp.annotations | indent 4}}
   name: {{ template "nginx-ingress.fullname" . }}-udp
 data:
 {{ tpl (toYaml .Values.udp) . | indent 2 }}

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -19,6 +19,10 @@ controller:
   # Will add custom configuration options to Nginx https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/
   config: {}
 
+  ## Annotations to be added to the controller config configuration configmap
+  ##
+  configAnnotations: {}
+
   # Will add custom headers before sending traffic to backends according to https://github.com/kubernetes/ingress-nginx/tree/master/docs/examples/customization/custom-headers
   proxySetHeaders: {}
 
@@ -92,15 +96,19 @@ controller:
   ##
   configMapNamespace: ""   # defaults to .Release.Namespace
 
-  ## Allows customization of the tcp-services-configmap namespace
+  ## Allows customization of the tcp-services-configmap
   ##
   tcp:
     configMapNamespace: ""   # defaults to .Release.Namespace
+    ## Annotations to be added to the tcp config configmap
+    annotations: {}
 
-  ## Allows customization of the udp-services-configmap namespace
+  ## Allows customization of the udp-services-configmap
   ##
   udp:
     configMapNamespace: ""   # defaults to .Release.Namespace
+    ## Annotations to be added to the udp config configmap
+    annotations: {}
 
   ## Additional command line arguments to pass to nginx-ingress-controller
   ## E.g. to specify the default SSL certificate you can use


### PR DESCRIPTION
Signed-off-by: Greg Sidelinger <gate@ilive4code.net>

<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
We are using [harness.io](https://harness.io) for deployments and they actually rename configmaps by default to allow for multiple versions of the app to be deployed at a time.  In order to disable this feature I need to be able to add an annotation on the configmap as documented [here](https://docs.harness.io/article/ttn8acijrz-versioning-and-annotations#annotations).  This PR adds support for annotations on the custom config, tcp and ucp configmaps as their names are passed in via command line switches.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested the chart updates locally.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
