### PR TITLE
fix: remove redundant health check to avoid liveness or readiness timeout

### DIFF
--- a/internal/ingress/controller/checker.go
+++ b/internal/ingress/controller/checker.go
@@ -61,16 +61,7 @@ func (n *NGINXController) Check(_ *http.Request) error {
 		return errors.Wrapf(err, "checking for NGINX process with PID %v", pid)
 	}
 
-	statusCode, _, err := nginx.NewGetStatusRequest(nginx.HealthPath)
-	if err != nil {
-		return errors.Wrapf(err, "checking if NGINX is running")
-	}
-
-	if statusCode != 200 {
-		return fmt.Errorf("ingress controller is not healthy (%v)", statusCode)
-	}
-
-	statusCode, _, err = nginx.NewGetStatusRequest("/is-dynamic-lb-initialized")
+	statusCode, _, err := nginx.NewGetStatusRequest("/is-dynamic-lb-initialized")
 	if err != nil {
 		return errors.Wrapf(err, "checking if the dynamic load balancer started")
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When the liveness timeout is set to 1 sec and the container load is high, occasionally encounter the container restart. 


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
