### PR TITLE
Fix helper for defaultbackend name

### DIFF
--- a/charts/ingress-nginx/templates/_helpers.tpl
+++ b/charts/ingress-nginx/templates/_helpers.tpl
@@ -58,7 +58,7 @@ Create a default fully qualified default backend name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "ingress-nginx.defaultBackend.fullname" -}}
-{{- printf "%s-%s" (include "ingress-nginx.fullname" .) .Values.defaultBackend.name | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s" (include "ingress-nginx.fullname" .) "defaultbackend" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
Signed-off-by: nicklasfrahm <nicklas.frahm@gmail.com>

Installing the helm chart fails with the following error if the defaultBackend is enabled:
```shell
$ helm install --set defaultBackend.enabled=yes ingress-nginx charts/ingress-nginx/
Error: rendered manifests contain a resource that already exists. Unable to continue with install: could not get information about the resource: invalid resource name "ingress-nginx-%!s(<nil>)": [may not contain '%']
```

The problem can be found by running:
```shell
$ helm template --set defaultBackend.enabled=yes ingress-nginx charts/ingress-nginx/ > template.yml
$ cat template.yml | grep "%"
  name: ingress-nginx-%!s(<nil>)
            - --default-backend-service=default/ingress-nginx-%!s(<nil>)
  name: ingress-nginx-%!s(<nil>)
```

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This will ensure that the helm chart installs with the default `values.yaml`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested by help of the aforementioned `helm template` command.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
