### PR TITLE
Serve correct TLS certificate for requests with uppercase host

### DIFF
--- a/rootfs/etc/nginx/lua/certificate.lua
+++ b/rootfs/etc/nginx/lua/certificate.lua
@@ -42,7 +42,10 @@ local function set_der_cert_and_key(der_cert, der_priv_key)
 end
 
 local function get_pem_cert_uid(raw_hostname)
-  local hostname = re_sub(raw_hostname, "\\.$", "", "jo")
+  -- Convert hostname to ASCII lowercase (see RFC 6125 6.4.1) so that requests with uppercase
+  -- host would lead to the right certificate being chosen (controller serves certificates for
+  -- lowercase hostnames as specified in Ingress object's spec.rules.host)
+  local hostname = re_sub(raw_hostname, "\\.$", "", "jo"):gsub("[A-Z]", function(c) return c:lower() end)
 
   local uid = certificate_servers:get(hostname)
   if uid then


### PR DESCRIPTION
## What this PR does / why we need it:

Follow-up to #5456 which didn't fully solve the problem. This time, I was able to test the full flow by editing a Lua script and trying an uppercase-host request like `curl -kv https://MY-UPPERCASE-HOST/`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?

Edited 0.32.0 controller image with this one-line change and saw that a request with uppercase host provides the TLS certificate specified in the `Ingress` object instead of falling back to the fake default certificate.

Unfortunately I don't have a good idea how to test it, since there's no example test requesting `/configuration/servers` or similar.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
