### PR TITLE
fix undefined variable $auth_cookie error due to when location is denied

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -1018,7 +1018,7 @@ stream {
         }
         {{ end }}
 
-
+        {{ if isLocationAllowed $location }}
         {{ if $externalAuth.SigninURL }}
         location {{ buildAuthSignURLLocation $location.Path $externalAuth.SigninURL }} {
             internal;
@@ -1027,6 +1027,7 @@ stream {
 
             return 302 {{ buildAuthSignURL $externalAuth.SigninURL }};
         }
+        {{ end }}
         {{ end }}
 
         location {{ $path }} {


### PR DESCRIPTION
Added `isLocationAllowed` check before using the `$auth_cookie` variable in `nginx.tmpl`.


<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
As described in #5130, a new reference to $auth_cookie variable does not get declared when location is [denied](https://github.com/Shopify/ingress-nginx/blob/561789fe813d9f72f16f0411669aaec5e4c7b3fb/rootfs/etc/nginx/template/nginx.tmpl#L1112). As a result, an `Undefined Nginx variable "$auth_cookie"` occurs preventing the config to be loaded properly. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):
-->
fixes #5130 


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added an e2e test that starts a controller, installs an ingress with incorrect annotation, and then deploys another ingress and asserts that the new ingress is reflected in the Nginx configuration.

No new unit tests are needed.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
