### PR TITLE
Add MaxMind GeoIP2 Anonymous IP support

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -211,11 +211,21 @@ http {
         $geoip2_isp_org organization;
     }
     {{ end }}
+
     {{ if eq $file "GeoIP2-Connection-Type.mmdb" }}
     geoip2 /etc/nginx/geoip/GeoIP2-Connection-Type.mmdb {
         $geoip2_connection_type connection_type;
     }
     {{ end }}
+
+    {{ if eq $file "GeoIP2-Anonymous-IP.mmdb" }}
+    geoip2 /etc/nginx/geoip/GeoIP2-Anonymous-IP.mmdb {
+        $geoip2_is_anon source=$remote_addr is_anonymous;
+        $geoip2_is_hosting_provider source=$remote_addr is_hosting_provider;
+        $geoip2_is_public_proxy source=$remote_addr is_public_proxy;
+    }
+    {{ end }}
+
     {{ end }}
 
     {{ end }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The NGINX Ingress Controller already [has extensive support for many MaxMind's GeoIP2 databases](https://github.com/foxdalas/ingress-nginx/blob/master/rootfs/etc/nginx/template/nginx.tmpl#L150-L219). It is, however, missing support for another crucial MaxMind GeoIP2 database, the [GeoIP2 Anonymous IP database](https://www.maxmind.com/en/solutions/geoip2-enterprise-product-suite/anonymous-ip-database). This PR adds support for it in a way that conforms to the way other MaxMind databases are supported.

For those with licence to the GeoIP2 Anonymous IP database, an additional entry to `--maxmind-edition-ids` can be supplied as such:
```
--maxmind-edition-ids="GeoLite2-City,GeoLite2-ASN,GeoIP2-Anonymous-IP"
```
This will trigger the [existing database download and checking flow](https://github.com/kubernetes/ingress-nginx/blob/master/internal/nginx/maxmind.go). If the database is downloaded successfully or is made available with a mounted volume, this PR exposes 3 new variables: `$geoip2_is_anon`, `$geoip2_is_hosting_provider`, and `$geoip2_is_public_proxy`. Those variables can then be freely used in a `ConfigMap` to add further functionality, such as annotating logs or blocking requests altogether.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With the new template loaded, new `proxy_set_header` lines to the deployment's `config.yaml` were added as such:
```
proxy_set_header X-Is-Anon $geoip2_is_anon;
proxy_set_header X-Is-Hosting-Provider $geoip2_is_hosting_provider;
proxy_set_header X-Is-Public-Proxy $geoip2_is_public_proxy;
```
After deployment, requests from AWS EC2 and Tor were sent to one of the Ingress endpoints. The forwarded requests were observed to have the correct header values indicating that the requests were "anonymous" or came from a hosting provider.
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
