### PR TITLE
Add wait-before-shutdown command line option

### DIFF
--- a/cmd/nginx/flags.go
+++ b/cmd/nginx/flags.go
@@ -121,6 +121,10 @@ different namespace than their own. May be used together with watch-namespace.`)
 			`Update the load-balancer status of Ingress objects when the controller shuts down.
 Requires the update-status parameter.`)
 
+		waitBeforeShutdown = flags.Int("wait-before-shutdown", 0,
+			`Delay shutting down nginx after a termination signal is received, to give time for 
+external load balancers to to update their statuses before the shutdown.`)
+
 		useNodeInternalIP = flags.Bool("report-node-internal-ip-address", false,
 			`Set the load-balancer status of Ingress objects to internal Node addresses instead of external.
 Requires the update-status parameter.`)
@@ -291,6 +295,7 @@ https://blog.maxmind.com/2019/12/18/significant-changes-to-accessing-and-using-g
 		PublishService:         *publishSvc,
 		PublishStatusAddress:   *publishStatusAddress,
 		UpdateStatusOnShutdown: *updateStatusOnShutdown,
+		WaitBeforeShutdown:     *waitBeforeShutdown,
 		UseNodeInternalIP:      *useNodeInternalIP,
 		SyncRateLimit:          *syncRateLimit,
 		ListenPorts: &ngx_config.ListenPorts{

--- a/docs/user-guide/cli-arguments.md
+++ b/docs/user-guide/cli-arguments.md
@@ -49,6 +49,7 @@ They are set in the container spec of the `nginx-ingress-controller` Deployment 
 | `--version`                       | Show release information about the NGINX Ingress controller and exit. |
 | `--vmodule moduleSpec`            | comma-separated list of pattern=N settings for file-filtered logging |
 | `--watch-namespace string`        | Namespace the controller watches for updates to Kubernetes objects. This includes Ingresses, Services and all configuration resources. All namespaces are watched if this parameter is left empty. |
+| `--wait-before-shutdown`          | Seconds to wait after receiving the shutdown signal, before stopping the nginx process. Useful with external load balancers. (default 0) |
 |`--validating-webhook`|The address to start an admission controller on|
 |`--validating-webhook-certificate`|The certificate the webhook is using for its TLS handling|
 |`--validating-webhook-key`|The key the webhook is using for its TLS handling|

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -78,6 +78,7 @@ type Configuration struct {
 	UseNodeInternalIP      bool
 	ElectionID             string
 	UpdateStatusOnShutdown bool
+	WaitBeforeShutdown     int
 
 	ListenPorts *ngx_config.ListenPorts
 

--- a/internal/ingress/controller/nginx.go
+++ b/internal/ingress/controller/nginx.go
@@ -384,6 +384,11 @@ func (n *NGINXController) Stop() error {
 	n.stopLock.Lock()
 	defer n.stopLock.Unlock()
 
+	if n.cfg.WaitBeforeShutdown > 0 {
+		klog.Infof("Waiting for %d seconds before stopping NGINX", n.cfg.WaitBeforeShutdown)
+		time.Sleep(time.Duration(n.cfg.WaitBeforeShutdown) * time.Second)
+	}
+
 	if n.syncQueue.IsShuttingDown() {
 		return fmt.Errorf("shutdown already in progress")
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Issue: #4726
This PR adds a --wait-before-shutdown CLI option (default: disabled) which causes it, upon receiving the shutdown signal, to wait for a configurable time before initiating nginx shutdown. This helps avoid issues when using external load balancers, which mostly rely on the healthcheck status.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):
-->
fixes #4726 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been running in production on GKE clusters fronted by ILB and NLB for a long time.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
