### PR TITLE
WIP: [#4479] Add stream-snippet as a ConfigMap option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ images/fastcgi-helloserver/rootfs/fastcgi-helloserver
 cmd/plugin/release/ingress-nginx.yaml
 cmd/plugin/release/*.tar.gz
 cmd/plugin/release/LICENSE
+

--- a/docs/development.md
+++ b/docs/development.md
@@ -5,6 +5,13 @@ It includes how to build, test, and release ingress controllers.
 
 ## Quick Start
 
+### Prerequisites
+1. Go >= 1.13
+2. Docker >= 19.0.3
+2. Helm 3
+3. [Kind](https://kind.sigs.k8s.io/) 
+4. [Parallel](https://www.gnu.org/software/parallel/)
+
 ### Getting the code
 
 The code must be checked out as a subdirectory of k8s.io, and not github.com.
@@ -20,6 +27,8 @@ cd ingress-nginx
 ### Initial developer environment build
 
 Ensure docker experimental features option is enabled for [buildx](https://docs.docker.com/buildx/working-with-buildx/)
+
+> In addition to enabling server experimental feature, the CLI experimental features should also be enabled for buildx to work.
 
 ```
 $ make dev-env

--- a/docs/user-guide/nginx-configuration/configmap.md
+++ b/docs/user-guide/nginx-configuration/configmap.md
@@ -141,6 +141,7 @@ The following table shows a configuration option's name, type, and the default v
 |[datadog-sample-rate](#datadog-sample-rate)|float|1.0|
 |[main-snippet](#main-snippet)|string|""|
 |[http-snippet](#http-snippet)|string|""|
+|[stream-snippet](#stream-snippet)|string|""|
 |[server-snippet](#server-snippet)|string|""|
 |[location-snippet](#location-snippet)|string|""|
 |[custom-http-errors](#custom-http-errors)|[]int|[]int{}|
@@ -844,6 +845,10 @@ Adds custom configuration to the main section of the nginx configuration.
 ## http-snippet
 
 Adds custom configuration to the http section of the nginx configuration.
+
+## stream-snippet
+
+Adds custom configuration to the stream section of the nginx configuration
 
 ## server-snippet
 

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -582,6 +582,9 @@ type Configuration struct {
 	// HTTPSnippet adds custom configuration to the http section of the nginx configuration
 	HTTPSnippet string `json:"http-snippet"`
 
+	// StreamSnippet adds custom configuration to the stream section of the nginx configuration
+	StreamSnippet string `json:"stream-snippet"`
+
 	// ServerSnippet adds custom configuration to all the servers in the nginx configuration
 	ServerSnippet string `json:"server-snippet"`
 

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -702,6 +702,11 @@ stream {
 
     error_log  {{ $cfg.ErrorLogPath }};
 
+    {{ if not (empty $cfg.StreamSnippet) }}
+    # Custom code snippet configured in the configuration configmap
+    {{ $cfg.StreamSnippet }}
+    {{ end }}
+
     upstream upstream_balancer {
         server 0.0.0.1:1234; # placeholder
 

--- a/test/e2e/settings/stream_snippet.go
+++ b/test/e2e/settings/stream_snippet.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package settings
+
+import (
+	"strings"
+
+	"github.com/onsi/ginkgo"
+
+	"k8s.io/ingress-nginx/test/e2e/framework"
+)
+
+var _ = framework.DescribeSetting("stream-snippet", func() {
+	f := framework.NewDefaultFramework("stream-snippet")
+	streamSnippet := "stream-snippet"
+
+	ginkgo.It("should add value of stream-snippet setting to nginx config", func() {
+		expectedComment := "# stream snippet"
+		f.UpdateNginxConfigMapData(streamSnippet, expectedComment)
+
+		f.WaitForNginxConfiguration(
+			func(cfg string) bool {
+				return strings.Contains(cfg, expectedComment)
+			})
+	})
+})


### PR DESCRIPTION
## What this PR does / why we need it:
This would make it possible to define extra configuration for the `stream`
context through the ConfigMap. An e2e test is added similar to the
existing `main-snippet` config option.

Additionally, this commit fills a few documentation gaps in the
development guide, found during testing the above change.

This resolves #4479 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
This resolves #4479 

## How Has This Been Tested?
Added an e2e test named `test/e2e/settings/stream_snippet.go`  and ran the end to end tests following the steps described in [development guide](https://github.com/kubernetes/ingress-nginx/blob/master/docs/development.md). All selected tests passed.

```
Ran 267 of 271 Specs in 929.406 seconds
SUCCESS! -- 267 Passed | 0 Failed | 0 Flaked | 0 Pending | 4 Skipped
```

>This PR is still WIP since I'm doing a final round of testing with a deployment on K8s. I will remove the status once the functional test passes.

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
