### PR TITLE
Update admission webhook image

### DIFF
--- a/charts/ingress-nginx/README.md
+++ b/charts/ingress-nginx/README.md
@@ -164,7 +164,7 @@ Parameter | Description | Default
 `controller.admissionWebhooks.service.type` | Type of admission webhook service to create | `ClusterIP`
 `controller.admissionWebhooks.patch.enabled` | If true, will use a pre and post install hooks to generate a CA and certificate to use for the prometheus operator tls proxy, and patch the created webhooks with the CA. | `true`
 `controller.admissionWebhooks.patch.image.repository` | Repository to use for the webhook integration jobs | `jettech/kube-webhook-certgen`
-`controller.admissionWebhooks.patch.image.tag` |  Tag to use for the webhook integration jobs | `v1.0.0`
+`controller.admissionWebhooks.patch.image.tag` |  Tag to use for the webhook integration jobs | `v1.2.0`
 `controller.admissionWebhooks.patch.image.pullPolicy` | Image pull policy for the webhook integration jobs | `IfNotPresent`
 `controller.admissionWebhooks.patch.priorityClassName` | Priority class for the webhook integration jobs | `""`
 `controller.admissionWebhooks.patch.podAnnotations` | Annotations for the webhook job pods | `{}`

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -365,7 +365,7 @@ controller:
       enabled: true
       image:
         repository: jettech/kube-webhook-certgen
-        tag: v1.0.0
+        tag: v1.2.0
         pullPolicy: IfNotPresent
       ## Provide a priority class name to the webhook patching job
       ##

--- a/deploy/static/provider/aws/deploy-tls-termination.yaml
+++ b/deploy/static/provider/aws/deploy-tls-termination.yaml
@@ -539,7 +539,7 @@ spec:
     spec:
       containers:
         - name: create
-          image: jettech/kube-webhook-certgen:v1.0.0
+          image: jettech/kube-webhook-certgen:v1.2.0
           imagePullPolicy: IfNotPresent
           args:
             - create
@@ -582,7 +582,7 @@ spec:
     spec:
       containers:
         - name: patch
-          image: jettech/kube-webhook-certgen:v1.0.0
+          image: jettech/kube-webhook-certgen:v1.2.0
           imagePullPolicy:
           args:
             - patch

--- a/deploy/static/provider/aws/deploy.yaml
+++ b/deploy/static/provider/aws/deploy.yaml
@@ -527,7 +527,7 @@ spec:
     spec:
       containers:
         - name: create
-          image: jettech/kube-webhook-certgen:v1.0.0
+          image: jettech/kube-webhook-certgen:v1.2.0
           imagePullPolicy: IfNotPresent
           args:
             - create
@@ -570,7 +570,7 @@ spec:
     spec:
       containers:
         - name: patch
-          image: jettech/kube-webhook-certgen:v1.0.0
+          image: jettech/kube-webhook-certgen:v1.2.0
           imagePullPolicy:
           args:
             - patch

--- a/deploy/static/provider/baremetal/deploy.yaml
+++ b/deploy/static/provider/baremetal/deploy.yaml
@@ -520,7 +520,7 @@ spec:
     spec:
       containers:
         - name: create
-          image: jettech/kube-webhook-certgen:v1.0.0
+          image: jettech/kube-webhook-certgen:v1.2.0
           imagePullPolicy: IfNotPresent
           args:
             - create
@@ -563,7 +563,7 @@ spec:
     spec:
       containers:
         - name: patch
-          image: jettech/kube-webhook-certgen:v1.0.0
+          image: jettech/kube-webhook-certgen:v1.2.0
           imagePullPolicy:
           args:
             - patch

--- a/deploy/static/provider/cloud/deploy.yaml
+++ b/deploy/static/provider/cloud/deploy.yaml
@@ -522,7 +522,7 @@ spec:
     spec:
       containers:
         - name: create
-          image: jettech/kube-webhook-certgen:v1.0.0
+          image: jettech/kube-webhook-certgen:v1.2.0
           imagePullPolicy: IfNotPresent
           args:
             - create
@@ -565,7 +565,7 @@ spec:
     spec:
       containers:
         - name: patch
-          image: jettech/kube-webhook-certgen:v1.0.0
+          image: jettech/kube-webhook-certgen:v1.2.0
           imagePullPolicy:
           args:
             - patch

--- a/deploy/static/provider/kind/deploy.yaml
+++ b/deploy/static/provider/kind/deploy.yaml
@@ -533,7 +533,7 @@ spec:
     spec:
       containers:
         - name: create
-          image: jettech/kube-webhook-certgen:v1.0.0
+          image: jettech/kube-webhook-certgen:v1.2.0
           imagePullPolicy: IfNotPresent
           args:
             - create
@@ -576,7 +576,7 @@ spec:
     spec:
       containers:
         - name: patch
-          image: jettech/kube-webhook-certgen:v1.0.0
+          image: jettech/kube-webhook-certgen:v1.2.0
           imagePullPolicy:
           args:
             - patch


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
Update the admission webhook image to v1.2.0.

jettech/kube-webhook-certgen:v1.0.0 -> jettech/kube-webhook-certgen:v1.2.0

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The currently used tag is amd64 only. Updating makes using ingress-nginx on arm nodes easier.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
Image update

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on arm64 cluster. I downloaded the baremetal manifest, updated the tags and applied the manifest.
Ingress-nginx successfully came up.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
