### PR TITLE
Fix reference to DH param secret, recommend larger parameter size

### DIFF
--- a/docs/examples/customization/ssl-dh-param/README.md
+++ b/docs/examples/customization/ssl-dh-param/README.md
@@ -27,7 +27,7 @@ $ kubectl create -f configmap.yaml
 ## Custom DH parameters secret
 
 ```console
-$> openssl dhparam 1024 2> /dev/null | base64
+$> openssl dhparam 4096 2> /dev/null | base64
 LS0tLS1CRUdJTiBESCBQQVJBTUVURVJ...
 ```
 
@@ -38,7 +38,7 @@ data:
   dhparam.pem: "LS0tLS1CRUdJTiBESCBQQVJBTUVURVJ..."
 kind: Secret
 metadata:
-  name: nginx-configuration
+  name: lb-dhparam
   namespace: ingress-nginx
   labels:
     app.kubernetes.io/name: ingress-nginx


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:

Did not test, but I'm very sure this was a typo in the README, leading to an incorrect reference to the DH param secret.

In addition, since lots of businesses are required to use >= 2048 bit parameters, recommend using 4096 in the documentation.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?

not tested

## Checklist:

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
