### PR TITLE
[helm chart] Renaming all instances of nginx-ingress to ingress-nginx

### DIFF
--- a/charts/ingress-nginx/README.md
+++ b/charts/ingress-nginx/README.md
@@ -51,7 +51,7 @@ The following table lists the configurable parameters of the ingress-nginx chart
 Parameter | Description | Default
 --- | --- | ---
 `controller.name` | name of the controller component | `controller`
-`controller.image.repository` | controller container image repository | `quay.io/kubernetes-ingress-controller/nginx-ingress-controller`
+`controller.image.repository` | controller container image repository | `quay.io/kubernetes-ingress-controller/ingress-nginx-controller`
 `controller.image.tag` | controller container image tag | `0.30.0`
 `controller.image.pullPolicy` | controller container image pull policy | `IfNotPresent`
 `controller.image.runAsUser` | User ID of the controller process. Value depends on the Linux distribution used inside of the container image. | `101`
@@ -272,7 +272,7 @@ You can add Prometheus annotations to the metrics service using `controller.metr
 Previous versions of this chart had a `controller.stats.*` configuration block, which is now obsolete due to the following changes in nginx ingress controller:
 * in [0.16.1](https://github.com/kubernetes/ingress-nginx/blob/master/Changelog.md#0161), the vts (virtual host traffic status) dashboard was removed
 * in [0.23.0](https://github.com/kubernetes/ingress-nginx/blob/master/Changelog.md#0230), the status page at port 18080 is now a unix socket webserver only available at localhost.
-  You can use `curl --unix-socket /tmp/nginx-status-server.sock http://localhost/nginx_status` inside the controller container to access it locally, or use the snippet from [nginx-ingress changelog](https://github.com/kubernetes/ingress-nginx/blob/master/Changelog.md#0230) to re-enable the http server
+  You can use `curl --unix-socket /tmp/nginx-status-server.sock http://localhost/nginx_status` inside the controller container to access it locally, or use the snippet from [ingress-nginx changelog](https://github.com/kubernetes/ingress-nginx/blob/master/Changelog.md#0230) to re-enable the http server
 
 ## ExternalDNS Service configuration
 
@@ -287,7 +287,7 @@ controller:
 
 ## AWS L7 ELB with SSL Termination
 
-Annotate the controller as shown in the [nginx-ingress l7 patch](https://github.com/kubernetes/ingress-nginx/blob/master/deploy/aws/l7/service-l7.yaml):
+Annotate the controller as shown in the [ingress-nginx l7 patch](https://github.com/kubernetes/ingress-nginx/blob/master/deploy/aws/l7/service-l7.yaml):
 
 ```yaml
 controller:
@@ -317,9 +317,9 @@ controller:
 
 ## Ingress Admission Webhooks
 
-With nginx-ingress-controller version 0.25+, the nginx ingress controller pod exposes an endpoint that will integrate with the `validatingwebhookconfiguration` Kubernetes feature to prevent bad ingress from being added to the cluster.
+With ingress-nginx-controller version 0.25+, the nginx ingress controller pod exposes an endpoint that will integrate with the `validatingwebhookconfiguration` Kubernetes feature to prevent bad ingress from being added to the cluster.
 
-With nginx-ingress-controller in 0.25.* work only with kubernetes 1.14+, 0.26 fix [this issue](https://github.com/kubernetes/ingress-nginx/pull/4521)
+With ingress-nginx-controller in 0.25.* work only with kubernetes 1.14+, 0.26 fix [this issue](https://github.com/kubernetes/ingress-nginx/pull/4521)
 
 ## Helm error when upgrading: spec.clusterIP: Invalid value: ""
 

--- a/charts/ingress-nginx/templates/NOTES.txt
+++ b/charts/ingress-nginx/templates/NOTES.txt
@@ -1,4 +1,4 @@
-The nginx-ingress controller has been installed.
+The ingress-nginx controller has been installed.
 
 {{- if contains "NodePort" .Values.controller.service.type }}
 Get the application URL by running these commands:
@@ -6,12 +6,12 @@ Get the application URL by running these commands:
 {{- if (not (empty .Values.controller.service.nodePorts.http)) }}
   export HTTP_NODE_PORT={{ .Values.controller.service.nodePorts.http }}
 {{- else }}
-  export HTTP_NODE_PORT=$(kubectl --namespace {{ .Release.Namespace }} get services -o jsonpath="{.spec.ports[0].nodePort}" {{ template "nginx-ingress.controller.fullname" . }})
+  export HTTP_NODE_PORT=$(kubectl --namespace {{ .Release.Namespace }} get services -o jsonpath="{.spec.ports[0].nodePort}" {{ template "ingress-nginx.controller.fullname" . }})
 {{- end }}
 {{- if (not (empty .Values.controller.service.nodePorts.https)) }}
   export HTTPS_NODE_PORT={{ .Values.controller.service.nodePorts.https }}
 {{- else }}
-  export HTTPS_NODE_PORT=$(kubectl --namespace {{ .Release.Namespace }} get services -o jsonpath="{.spec.ports[1].nodePort}" {{ template "nginx-ingress.controller.fullname" . }})
+  export HTTPS_NODE_PORT=$(kubectl --namespace {{ .Release.Namespace }} get services -o jsonpath="{.spec.ports[1].nodePort}" {{ template "ingress-nginx.controller.fullname" . }})
 {{- end }}
   export NODE_IP=$(kubectl --namespace {{ .Release.Namespace }} get nodes -o jsonpath="{.items[0].status.addresses[1].address}")
 
@@ -19,10 +19,10 @@ Get the application URL by running these commands:
   echo "Visit https://$NODE_IP:$HTTPS_NODE_PORT to access your application via HTTPS."
 {{- else if contains "LoadBalancer" .Values.controller.service.type }}
 It may take a few minutes for the LoadBalancer IP to be available.
-You can watch the status by running 'kubectl --namespace {{ .Release.Namespace }} get services -o wide -w {{ template "nginx-ingress.controller.fullname" . }}'
+You can watch the status by running 'kubectl --namespace {{ .Release.Namespace }} get services -o wide -w {{ template "ingress-nginx.controller.fullname" . }}'
 {{- else if contains "ClusterIP"  .Values.controller.service.type }}
 Get the application URL by running these commands:
-  export POD_NAME=$(kubectl --namespace {{ .Release.Namespace }} get pods -o jsonpath="{.items[0].metadata.name}" -l "app={{ template "nginx-ingress.name" . }},component={{ .Values.controller.name }},release={{ .Release.Name }}")
+  export POD_NAME=$(kubectl --namespace {{ .Release.Namespace }} get pods -o jsonpath="{.items[0].metadata.name}" -l "app={{ template "ingress-nginx.name" . }},component={{ .Values.controller.name }},release={{ .Release.Name }}")
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:80
   echo "Visit http://127.0.0.1:8080 to access your application."
 {{- end }}

--- a/charts/ingress-nginx/templates/_helpers.tpl
+++ b/charts/ingress-nginx/templates/_helpers.tpl
@@ -2,14 +2,14 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "nginx-ingress.name" -}}
+{{- define "ingress-nginx.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "nginx-ingress.chart" -}}
+{{- define "ingress-nginx.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -17,7 +17,7 @@ Create chart name and version as used by the chart label.
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "nginx-ingress.fullname" -}}
+{{- define "ingress-nginx.fullname" -}}
 {{- if .Values.fullnameOverride -}}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
@@ -34,8 +34,8 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 Create a default fully qualified controller name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "nginx-ingress.controller.fullname" -}}
-{{- printf "%s-%s" (include "nginx-ingress.fullname" .) .Values.controller.name | trunc 63 | trimSuffix "-" -}}
+{{- define "ingress-nginx.controller.fullname" -}}
+{{- printf "%s-%s" (include "ingress-nginx.fullname" .) .Values.controller.name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
@@ -47,8 +47,8 @@ service generated.
 Users can provide an override for an explicit service they want bound via `.Values.controller.publishService.pathOverride`
 
 */}}
-{{- define "nginx-ingress.controller.publishServicePath" -}}
-{{- $defServiceName := printf "%s/%s" .Release.Namespace (include "nginx-ingress.controller.fullname" .) -}}
+{{- define "ingress-nginx.controller.publishServicePath" -}}
+{{- $defServiceName := printf "%s/%s" .Release.Namespace (include "ingress-nginx.controller.fullname" .) -}}
 {{- $servicePath := default $defServiceName .Values.controller.publishService.pathOverride }}
 {{- print $servicePath | trimSuffix "-" -}}
 {{- end -}}
@@ -57,16 +57,16 @@ Users can provide an override for an explicit service they want bound via `.Valu
 Create a default fully qualified default backend name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "nginx-ingress.defaultBackend.fullname" -}}
-{{- printf "%s-%s" (include "nginx-ingress.fullname" .) .Values.defaultBackend.name | trunc 63 | trimSuffix "-" -}}
+{{- define "ingress-nginx.defaultBackend.fullname" -}}
+{{- printf "%s-%s" (include "ingress-nginx.fullname" .) .Values.defaultBackend.name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 Create the name of the controller service account to use
 */}}
-{{- define "nginx-ingress.serviceAccountName" -}}
+{{- define "ingress-nginx.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create -}}
-    {{ default (include "nginx-ingress.fullname" .) .Values.serviceAccount.name }}
+    {{ default (include "ingress-nginx.fullname" .) .Values.serviceAccount.name }}
 {{- else -}}
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
@@ -75,9 +75,9 @@ Create the name of the controller service account to use
 {{/*
 Create the name of the backend service account to use - only used when podsecuritypolicy is also enabled
 */}}
-{{- define "nginx-ingress.defaultBackend.serviceAccountName" -}}
+{{- define "ingress-nginx.defaultBackend.serviceAccountName" -}}
 {{- if .Values.defaultBackend.serviceAccount.create -}}
-    {{ default (printf "%s-backend" (include "nginx-ingress.fullname" .)) .Values.defaultBackend.serviceAccount.name }}
+    {{ default (printf "%s-backend" (include "ingress-nginx.fullname" .)) .Values.defaultBackend.serviceAccount.name }}
 {{- else -}}
     {{ default "default-backend" .Values.defaultBackend.serviceAccount.name }}
 {{- end -}}

--- a/charts/ingress-nginx/templates/addheaders-configmap.yaml
+++ b/charts/ingress-nginx/templates/addheaders-configmap.yaml
@@ -3,12 +3,12 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app: {{ template "nginx-ingress.name" . }}
-    chart: {{ template "nginx-ingress.chart" . }}
+    app: {{ template "ingress-nginx.name" . }}
+    chart: {{ template "ingress-nginx.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "nginx-ingress.fullname" . }}-custom-add-headers
+  name: {{ template "ingress-nginx.fullname" . }}-custom-add-headers
 data:
 {{ toYaml .Values.controller.addHeaders | indent 2 }}
 {{- end }}

--- a/charts/ingress-nginx/templates/admission-webhooks/job-patch/clusterrole.yaml
+++ b/charts/ingress-nginx/templates/admission-webhooks/job-patch/clusterrole.yaml
@@ -2,13 +2,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name:  {{ template "nginx-ingress.fullname" . }}-admission
+  name:  {{ template "ingress-nginx.fullname" . }}-admission
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    app: {{ template "nginx-ingress.name" . }}
-    chart: {{ template "nginx-ingress.chart" . }}
+    app: {{ template "ingress-nginx.name" . }}
+    chart: {{ template "ingress-nginx.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
@@ -25,6 +25,6 @@ rules:
     resources: ['podsecuritypolicies']
     verbs:     ['use']
     resourceNames:
-    - {{ template "nginx-ingress.fullname" . }}-admission
+    - {{ template "ingress-nginx.fullname" . }}-admission
 {{- end }}
 {{- end }}

--- a/charts/ingress-nginx/templates/admission-webhooks/job-patch/clusterrolebinding.yaml
+++ b/charts/ingress-nginx/templates/admission-webhooks/job-patch/clusterrolebinding.yaml
@@ -2,22 +2,22 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name:  {{ template "nginx-ingress.fullname" . }}-admission
+  name:  {{ template "ingress-nginx.fullname" . }}-admission
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    app: {{ template "nginx-ingress.name" . }}
-    chart: {{ template "nginx-ingress.chart" . }}
+    app: {{ template "ingress-nginx.name" . }}
+    chart: {{ template "ingress-nginx.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "nginx-ingress.fullname" . }}-admission
+  name: {{ template "ingress-nginx.fullname" . }}-admission
 subjects:
   - kind: ServiceAccount
-    name: {{ template "nginx-ingress.fullname" . }}-admission
+    name: {{ template "ingress-nginx.fullname" . }}-admission
     namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/charts/ingress-nginx/templates/admission-webhooks/job-patch/job-createSecret.yaml
+++ b/charts/ingress-nginx/templates/admission-webhooks/job-patch/job-createSecret.yaml
@@ -2,13 +2,13 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ template "nginx-ingress.fullname" . }}-admission-create
+  name: {{ template "ingress-nginx.fullname" . }}-admission-create
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    app: {{ template "nginx-ingress.name" . }}
-    chart: {{ template "nginx-ingress.chart" . }}
+    app: {{ template "ingress-nginx.name" . }}
+    chart: {{ template "ingress-nginx.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
@@ -19,14 +19,14 @@ spec:
   {{- end }}
   template:
     metadata:
-      name: {{ template "nginx-ingress.fullname" . }}-admission-create
+      name: {{ template "ingress-nginx.fullname" . }}-admission-create
 {{- with .Values.controller.admissionWebhooks.patch.podAnnotations }}
       annotations:
 {{ toYaml .  | indent 8 }}
 {{- end }}
       labels:
-        app: {{ template "nginx-ingress.name" . }}
-        chart: {{ template "nginx-ingress.chart" . }}
+        app: {{ template "ingress-nginx.name" . }}
+        chart: {{ template "ingress-nginx.chart" . }}
         component: "{{ .Values.controller.name }}"
         heritage: {{ .Release.Service }}
         release: {{ .Release.Name }}
@@ -40,11 +40,11 @@ spec:
           imagePullPolicy: {{ .Values.controller.admissionWebhooks.patch.image.pullPolicy }}
           args:
             - create
-            - --host={{ template "nginx-ingress.controller.fullname" . }}-admission,{{ template "nginx-ingress.controller.fullname" . }}-admission.{{ .Release.Namespace }}.svc
+            - --host={{ template "ingress-nginx.controller.fullname" . }}-admission,{{ template "ingress-nginx.controller.fullname" . }}-admission.{{ .Release.Namespace }}.svc
             - --namespace={{ .Release.Namespace }}
-            - --secret-name={{ template "nginx-ingress.fullname". }}-admission
+            - --secret-name={{ template "ingress-nginx.fullname". }}-admission
       restartPolicy: OnFailure
-      serviceAccountName: {{ template "nginx-ingress.fullname" . }}-admission
+      serviceAccountName: {{ template "ingress-nginx.fullname" . }}-admission
       {{- with .Values.controller.admissionWebhooks.patch.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/charts/ingress-nginx/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
+++ b/charts/ingress-nginx/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
@@ -2,13 +2,13 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ template "nginx-ingress.fullname" . }}-admission-patch
+  name: {{ template "ingress-nginx.fullname" . }}-admission-patch
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    app: {{ template "nginx-ingress.name" . }}
-    chart: {{ template "nginx-ingress.chart" . }}
+    app: {{ template "ingress-nginx.name" . }}
+    chart: {{ template "ingress-nginx.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
@@ -19,14 +19,14 @@ spec:
   {{- end }}
   template:
     metadata:
-      name:   {{ template "nginx-ingress.fullname" . }}-admission-patch
+      name:   {{ template "ingress-nginx.fullname" . }}-admission-patch
 {{- with .Values.controller.admissionWebhooks.patch.podAnnotations }}
       annotations:
 {{ toYaml .  | indent 8 }}
 {{- end }}
       labels:
-        app: {{ template "nginx-ingress.name" . }}
-        chart: {{ template "nginx-ingress.chart" . }}
+        app: {{ template "ingress-nginx.name" . }}
+        chart: {{ template "ingress-nginx.chart" . }}
         component: "{{ .Values.controller.name }}"
         heritage: {{ .Release.Service }}
         release: {{ .Release.Name }}
@@ -40,13 +40,13 @@ spec:
           imagePullPolicy: {{ .Values.controller.admissionWebhooks.patch.pullPolicy }}
           args:
             - patch
-            - --webhook-name={{ template "nginx-ingress.fullname" . }}-admission
+            - --webhook-name={{ template "ingress-nginx.fullname" . }}-admission
             - --namespace={{ .Release.Namespace }}
             - --patch-mutating=false
-            - --secret-name={{ template "nginx-ingress.fullname". }}-admission
+            - --secret-name={{ template "ingress-nginx.fullname". }}-admission
             - --patch-failure-policy={{ .Values.controller.admissionWebhooks.failurePolicy }}
       restartPolicy: OnFailure
-      serviceAccountName: {{ template "nginx-ingress.fullname" . }}-admission
+      serviceAccountName: {{ template "ingress-nginx.fullname" . }}-admission
       {{- with .Values.controller.admissionWebhooks.patch.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/charts/ingress-nginx/templates/admission-webhooks/job-patch/psp.yaml
+++ b/charts/ingress-nginx/templates/admission-webhooks/job-patch/psp.yaml
@@ -2,13 +2,13 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: {{ template "nginx-ingress.fullname" . }}-admission
+  name: {{ template "ingress-nginx.fullname" . }}-admission
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    app: {{ template "nginx-ingress.name" . }}
-    chart: {{ template "nginx-ingress.chart" . }}
+    app: {{ template "ingress-nginx.name" . }}
+    chart: {{ template "ingress-nginx.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}

--- a/charts/ingress-nginx/templates/admission-webhooks/job-patch/role.yaml
+++ b/charts/ingress-nginx/templates/admission-webhooks/job-patch/role.yaml
@@ -2,13 +2,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name:  {{ template "nginx-ingress.fullname" . }}-admission
+  name:  {{ template "ingress-nginx.fullname" . }}-admission
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    app: {{ template "nginx-ingress.name" . }}
-    chart: {{ template "nginx-ingress.chart" . }}
+    app: {{ template "ingress-nginx.name" . }}
+    chart: {{ template "ingress-nginx.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}

--- a/charts/ingress-nginx/templates/admission-webhooks/job-patch/rolebinding.yaml
+++ b/charts/ingress-nginx/templates/admission-webhooks/job-patch/rolebinding.yaml
@@ -2,22 +2,22 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name:  {{ template "nginx-ingress.fullname" . }}-admission
+  name:  {{ template "ingress-nginx.fullname" . }}-admission
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    app: {{ template "nginx-ingress.name" . }}
-    chart: {{ template "nginx-ingress.chart" . }}
+    app: {{ template "ingress-nginx.name" . }}
+    chart: {{ template "ingress-nginx.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ template "nginx-ingress.fullname" . }}-admission
+  name: {{ template "ingress-nginx.fullname" . }}-admission
 subjects:
   - kind: ServiceAccount
-    name: {{ template "nginx-ingress.fullname" . }}-admission
+    name: {{ template "ingress-nginx.fullname" . }}-admission
     namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/charts/ingress-nginx/templates/admission-webhooks/job-patch/serviceaccount.yaml
+++ b/charts/ingress-nginx/templates/admission-webhooks/job-patch/serviceaccount.yaml
@@ -2,13 +2,13 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name:  {{ template "nginx-ingress.fullname" . }}-admission
+  name:  {{ template "ingress-nginx.fullname" . }}-admission
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    app: {{ template "nginx-ingress.name" . }}
-    chart: {{ template "nginx-ingress.chart" . }}
+    app: {{ template "ingress-nginx.name" . }}
+    chart: {{ template "ingress-nginx.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}

--- a/charts/ingress-nginx/templates/admission-webhooks/validating-webhook.yaml
+++ b/charts/ingress-nginx/templates/admission-webhooks/validating-webhook.yaml
@@ -3,12 +3,12 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   labels:
-    app: {{ template "nginx-ingress.name" . }}-admission
-    chart: {{ template "nginx-ingress.chart" . }}
+    app: {{ template "ingress-nginx.name" . }}-admission
+    chart: {{ template "ingress-nginx.chart" . }}
     component: "admission-webhook"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "nginx-ingress.fullname" . }}-admission
+  name: {{ template "ingress-nginx.fullname" . }}-admission
 webhooks:
   - name: validate.nginx.ingress.kubernetes.io
     rules:
@@ -26,6 +26,6 @@ webhooks:
     clientConfig:
       service:
         namespace: {{ .Release.Namespace }}
-        name: {{ template "nginx-ingress.controller.fullname" . }}-admission
+        name: {{ template "ingress-nginx.controller.fullname" . }}-admission
         path: /extensions/v1beta1/ingresses
 {{- end }}

--- a/charts/ingress-nginx/templates/clusterrole.yaml
+++ b/charts/ingress-nginx/templates/clusterrole.yaml
@@ -3,11 +3,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app: {{ template "nginx-ingress.name" . }}
-    chart: {{ template "nginx-ingress.chart" . }}
+    app: {{ template "ingress-nginx.name" . }}
+    chart: {{ template "ingress-nginx.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "nginx-ingress.fullname" . }}
+  name: {{ template "ingress-nginx.fullname" . }}
 rules:
   - apiGroups:
       - ""

--- a/charts/ingress-nginx/templates/clusterrolebinding.yaml
+++ b/charts/ingress-nginx/templates/clusterrolebinding.yaml
@@ -3,17 +3,17 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    app: {{ template "nginx-ingress.name" . }}
-    chart: {{ template "nginx-ingress.chart" . }}
+    app: {{ template "ingress-nginx.name" . }}
+    chart: {{ template "ingress-nginx.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "nginx-ingress.fullname" . }}
+  name: {{ template "ingress-nginx.fullname" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "nginx-ingress.fullname" . }}
+  name: {{ template "ingress-nginx.fullname" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ template "nginx-ingress.serviceAccountName" . }}
+    name: {{ template "ingress-nginx.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/charts/ingress-nginx/templates/controller-configmap.yaml
+++ b/charts/ingress-nginx/templates/controller-configmap.yaml
@@ -3,20 +3,20 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app: {{ template "nginx-ingress.name" . }}
-    chart: {{ template "nginx-ingress.chart" . }}
+    app: {{ template "ingress-nginx.name" . }}
+    chart: {{ template "ingress-nginx.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   annotations:
 {{ toYaml .Values.controller.configAnnotations | indent 4}}
-  name: {{ template "nginx-ingress.controller.fullname" . }}
+  name: {{ template "ingress-nginx.controller.fullname" . }}
 data:
 {{- if .Values.controller.addHeaders }}
-  add-headers: {{ .Release.Namespace }}/{{ template "nginx-ingress.fullname" . }}-custom-add-headers
+  add-headers: {{ .Release.Namespace }}/{{ template "ingress-nginx.fullname" . }}-custom-add-headers
 {{- end }}
 {{- if or .Values.controller.proxySetHeaders .Values.controller.headers }}
-  proxy-set-headers: {{ .Release.Namespace }}/{{ template "nginx-ingress.fullname" . }}-custom-proxy-headers
+  proxy-set-headers: {{ .Release.Namespace }}/{{ template "ingress-nginx.fullname" . }}-custom-proxy-headers
 {{- end }}
 {{- if .Values.controller.config }}
 {{ toYaml .Values.controller.config | indent 2 }}

--- a/charts/ingress-nginx/templates/controller-daemonset.yaml
+++ b/charts/ingress-nginx/templates/controller-daemonset.yaml
@@ -5,18 +5,18 @@ apiVersion: {{ template "deployment.apiVersion" . }}
 kind: DaemonSet
 metadata:
   labels:
-    app: {{ template "nginx-ingress.name" . }}
-    chart: {{ template "nginx-ingress.chart" . }}
+    app: {{ template "ingress-nginx.name" . }}
+    chart: {{ template "ingress-nginx.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "nginx-ingress.controller.fullname" . }}
-  annotations:    
+  name: {{ template "ingress-nginx.controller.fullname" . }}
+  annotations:
 {{ toYaml .Values.controller.deploymentAnnotations | indent 4}}
 spec:
   selector:
     matchLabels:
-      app: {{ template "nginx-ingress.name" . }}
+      app: {{ template "ingress-nginx.name" . }}
       release: {{ .Release.Name }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   updateStrategy:
@@ -31,7 +31,7 @@ spec:
       {{- end }}
       {{- end }}
       labels:
-        app: {{ template "nginx-ingress.name" . }}
+        app: {{ template "ingress-nginx.name" . }}
         component: "{{ .Values.controller.name }}"
         release: {{ .Release.Name }}
         {{- if .Values.controller.podLabels }}
@@ -55,7 +55,7 @@ spec:
 {{ toYaml .Values.controller.podSecurityContext | indent 8 }}
       {{- end }}
       containers:
-        - name: {{ template "nginx-ingress.name" . }}-{{ .Values.controller.name }}
+        - name: {{ template "ingress-nginx.name" . }}-{{ .Values.controller.name }}
           image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
           imagePullPolicy: "{{ .Values.controller.image.pullPolicy }}"
           {{- if .Values.controller.lifecycle }}
@@ -63,9 +63,9 @@ spec:
 {{ toYaml .Values.controller.lifecycle | indent 12 }}
           {{- end }}
           args:
-            - /nginx-ingress-controller
+            - /ingress-nginx-controller
           {{- if .Values.defaultBackend.enabled }}
-            - --default-backend-service={{ .Release.Namespace }}/{{ template "nginx-ingress.defaultBackend.fullname" . }}
+            - --default-backend-service={{ .Release.Namespace }}/{{ template "ingress-nginx.defaultBackend.fullname" . }}
           {{- else }}
             {{- if (semverCompare "<0.21.0" .Values.controller.image.tag) }}
             - --default-backend-service={{ required ".Values.controller.defaultBackendService is required if .Values.defaultBackend.enabled=false and .Values.controller.image.tag < 0.21.0" .Values.controller.defaultBackendService }}
@@ -74,7 +74,7 @@ spec:
             {{- end }}
           {{- end }}
           {{- if and (semverCompare ">=0.9.0-beta.1" .Values.controller.image.tag) .Values.controller.publishService.enabled }}
-            - --publish-service={{ template "nginx-ingress.controller.publishServicePath" . }}
+            - --publish-service={{ template "ingress-nginx.controller.publishServicePath" . }}
           {{- end }}
           {{- if (semverCompare ">=0.9.0-beta.1" .Values.controller.image.tag) }}
             - --election-id={{ .Values.controller.electionID }}
@@ -83,15 +83,15 @@ spec:
             - --ingress-class={{ .Values.controller.ingressClass }}
           {{- end }}
           {{- if (semverCompare ">=0.9.0-beta.1" .Values.controller.image.tag) }}
-            - --configmap={{ .Release.Namespace }}/{{ template "nginx-ingress.controller.fullname" . }}
+            - --configmap={{ .Release.Namespace }}/{{ template "ingress-nginx.controller.fullname" . }}
           {{- else }}
-            - --nginx-configmap={{ .Release.Namespace }}/{{ template "nginx-ingress.controller.fullname" . }}
+            - --nginx-configmap={{ .Release.Namespace }}/{{ template "ingress-nginx.controller.fullname" . }}
           {{- end }}
           {{- if .Values.tcp }}
-            - --tcp-services-configmap={{ .Release.Namespace }}/{{ template "nginx-ingress.fullname" . }}-tcp
+            - --tcp-services-configmap={{ .Release.Namespace }}/{{ template "ingress-nginx.fullname" . }}-tcp
           {{- end }}
           {{- if .Values.udp }}
-            - --udp-services-configmap={{ .Release.Namespace }}/{{ template "nginx-ingress.fullname" . }}-udp
+            - --udp-services-configmap={{ .Release.Namespace }}/{{ template "ingress-nginx.fullname" . }}-udp
           {{- end }}
           {{- if .Values.controller.scope.enabled }}
             - --watch-namespace={{ default .Release.Namespace .Values.controller.scope.namespace }}
@@ -229,7 +229,7 @@ spec:
       affinity:
 {{ toYaml .Values.controller.affinity | indent 8 }}
     {{- end }}
-      serviceAccountName: {{ template "nginx-ingress.serviceAccountName" . }}
+      serviceAccountName: {{ template "ingress-nginx.serviceAccountName" . }}
       terminationGracePeriodSeconds: 60
 {{- if (or .Values.controller.customTemplate.configMapName .Values.controller.extraVolumeMounts .Values.controller.admissionWebhooks.enabled .Values.controller.extraVolumes) }}
       volumes:
@@ -245,7 +245,7 @@ spec:
 {{- if .Values.controller.admissionWebhooks.enabled }}
         - name: webhook-cert
           secret:
-            secretName: {{ template "nginx-ingress.fullname". }}-admission
+            secretName: {{ template "ingress-nginx.fullname". }}-admission
 {{- end }}
 {{- if .Values.controller.extraVolumes }}
 {{ toYaml .Values.controller.extraVolumes | indent 8}}

--- a/charts/ingress-nginx/templates/controller-deployment.yaml
+++ b/charts/ingress-nginx/templates/controller-deployment.yaml
@@ -3,18 +3,18 @@ apiVersion: {{ template "deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   labels:
-    app: {{ template "nginx-ingress.name" . }}
-    chart: {{ template "nginx-ingress.chart" . }}
+    app: {{ template "ingress-nginx.name" . }}
+    chart: {{ template "ingress-nginx.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "nginx-ingress.controller.fullname" . }}
+  name: {{ template "ingress-nginx.controller.fullname" . }}
   annotations:
 {{ toYaml .Values.controller.deploymentAnnotations | indent 4}}
 spec:
   selector:
     matchLabels:
-      app: {{ template "nginx-ingress.name" . }}
+      app: {{ template "ingress-nginx.name" . }}
       release: {{ .Release.Name }}
 {{- if not .Values.controller.autoscaling.enabled }}
   replicas: {{ .Values.controller.replicaCount }}
@@ -32,7 +32,7 @@ spec:
       {{- end }}
       {{- end }}
       labels:
-        app: {{ template "nginx-ingress.name" . }}
+        app: {{ template "ingress-nginx.name" . }}
         component: "{{ .Values.controller.name }}"
         release: {{ .Release.Name }}
         {{- if .Values.controller.podLabels }}
@@ -56,7 +56,7 @@ spec:
 {{ toYaml .Values.controller.podSecurityContext | indent 8 }}
       {{- end }}
       containers:
-        - name: {{ template "nginx-ingress.name" . }}-{{ .Values.controller.name }}
+        - name: {{ template "ingress-nginx.name" . }}-{{ .Values.controller.name }}
           image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
           imagePullPolicy: "{{ .Values.controller.image.pullPolicy }}"
           {{- if .Values.controller.lifecycle }}
@@ -64,9 +64,9 @@ spec:
 {{ toYaml .Values.controller.lifecycle | indent 12 }}
           {{- end }}
           args:
-            - /nginx-ingress-controller
+            - /ingress-nginx-controller
           {{- if .Values.defaultBackend.enabled }}
-            - --default-backend-service={{ .Release.Namespace }}/{{ template "nginx-ingress.defaultBackend.fullname" . }}
+            - --default-backend-service={{ .Release.Namespace }}/{{ template "ingress-nginx.defaultBackend.fullname" . }}
           {{- else }}
             {{- if (semverCompare "<0.21.0" .Values.controller.image.tag) }}
             - --default-backend-service={{ required ".Values.controller.defaultBackendService is required if .Values.defaultBackend.enabled=false and .Values.controller.image.tag < 0.21.0" .Values.controller.defaultBackendService }}
@@ -75,7 +75,7 @@ spec:
             {{- end }}
           {{- end }}
           {{- if and (semverCompare ">=0.9.0-beta.1" .Values.controller.image.tag) .Values.controller.publishService.enabled }}
-            - --publish-service={{ template "nginx-ingress.controller.publishServicePath" . }}
+            - --publish-service={{ template "ingress-nginx.controller.publishServicePath" . }}
           {{- end }}
           {{- if (semverCompare ">=0.9.0-beta.1" .Values.controller.image.tag) }}
             - --election-id={{ .Values.controller.electionID }}
@@ -84,15 +84,15 @@ spec:
             - --ingress-class={{ .Values.controller.ingressClass }}
           {{- end }}
           {{- if (semverCompare ">=0.9.0-beta.1" .Values.controller.image.tag) }}
-            - --configmap={{ default .Release.Namespace .Values.controller.configMapNamespace }}/{{ template "nginx-ingress.controller.fullname" . }}
+            - --configmap={{ default .Release.Namespace .Values.controller.configMapNamespace }}/{{ template "ingress-nginx.controller.fullname" . }}
           {{- else }}
-            - --nginx-configmap={{ default .Release.Namespace .Values.controller.configMapNamespace }}/{{ template "nginx-ingress.controller.fullname" . }}
+            - --nginx-configmap={{ default .Release.Namespace .Values.controller.configMapNamespace }}/{{ template "ingress-nginx.controller.fullname" . }}
           {{- end }}
           {{- if .Values.tcp }}
-            - --tcp-services-configmap={{ default .Release.Namespace .Values.controller.tcp.configMapNamespace }}/{{ template "nginx-ingress.fullname" . }}-tcp
+            - --tcp-services-configmap={{ default .Release.Namespace .Values.controller.tcp.configMapNamespace }}/{{ template "ingress-nginx.fullname" . }}-tcp
           {{- end }}
           {{- if .Values.udp }}
-            - --udp-services-configmap={{ default .Release.Namespace .Values.controller.udp.configMapNamespace }}/{{ template "nginx-ingress.fullname" . }}-udp
+            - --udp-services-configmap={{ default .Release.Namespace .Values.controller.udp.configMapNamespace }}/{{ template "ingress-nginx.fullname" . }}-udp
           {{- end }}
           {{- if .Values.controller.scope.enabled }}
             - --watch-namespace={{ default .Release.Namespace .Values.controller.scope.namespace }}
@@ -221,7 +221,7 @@ spec:
       affinity:
 {{ toYaml .Values.controller.affinity | indent 8 }}
     {{- end }}
-      serviceAccountName: {{ template "nginx-ingress.serviceAccountName" . }}
+      serviceAccountName: {{ template "ingress-nginx.serviceAccountName" . }}
       terminationGracePeriodSeconds: {{ .Values.controller.terminationGracePeriodSeconds }}
 {{- if (or .Values.controller.customTemplate.configMapName .Values.controller.extraVolumeMounts .Values.controller.admissionWebhooks.enabled .Values.controller.extraVolumes) }}
       volumes:
@@ -237,7 +237,7 @@ spec:
 {{- if .Values.controller.admissionWebhooks.enabled }}
         - name: webhook-cert
           secret:
-            secretName: {{ template "nginx-ingress.fullname". }}-admission
+            secretName: {{ template "ingress-nginx.fullname". }}-admission
 {{- end }}
 {{- if .Values.controller.extraVolumes }}
 {{ toYaml .Values.controller.extraVolumes | indent 8}}

--- a/charts/ingress-nginx/templates/controller-hpa.yaml
+++ b/charts/ingress-nginx/templates/controller-hpa.yaml
@@ -4,17 +4,17 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   labels:
-    app: {{ template "nginx-ingress.name" . }}
-    chart: {{ template "nginx-ingress.chart" . }}
+    app: {{ template "ingress-nginx.name" . }}
+    chart: {{ template "ingress-nginx.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "nginx-ingress.controller.fullname" . }}
+  name: {{ template "ingress-nginx.controller.fullname" . }}
 spec:
   scaleTargetRef:
     apiVersion: {{ template "deployment.apiVersion" . }}
     kind: Deployment
-    name: {{ template "nginx-ingress.controller.fullname" . }}
+    name: {{ template "ingress-nginx.controller.fullname" . }}
   minReplicas: {{ .Values.controller.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.controller.autoscaling.maxReplicas }}
   metrics:

--- a/charts/ingress-nginx/templates/controller-metrics-service.yaml
+++ b/charts/ingress-nginx/templates/controller-metrics-service.yaml
@@ -12,12 +12,12 @@ metadata:
 {{- if .Values.controller.metrics.service.labels }}
 {{ toYaml .Values.controller.metrics.service.labels | indent 4 }}
 {{- end }}
-    app: {{ template "nginx-ingress.name" . }}
-    chart: {{ template "nginx-ingress.chart" . }}
+    app: {{ template "ingress-nginx.name" . }}
+    chart: {{ template "ingress-nginx.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "nginx-ingress.controller.fullname" . }}-metrics
+  name: {{ template "ingress-nginx.controller.fullname" . }}-metrics
 spec:
 {{- if not .Values.controller.metrics.service.omitClusterIP }}
   {{- with .Values.controller.metrics.service.clusterIP }}
@@ -40,7 +40,7 @@ spec:
       port: {{ .Values.controller.metrics.service.servicePort }}
       targetPort: metrics
   selector:
-    app: {{ template "nginx-ingress.name" . }}
+    app: {{ template "ingress-nginx.name" . }}
     component: "{{ .Values.controller.name }}"
     release: {{ .Release.Name }}
   type: "{{ .Values.controller.metrics.service.type }}"

--- a/charts/ingress-nginx/templates/controller-poddisruptionbudget.yaml
+++ b/charts/ingress-nginx/templates/controller-poddisruptionbudget.yaml
@@ -3,16 +3,16 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    app: {{ template "nginx-ingress.name" . }}
-    chart: {{ template "nginx-ingress.chart" . }}
+    app: {{ template "ingress-nginx.name" . }}
+    chart: {{ template "ingress-nginx.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "nginx-ingress.controller.fullname" . }}
+  name: {{ template "ingress-nginx.controller.fullname" . }}
 spec:
   selector:
     matchLabels:
-      app: {{ template "nginx-ingress.name" . }}
+      app: {{ template "ingress-nginx.name" . }}
       release: {{ .Release.Name }}
       component: "{{ .Values.controller.name }}"
   minAvailable: {{ .Values.controller.minAvailable }}

--- a/charts/ingress-nginx/templates/controller-prometheusrules.yaml
+++ b/charts/ingress-nginx/templates/controller-prometheusrules.yaml
@@ -2,13 +2,13 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  name: {{ template "nginx-ingress.controller.fullname" . }}
+  name: {{ template "ingress-nginx.controller.fullname" . }}
   {{- if .Values.controller.metrics.prometheusRule.namespace }}
   namespace: {{ .Values.controller.metrics.prometheusRule.namespace }}
   {{- end }}
   labels:
-    app: {{ template "nginx-ingress.name" . }}
-    chart: {{ template "nginx-ingress.chart" . }}
+    app: {{ template "ingress-nginx.name" . }}
+    chart: {{ template "ingress-nginx.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
@@ -18,7 +18,7 @@ metadata:
 spec:
   {{- with .Values.controller.metrics.prometheusRule.rules }}
   groups:
-  - name: {{ template "nginx-ingress.name" $ }}
+  - name: {{ template "ingress-nginx.name" $ }}
     rules: {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/charts/ingress-nginx/templates/controller-psp.yaml
+++ b/charts/ingress-nginx/templates/controller-psp.yaml
@@ -2,10 +2,10 @@
 apiVersion: {{ template "podSecurityPolicy.apiVersion" . }}
 kind: PodSecurityPolicy
 metadata:
-  name: {{ template "nginx-ingress.fullname" . }}
+  name: {{ template "ingress-nginx.fullname" . }}
   labels:
-    app: {{ template "nginx-ingress.name" . }}
-    chart: {{ template "nginx-ingress.chart" . }}
+    app: {{ template "ingress-nginx.name" . }}
+    chart: {{ template "ingress-nginx.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:

--- a/charts/ingress-nginx/templates/controller-role.yaml
+++ b/charts/ingress-nginx/templates/controller-role.yaml
@@ -3,11 +3,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    app: {{ template "nginx-ingress.name" . }}
-    chart: {{ template "nginx-ingress.chart" . }}
+    app: {{ template "ingress-nginx.name" . }}
+    chart: {{ template "ingress-nginx.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "nginx-ingress.fullname" . }}
+  name: {{ template "ingress-nginx.fullname" . }}
 rules:
   - apiGroups:
       - ""
@@ -85,7 +85,7 @@ rules:
   - apiGroups:      ['{{ template "podSecurityPolicy.apiGroup" . }}']
     resources:      ['podsecuritypolicies']
     verbs:          ['use']
-    resourceNames:  [{{ template "nginx-ingress.fullname" . }}]
+    resourceNames:  [{{ template "ingress-nginx.fullname" . }}]
 {{- end }}
 
 {{- end -}}

--- a/charts/ingress-nginx/templates/controller-rolebinding.yaml
+++ b/charts/ingress-nginx/templates/controller-rolebinding.yaml
@@ -3,17 +3,17 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    app: {{ template "nginx-ingress.name" . }}
-    chart: {{ template "nginx-ingress.chart" . }}
+    app: {{ template "ingress-nginx.name" . }}
+    chart: {{ template "ingress-nginx.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "nginx-ingress.fullname" . }}
+  name: {{ template "ingress-nginx.fullname" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ template "nginx-ingress.fullname" . }}
+  name: {{ template "ingress-nginx.fullname" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ template "nginx-ingress.serviceAccountName" . }}
+    name: {{ template "ingress-nginx.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/charts/ingress-nginx/templates/controller-service.yaml
+++ b/charts/ingress-nginx/templates/controller-service.yaml
@@ -12,12 +12,12 @@ metadata:
 {{- if .Values.controller.service.labels }}
 {{ toYaml .Values.controller.service.labels | indent 4 }}
 {{- end }}
-    app: {{ template "nginx-ingress.name" . }}
-    chart: {{ template "nginx-ingress.chart" . }}
+    app: {{ template "ingress-nginx.name" . }}
+    chart: {{ template "ingress-nginx.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "nginx-ingress.controller.fullname" . }}
+  name: {{ template "ingress-nginx.controller.fullname" . }}
 spec:
 {{- if not .Values.controller.service.omitClusterIP }}
   {{- with .Values.controller.service.clusterIP }}
@@ -87,7 +87,7 @@ spec:
      {{- end }}
   {{- end }}
   selector:
-    app: {{ template "nginx-ingress.name" . }}
+    app: {{ template "ingress-nginx.name" . }}
     component: "{{ .Values.controller.name }}"
     release: {{ .Release.Name }}
   type: "{{ .Values.controller.service.type }}"

--- a/charts/ingress-nginx/templates/controller-serviceaccount.yaml
+++ b/charts/ingress-nginx/templates/controller-serviceaccount.yaml
@@ -3,9 +3,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app: {{ template "nginx-ingress.name" . }}
-    chart: {{ template "nginx-ingress.chart" . }}
+    app: {{ template "ingress-nginx.name" . }}
+    chart: {{ template "ingress-nginx.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "nginx-ingress.serviceAccountName" . }}
+  name: {{ template "ingress-nginx.serviceAccountName" . }}
 {{- end -}}

--- a/charts/ingress-nginx/templates/controller-servicemonitor.yaml
+++ b/charts/ingress-nginx/templates/controller-servicemonitor.yaml
@@ -2,13 +2,13 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ template "nginx-ingress.controller.fullname" . }}
+  name: {{ template "ingress-nginx.controller.fullname" . }}
   {{- if .Values.controller.metrics.serviceMonitor.namespace }}
   namespace: {{ .Values.controller.metrics.serviceMonitor.namespace }}
   {{- end }}
   labels:
-    app: {{ template "nginx-ingress.name" . }}
-    chart: {{ template "nginx-ingress.chart" . }}
+    app: {{ template "ingress-nginx.name" . }}
+    chart: {{ template "ingress-nginx.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
@@ -32,7 +32,7 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      app: {{ template "nginx-ingress.name" . }}
+      app: {{ template "ingress-nginx.name" . }}
       component: "{{ .Values.controller.name }}"
       release: {{ .Release.Name }}
 {{- end }}

--- a/charts/ingress-nginx/templates/controller-webhook-service.yaml
+++ b/charts/ingress-nginx/templates/controller-webhook-service.yaml
@@ -9,12 +9,12 @@ metadata:
   {{- end }}
 {{- end }}
   labels:
-    app: {{ template "nginx-ingress.name" . }}
-    chart: {{ template "nginx-ingress.chart" . }}
+    app: {{ template "ingress-nginx.name" . }}
+    chart: {{ template "ingress-nginx.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "nginx-ingress.controller.fullname" . }}-admission
+  name: {{ template "ingress-nginx.controller.fullname" . }}-admission
 spec:
 {{- if not .Values.controller.admissionWebhooks.service.omitClusterIP }}
   {{- with .Values.controller.admissionWebhooks.service.clusterIP }}
@@ -37,7 +37,7 @@ spec:
       port: 443
       targetPort: webhook
   selector:
-    app: {{ template "nginx-ingress.name" . }}
+    app: {{ template "ingress-nginx.name" . }}
     component: "{{ .Values.controller.name }}"
     release: {{ .Release.Name }}
   type: "{{ .Values.controller.admissionWebhooks.service.type }}"

--- a/charts/ingress-nginx/templates/default-backend-deployment.yaml
+++ b/charts/ingress-nginx/templates/default-backend-deployment.yaml
@@ -3,16 +3,16 @@ apiVersion: {{ template "deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   labels:
-    app: {{ template "nginx-ingress.name" . }}
-    chart: {{ template "nginx-ingress.chart" . }}
+    app: {{ template "ingress-nginx.name" . }}
+    chart: {{ template "ingress-nginx.chart" . }}
     component: "{{ .Values.defaultBackend.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "nginx-ingress.defaultBackend.fullname" . }}
+  name: {{ template "ingress-nginx.defaultBackend.fullname" . }}
 spec:
   selector:
     matchLabels:
-      app: {{ template "nginx-ingress.name" . }}
+      app: {{ template "ingress-nginx.name" . }}
       release: {{ .Release.Name }}
   replicas: {{ .Values.defaultBackend.replicaCount }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
@@ -25,7 +25,7 @@ spec:
       {{- end }}
     {{- end }}
       labels:
-        app: {{ template "nginx-ingress.name" . }}
+        app: {{ template "ingress-nginx.name" . }}
         component: "{{ .Values.defaultBackend.name }}"
         release: {{ .Release.Name }}
         {{- if .Values.defaultBackend.podLabels }}
@@ -44,7 +44,7 @@ spec:
 {{ toYaml .Values.defaultBackend.podSecurityContext | indent 8 }}
       {{- end }}
       containers:
-        - name: {{ template "nginx-ingress.name" . }}-{{ .Values.defaultBackend.name }}
+        - name: {{ template "ingress-nginx.name" . }}-{{ .Values.defaultBackend.name }}
           image: "{{ .Values.defaultBackend.image.repository }}:{{ .Values.defaultBackend.image.tag }}"
           imagePullPolicy: "{{ .Values.defaultBackend.image.pullPolicy }}"
           args:
@@ -91,7 +91,7 @@ spec:
       nodeSelector:
 {{ toYaml .Values.defaultBackend.nodeSelector | indent 8 }}
     {{- end }}
-      serviceAccountName: {{ template "nginx-ingress.defaultBackend.serviceAccountName" . }}
+      serviceAccountName: {{ template "ingress-nginx.defaultBackend.serviceAccountName" . }}
     {{- if .Values.defaultBackend.tolerations }}
       tolerations:
 {{ toYaml .Values.defaultBackend.tolerations | indent 8 }}

--- a/charts/ingress-nginx/templates/default-backend-poddisruptionbudget.yaml
+++ b/charts/ingress-nginx/templates/default-backend-poddisruptionbudget.yaml
@@ -3,16 +3,16 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    app: {{ template "nginx-ingress.name" . }}
-    chart: {{ template "nginx-ingress.chart" . }}
+    app: {{ template "ingress-nginx.name" . }}
+    chart: {{ template "ingress-nginx.chart" . }}
     component: "{{ .Values.defaultBackend.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "nginx-ingress.defaultBackend.fullname" . }}
+  name: {{ template "ingress-nginx.defaultBackend.fullname" . }}
 spec:
   selector:
     matchLabels:
-      app: {{ template "nginx-ingress.name" . }}
+      app: {{ template "ingress-nginx.name" . }}
       release: {{ .Release.Name }}
       component: "{{ .Values.defaultBackend.name }}"
   minAvailable: {{ .Values.defaultBackend.minAvailable }}

--- a/charts/ingress-nginx/templates/default-backend-psp.yaml
+++ b/charts/ingress-nginx/templates/default-backend-psp.yaml
@@ -2,10 +2,10 @@
 apiVersion: {{ template "podSecurityPolicy.apiVersion" . }}
 kind: PodSecurityPolicy
 metadata:
-  name: {{ template "nginx-ingress.fullname" . }}-backend
+  name: {{ template "ingress-nginx.fullname" . }}-backend
   labels:
-    app: {{ template "nginx-ingress.name" . }}
-    chart: {{ template "nginx-ingress.chart" . }}
+    app: {{ template "ingress-nginx.name" . }}
+    chart: {{ template "ingress-nginx.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:

--- a/charts/ingress-nginx/templates/default-backend-role.yaml
+++ b/charts/ingress-nginx/templates/default-backend-role.yaml
@@ -3,14 +3,14 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    app: {{ template "nginx-ingress.name" . }}
-    chart: {{ template "nginx-ingress.chart" . }}
+    app: {{ template "ingress-nginx.name" . }}
+    chart: {{ template "ingress-nginx.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "nginx-ingress.fullname" . }}-backend
+  name: {{ template "ingress-nginx.fullname" . }}-backend
 rules:
   - apiGroups:      ['{{ template "podSecurityPolicy.apiGroup" . }}']
     resources:      ['podsecuritypolicies']
     verbs:          ['use']
-    resourceNames:  [{{ template "nginx-ingress.fullname" . }}-backend]
+    resourceNames:  [{{ template "ingress-nginx.fullname" . }}-backend]
 {{- end -}}

--- a/charts/ingress-nginx/templates/default-backend-rolebinding.yaml
+++ b/charts/ingress-nginx/templates/default-backend-rolebinding.yaml
@@ -3,17 +3,17 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    app: {{ template "nginx-ingress.name" . }}
-    chart: {{ template "nginx-ingress.chart" . }}
+    app: {{ template "ingress-nginx.name" . }}
+    chart: {{ template "ingress-nginx.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "nginx-ingress.fullname" . }}-backend
+  name: {{ template "ingress-nginx.fullname" . }}-backend
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ template "nginx-ingress.fullname" . }}-backend
+  name: {{ template "ingress-nginx.fullname" . }}-backend
 subjects:
   - kind: ServiceAccount
-    name: {{ template "nginx-ingress.defaultBackend.serviceAccountName" . }}
+    name: {{ template "ingress-nginx.defaultBackend.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/charts/ingress-nginx/templates/default-backend-service.yaml
+++ b/charts/ingress-nginx/templates/default-backend-service.yaml
@@ -9,12 +9,12 @@ metadata:
   {{- end }}
 {{- end }}
   labels:
-    app: {{ template "nginx-ingress.name" . }}
-    chart: {{ template "nginx-ingress.chart" . }}
+    app: {{ template "ingress-nginx.name" . }}
+    chart: {{ template "ingress-nginx.chart" . }}
     component: "{{ .Values.defaultBackend.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "nginx-ingress.defaultBackend.fullname" . }}
+  name: {{ template "ingress-nginx.defaultBackend.fullname" . }}
 spec:
 {{- if not .Values.defaultBackend.service.omitClusterIP }}
   {{- with .Values.defaultBackend.service.clusterIP }}
@@ -38,7 +38,7 @@ spec:
       protocol: TCP
       targetPort: http
   selector:
-    app: {{ template "nginx-ingress.name" . }}
+    app: {{ template "ingress-nginx.name" . }}
     component: "{{ .Values.defaultBackend.name }}"
     release: {{ .Release.Name }}
   type: "{{ .Values.defaultBackend.service.type }}"

--- a/charts/ingress-nginx/templates/default-backend-serviceaccount.yaml
+++ b/charts/ingress-nginx/templates/default-backend-serviceaccount.yaml
@@ -3,9 +3,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app: {{ template "nginx-ingress.name" . }}
-    chart: {{ template "nginx-ingress.chart" . }}
+    app: {{ template "ingress-nginx.name" . }}
+    chart: {{ template "ingress-nginx.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "nginx-ingress.defaultBackend.serviceAccountName" . }}
+  name: {{ template "ingress-nginx.defaultBackend.serviceAccountName" . }}
 {{- end }}

--- a/charts/ingress-nginx/templates/proxyheaders-configmap.yaml
+++ b/charts/ingress-nginx/templates/proxyheaders-configmap.yaml
@@ -3,12 +3,12 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app: {{ template "nginx-ingress.name" . }}
-    chart: {{ template "nginx-ingress.chart" . }}
+    app: {{ template "ingress-nginx.name" . }}
+    chart: {{ template "ingress-nginx.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "nginx-ingress.fullname" . }}-custom-proxy-headers
+  name: {{ template "ingress-nginx.fullname" . }}-custom-proxy-headers
 data:
 {{- if .Values.controller.proxySetHeaders }}
 {{ toYaml .Values.controller.proxySetHeaders | indent 2 }}

--- a/charts/ingress-nginx/templates/tcp-configmap.yaml
+++ b/charts/ingress-nginx/templates/tcp-configmap.yaml
@@ -3,14 +3,14 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app: {{ template "nginx-ingress.name" . }}
-    chart: {{ template "nginx-ingress.chart" . }}
+    app: {{ template "ingress-nginx.name" . }}
+    chart: {{ template "ingress-nginx.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   annotations:
 {{ toYaml .Values.controller.tcp.annotations | indent 4}}
-  name: {{ template "nginx-ingress.fullname" . }}-tcp
+  name: {{ template "ingress-nginx.fullname" . }}-tcp
 data:
 {{ tpl (toYaml .Values.tcp) . | indent 2 }}
 {{- end }}

--- a/charts/ingress-nginx/templates/udp-configmap.yaml
+++ b/charts/ingress-nginx/templates/udp-configmap.yaml
@@ -3,14 +3,14 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app: {{ template "nginx-ingress.name" . }}
-    chart: {{ template "nginx-ingress.chart" . }}
+    app: {{ template "ingress-nginx.name" . }}
+    chart: {{ template "ingress-nginx.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   annotations:
 {{ toYaml .Values.controller.udp.annotations | indent 4}}
-  name: {{ template "nginx-ingress.fullname" . }}-udp
+  name: {{ template "ingress-nginx.fullname" . }}-udp
 data:
 {{ tpl (toYaml .Values.udp) . | indent 2 }}
 {{- end }}

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -4,7 +4,7 @@
 controller:
   name: controller
   image:
-    repository: quay.io/kubernetes-ingress-controller/nginx-ingress-controller
+    repository: quay.io/kubernetes-ingress-controller/ingress-nginx-controller
     tag: "0.30.0"
     pullPolicy: IfNotPresent
     # www-data -> uid 101
@@ -110,7 +110,7 @@ controller:
     ## Annotations to be added to the udp config configmap
     annotations: {}
 
-  ## Additional command line arguments to pass to nginx-ingress-controller
+  ## Additional command line arguments to pass to ingress-nginx-controller
   ## E.g. to specify the default SSL certificate you can use
   ## extraArgs:
   ##   default-ssl-certificate: "<namespace>/<secret_name>"
@@ -168,7 +168,7 @@ controller:
     #         - key: app
     #           operator: In
     #           values:
-    #           - nginx-ingress
+    #           - ingress-nginx
     #       topologyKey: kubernetes.io/hostname
 
     # # An example of required pod anti-affinity
@@ -179,7 +179,7 @@ controller:
     #       - key: app
     #         operator: In
     #         values:
-    #         - nginx-ingress
+    #         - ingress-nginx
     #     topologyKey: "kubernetes.io/hostname"
 
   ## terminationGracePeriodSeconds


### PR DESCRIPTION
## What this PR does / why we need it: 
Renaming the resources created by the chart to `ingress-nginx` as per https://github.com/kubernetes/ingress-nginx/issues/5161 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?
Has not been tested.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
