### PR TITLE
Add e2e tests for helm chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -266,6 +266,10 @@ misspell: check-go-version ## Check for spelling errors.
 kind-e2e-test: check-go-version ## Run e2e tests using kind.
 	@test/e2e/run.sh
 
+.PHONY: kind-e2e-chart-tests
+kind-e2e-chart-tests: ## Run helm chart e2e tests
+	@test/e2e/run-chart-test.sh
+
 .PHONY: run-ingress-controller
 run-ingress-controller: ## Run the ingress controller locally using a kubectl proxy connection.
 	@build/run-ingress-controller.sh

--- a/charts/ingress-nginx/ci/daemonset-customconfig-values.yaml
+++ b/charts/ingress-nginx/ci/daemonset-customconfig-values.yaml
@@ -1,4 +1,9 @@
 controller:
   kind: DaemonSet
+  admissionWebhooks:
+    enabled: false
+  service:
+    type: ClusterIP
+
   config:
     use-proxy-protocol: "true"

--- a/charts/ingress-nginx/ci/daemonset-customnodeport-values.yaml
+++ b/charts/ingress-nginx/ci/daemonset-customnodeport-values.yaml
@@ -1,5 +1,8 @@
 controller:
   kind: DaemonSet
+  admissionWebhooks:
+    enabled: false
+
   service:
     type: NodePort
     nodePorts:

--- a/charts/ingress-nginx/ci/daemonset-headers-values.yaml
+++ b/charts/ingress-nginx/ci/daemonset-headers-values.yaml
@@ -1,6 +1,10 @@
 controller:
   kind: DaemonSet
+  admissionWebhooks:
+    enabled: false
   addHeaders:
     X-Frame-Options: deny
   proxySetHeaders:
     X-Forwarded-Proto: https
+  service:
+    type: ClusterIP

--- a/charts/ingress-nginx/ci/daemonset-nodeport-values.yaml
+++ b/charts/ingress-nginx/ci/daemonset-nodeport-values.yaml
@@ -1,4 +1,6 @@
 controller:
   kind: DaemonSet
+  admissionWebhooks:
+    enabled: false
   service:
     type: NodePort

--- a/charts/ingress-nginx/ci/daemonset-tcp-udp-configMapNamespace-values.yaml
+++ b/charts/ingress-nginx/ci/daemonset-tcp-udp-configMapNamespace-values.yaml
@@ -1,5 +1,7 @@
 controller:
   kind: DaemonSet
+  admissionWebhooks:
+    enabled: false
   service:
     type: ClusterIP
   tcp:

--- a/charts/ingress-nginx/ci/daemonset-tcp-udp-values.yaml
+++ b/charts/ingress-nginx/ci/daemonset-tcp-udp-values.yaml
@@ -1,5 +1,7 @@
 controller:
   kind: DaemonSet
+  admissionWebhooks:
+    enabled: false
   service:
     type: ClusterIP
 

--- a/charts/ingress-nginx/ci/daemonset-tcp-values.yaml
+++ b/charts/ingress-nginx/ci/daemonset-tcp-values.yaml
@@ -1,5 +1,9 @@
 controller:
   kind: DaemonSet
+  admissionWebhooks:
+    enabled: false
+  service:
+    type: ClusterIP
 
 tcp:
   9000: "default/test:8080"

--- a/charts/ingress-nginx/ci/deamonset-default-values.yaml
+++ b/charts/ingress-nginx/ci/deamonset-default-values.yaml
@@ -1,2 +1,6 @@
 controller:
   kind: DaemonSet
+  admissionWebhooks:
+    enabled: false
+  service:
+    type: ClusterIP

--- a/charts/ingress-nginx/ci/deamonset-metrics-values.yaml
+++ b/charts/ingress-nginx/ci/deamonset-metrics-values.yaml
@@ -1,4 +1,8 @@
 controller:
   kind: DaemonSet
+  admissionWebhooks:
+    enabled: false
   metrics:
     enabled: true
+  service:
+    type: ClusterIP

--- a/charts/ingress-nginx/ci/deamonset-psp-values.yaml
+++ b/charts/ingress-nginx/ci/deamonset-psp-values.yaml
@@ -1,5 +1,9 @@
 controller:
   kind: DaemonSet
+  admissionWebhooks:
+    enabled: false
+  service:
+    type: ClusterIP
 
 podSecurityPolicy:
   enabled: true

--- a/charts/ingress-nginx/ci/deamonset-webhook-and-psp-values.yaml
+++ b/charts/ingress-nginx/ci/deamonset-webhook-and-psp-values.yaml
@@ -2,6 +2,8 @@ controller:
   kind: DaemonSet
   admissionWebhooks:
     enabled: true
+  service:
+    type: ClusterIP
 
 podSecurityPolicy:
   enabled: true

--- a/charts/ingress-nginx/ci/deamonset-webhook-values.yaml
+++ b/charts/ingress-nginx/ci/deamonset-webhook-values.yaml
@@ -2,3 +2,5 @@ controller:
   kind: DaemonSet
   admissionWebhooks:
     enabled: true
+  service:
+    type: ClusterIP

--- a/charts/ingress-nginx/ci/deployment-autoscaling-values.yaml
+++ b/charts/ingress-nginx/ci/deployment-autoscaling-values.yaml
@@ -1,3 +1,7 @@
 controller:
   autoscaling:
     enabled: true
+  admissionWebhooks:
+    enabled: false
+  service:
+    type: ClusterIP

--- a/charts/ingress-nginx/ci/deployment-customconfig-values.yaml
+++ b/charts/ingress-nginx/ci/deployment-customconfig-values.yaml
@@ -1,3 +1,7 @@
 controller:
   config:
     use-proxy-protocol: "true"
+  admissionWebhooks:
+    enabled: false
+  service:
+    type: ClusterIP

--- a/charts/ingress-nginx/ci/deployment-customnodeport-values.yaml
+++ b/charts/ingress-nginx/ci/deployment-customnodeport-values.yaml
@@ -1,4 +1,6 @@
 controller:
+  admissionWebhooks:
+    enabled: false
   service:
     type: NodePort
     nodePorts:

--- a/charts/ingress-nginx/ci/deployment-default-values.yaml
+++ b/charts/ingress-nginx/ci/deployment-default-values.yaml
@@ -1,1 +1,4 @@
 # Left blank to test default values
+controller:
+  service:
+    type: ClusterIP

--- a/charts/ingress-nginx/ci/deployment-headers-values.yaml
+++ b/charts/ingress-nginx/ci/deployment-headers-values.yaml
@@ -1,5 +1,9 @@
 controller:
+  admissionWebhooks:
+    enabled: false
   addHeaders:
     X-Frame-Options: deny
   proxySetHeaders:
     X-Forwarded-Proto: https
+  service:
+    type: ClusterIP

--- a/charts/ingress-nginx/ci/deployment-metrics-values.yaml
+++ b/charts/ingress-nginx/ci/deployment-metrics-values.yaml
@@ -1,3 +1,7 @@
 controller:
+  admissionWebhooks:
+    enabled: false
   metrics:
     enabled: true
+  service:
+    type: ClusterIP

--- a/charts/ingress-nginx/ci/deployment-nodeport-values.yaml
+++ b/charts/ingress-nginx/ci/deployment-nodeport-values.yaml
@@ -1,3 +1,5 @@
 controller:
+  admissionWebhooks:
+    enabled: false
   service:
     type: NodePort

--- a/charts/ingress-nginx/ci/deployment-psp-values.yaml
+++ b/charts/ingress-nginx/ci/deployment-psp-values.yaml
@@ -1,2 +1,6 @@
+controller:
+  service:
+    type: ClusterIP
+
 podSecurityPolicy:
   enabled: true

--- a/charts/ingress-nginx/ci/deployment-tcp-udp-configMapNamespace-values.yaml
+++ b/charts/ingress-nginx/ci/deployment-tcp-udp-configMapNamespace-values.yaml
@@ -1,4 +1,6 @@
 controller:
+  admissionWebhooks:
+    enabled: false
   service:
     type: ClusterIP
   tcp:

--- a/charts/ingress-nginx/ci/deployment-tcp-udp-values.yaml
+++ b/charts/ingress-nginx/ci/deployment-tcp-udp-values.yaml
@@ -1,4 +1,6 @@
 controller:
+  admissionWebhooks:
+    enabled: false
   service:
     type: ClusterIP
 

--- a/charts/ingress-nginx/ci/deployment-tcp-values.yaml
+++ b/charts/ingress-nginx/ci/deployment-tcp-values.yaml
@@ -1,3 +1,7 @@
+controller:
+  service:
+    type: ClusterIP
+
 tcp:
   9000: "default/test:8080"
   9001: "default/test:8080"

--- a/charts/ingress-nginx/ci/deployment-webhook-and-psp-values.yaml
+++ b/charts/ingress-nginx/ci/deployment-webhook-and-psp-values.yaml
@@ -1,6 +1,8 @@
 controller:
   admissionWebhooks:
     enabled: true
+  service:
+    type: ClusterIP
 
 podSecurityPolicy:
   enabled: true

--- a/charts/ingress-nginx/ci/deployment-webhook-values.yaml
+++ b/charts/ingress-nginx/ci/deployment-webhook-values.yaml
@@ -1,3 +1,5 @@
 controller:
   admissionWebhooks:
     enabled: true
+  service:
+    type: ClusterIP

--- a/test/e2e/kind.yaml
+++ b/test/e2e/kind.yaml
@@ -1,6 +1,14 @@
 kind: Cluster
-apiVersion: kind.sigs.k8s.io/v1alpha3
+apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
 - role: worker
 - role: worker
+kubeadmConfigPatches:
+- |
+  kind: ClusterConfiguration
+  metadata:
+    name: config
+  controllerManager:
+    extraArgs:
+      namespace-sync-period: 10s

--- a/test/e2e/run-chart-test.sh
+++ b/test/e2e/run-chart-test.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+cleanup() {
+  if [[ "${KUBETEST_IN_DOCKER:-}" == "true" ]]; then
+    kind "export" logs --name ${KIND_CLUSTER_NAME} "${ARTIFACTS}/logs" || true
+  fi
+
+  kind delete cluster \
+    --name ${KIND_CLUSTER_NAME}
+}
+
+trap cleanup EXIT
+
+if ! command -v kind --version &> /dev/null; then
+  echo "kind is not installed. Use the package manager or visit the official site https://kind.sigs.k8s.io/"
+  exit 1
+fi
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+export K8S_VERSION=${K8S_VERSION:-v1.18.0@sha256:0e20578828edd939d25eb98496a685c76c98d54084932f76069f886ec315d694}
+
+KIND_CLUSTER_NAME="ingress-nginx-dev"
+
+echo "[dev-env] creating Kubernetes cluster with kind"
+export KUBECONFIG="${HOME}/.kube/kind-config-${KIND_CLUSTER_NAME}"
+kind create cluster \
+  --name ${KIND_CLUSTER_NAME} \
+  --config "${DIR}/kind.yaml" \
+  --retain \
+  --image "kindest/node:${K8S_VERSION}"
+
+echo "Kubernetes cluster:"
+kubectl get nodes -o wide
+
+echo "[dev-env] running helm chart e2e tests..."
+docker run --rm --interactive --network host \
+    --name ct \
+    --volume $KUBECONFIG:/root/.kube/config \
+    --volume "${DIR}/../../":/workdir \
+    --workdir /workdir \
+    quay.io/helmpack/chart-testing:v3.0.0-rc.1 ct install \
+        --charts charts/ingress-nginx \
+        --helm-extra-args "--timeout 120s"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:

This is required for the migration of the helm chart. There are two changes in the tests: service type=ClusterIP instead of LoadBalancer (which makes no sense) and admissionWebhook enabled=false.

ref: #5161

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
