### PR TITLE
Add URL to official grafana dashboards

### DIFF
--- a/docs/user-guide/monitoring.md
+++ b/docs/user-guide/monitoring.md
@@ -74,6 +74,6 @@ According to the above example, this URL will be http://10.192.0.3:31086
 
 The username and password is `admin`
 
-After the login you can import the Grafana dashboard from _https://github.com/kubernetes/ingress-nginx/tree/master/deploy/grafana/dashboards_
+After the login you can import the Grafana dashboard from [official dashboards](https://github.com/kubernetes/ingress-nginx/tree/master/deploy/grafana/dashboards)
 
 ![Dashboard](../images/grafana.png)


### PR DESCRIPTION
Convert URL for grafana dashboards from italic text to clickable link.

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
Improve user experience when using documentation.
Instead of forcing the reader to copy/paste the text, now it is possible just to click on it, yay Internet!
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
No tests.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
