### PR TITLE
Make quote function to render pointers in the template properly

### DIFF
--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -219,6 +219,8 @@ func quote(input interface{}) string {
 		inputStr = input
 	case fmt.Stringer:
 		inputStr = input.String()
+	case *string:
+		inputStr = *input
 	default:
 		inputStr = fmt.Sprintf("%v", input)
 	}

--- a/internal/ingress/controller/template/template_test.go
+++ b/internal/ingress/controller/template/template_test.go
@@ -256,10 +256,12 @@ func TestFormatIP(t *testing.T) {
 }
 
 func TestQuote(t *testing.T) {
+	foo := "foo"
 	cases := map[interface{}]string{
 		"foo":      `"foo"`,
 		"\"foo\"":  `"\"foo\""`,
 		"foo\nbar": `"foo\nbar"`,
+		&foo:       `"foo"`,
 		10:         `"10"`,
 	}
 	for input, output := range cases {


### PR DESCRIPTION
## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
For now, the reason why location is denied printed in an Nginx configuration file via comment.
But it looks unclear because we see the only pointer, not the error message itself.

For example, the log of nginx contoller configuration change.
```
-                       # Location denied. Reason: "0xc000323440"
+                       # Location denied. Reason: "0xc000c0f560"
                        return 503;
```

This happens, because quote function in templates works incorrectly with pointers. And the `Denied` field in the `Location` structure is a pointer.

This PR provides a fix for the quote function.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested the patched docker image in the ordinary kubeadm installed Kubernetes cluster. I also added the necessary unit test.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.