### PR TITLE
Ability to separately disable access log in http and stream contexts

### DIFF
--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -157,9 +157,18 @@ type Configuration struct {
 	// http://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_timeout
 	ClientBodyTimeout int `json:"client-body-timeout,omitempty"`
 
-	// DisableAccessLog disables the Access Log globally from NGINX ingress controller
-	//http://nginx.org/en/docs/http/ngx_http_log_module.html
+	// DisableAccessLog disables the Access Log globally for both HTTP and Stream contexts from NGINX ingress controller
+	// http://nginx.org/en/docs/http/ngx_http_log_module.html
+	// http://nginx.org/en/docs/stream/ngx_stream_log_module.html
 	DisableAccessLog bool `json:"disable-access-log,omitempty"`
+
+	// DisableHTTPAccessLog disables the Access Log for http context globally from NGINX ingress controller
+	// http://nginx.org/en/docs/http/ngx_http_log_module.html
+	DisableHTTPAccessLog bool `json:"disable-http-access-log,omitempty"`
+
+	// DisableStreamAccessLog disables the Access Log for stream context globally from NGINX ingress controller
+	// http://nginx.org/en/docs/stream/ngx_stream_log_module.html
+	DisableStreamAccessLog bool `json:"disable-stream-access-log,omitempty"`
 
 	// DisableIpv6DNS disables IPv6 for nginx resolver
 	DisableIpv6DNS bool `json:"disable-ipv6-dns"`

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -315,7 +315,7 @@ http {
         default 1;
     }
 
-    {{ if $cfg.DisableAccessLog }}
+    {{ if or $cfg.DisableAccessLog $cfg.DisableHTTPAccessLog }}
     access_log off;
     {{ else }}
     {{ if $cfg.EnableSyslog }}
@@ -684,7 +684,7 @@ stream {
 
     log_format log_stream '{{ $cfg.LogFormatStream }}';
 
-    {{ if $cfg.DisableAccessLog }}
+    {{ if or $cfg.DisableAccessLog $cfg.DisableStreamAccessLog }}
     access_log off;
     {{ else }}
     access_log {{ $cfg.AccessLogPath }} log_stream {{ $cfg.AccessLogParams }};

--- a/test/e2e/annotations/disableaccesslog.go
+++ b/test/e2e/annotations/disableaccesslog.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package annotations
+
+import (
+	"strings"
+
+	"github.com/onsi/ginkgo"
+
+	"k8s.io/ingress-nginx/test/e2e/framework"
+)
+
+var _ = framework.DescribeAnnotation("disable-access-log disable-http-access-log disable-stream-access-log", func() {
+	f := framework.NewDefaultFramework("disableaccesslog")
+
+	ginkgo.BeforeEach(func() {
+		f.NewEchoDeployment()
+	})
+
+	ginkgo.It("disable-access-log set access_log off", func() {
+		host := "disableaccesslog.foo.com"
+		annotations := map[string]string{
+			"nginx.ingress.kubernetes.io/disable-access-log": "true",
+		}
+
+		ing := framework.NewSingleIngress(host, "/", host, f.Namespace, framework.EchoService, 80, annotations)
+		f.EnsureIngress(ing)
+
+		f.WaitForNginxServer(host,
+			func(server string) bool {
+				str := `
+                                multiline
+                                string.`
+				return strings.Contains(server, `access_log off;`)
+			})
+	})
+
+	ginkgo.It("disable-http-access-log set access_log off", func() {
+		host := "disablehttpaccesslog.foo.com"
+		annotations := map[string]string{
+			"nginx.ingress.kubernetes.io/disable-http-access-log": "true",
+		}
+
+		ing := framework.NewSingleIngress(host, "/", host, f.Namespace, framework.EchoService, 80, annotations)
+		f.EnsureIngress(ing)
+
+		f.WaitForNginxServer(host,
+			func(server string) bool {
+				return strings.Contains(server, `access_log off;`)
+			})
+	})
+
+	ginkgo.It("disable-stream-access-log set access_log off", func() {
+		host := "disablehttpaccesslog.foo.com"
+		annotations := map[string]string{
+			"nginx.ingress.kubernetes.io/disable-stream-access-log": "true",
+		}
+
+		ing := framework.NewSingleIngress(host, "/", host, f.Namespace, framework.EchoService, 80, annotations)
+		f.EnsureIngress(ing)
+
+		f.WaitForNginxServer(host,
+			func(server string) bool {
+				return strings.Contains(server, `access_log off;`)
+			})
+	})
+})


### PR DESCRIPTION
Two new configuration options:
`disable-http-access-log`
`disable-stream-access-log`

Should resolve issue with enormous amount of `TCP 200` useless entries in logs

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #2406
-->

## How Has This Been Tested?
No time to test. Changes are trivial. Having millions of useless TCP 200 in my logs and my Elasticsearch is going to explode soon

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
