### PR TITLE
Support custom HPA metrics

### DIFF
--- a/charts/ingress-nginx/Chart.yaml
+++ b/charts/ingress-nginx/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: ingress-nginx
-version: 2.3.0
+version: 2.4.0
 appVersion: 0.32.0
 home: https://github.com/kubernetes/ingress-nginx
 description: Ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer

--- a/charts/ingress-nginx/README.md
+++ b/charts/ingress-nginx/README.md
@@ -79,6 +79,7 @@ Parameter | Description | Default
 `controller.autoscaling.maxReplicas` | If autoscaling enabled, this field sets maximum replica count | `11`
 `controller.autoscaling.targetCPUUtilizationPercentage` | Target CPU utilization percentage to scale | `"50"`
 `controller.autoscaling.targetMemoryUtilizationPercentage` | Target memory utilization percentage to scale | `"50"`
+`controller.autoscaling.autoscalingTemplate` | If autoscaling template provided, creates custom autoscaling metric | false
 `controller.hostPort.enabled` | This enable `hostPort` for ports defined in TCP/80 and TCP/443 | false
 `controller.hostPort.ports.http` | If `controller.hostPort.enabled` is `true` and this is non-empty, it sets the hostPort | `"80"`
 `controller.hostPort.ports.https` | If `controller.hostPort.enabled` is `true` and this is non-empty, it sets the hostPort | `"443"`

--- a/charts/ingress-nginx/templates/controller-hpa.yaml
+++ b/charts/ingress-nginx/templates/controller-hpa.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.controller.autoscaling.enabled (or (eq .Values.controller.kind "Deployment") (eq .Values.controller.kind "Both")) -}}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   labels:
@@ -15,15 +15,22 @@ spec:
   maxReplicas: {{ .Values.controller.autoscaling.maxReplicas }}
   metrics:
   {{- with .Values.controller.autoscaling.targetCPUUtilizationPercentage }}
-    - type: Resource
-      resource:
-        name: cpu
-        targetAverageUtilization: {{ . }}
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ . }}
   {{- end }}
   {{- with .Values.controller.autoscaling.targetMemoryUtilizationPercentage }}
-    - type: Resource
-      resource:
-        name: memory
-        targetAverageUtilization: {{ . }}
+  - type: Resource 
+    resource: 
+      name: memory 
+      target:
+        type: Utilization
+        averageUtilization: {{ . }}
+  {{- end }}
+  {{- with .Values.controller.autoscalingTemplate }}
+{{- toYaml . | nindent 2 }}
   {{- end }}
 {{- end }}

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -226,10 +226,10 @@ controller:
   resources:
   #  limits:
   #    cpu: 100m
-  #    memory: 90Mi
+  #    memory: 200Mi
     requests:
       cpu: 100m
-      memory: 90Mi
+      memory: 200Mi
 
   autoscaling:
     enabled: false
@@ -237,6 +237,17 @@ controller:
     maxReplicas: 11
     targetCPUUtilizationPercentage: 50
     targetMemoryUtilizationPercentage: 50
+
+  autoscalingTemplate: []
+  # Custom or additional autoscaling metrics
+  # ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-custom-metrics
+  #- type: Pods
+  #  pods:
+  #    metric:
+  #      name: nginx_ingress_controller_nginx_process_requests_total
+  #    target:
+  #      type: AverageValue
+  #      averageValue: 10000m
 
   ## Enable mimalloc as a drop-in replacement for malloc.
   ## ref: https://github.com/microsoft/mimalloc


### PR DESCRIPTION
## What this PR does / why we need it:
This PR allow you use custom metric for HPA also increasing default resources request fix issue with useless autoscaling without any load. 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?
Helm chart was tested on kubernetes 1.16.10 with and without custom metric.

## Checklist:
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
