### PR TITLE
[WIP] eagerly fetch and cache OCSP responses

### DIFF
--- a/rootfs/etc/nginx/lua/configuration.lua
+++ b/rootfs/etc/nginx/lua/configuration.lua
@@ -93,6 +93,11 @@ local function handle_servers()
       local msg = string.format("certificate_data dictionary is full, LRU entry has been removed to store %s", uid)
       ngx.log(ngx.WARN, msg)
     end
+    if success then
+      -- trigger a timer to fetch OCSP response and cache
+      -- but if we require certificate module here then there will be circular dependency
+      -- maybe we should refactor and let the certificate module to handle this configuration request
+    end
   end
 
   if #err_buf > 0 then


### PR DESCRIPTION
## What this PR does / why we need it:

The initial OCSP stapling implementation in https://github.com/kubernetes/ingress-nginx/pull/5133, fetches OCSP responses lazily after the first request. That means the first request will miss OCSP response. In order to avoid that this PR enqueues a fetch and cache job for a certificate as soon as it gets pushed to Lua in memory configuration. That means starting right with the first request ingress-nginx will staple OCSP responses.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
