### PR TITLE
pass original request id to external auth server as a different header

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -951,7 +951,8 @@ stream {
             proxy_pass_request_body     off;
             proxy_set_header            Content-Length          "";
             proxy_set_header            X-Forwarded-Proto       "";
-            proxy_set_header            X-Request-ID            $req_id;
+            proxy_set_header            X-Request-ID            "";
+            proxy_set_header            X-Parent-Request-ID     $req_id;
 
             {{ if $externalAuth.Method }}
             proxy_method                {{ $externalAuth.Method }};


### PR DESCRIPTION
## What this PR does / why we need it:
When external authentication is configured for a given client request, NGINX makes a subrequest to the external auth server to authenticate the request. Semantically the subrequest is a different request, even though it is related to the original request. Therefore it should not inherit the request ID from the original request. In this PR I'm passing the original request ID in a different header (`X-Parent-Request-ID`) which will still let the external auth server to relate the subrequet to its parent.

See https://github.com/kubernetes/ingress-nginx/issues/5280 and https://github.com/kubernetes/ingress-nginx/pull/5301

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
