### PR TITLE
ensure make lua-test runs locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,8 +53,6 @@ GIT_COMMIT ?= git-$(shell git rev-parse --short HEAD)
 
 PKG = k8s.io/ingress-nginx
 
-BUSTED_ARGS =-v --pattern=_test
-
 HOST_ARCH = $(shell which go >/dev/null 2>&1 && go env GOARCH)
 ARCH ?= $(HOST_ARCH)
 ifeq ($(ARCH),)

--- a/build/test-lua.sh
+++ b/build/test-lua.sh
@@ -23,6 +23,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+BUSTED_ARGS="-v --pattern=_test"
+
 resty \
   -I ./rootfs/etc/nginx/lua \
   --shdict "configuration_data 5M" \


### PR DESCRIPTION
## What this PR does / why we need it:

Otherwise I get the following error:

```
> ingress-nginx (master)$ make lua-test
/bin/bash: --pattern=_test: command not found
make: *** [lua-test] Error 127
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
