### PR TITLE
update the helm v3 install way

### DIFF
--- a/docs/deploy/index.md
+++ b/docs/deploy/index.md
@@ -175,7 +175,7 @@ To install the chart with the release name `ingress-nginx`:
 
 ```console
 helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
-helm install ingress-nginx
+helm install my-release-name ingress-nginx
 ```
 
 If you are using [Helm 2](https://v2.helm.sh/) then specify release name using `--name` flag


### PR DESCRIPTION
Hi,

It seems the helm v3 installation 101 is not correct.

In helm 3
```console
Usage:
  helm install [NAME] [CHART] [flags]
```

# reference
https://docs.nginx.com/nginx-ingress-controller/installation/installation-with-helm/#installing-via-helm-repository

Best,
Alpha