### PR TITLE
Dynamic LB sync non-external backends only when necessary

### DIFF
--- a/rootfs/etc/nginx/lua/balancer.lua
+++ b/rootfs/etc/nginx/lua/balancer.lua
@@ -36,6 +36,8 @@ local IMPLEMENTATIONS = {
 
 local _M = {}
 local balancers = {}
+local external_backends = {}
+local last_timestamp = 0
 
 local function get_implementation(backend)
   local name = backend["load-balance"] or DEFAULT_LB_ALG
@@ -92,6 +94,12 @@ local function format_ipv6_endpoints(endpoints)
   return formatted_endpoints
 end
 
+local function use_external_name(backend)
+  local serv_type = backend.service and backend.service.spec
+                       and backend.service.spec["type"]
+  return serv_type == "ExternalName"
+end
+
 local function sync_backend(backend)
   if not backend.endpoints or #backend.endpoints == 0 then
     balancers[backend.name] = nil
@@ -117,9 +125,7 @@ local function sync_backend(backend)
     return
   end
 
-  local service_type = backend.service and backend.service.spec
-                       and backend.service.spec["type"]
-  if service_type == "ExternalName" then
+  if use_external_name(backend) then
     backend = resolve_external_names(backend)
   end
 
@@ -129,6 +135,15 @@ local function sync_backend(backend)
 end
 
 local function sync_backends()
+  local timestamp = configuration.get_timestamp_data()
+  if timestamp <= last_timestamp then
+    for _, external_backend in pairs(external_backends) do
+      sync_backend(external_backend)
+    end
+    return
+  end
+  last_timestamp = timestamp
+
   local backends_data = configuration.get_backends_data()
   if not backends_data then
     balancers = {}
@@ -145,11 +160,16 @@ local function sync_backends()
   for _, new_backend in ipairs(new_backends) do
     sync_backend(new_backend)
     balancers_to_keep[new_backend.name] = balancers[new_backend.name]
+    if use_external_name(new_backend) then
+      local external_backend = util.deepcopy(new_backend)
+      external_backends[external_backend.name] = external_backend
+    end
   end
 
   for backend_name, _ in pairs(balancers) do
     if not balancers_to_keep[backend_name] then
       balancers[backend_name] = nil
+      external_backends[backend_name] = nil
     end
   end
 end

--- a/rootfs/etc/nginx/lua/configuration.lua
+++ b/rootfs/etc/nginx/lua/configuration.lua
@@ -189,7 +189,8 @@ local function handle_backends()
   local raw_backends_last_synced_at = ngx.time()
   success, err = configuration_data:set("raw_backends_last_synced_at", raw_backends_last_synced_at)
   if not success then
-    ngx.log(ngx.ERR, "dynamic-configuration: error updating when backends sync, new upstream peers wait for force syncing: " .. tostring(err))
+    ngx.log(ngx.ERR, "dynamic-configuration: error updating when backends sync, " ..
+                     "new upstream peers waiting for force syncing: " .. tostring(err))
     ngx.status = ngx.HTTP_BAD_REQUEST
     return
   end

--- a/rootfs/etc/nginx/lua/configuration.lua
+++ b/rootfs/etc/nginx/lua/configuration.lua
@@ -17,12 +17,12 @@ function _M.get_general_data()
   return configuration_data:get("general")
 end
 
-function _M.get_timestamp_data()
-  local timestamp = configuration_data:get("timestamp")
-  if timestamp == nil then
-    timestamp = 1
+function _M.get_raw_backends_last_synced_at()
+  local raw_backends_last_synced_at = configuration_data:get("raw_backends_last_synced_at")
+  if raw_backends_last_synced_at == nil then
+    raw_backends_last_synced_at = 1
   end
-  return timestamp
+  return raw_backends_last_synced_at
 end
 
 local function fetch_request_body()
@@ -185,10 +185,11 @@ local function handle_backends()
     return
   end
 
-  local timestamp = os.time()
-  success, err = configuration_data:set("timestamp", timestamp)
+  ngx.update_time()
+  local raw_backends_last_synced_at = ngx.time()
+  success, err = configuration_data:set("raw_backends_last_synced_at", raw_backends_last_synced_at)
   if not success then
-    ngx.log(ngx.ERR, "dynamic-configuration: error setting sync timestamp: " .. tostring(err))
+    ngx.log(ngx.ERR, "dynamic-configuration: error updating when backends sync, new upstream peers wait for force syncing: " .. tostring(err))
     ngx.status = ngx.HTTP_BAD_REQUEST
     return
   end

--- a/rootfs/etc/nginx/lua/configuration.lua
+++ b/rootfs/etc/nginx/lua/configuration.lua
@@ -17,6 +17,14 @@ function _M.get_general_data()
   return configuration_data:get("general")
 end
 
+function _M.get_timestamp_data()
+  local timestamp = configuration_data:get("timestamp")
+  if timestamp == nil then
+    timestamp = 1
+  end
+  return timestamp
+end
+
 local function fetch_request_body()
   ngx.req.read_body()
   local body = ngx.req.get_body_data()
@@ -173,6 +181,14 @@ local function handle_backends()
   local success, err = configuration_data:set("backends", backends)
   if not success then
     ngx.log(ngx.ERR, "dynamic-configuration: error updating configuration: " .. tostring(err))
+    ngx.status = ngx.HTTP_BAD_REQUEST
+    return
+  end
+
+  local timestamp = os.time()
+  success, err = configuration_data:set("timestamp", timestamp)
+  if not success then
+    ngx.log(ngx.ERR, "dynamic-configuration: error setting sync timestamp: " .. tostring(err))
     ngx.status = ngx.HTTP_BAD_REQUEST
     return
   end

--- a/rootfs/etc/nginx/lua/tcp_udp_balancer.lua
+++ b/rootfs/etc/nginx/lua/tcp_udp_balancer.lua
@@ -17,6 +17,8 @@ local IMPLEMENTATIONS = {
 
 local _M = {}
 local balancers = {}
+local external_backends = {}
+local last_timestamp = 0
 
 local function get_implementation(backend)
   local name = backend["load-balance"] or DEFAULT_LB_ALG
@@ -55,6 +57,12 @@ local function format_ipv6_endpoints(endpoints)
   return formatted_endpoints
 end
 
+local function use_external_name(backend)
+  local serv_type = backend.service and backend.service.spec
+                      and backend.service.spec["type"]
+  return serv_type == "ExternalName"
+end
+
 local function sync_backend(backend)
   if not backend.endpoints or #backend.endpoints == 0 then
     return
@@ -81,8 +89,7 @@ local function sync_backend(backend)
     return
   end
 
-  local service_type = backend.service and backend.service.spec and backend.service.spec["type"]
-  if service_type == "ExternalName" then
+  if use_external_name(backend) then
     backend = resolve_external_names(backend)
   end
 
@@ -92,6 +99,15 @@ local function sync_backend(backend)
 end
 
 local function sync_backends()
+  local timestamp = configuration.get_timestamp_data()
+  if timestamp <= last_timestamp then
+    for _, external_backend in pairs(external_backends) do
+      sync_backend(external_backend)
+    end
+    return
+  end
+  last_timestamp = timestamp
+
   local backends_data = configuration.get_backends_data()
   if not backends_data then
     balancers = {}
@@ -108,11 +124,16 @@ local function sync_backends()
   for _, new_backend in ipairs(new_backends) do
     sync_backend(new_backend)
     balancers_to_keep[new_backend.name] = balancers[new_backend.name]
+    if use_external_name(new_backend) then
+      local external_backend = util.deepcopy(new_backend)
+      external_backends[external_backend.name] = external_backend
+    end
   end
 
   for backend_name, _ in pairs(balancers) do
     if not balancers_to_keep[backend_name] then
       balancers[backend_name] = nil
+      external_backends[backend_name] = nil
     end
   end
 end

--- a/rootfs/etc/nginx/lua/tcp_udp_balancer.lua
+++ b/rootfs/etc/nginx/lua/tcp_udp_balancer.lua
@@ -100,7 +100,7 @@ local function sync_backend(backend)
 end
 
 local function sync_backends()
-  local raw_backends_last_sync = configuration.get_raw_backends_last_synced_at()
+  local raw_backends_last_synced_at = configuration.get_raw_backends_last_synced_at()
   ngx.update_time()
   local current_timestamp = ngx.time()
   if current_timestamp - backends_last_synced_at < BACKENDS_FORCE_SYNC_INTERVAL

--- a/rootfs/etc/nginx/lua/tcp_udp_balancer.lua
+++ b/rootfs/etc/nginx/lua/tcp_udp_balancer.lua
@@ -9,6 +9,7 @@ local round_robin = require("balancer.round_robin")
 -- for an Nginx worker to pick up the new list of upstream peers
 -- it will take <the delay until controller POSTed the backend object to the Nginx endpoint> + BACKENDS_SYNC_INTERVAL
 local BACKENDS_SYNC_INTERVAL = 1
+local BACKENDS_FORCE_SYNC_INTERVAL = 30
 
 local DEFAULT_LB_ALG = "round_robin"
 local IMPLEMENTATIONS = {
@@ -17,8 +18,8 @@ local IMPLEMENTATIONS = {
 
 local _M = {}
 local balancers = {}
-local external_backends = {}
-local last_timestamp = 0
+local backends_with_external_name = {}
+local backends_last_synced_at = 0
 
 local function get_implementation(backend)
   local name = backend["load-balance"] or DEFAULT_LB_ALG
@@ -57,7 +58,7 @@ local function format_ipv6_endpoints(endpoints)
   return formatted_endpoints
 end
 
-local function use_external_name(backend)
+local function is_backend_with_external_name(backend)
   local serv_type = backend.service and backend.service.spec
                       and backend.service.spec["type"]
   return serv_type == "ExternalName"
@@ -89,7 +90,7 @@ local function sync_backend(backend)
     return
   end
 
-  if use_external_name(backend) then
+  if is_backend_with_external_name(backend) then
     backend = resolve_external_names(backend)
   end
 
@@ -99,14 +100,16 @@ local function sync_backend(backend)
 end
 
 local function sync_backends()
-  local timestamp = configuration.get_timestamp_data()
-  if timestamp <= last_timestamp then
-    for _, external_backend in pairs(external_backends) do
-      sync_backend(external_backend)
+  local raw_backends_last_sync = configuration.get_raw_backends_last_synced_at()
+  ngx.update_time()
+  local current_timestamp = ngx.time()
+  if current_timestamp - backends_last_synced_at < BACKENDS_FORCE_SYNC_INTERVAL
+      and raw_backends_last_synced_at <= backends_last_synced_at then
+    for _, backend_with_external_name in pairs(backends_with_external_name) do
+      sync_backend(backend_with_external_name)
     end
     return
   end
-  last_timestamp = timestamp
 
   local backends_data = configuration.get_backends_data()
   if not backends_data then
@@ -124,18 +127,19 @@ local function sync_backends()
   for _, new_backend in ipairs(new_backends) do
     sync_backend(new_backend)
     balancers_to_keep[new_backend.name] = balancers[new_backend.name]
-    if use_external_name(new_backend) then
-      local external_backend = util.deepcopy(new_backend)
-      external_backends[external_backend.name] = external_backend
+    if is_backend_with_external_name(new_backend) then
+      local backend_with_external_name = util.deepcopy(new_backend)
+      backends_with_external_name[backend_with_external_name.name] = backend_with_external_name
     end
   end
 
   for backend_name, _ in pairs(balancers) do
     if not balancers_to_keep[backend_name] then
       balancers[backend_name] = nil
-      external_backends[backend_name] = nil
+      backends_with_external_name[backend_name] = nil
     end
   end
+  backends_last_synced_at = raw_backends_last_synced_at
 end
 
 local function get_balancer()

--- a/rootfs/etc/nginx/lua/tcp_udp_configuration.lua
+++ b/rootfs/etc/nginx/lua/tcp_udp_configuration.lua
@@ -46,7 +46,8 @@ function _M.call()
   local raw_backends_last_synced_at = ngx.time()
   success, err = tcp_udp_configuration_data:set("raw_backends_last_synced_at", raw_backends_last_synced_at)
   if not success then
-    ngx.log(ngx.ERR, "dynamic-configuration: error updating when backends sync, new upstream peers wait for force syncing: " .. tostring(err))
+    ngx.log(ngx.ERR, "dynamic-configuration: error updating when backends sync, " ..
+                     "new upstream peers waiting for force syncing: " .. tostring(err))
     ngx.status = ngx.HTTP_BAD_REQUEST
     return
   end

--- a/rootfs/etc/nginx/lua/tcp_udp_configuration.lua
+++ b/rootfs/etc/nginx/lua/tcp_udp_configuration.lua
@@ -7,6 +7,14 @@ function _M.get_backends_data()
   return tcp_udp_configuration_data:get("backends")
 end
 
+function _M.get_timestamp_data()
+  local timestamp = tcp_udp_configuration_data:get("timestamp")
+  if timestamp == nil then
+    timestamp = 1
+  end
+  return timestamp
+end
+
 function _M.call()
   local sock, err = ngx.req.socket(true)
   if not sock then
@@ -31,6 +39,14 @@ function _M.call()
   if not success then
     ngx.log(ngx.ERR, "dynamic-configuration: error updating configuration: " .. tostring(err_conf))
     ngx.say("error: ", err_conf)
+    return
+  end
+
+  local timestamp = os.time()
+  success, err = tcp_udp_configuration_data:set("timestamp", timestamp)
+  if not success then
+    ngx.log(ngx.ERR, "dynamic-configuration: error setting sync timestamp: " .. tostring(err))
+    ngx.status = ngx.HTTP_BAD_REQUEST
     return
   end
 end

--- a/rootfs/etc/nginx/lua/tcp_udp_configuration.lua
+++ b/rootfs/etc/nginx/lua/tcp_udp_configuration.lua
@@ -7,12 +7,12 @@ function _M.get_backends_data()
   return tcp_udp_configuration_data:get("backends")
 end
 
-function _M.get_timestamp_data()
-  local timestamp = tcp_udp_configuration_data:get("timestamp")
-  if timestamp == nil then
-    timestamp = 1
+function _M.get_raw_backends_last_synced_at_data()
+  local raw_backends_last_synced_at = tcp_udp_configuration_data:get("raw_backends_last_synced_at")
+  if raw_backends_last_synced_at == nil then
+    raw_backends_last_synced_at = 1
   end
-  return timestamp
+  return raw_backends_last_synced_at
 end
 
 function _M.call()
@@ -42,10 +42,11 @@ function _M.call()
     return
   end
 
-  local timestamp = os.time()
-  success, err = tcp_udp_configuration_data:set("timestamp", timestamp)
+  ngx.update_time()
+  local raw_backends_last_synced_at = ngx.time()
+  success, err = tcp_udp_configuration_data:set("raw_backends_last_synced_at", raw_backends_last_synced_at)
   if not success then
-    ngx.log(ngx.ERR, "dynamic-configuration: error setting sync timestamp: " .. tostring(err))
+    ngx.log(ngx.ERR, "dynamic-configuration: error updating when backends sync, new upstream peers wait for force syncing: " .. tostring(err))
     ngx.status = ngx.HTTP_BAD_REQUEST
     return
   end


### PR DESCRIPTION
The PR records a timestamp in nginx shared configuration when API "/configuration/backends" is called by ingress controller. Every second each nginx worker checks whether it is necessary to sync non-external backends.

## What this PR does / why we need it:
In our Kubernetes cluster with thousands of service and ingress resources, each of nginx workers syncing backends every second leads to quite heavy load for CPUs. In my testing environment with no input requests, impact on cpu usage is showed as below. Heavy CPU load also seriously affects request time of Biz APIs.
Although it is necessary to sync backends of services using ExternalName since DNS may change anytime, frequent sync of non-external backends can be avoided. 
![cpu_usage_by_svc_num](https://user-images.githubusercontent.com/2732728/80129921-61dd4300-85ca-11ea-8310-296dc8c6818c.JPG)

## Types of changes
I'm not sure about the type of change, but how dynamic LB works internally is actually modified. Perhaps Breaking change?
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
Create N ingress rules and corresponding N non-ExternalName services. Each ingress rule makes a route to one of the services. Without the patch, when N is large, each nginx worker runs out much of its CPU core as the figure above shows.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
