### PR TITLE
Actually enable TLSv1.3 by default

### DIFF
--- a/docs/user-guide/nginx-configuration/configmap.md
+++ b/docs/user-guide/nginx-configuration/configmap.md
@@ -516,9 +516,11 @@ Please check the result of the configuration using `https://ssllabs.com/ssltest/
 
 ## ssl-early-data
 
-Enables or disables TLS 1.3 [early data](https://tools.ietf.org/html/rfc8446#section-2.3)
+Enables or disables TLS 1.3 [early data](https://tools.ietf.org/html/rfc8446#section-2.3), also known as Zero Round Trip
+Time Resumption (0-RTT).
 
-This requires `ssl-protocols` to have `TLSv1.3` enabled.
+This requires `ssl-protocols` to have `TLSv1.3` enabled. Enable this with caution, because requests sent within early
+data are subject to [replay attacks](https://tools.ietf.org/html/rfc8470).
 
 [ssl_early_data](http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_early_data). The default is: `false`.
 

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -70,7 +70,7 @@ const (
 
 	// SSL enabled protocols to use
 	// http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_protocols
-	sslProtocols = "TLSv1.2"
+	sslProtocols = "TLSv1.2 TLSv1.3"
 
 	// Disable TLS 1.3 early data
 	// http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_early_data

--- a/test/e2e/settings/tls.go
+++ b/test/e2e/settings/tls.go
@@ -64,7 +64,10 @@ var _ = framework.DescribeSetting("[SSL] TLS protocols, ciphers and headers)", f
 		})
 
 		ginkgo.It("setting cipher suite", func() {
-			f.UpdateNginxConfigMapData(sslCiphers, testCiphers)
+			f.SetNginxConfigMapData(map[string]string{
+				sslCiphers:   testCiphers,
+				sslProtocols: "TLSv1.2",
+			})
 
 			f.WaitForNginxConfiguration(
 				func(cfg string) bool {


### PR DESCRIPTION
## What this PR does / why we need it:

Fix for 049b25e566862c627b16a1698ebe68fc1e5b20b2 (#5358) which mistakenly only updated documentation.

## Types of changes

New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested these settings using the settings ConfigMap.

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.