### PR TITLE
Add configuration option for the runAsUser parameter of the webhook patch job

### DIFF
--- a/charts/ingress-nginx/templates/admission-webhooks/job-patch/job-createSecret.yaml
+++ b/charts/ingress-nginx/templates/admission-webhooks/job-patch/job-createSecret.yaml
@@ -43,5 +43,5 @@ spec:
     {{- end }}
       securityContext:
         runAsNonRoot: true
-        runAsUser: {{ .Values.controller.admissionWebhooks.patch.image.runAsUser }}
+        runAsUser: {{ .Values.controller.admissionWebhooks.patch.runAsUser }}
 {{- end }}

--- a/charts/ingress-nginx/templates/admission-webhooks/job-patch/job-createSecret.yaml
+++ b/charts/ingress-nginx/templates/admission-webhooks/job-patch/job-createSecret.yaml
@@ -43,5 +43,5 @@ spec:
     {{- end }}
       securityContext:
         runAsNonRoot: true
-        runAsUser: 2000
+        runAsUser: {{ .Values.controller.admissionWebhooks.patch.image.runAsUser }}
 {{- end }}

--- a/charts/ingress-nginx/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
+++ b/charts/ingress-nginx/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
@@ -45,5 +45,5 @@ spec:
     {{- end }}
       securityContext:
         runAsNonRoot: true
-        runAsUser: 2000
+        runAsUser: {{ .Values.controller.admissionWebhooks.patch.image.runAsUser }}
 {{- end }}

--- a/charts/ingress-nginx/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
+++ b/charts/ingress-nginx/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
@@ -45,5 +45,5 @@ spec:
     {{- end }}
       securityContext:
         runAsNonRoot: true
-        runAsUser: {{ .Values.controller.admissionWebhooks.patch.image.runAsUser }}
+        runAsUser: {{ .Values.controller.admissionWebhooks.patch.runAsUser }}
 {{- end }}

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -362,12 +362,12 @@ controller:
         repository: jettech/kube-webhook-certgen
         tag: v1.2.0
         pullPolicy: IfNotPresent
-        runAsUser: 2000
       ## Provide a priority class name to the webhook patching job
       ##
       priorityClassName: ""
       podAnnotations: {}
       nodeSelector: {}
+      runAsUser: 2000
 
   metrics:
     port: 10254

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -362,6 +362,7 @@ controller:
         repository: jettech/kube-webhook-certgen
         tag: v1.2.0
         pullPolicy: IfNotPresent
+        runAsUser: 2000
       ## Provide a priority class name to the webhook patching job
       ##
       priorityClassName: ""


### PR DESCRIPTION
## What this PR does / why we need it:
The value of `runAsUser` in the webhook patch jobs was not configurable via the values.yaml. 
Configurability means more flexibility in environments where the legal range of users is defined by an admin.
The default value remained the one used so far: 2000
Other appearances of the runAsUser are already configurable via the values.yaml

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes

## How Has This Been Tested?

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
