### PR TITLE
do not require go for building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,11 @@ PKG = k8s.io/ingress-nginx
 
 BUSTED_ARGS =-v --pattern=_test
 
-ARCH ?= $(shell go env GOARCH)
+HOST_ARCH = $(shell which go >/dev/null 2>&1 && go env GOARCH)
+ARCH ?= $(HOST_ARCH)
+ifeq ($(ARCH),)
+    $(error mandatory variable ARCH is empty, either set it when calling the command or make sure 'go env GOARCH' works)
+endif
 
 REGISTRY ?= quay.io/kubernetes-ingress-controller
 

--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,6 @@
 # Add the following 'help' target to your Makefile
 # And add help text after each target name starting with '\#\#'
 
-ifeq ($(shell which go >/dev/null 2>&1; echo $$?), 1)
-    $(error Can't find 'go' in PATH, please fix and retry. See http://golang.org/doc/install for installation instructions.)
-endif
-
 .DEFAULT_GOAL:=help
 
 .EXPORT_ALL_VARIABLES:
@@ -274,7 +270,12 @@ run-ingress-controller: ## Run the ingress controller locally using a kubectl pr
 
 .PHONY: check-go-version
 check-go-version:
+ifeq ($(USE_DOCKER), true)
+	@build/run-in-docker.sh \
+		hack/check-go-version.sh
+else
 	@hack/check-go-version.sh
+endif
 
 .PHONY: init-docker-buildx
 init-docker-buildx:

--- a/build/run-in-docker.sh
+++ b/build/run-in-docker.sh
@@ -43,7 +43,10 @@ KUBE_ROOT=$(cd $(dirname "${BASH_SOURCE}")/.. && pwd -P)
 FLAGS=$@
 
 PKG=k8s.io/ingress-nginx
-ARCH=$(go env GOARCH)
+ARCH=${ARCH:-}
+if [[ -z "$ARCH" ]]; then
+  ARCH=$(go env GOARCH)
+fi
 
 # create output directory as current user to avoid problem with docker.
 mkdir -p "${KUBE_ROOT}/bin" "${KUBE_ROOT}/bin/${ARCH}"


### PR DESCRIPTION
## What this PR does / why we need it:
Rel https://github.com/kubernetes/ingress-nginx/pull/5216

Given `USE_DOCKER` is `true` by default in the Makefile we should not require Go by default on the host machine.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
