### PR TITLE
Add support for an internal load balancer along with an external one

### DIFF
--- a/charts/ingress-nginx/Chart.yaml
+++ b/charts/ingress-nginx/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: ingress-nginx
-version: 2.4.0
+version: 2.5.0
 appVersion: 0.33.0
 home: https://github.com/kubernetes/ingress-nginx
 description: Ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer

--- a/charts/ingress-nginx/ci/daemonset-internal-lb-values.yaml
+++ b/charts/ingress-nginx/ci/daemonset-internal-lb-values.yaml
@@ -1,0 +1,10 @@
+controller:
+  kind: DaemonSet
+  admissionWebhooks:
+    enabled: false
+  service:
+    type: ClusterIP
+    internal:
+      enabled: true
+      annotations:
+        service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0

--- a/charts/ingress-nginx/ci/deployment-internal-lb-values.yaml
+++ b/charts/ingress-nginx/ci/deployment-internal-lb-values.yaml
@@ -1,0 +1,9 @@
+controller:
+  admissionWebhooks:
+    enabled: false
+  service:
+    type: ClusterIP
+    internal:
+      enabled: true
+      annotations:
+        service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0

--- a/charts/ingress-nginx/templates/controller-service-internal.yaml
+++ b/charts/ingress-nginx/templates/controller-service-internal.yaml
@@ -1,0 +1,41 @@
+{{- if and .Values.controller.service.enabled .Values.controller.service.internal.enabled .Values.controller.service.internal.annotations}}
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+  {{- range $key, $value := .Values.controller.service.internal.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  labels:
+    {{- include "ingress-nginx.labels" . | nindent 4 }}
+    app.kubernetes.io/component: controller
+  {{- if .Values.controller.service.labels }}
+    {{- toYaml .Values.controller.service.labels | nindent 4 }}
+  {{- end }}
+  name: {{ include "ingress-nginx.controller.fullname" . }}-internal
+spec:
+  type: "{{ .Values.controller.service.type }}"
+  ports:
+  {{- $setNodePorts := (or (eq .Values.controller.service.type "NodePort") (eq .Values.controller.service.type "LoadBalancer")) }}
+  {{- if .Values.controller.service.enableHttp }}
+    - name: http
+      port: {{ .Values.controller.service.ports.http }}
+      protocol: TCP
+      targetPort: {{ .Values.controller.service.targetPorts.http }}
+    {{- if (and $setNodePorts (not (empty .Values.controller.service.nodePorts.http))) }}
+      nodePort: {{ .Values.controller.service.nodePorts.http }}
+    {{- end }}
+  {{- end }}
+  {{- if .Values.controller.service.enableHttps }}
+    - name: https
+      port: {{ .Values.controller.service.ports.https }}
+      protocol: TCP
+      targetPort: {{ .Values.controller.service.targetPorts.https }}
+    {{- if (and $setNodePorts (not (empty .Values.controller.service.nodePorts.https))) }}
+      nodePort: {{ .Values.controller.service.nodePorts.https }}
+    {{- end }}
+  {{- end }}
+  selector:
+    {{- include "ingress-nginx.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: controller
+{{- end }}

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -302,6 +302,12 @@ controller:
       tcp: {}
       udp: {}
 
+    ## Enables an additional internal load balancer (besides the external one).
+    ## Annotations are mandatory for the load balancer to come up. Varies with the cloud service.
+    internal:
+      enabled: false
+      annotations: {}
+
   extraContainers: []
   ## Additional containers to be added to the controller pod.
   ## See https://github.com/lemonldap-ng-controller/lemonldap-ng-controller as example.


### PR DESCRIPTION
Signed-off-by: Luis Garnica Guilarte <luisgarnica42@gmail.com>

<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
My team and people from other companies have found uses cases where they have a DNS in split-view configuration and need two ingress to handle internal and external requests for the same deployment. A way for doing this is having a second nginx ignress controller with a different class name like "nginx-internal" which handles these internal connections. This requires like mentioned to have two separate controllers and also two ingress objects per deployment.

With this method (which is proven to work and is being used in production by several people) an identical load balancer to the existing external is deployed with the same ingress controller, but the last one having annotations for being an internal load balancer.

By default ingress objects created will point to the external load balancer address. But if within the private network (AWS VPC, etc..) a host URL can be resolved to the internal load balancer address, the existing ingress controller will handle this request.

Example: (suppose an AWS VPC with Route53 split-view setup)

After chart deployment two LoadBalancers are created:
```
kube-system    nginx-ingress-controller            LoadBalancer   172.20.163.235   a918d1608db52464jbef89570f0b0e86-1213156713.eu-west-1.elb.amazonaws.com           80:31838/TCP,443:32682/TCP   16h
kube-system    nginx-ingress-controller-internal   LoadBalancer   172.20.18.98     internal-a43bec90d21af42fbj386f131f86b817-869934591.eu-west-1.elb.amazonaws.com   80:30460/TCP,443:32104/TCP   5s
```

And we also create a sample app with an ingress object:

```
$ kubectl get ing
NAME                HOSTS                          ADDRESS                                                                   PORTS     AGE
guestbook-ingress   guestbook-app.domain.tld   a918d1608db52464jbef89570f0b0e86-1213156713.eu-west-1.elb.amazonaws.com   80, 443   6s
```

In Route53 we set a record in the public zone
```
guestbook-app.domain.tld CNAME a918d1608db52464jbef89570f0b0e86-1213156713.eu-west-1.elb.amazonaws.com
```
Then in the private zone
```
guestbook-app.domain.tld CNAME internal-a43bec90d21af42fbj386f131f86b817-869934591.eu-west-1.elb.amazonaws.com
```
If doing a request to `guestbook-app.domain.tld` from outside the VPC, the external LoadBalancer will handle it. While if making the request to the same domain within the VPC the internal LoadBalancer will handle it, But in both cases hitting the same and single nginx ingress controller.

Example of DNS resolution with the previous setup
*outside the VPC*
```
$ nslookup guestbook-app.domain.tld
Server:		192.168.1.1
Address:	192.168.1.1#53

Non-authoritative answer:
guestbook-app.domain.tld	canonical name = a918d1608db52464jbef89570f0b0e86-1213156713.eu-west-1.elb.amazonaws.com.
Name:	a918d1608db52464jbef89570f0b0e86-1213156713.eu-west-1.elb.amazonaws.com
Address: 51.11.248.22
Name:	a918d1608db52464jbef89570f0b0e86-1213156713.eu-west-1.elb.amazonaws.com
Address: 61.52.15.25
```
*within the VPC*
```
[ec2-user@ip-10-30-1-221 ~]$ nslookup guestbook-app.domain.tld
Server:		10.30.0.2
Address:	10.30.0.2#53

Non-authoritative answer:
guestbook-app.domain.tld	canonical name = internal-a43bec90d21af42fbj386f131f86b817-869934591.eu-west-1.elb.amazonaws.com.
Name:	internal-a43bec90d21af42fbj386f131f86b817-869934591.eu-west-1.elb.amazonaws.com Address: 10.30.2.93
Name:	internal-a43bec90d21af42fbj386f131f86b817-869934591.eu-west-1.elb.amazonaws.com Address: 10.30.3.142
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
None.

## How Has This Been Tested?

Environment: AWS EKS 1.16 cluster

Tests:
lint: `helm lint .`
template: `helm template .` and `helm template . -f custom-values.yaml`

**custom-values.yaml** enabled/configured the new funcionality.

First, the chart was deployed with default values. A sample app was deployed and the default external ingress worked OK.

After that, the new functionality was enabled and configured in values file and the release was upgraded with: `helm upgrade ingress-nginx charts/ingress-nginx -i --atomic --cleanup-on-fail --namespace kube-system --version 2.4.0 -f values/ingress.yaml`

It created the new internal load balancer. I tested first the external load balancer → still working OK.
Then I tested the internal load balancer with the approach described in _"What this PR does / why we need it"_

Then I modified again the values file for disabling the new funcionality and did the same `helm upgrade` as before → The internal load balancer was taken out of service and the external load balancer kept working OK.

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
