### PR TITLE
fix oauth2-proxy image repository

### DIFF
--- a/docs/examples/auth/oauth-external-auth/oauth2-proxy.yaml
+++ b/docs/examples/auth/oauth-external-auth/oauth2-proxy.yaml
@@ -31,7 +31,7 @@ spec:
         # docker run -ti --rm python:3-alpine python -c 'import secrets,base64; print(base64.b64encode(base64.b64encode(secrets.token_bytes(16))));'
         - name: OAUTH2_PROXY_COOKIE_SECRET
           value: SECRET
-        image: quay.io/pusher/oauth2_proxy:latest
+        image: quay.io/oauth2-proxy/oauth2-proxy:latest
         imagePullPolicy: Always
         name: oauth2-proxy
         ports:


### PR DESCRIPTION
Fix oauth2-proxy image repository

## What this PR does / why we need it:
oauth2-proxy([used here](https://github.com/kubernetes/ingress-nginx/tree/master/docs/examples/auth/oauth-external-auth)) project change container image hosting repository.(https://github.com/oauth2-proxy/oauth2-proxy/pull/464)
Please fix container image place on example resource.


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
