### PR TITLE
Add support for IngressClass and ingress.class annotation

### DIFF
--- a/charts/ingress-nginx/templates/clusterrole.yaml
+++ b/charts/ingress-nginx/templates/clusterrole.yaml
@@ -65,4 +65,12 @@ rules:
       - ingresses/status
     verbs:
       - update
+  - apiGroups:
+      - "networking.k8s.io" # k8s 1.14+
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
 {{- end }}

--- a/charts/ingress-nginx/templates/controller-role.yaml
+++ b/charts/ingress-nginx/templates/controller-role.yaml
@@ -50,6 +50,14 @@ rules:
     verbs:
       - update
   - apiGroups:
+      - "networking.k8s.io" # k8s 1.14+
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - ""
     resources:
       - configmaps

--- a/deploy/static/provider/aws/deploy-tls-termination.yaml
+++ b/deploy/static/provider/aws/deploy-tls-termination.yaml
@@ -106,6 +106,14 @@ rules:
       - ingresses/status
     verbs:
       - update
+  - apiGroups:
+      - networking.k8s.io   # k8s 1.14+
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
 ---
 # Source: ingress-nginx/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -184,6 +192,14 @@ rules:
       - ingresses/status
     verbs:
       - update
+  - apiGroups:
+      - networking.k8s.io   # k8s 1.14+
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - ''
     resources:

--- a/deploy/static/provider/aws/deploy.yaml
+++ b/deploy/static/provider/aws/deploy.yaml
@@ -99,6 +99,14 @@ rules:
       - ingresses/status
     verbs:
       - update
+  - apiGroups:
+      - networking.k8s.io   # k8s 1.14+
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
 ---
 # Source: ingress-nginx/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -177,6 +185,14 @@ rules:
       - ingresses/status
     verbs:
       - update
+  - apiGroups:
+      - networking.k8s.io   # k8s 1.14+
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - ''
     resources:

--- a/deploy/static/provider/baremetal/deploy.yaml
+++ b/deploy/static/provider/baremetal/deploy.yaml
@@ -99,6 +99,14 @@ rules:
       - ingresses/status
     verbs:
       - update
+  - apiGroups:
+      - networking.k8s.io   # k8s 1.14+
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
 ---
 # Source: ingress-nginx/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -177,6 +185,14 @@ rules:
       - ingresses/status
     verbs:
       - update
+  - apiGroups:
+      - networking.k8s.io   # k8s 1.14+
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - ''
     resources:

--- a/deploy/static/provider/cloud/deploy.yaml
+++ b/deploy/static/provider/cloud/deploy.yaml
@@ -99,6 +99,14 @@ rules:
       - ingresses/status
     verbs:
       - update
+  - apiGroups:
+      - networking.k8s.io   # k8s 1.14+
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
 ---
 # Source: ingress-nginx/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -177,6 +185,14 @@ rules:
       - ingresses/status
     verbs:
       - update
+  - apiGroups:
+      - networking.k8s.io   # k8s 1.14+
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - ''
     resources:

--- a/deploy/static/provider/kind/deploy.yaml
+++ b/deploy/static/provider/kind/deploy.yaml
@@ -99,6 +99,14 @@ rules:
       - ingresses/status
     verbs:
       - update
+  - apiGroups:
+      - networking.k8s.io   # k8s 1.14+
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
 ---
 # Source: ingress-nginx/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -177,6 +185,14 @@ rules:
       - ingresses/status
     verbs:
       - update
+  - apiGroups:
+      - networking.k8s.io   # k8s 1.14+
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - ''
     resources:

--- a/internal/ingress/annotations/class/main_test.go
+++ b/internal/ingress/annotations/class/main_test.go
@@ -54,10 +54,10 @@ func TestIsValidClass(t *testing.T) {
 		},
 	}
 
+	data := map[string]string{}
+	ing.SetAnnotations(data)
 	for _, test := range tests {
-		if test.ingress != "" {
-			ing.Spec.IngressClassName = &test.ingress
-		}
+		ing.Annotations[IngressKey] = test.ingress
 
 		IngressClass = test.controller
 		DefaultClass = test.defClass

--- a/internal/ingress/controller/controller_test.go
+++ b/internal/ingress/controller/controller_test.go
@@ -190,8 +190,7 @@ func TestCheckIngress(t *testing.T) {
 	}
 
 	t.Run("When the ingress class differs from nginx", func(t *testing.T) {
-		class := "different"
-		ing.Spec.IngressClassName = &class
+		ing.ObjectMeta.Annotations["kubernetes.io/ingress.class"] = "different"
 		nginx.command = testNginxTestCommand{
 			t:   t,
 			err: fmt.Errorf("test error"),
@@ -202,8 +201,7 @@ func TestCheckIngress(t *testing.T) {
 	})
 
 	t.Run("when the class is the nginx one", func(t *testing.T) {
-		class := "nginx"
-		ing.Spec.IngressClassName = &class
+		ing.ObjectMeta.Annotations["kubernetes.io/ingress.class"] = "nginx"
 		nginx.command = testNginxTestCommand{
 			t:        t,
 			err:      nil,

--- a/internal/ingress/controller/store/store.go
+++ b/internal/ingress/controller/store/store.go
@@ -949,28 +949,16 @@ func toIngress(obj interface{}) (*networkingv1beta1.Ingress, bool) {
 			return nil, false
 		}
 
-		ing.Spec.IngressClassName = extractClassName(ing)
 		setDefaultPathTypeIfEmpty(ing)
-
 		return ing, true
 	}
 
 	if ing, ok := obj.(*networkingv1beta1.Ingress); ok {
-		ing.Spec.IngressClassName = extractClassName(ing)
 		setDefaultPathTypeIfEmpty(ing)
-
 		return ing, true
 	}
 
 	return nil, false
-}
-
-func extractClassName(ing *networkingv1beta1.Ingress) *string {
-	if c, ok := ing.Annotations[class.IngressKey]; ok {
-		return &c
-	}
-
-	return nil
 }
 
 // Default path type is Prefix to not break existing definitions

--- a/internal/k8s/main.go
+++ b/internal/k8s/main.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/klog"
 
 	apiv1 "k8s.io/api/core/v1"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/version"
 	clientset "k8s.io/client-go/kubernetes"
@@ -120,6 +121,13 @@ var IsNetworkingIngressAvailable bool
 
 // IsIngressV1Ready indicates if the running Kubernetes version is at least v1.18.0
 var IsIngressV1Ready bool
+
+// IngressClass indicates the class of the Ingress to use as filter
+var IngressClass *networkingv1beta1.IngressClass
+
+// IngressNGINXController defines the valid value of IngressClass
+// Controller field for ingress-nginx
+const IngressNGINXController = "k8s.io/ingress-nginx"
 
 // NetworkingIngressAvailable checks if the package "k8s.io/api/networking/v1beta1"
 // is available or not and if Ingress V1 is supported (k8s >= v1.18.0)

--- a/test/e2e/framework/exec.go
+++ b/test/e2e/framework/exec.go
@@ -55,7 +55,7 @@ func (f *Framework) GetLbAlgorithm(serviceName string, servicePort int) (string,
 
 // ExecIngressPod executes a command inside the first container in ingress controller running pod
 func (f *Framework) ExecIngressPod(command string) (string, error) {
-	pod, err := getIngressNGINXPod(f.Namespace, f.KubeClientSet)
+	pod, err := GetIngressNGINXPod(f.Namespace, f.KubeClientSet)
 	if err != nil {
 		return "", err
 	}

--- a/test/e2e/framework/k8s.go
+++ b/test/e2e/framework/k8s.go
@@ -213,7 +213,8 @@ func podRunningReady(p *core.Pod) (bool, error) {
 	return true, nil
 }
 
-func getIngressNGINXPod(ns string, kubeClientSet kubernetes.Interface) (*core.Pod, error) {
+// GetIngressNGINXPod returns the ingress controller running pod
+func GetIngressNGINXPod(ns string, kubeClientSet kubernetes.Interface) (*core.Pod, error) {
 	l, err := kubeClientSet.CoreV1().Pods(ns).List(context.TODO(), metav1.ListOptions{
 		LabelSelector: "app.kubernetes.io/name=ingress-nginx",
 	})

--- a/test/e2e/settings/ingress_class.go
+++ b/test/e2e/settings/ingress_class.go
@@ -18,27 +18,51 @@ package settings
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/onsi/ginkgo"
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
+	networking "k8s.io/api/networking/v1beta1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"k8s.io/ingress-nginx/internal/ingress/annotations/class"
+	"k8s.io/ingress-nginx/internal/k8s"
 	"k8s.io/ingress-nginx/test/e2e/framework"
 )
 
 var _ = framework.IngressNginxDescribe("[Flag] ingress-class", func() {
 	f := framework.NewDefaultFramework("ingress-class")
 
+	f.KubeClientSet.RbacV1().ClusterRoles().Create(context.TODO(), &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "ingress-nginx-class"},
+		Rules: []rbacv1.PolicyRule{{
+			APIGroups: []string{"networking.k8s.io"},
+			Resources: []string{"ingressclasses"},
+			Verbs:     []string{"get", "list", "watch"},
+		}},
+	}, metav1.CreateOptions{})
+
+	f.KubeClientSet.RbacV1().ClusterRoleBindings().Create(context.TODO(), &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ingress-nginx-class",
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     "ingress-nginx-class",
+		},
+	}, metav1.CreateOptions{})
+
 	ginkgo.BeforeEach(func() {
 		f.NewEchoDeploymentWithReplicas(1)
 	})
 
 	ginkgo.Context("Without a specific ingress-class", func() {
-
 		ginkgo.It("should ignore Ingress with class", func() {
 			invalidHost := "foo"
 			annotations := map[string]string{
@@ -74,7 +98,15 @@ var _ = framework.IngressNginxDescribe("[Flag] ingress-class", func() {
 		ginkgo.BeforeEach(func() {
 			err := framework.UpdateDeployment(f.KubeClientSet, f.Namespace, "nginx-ingress-controller", 1,
 				func(deployment *appsv1.Deployment) error {
-					args := deployment.Spec.Template.Spec.Containers[0].Args
+					args := []string{}
+					for _, v := range deployment.Spec.Template.Spec.Containers[0].Args {
+						if strings.Contains(v, "--ingress-class") {
+							continue
+						}
+
+						args = append(args, v)
+					}
+
 					args = append(args, "--ingress-class=testclass")
 					deployment.Spec.Template.Spec.Containers[0].Args = args
 					_, err := f.KubeClientSet.AppsV1().Deployments(f.Namespace).Update(context.TODO(), deployment, metav1.UpdateOptions{})
@@ -153,5 +185,150 @@ var _ = framework.IngressNginxDescribe("[Flag] ingress-class", func() {
 				Expect().
 				Status(http.StatusNotFound)
 		})
+	})
+
+	ginkgo.It("check scenarios for IngressClass and ingress.class annotation", func() {
+		if !f.IsIngressV1Ready {
+			ginkgo.Skip("Test requires Kubernetes v1.18 or higher")
+		}
+
+		ingressClassName := "test-new-ingress-class"
+
+		ingressClass, err := f.KubeClientSet.NetworkingV1beta1().IngressClasses().
+			Create(context.TODO(), &networking.IngressClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: ingressClassName,
+				},
+				Spec: networking.IngressClassSpec{
+					Controller: k8s.IngressNGINXController,
+				},
+			}, metav1.CreateOptions{})
+
+		if ingressClass == nil {
+			assert.Nil(ginkgo.GinkgoT(), err, "creating IngressClass")
+		}
+
+		pod, err := framework.GetIngressNGINXPod(f.Namespace, f.KubeClientSet)
+		assert.Nil(ginkgo.GinkgoT(), err, "searching ingress controller pod")
+		serviceAccount := pod.Spec.ServiceAccountName
+
+		crb, err := f.KubeClientSet.RbacV1().ClusterRoleBindings().Get(context.Background(), "ingress-nginx-class", metav1.GetOptions{})
+		assert.Nil(ginkgo.GinkgoT(), err, "searching cluster role binding")
+
+		// add service of current namespace
+		crb.Subjects = append(crb.Subjects, rbacv1.Subject{
+			APIGroup:  "",
+			Kind:      "ServiceAccount",
+			Name:      serviceAccount,
+			Namespace: f.Namespace,
+		})
+
+		_, err = f.KubeClientSet.RbacV1().ClusterRoleBindings().Update(context.Background(), crb, metav1.UpdateOptions{})
+		assert.Nil(ginkgo.GinkgoT(), err, "searching cluster role binding")
+
+		err = framework.UpdateDeployment(f.KubeClientSet, f.Namespace, "nginx-ingress-controller", 1,
+			func(deployment *appsv1.Deployment) error {
+				args := []string{}
+				for _, v := range deployment.Spec.Template.Spec.Containers[0].Args {
+					if strings.Contains(v, "--ingress-class") {
+						continue
+					}
+
+					args = append(args, v)
+				}
+
+				args = append(args, fmt.Sprintf("--ingress-class=%v", ingressClassName))
+				deployment.Spec.Template.Spec.Containers[0].Args = args
+				_, err := f.KubeClientSet.AppsV1().Deployments(f.Namespace).Update(context.TODO(), deployment, metav1.UpdateOptions{})
+				return err
+			})
+		assert.Nil(ginkgo.GinkgoT(), err, "updating ingress controller deployment flags")
+
+		host := "ingress.class"
+
+		ginkgo.By("only having IngressClassName")
+		ing := framework.NewSingleIngress(host, "/", host, f.Namespace, framework.EchoService, 80, nil)
+		ing.Spec.IngressClassName = &ingressClassName
+		f.EnsureIngress(ing)
+
+		f.WaitForNginxServer(host, func(cfg string) bool {
+			return strings.Contains(cfg, fmt.Sprintf("server_name %v", host))
+		})
+
+		f.HTTPTestClient().
+			GET("/").
+			WithHeader("Host", host).
+			Expect().
+			Status(http.StatusOK)
+
+		ginkgo.By("only having ingress.class annotation")
+		ing, err = f.KubeClientSet.NetworkingV1beta1().Ingresses(f.Namespace).Get(context.TODO(), host, metav1.GetOptions{})
+		assert.Nil(ginkgo.GinkgoT(), err)
+
+		ing.Annotations = map[string]string{
+			class.IngressKey: ingressClassName,
+		}
+		ing.Spec.IngressClassName = nil
+
+		_, err = f.KubeClientSet.NetworkingV1beta1().Ingresses(f.Namespace).Update(context.TODO(), ing, metav1.UpdateOptions{})
+		assert.Nil(ginkgo.GinkgoT(), err)
+
+		f.WaitForNginxConfiguration(func(cfg string) bool {
+			return strings.Contains(cfg, fmt.Sprintf("server_name %v", host))
+		})
+
+		time.Sleep(2 * time.Second)
+
+		f.HTTPTestClient().
+			GET("/").
+			WithHeader("Host", host).
+			Expect().
+			Status(http.StatusOK)
+
+		ginkgo.By("having an invalid ingress.class annotation and no IngressClassName")
+		ing, err = f.KubeClientSet.NetworkingV1beta1().Ingresses(f.Namespace).Get(context.TODO(), host, metav1.GetOptions{})
+		assert.Nil(ginkgo.GinkgoT(), err)
+
+		ing.Annotations = map[string]string{
+			class.IngressKey: "invalid",
+		}
+		ing.Spec.IngressClassName = nil
+
+		_, err = f.KubeClientSet.NetworkingV1beta1().Ingresses(f.Namespace).Update(context.TODO(), ing, metav1.UpdateOptions{})
+		assert.Nil(ginkgo.GinkgoT(), err)
+
+		time.Sleep(2 * time.Second)
+
+		f.WaitForNginxConfiguration(func(cfg string) bool {
+			return !strings.Contains(cfg, fmt.Sprintf("server_name %v", host))
+		})
+
+		f.HTTPTestClient().
+			GET("/").
+			WithHeader("Host", host).
+			Expect().
+			Status(http.StatusNotFound)
+
+		ginkgo.By("not having ingress.class annotation and invalid IngressClassName")
+		ing, err = f.KubeClientSet.NetworkingV1beta1().Ingresses(f.Namespace).Get(context.TODO(), host, metav1.GetOptions{})
+		assert.Nil(ginkgo.GinkgoT(), err)
+		ing.Annotations = map[string]string{}
+		invalidClassName := "invalidclass"
+		ing.Spec.IngressClassName = &invalidClassName
+
+		_, err = f.KubeClientSet.NetworkingV1beta1().Ingresses(f.Namespace).Update(context.TODO(), ing, metav1.UpdateOptions{})
+		assert.Nil(ginkgo.GinkgoT(), err)
+
+		time.Sleep(2 * time.Second)
+
+		f.WaitForNginxConfiguration(func(cfg string) bool {
+			return !strings.Contains(cfg, fmt.Sprintf("server_name %v", host))
+		})
+
+		f.HTTPTestClient().
+			GET("/").
+			WithHeader("Host", host).
+			Expect().
+			Status(http.StatusNotFound)
 	})
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:

Add support for new IngressClass resource, keeping support for `ingress.class` annotation.

Ingress controller deployment flag: `--ingress-class=internal`
Existing ingresses with annotation: `kubernetes.io/ingress.class: "internal"`
New IngressClass:

```
apiVersion: networking.k8s.io/v1beta1
kind: IngressClass
metadata:
  name: "internal"
  namespace: "ingress-nginx"
spec:
  controller: "k8s.io/ingress-nginx"
```

The flag will be reused for the annotation and the new IngressClass resource.
The ingress controller will check the IngressClass on startup in the same namespace where is running

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes

replaces https://github.com/kubernetes/ingress-nginx/pull/5354

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
