### PR TITLE
Add prometheus annotations documentation

### DIFF
--- a/docs/user-guide/monitoring.md
+++ b/docs/user-guide/monitoring.md
@@ -23,6 +23,11 @@ Running the following command deploys prometheus in Kubernetes:
 kubectl apply --kustomize github.com/kubernetes/ingress-nginx/deploy/prometheus/
 ```
 
+You will also need to configure `ingress-nginx-controller` deployment to be monitored by Prometheus by setting following Kubernetes annotations:
+
+- `prometheus.io/scrape` to `true` to enable monitoring
+- `prometheus.io/port` to `10254` port of the metrics endpoint
+
 ### Prometheus Dashboard
 
 Open Prometheus dashboard in a web browser:


### PR DESCRIPTION
I am new to prometheus and grafana, I walked through https://kubernetes.github.io/ingress-nginx/user-guide/monitoring/ quite quickly and then got stuck figuring out why there are no metrics, then I found `charts/ingress-nginx/values.yaml` that has commented out lines with `prometheus.io/port` and `prometheus.io/scrape`. At the end I updated the deployment with these annotations and the metrics started showing up ✨✨✨. I have updated the documentation to point out that these annotations should be there.

Maybe there is an easier way to get this working?

```diff
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
     ...
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
   ...
   template:
     metadata:
       labels:
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/instance: ingress-nginx
         app.kubernetes.io/component: controller
+      annotations:
+        prometheus.io/port: "10254"
+        prometheus.io/scrape: "true"
 ...
```