### PR TITLE
Fix MaxWorkerOpenFiles calculation on high cores nodes

### DIFF
--- a/internal/ingress/controller/nginx.go
+++ b/internal/ingress/controller/nginx.go
@@ -531,12 +531,7 @@ func (n NGINXController) generateTemplate(cfg ngx_config.Configuration, ingressC
 	if cfg.MaxWorkerOpenFiles == 0 {
 		// the limit of open files is per worker process
 		// and we leave some room to avoid consuming all the FDs available
-		wp, err := strconv.Atoi(cfg.WorkerProcesses)
-		klog.V(3).Infof("Number of worker processes: %d", wp)
-		if err != nil {
-			wp = 1
-		}
-		maxOpenFiles := (rlimitMaxNumFiles() / wp) - 1024
+		maxOpenFiles := rlimitMaxNumFiles() - 1024
 		klog.V(3).Infof("Maximum number of open file descriptors: %d", maxOpenFiles)
 		if maxOpenFiles < 1024 {
 			// this means the value of RLIMIT_NOFILE is too low.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
### Problem
Default MaxWorkerOpenFiles value becomes too low on high spec nodes with multiple of cores.
As workaround it always possible to provide exact value through configMap: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#max-worker-open-files

### Description
Currently max opened files is calculated based on `RLIMIT_NOFILE` divided on amount of working processes.
https://github.com/kubernetes/ingress-nginx/blob/07b70f68bd9b4367c5266ec2cb068f97e4a5b40a/internal/ingress/controller/nginx.go#L539-L544

Working processes is calculated based on amount of cores.
https://github.com/kubernetes/ingress-nginx/blob/bef2efc4f303b728b9f5ef9326fbcd25376d5e6b/internal/ingress/controller/config/config.go#L751

Our example:
```
$ sysctl fs.file-max
fs.file-max = 6506158
$ ulimit -Sn
65536
$ ulimit -Hn
65536
$ lscpu  | grep 'CPU(s)' | head -n 1
CPU(s):              40
```

As a result, we have `65536  / 40 - 1024 = 614.4`. This is less than `1024`, so `1024` is actually used. 
This value is too small for single worker on heavy loaded server with thousands total connections.

### Solution
Since RLIMIT_NOFILE is already a value for single process, there's no need divide for worker_processes.

<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->
Related issues and PRs:
* https://github.com/kubernetes/ingress-nginx/issues/2055 - similar problem
* https://github.com/kubernetes/ingress-nginx/issues/2157 - similar problem
* https://github.com/kubernetes/ingress-nginx/pull/2050 (this tries use Global value of max opened files)
* https://github.com/kubernetes/ingress-nginx/pull/2241 (this reverts that change and per-process value of max opened files)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
