### PR TITLE
Remove noisy dns log

### DIFF
--- a/rootfs/etc/nginx/lua/util/dns.lua
+++ b/rootfs/etc/nginx/lua/util/dns.lua
@@ -53,8 +53,6 @@ local function a_records_and_min_ttl(answers)
 end
 
 local function resolve_host_for_qtype(r, host, qtype)
-  ngx_log(ngx_INFO, string_format("resolving %s with qtype %s", host, qtype))
-
   local answers, err = r:query(host, { qtype = qtype }, {})
   if not answers then
     return nil, -1, err


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:

Removes OCSP queries from the log

> 2020/04/23 02:12:26 [info] 194#194: *459665 [lua] dns.lua:56: resolve_host_for_qtype(): resolving ocsp.int-x3.letsencrypt.org.svc.cluster.local with qtype 1, context: ngx.timer, client: 44.233.116.55, server: 0.0.0.0:443

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
