### PR TITLE
Add documentation for loading e2e tests without using minikube

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -79,12 +79,11 @@ The e2e test image can also be built through the Makefile.
 $ make -C test/e2e-image image
 ```
 
-You can then make this image available on your minikube host by exporting the image and loading it with the minikube docker context:
+Then you can load the docker image using kind: 
 
 ```console
-$ docker save nginx-ingress-controller:e2e |  (eval $(minikube docker-env) && docker load)
+$ kind load docker-image --name="ingress-nginx-dev" nginx-ingress-controller:e2e
 ```
-
 
 ### Nginx Controller
 
@@ -125,7 +124,12 @@ If you have access to a Kubernetes cluster, you can also run e2e tests using gin
 
 ```console
 $ cd $GOPATH/src/k8s.io/ingress-nginx
-$ make e2e-test
+$ KIND_CLUSTER_NAME="ingress-nginx-test" make kind-e2e-test
+```
+To set focus to a particular set of tests, a FOCUS flag can be set.
+
+```console
+KIND_CLUSTER_NAME="ingress-nginx-test" FOCUS="no-auth-locations" make kind-e2e-test
 ```
 
 NOTE: if your e2e pod keeps hanging in an ImagePullBackoff, make sure you've made your e2e nginx-ingress-controller image available to minikube as explained in the **Building the e2e test image** section


### PR DESCRIPTION
Use Kind to build the e2e test image and subsequently run the tests

<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The current documentation builds the e2e tests in a minikube context, but will be problematic if the environment wasn't set up with minikube. 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation change

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Documentation changes, no tests
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide

