### PR TITLE
Do not reload NGINX if master process dies

### DIFF
--- a/internal/ingress/controller/nginx.go
+++ b/internal/ingress/controller/nginx.go
@@ -343,17 +343,10 @@ func (n *NGINXController) Start() {
 			// issues because of this behavior.
 			// To avoid this issue we restart nginx in case of errors.
 			if process.IsRespawnIfRequired(err) {
-				process.WaitUntilPortIsAvailable(n.cfg.ListenPorts.HTTP)
 				// release command resources
-				cmd.Process.Release()
-				// start a new nginx master process if the controller is not being stopped
-				cmd = n.command.ExecCommand()
-				cmd.SysProcAttr = &syscall.SysProcAttr{
-					Setpgid: true,
-					Pgid:    0,
-				}
-				n.start(cmd)
+				return
 			}
+
 		case event := <-n.updateCh.Out():
 			if n.isShuttingDown {
 				break


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:

When the NGINX process dies, for any reason, we start a new one. From the report in #5587, that I can reproduce I see the issue is the lua configuration is not sent and that means the lua load balancer is not initialized. The error in the report shows the SSL certificate returned is the fake one because the certificate already exists and the nginx.conf file is valid but none of the lua objects are there.
Before this change the health-checks start failing and the pod is restarted after a couple of seconds. With these changes there is no reload.

Note: health check failures are not displayed in the default log level (k8s code) because of security reason (could leak private information)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes

fixes #5587

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
