### PR TITLE
Updates deploy webhook example to match docs

### DIFF
--- a/deploy/validating-webhook.yaml.tpl
+++ b/deploy/validating-webhook.yaml.tpl
@@ -19,7 +19,7 @@ webhooks:
   clientConfig:
     service:
       namespace: ingress-nginx
-      name: nginx-ingress-webhook
+      name: ingress-validation-webhook
       path: /networking.k8s.io/v1beta1/ingresses
     caBundle: <certificate.pem | base64>
 ---

--- a/docs/deploy/validating-webhook.md
+++ b/docs/deploy/validating-webhook.md
@@ -122,7 +122,7 @@ To check that your kube API server runs with the required flags, please refer to
 
 ### Additional kubernetes objects
 
-Once both the ingress controller and the kube API server are configured to serve the webhook, add the you can configure the webhook with the following objects:
+Once both the ingress controller and the kube API server are configured to serve the webhook, you can configure the webhook with the following objects:
 
 ```yaml
 apiVersion: v1


### PR DESCRIPTION
_What this PR does / why we need it:_
Fixes docs for validating webhook. The ValidatingWebhookConfiguration should correctly target [the service](https://github.com/kubernetes/ingress-nginx/blob/master/deploy/with-validating-webhook.yaml.tpl#L5) as shown [in the docs](https://github.com/kubernetes/ingress-nginx/blob/master/docs/deploy/validating-webhook.md). Also fixes typo. 

I can create an issue for tracking. 
