### PR TITLE
Case-insensitive TLS host matching

### DIFF
--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -1351,9 +1351,12 @@ func extractTLSSecretName(host string, ing *ingress.Ingress,
 	}
 
 	// naively return Secret name from TLS spec if host name matches
+	lowercaseHost := toLowerCaseASCII(host)
 	for _, tls := range ing.Spec.TLS {
-		if sets.NewString(tls.Hosts...).Has(host) {
-			return tls.SecretName
+		for _, tlsHost := range tls.Hosts {
+			if toLowerCaseASCII(tlsHost) == lowercaseHost {
+				return tls.SecretName
+			}
 		}
 	}
 

--- a/internal/ingress/controller/controller_test.go
+++ b/internal/ingress/controller/controller_test.go
@@ -818,6 +818,33 @@ func TestExtractTLSSecretName(t *testing.T) {
 			},
 			"demo",
 		},
+		"ingress tls, hosts, matching cert cn, uppercase host": {
+			"FOO.BAR",
+			&ingress.Ingress{
+				Ingress: networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test",
+					},
+					Spec: networking.IngressSpec{
+						TLS: []networking.IngressTLS{
+							{
+								Hosts:      []string{"foo.bar", "example.com"},
+								SecretName: "demo",
+							},
+						},
+						Rules: []networking.IngressRule{
+							{
+								Host: "foo.bar",
+							},
+						},
+					},
+				},
+			},
+			func(string) (*ingress.SSLCert, error) {
+				return nil, nil
+			},
+			"demo",
+		},
 	}
 
 	for title, tc := range testCases {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Right now, TLS host comparison is implemented as case-sensitive. For example, compressed QR codes of [alphanumeric type](https://en.wikipedia.org/wiki/QR_code#Storage) only allow uppercase letters, and therefore a URL contained in a QR code might also be requested as-is (with uppercase domain name and query) depending on the client. DNS/X509-related RFCs state that comparison must be case-insensitive for the ASCII human-readable character range. That is already the case for [`VerifyHostname`](https://golang.org/src/crypto/x509/verify.go) and correctly implemented for certificate SAN/CN matching, but the controller also first has to match the host against an ingress rule. This PR fixes the comparison.

Before the fix:

```
$ echo | openssl s_client -connect my-host:443 -servername my-host | grep subject=
[...]
subject=/...the expected certificate.../CN=my-host

$ echo | openssl s_client -connect my-host:443 -servername MY-HOST | grep subject=
[...]
subject=/O=Acme Co/CN=Kubernetes Ingress Controller Fake Certificate
```

There is no obvious workaround to accept uppercase host names:

```
The Ingress "my-ingress" is invalid: spec.tls[1].hosts: Invalid value: "SOME-UPPERCASE-HOST": a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

New unit test which was failing before the fix

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
