### PR TITLE
Register metrics for custom-error-pages

### DIFF
--- a/images/custom-error-pages/main.go
+++ b/images/custom-error-pages/main.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
@@ -62,6 +63,11 @@ const (
 	// the location on disk of files served by the handler.
 	ErrFilesPathVar = "ERROR_FILES_PATH"
 )
+
+func init() {
+	prometheus.MustRegister(requestCount)
+	prometheus.MustRegister(requestDuration)
+}
 
 func main() {
 	errFilesPath := "/www"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
Request count and timer weren't visible on /metrics endpoint since they
haven't been registered in prometheus DefaultRegister.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
1. Run version 0.4 (current) on port 8081
```
docker run --name cep_0_4 -p "8081:8080" -d --rm quay.io/kubernetes-ingress-controller/custom-error-pages-amd64:0.4
```

2. Run version 0.5 (new version - build from this PR) on port 8082
```
docker run --name cep_0_4 -p "8082:8080" -d --rm quay.io/kubernetes-ingress-controller/custom-error-pages-amd64:0.5
```

3. Send requests to version 0.4
```
for i in {1..5}; do curl 'http://localhost:8081/'; done
```

4. Send requests to version 0.5
```
for i in {1..5}; do curl 'http://localhost:8082/'; done
```

5. Check /metrics endpoint for version 0.4
```
$ curl "http://localhost:8081/metrics" 2>&1 | grep 'default_http_backend_http_request'
<EMPTY>
```

6. Check /metrics endpoint for version 0.5
```
curl "http://localhost:8082/metrics" 2>&1 | grep 'default_http_backend_http_request'

# TYPE default_http_backend_http_request_count_total counter
default_http_backend_http_request_count_total{proto="1.1"} 5
# HELP default_http_backend_http_request_duration_milliseconds Histogram of the time (in milliseconds) each request took.
# TYPE default_http_backend_http_request_duration_milliseconds histogram
...
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
