### PR TITLE
Make liveness probe more resilient than readiness probe

### DIFF
--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -198,7 +198,7 @@ controller:
   ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
   ##
   livenessProbe:
-    failureThreshold: 3
+    failureThreshold: 5
     initialDelaySeconds: 10
     periodSeconds: 10
     successThreshold: 1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In ingress-nginx case, having liveness probe configured exactly the same as readiness probe is a bad practice. Under conditions where load exceeds the capacity it can lead to cascading failure of all replicas.

Configuration with liveness probe more fault tolerant than readiness probe acts as a load shedding:
- readiness probe fails sooner, and cuts of inflow of excess load;
- liveness probe with higher tolerance for temporary resource exhaustion keeps container up allowing it some more time to process requests received so far, reducing the load

If higher fault tolerance of liveness probe is problem to detect startup failures fast - an (optional, disabled or enabled by default) [startup probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) could be supported to be configured in addition to liveness and readiness probe. This can be done in the same or in a separate PR - I'm open to suggestions.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
To simulate the overload:
- reduced ingress-nginx capacity by configuring low max-worker-connections, and running two nginx replicas only, each with 4 worker processes;
- used https://github.com/stormforger/testapp as backend (with matching Ingress resource), and its echo endpoint with delay support;
- using [hey](https://github.com/rakyll/hey) generated the load which exceeds the nginx capacity.

Before the change, when overloaded, replica would get to be restarted by kubelet, slowing down recovery from overload, reducing capacity to process requests.

After the change, when overloaded, replica would not get restarted by the kubelet; as readiness probe fails no additional load gets received; as requests get handled, capacity is freed up; as soon as readiness probe passes again replica can receive additional load; this allowed replica under the same load to successfully handle much more requests.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
