### PR TITLE
Webhook: admit ingress failed when the same path and host has defined

### DIFF
--- a/internal/ingress/controller/controller_test.go
+++ b/internal/ingress/controller/controller_test.go
@@ -200,6 +200,28 @@ func TestCheckIngress(t *testing.T) {
 		}
 	})
 
+	t.Run("When the ingress host path has defined", func(t *testing.T) {
+		ing.ObjectMeta.Annotations["kubernetes.io/ingress.class"] = "nginx"
+		nginx.store = fakeIngressStore{
+			ingresses: []*ingress.Ingress{
+				{
+					Ingress:           *ing.DeepCopy(),
+					ParsedAnnotations: &annotations.Ingress{},
+				},
+			},
+		}
+		testIng := ing.DeepCopy()
+		testIng.Name = "other-ingress"
+		nginx.command = testNginxTestCommand{
+			t:        t,
+			err:      fmt.Errorf("test error"),
+			expected: "_,example.com",
+		}
+		if nginx.CheckIngress(testIng) == nil {
+			t.Errorf("with a new ingress with same host path defined, an error should be returned")
+		}
+	})
+
 	t.Run("when the class is the nginx one", func(t *testing.T) {
 		ing.ObjectMeta.Annotations["kubernetes.io/ingress.class"] = "nginx"
 		nginx.command = testNginxTestCommand{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->
fix: https://github.com/kubernetes/ingress-nginx/issues/5651

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
