### PR TITLE
Fix controller.publishService.enabled on README

### DIFF
--- a/charts/ingress-nginx/README.md
+++ b/charts/ingress-nginx/README.md
@@ -95,7 +95,7 @@ Parameter | Description | Default
 `controller.resources` | controller pod resource requests & limits | `{}`
 `controller.priorityClassName` | controller priorityClassName | `nil`
 `controller.lifecycle` | controller pod lifecycle hooks | `{}`
-`controller.publishService.enabled` | if true, the controller will set the endpoint records on the ingress objects to reflect those on the service | `false`
+`controller.publishService.enabled` | if true, the controller will set the endpoint records on the ingress objects to reflect those on the service | `true`
 `controller.publishService.pathOverride` | override of the default publish-service name | `""`
 `controller.service.annotations` | annotations for controller service | `{}`
 `controller.service.labels` | labels for controller service | `{}`


### PR DESCRIPTION
This is fixing the default value of `controller.publishService.enabled` on README based on https://github.com/kubernetes/ingress-nginx/blob/master/charts/ingress-nginx/values.yaml#L80
