### PR TITLE
build: remove unnecessary tag line in e2e

### DIFF
--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -99,7 +99,6 @@ else
   exit
 fi
 
-# Remove after https://github.com/kubernetes/ingress-nginx/pull/4271 is merged
 docker tag ${REGISTRY}/nginx-ingress-controller-${ARCH}:${TAG} ${REGISTRY}/nginx-ingress-controller:${TAG}
 
 # Preload images used in e2e tests


### PR DESCRIPTION


Signed-off-by: Christopher M. Luciano <cmluciano@us.ibm.com>

<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
The comment on this block states that this line should be removed
after the multi-arch image action is merged in the Makefile.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
#4271 was merged in July 2019.

## How Has This Been Tested?
- e2e tests should be unaffected

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
