### PR TITLE
canary supports Weighted Consistent Hashing

### DIFF
--- a/internal/ingress/annotations/canary/main.go
+++ b/internal/ingress/annotations/canary/main.go
@@ -101,7 +101,5 @@ func (c canary) Parse(ing *networking.Ingress) (interface{}, error) {
 		return nil, errors.NewInvalidAnnotationConfiguration("canary", "configured but not enabled")
 	}
 
-
-
 	return config, nil
 }

--- a/internal/ingress/annotations/canary/main.go
+++ b/internal/ingress/annotations/canary/main.go
@@ -36,6 +36,8 @@ type Config struct {
 	HeaderValue   string
 	HeaderPattern string
 	Cookie        string
+	HashHeader        string
+	HashHeaderWeight        int
 }
 
 // NewParser parses the ingress for canary related annotations
@@ -79,10 +81,27 @@ func (c canary) Parse(ing *networking.Ingress) (interface{}, error) {
 		config.Cookie = ""
 	}
 
+	config.HashHeader, err = parser.GetStringAnnotation("canary-by-hash-header", ing)
+	if err != nil {
+		config.HashHeader = ""
+	}
+
+	config.HashHeaderWeight, err = parser.GetIntAnnotation("canary-by-hash-header-weight", ing)
+	if err != nil {
+		config.HashHeaderWeight = 0
+	}
+
+	if len(config.HashHeader) == 0 || config.HashHeaderWeight == 0  {
+		config.HashHeader = ""
+		config.HashHeaderWeight = 0
+	}
+
 	if !config.Enabled && (config.Weight > 0 || len(config.Header) > 0 || len(config.HeaderValue) > 0 || len(config.Cookie) > 0 ||
-		len(config.HeaderPattern) > 0) {
+		len(config.HeaderPattern) > 0 || len(config.HashHeader) > 0 || config.HashHeaderWeight > 0) {
 		return nil, errors.NewInvalidAnnotationConfiguration("canary", "configured but not enabled")
 	}
+
+
 
 	return config, nil
 }

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -756,6 +756,8 @@ func (n *NGINXController) createUpstreams(data []*ingress.Ingress, du *ingress.B
 					HeaderValue:   anns.Canary.HeaderValue,
 					HeaderPattern: anns.Canary.HeaderPattern,
 					Cookie:        anns.Canary.Cookie,
+					HashHeader:        anns.Canary.HashHeader,
+					HashHeaderWeight:        anns.Canary.HashHeaderWeight,
 				}
 			}
 
@@ -820,6 +822,8 @@ func (n *NGINXController) createUpstreams(data []*ingress.Ingress, du *ingress.B
 						HeaderValue:   anns.Canary.HeaderValue,
 						HeaderPattern: anns.Canary.HeaderPattern,
 						Cookie:        anns.Canary.Cookie,
+						HashHeader:        anns.Canary.HashHeader,
+						HashHeaderWeight:        anns.Canary.HashHeaderWeight,
 					}
 				}
 

--- a/internal/ingress/types.go
+++ b/internal/ingress/types.go
@@ -123,8 +123,8 @@ type TrafficShapingPolicy struct {
 	HeaderPattern string `json:"headerPattern"`
 	// Cookie on which to redirect requests to this backend
 	Cookie string `json:"cookie"`
-	// HashHeader
-	// hash(the value of Header) % 100 Weight (0-100) of traffic to redirect to the backend
+	// HashHeader on which to redirect requests to this backend
+	// hash(the value of Header) % 100 ,Weight (0-100) of traffic to redirect to the backend
 	HashHeader string `json:"hashHeader"`
 	//HashHeaderWeight 20 means 20%
 	HashHeaderWeight int `json:"hashHeaderWeight"`

--- a/internal/ingress/types.go
+++ b/internal/ingress/types.go
@@ -123,6 +123,11 @@ type TrafficShapingPolicy struct {
 	HeaderPattern string `json:"headerPattern"`
 	// Cookie on which to redirect requests to this backend
 	Cookie string `json:"cookie"`
+	// HashHeader
+	// hash(the value of Header) % 100 Weight (0-100) of traffic to redirect to the backend
+	HashHeader string `json:"hashHeader"`
+	//HashHeaderWeight 20 means 20%
+	HashHeaderWeight int `json:"hashHeaderWeight"`
 }
 
 // HashInclude defines if a field should be used or not to calculate the hash

--- a/rootfs/etc/nginx/lua/balancer.lua
+++ b/rootfs/etc/nginx/lua/balancer.lua
@@ -250,7 +250,7 @@ local function route_to_alternative_balancer(balancer)
       "-", "_")
     local hash_header_value = ngx.var["http_" .. target_hash_header]
     if hash_header_value then
-      if math.abs(hashcode(hash_header_value)) % 100 <= traffic_shaping_policy.hashHeaderWeight then
+      if math.abs(hashcode(hash_header_value)) % 100 < traffic_shaping_policy.hashHeaderWeight then
         return true
       end
     end

--- a/rootfs/etc/nginx/lua/balancer.lua
+++ b/rootfs/etc/nginx/lua/balancer.lua
@@ -17,7 +17,7 @@ local tostring = tostring
 local pairs = pairs
 local math = math
 local ngx = ngx
-local hashcode = require("balancer.hashcode").str_hash_to_uint
+local hashcode = require("balancer.hashcode").str_hash_to_int
 
 -- measured in seconds
 -- for an Nginx worker to pick up the new list of upstream peers

--- a/rootfs/etc/nginx/lua/balancer.lua
+++ b/rootfs/etc/nginx/lua/balancer.lua
@@ -244,6 +244,15 @@ local function route_to_alternative_balancer(balancer)
     return true
   end
 
+  local target_hash_header = util.replace_special_char(traffic_shaping_policy.hashHeader,
+    "-", "_")
+  local hash_header_value = ngx.var["http_" .. target_hash_header]
+  if hash_header_value then
+    if math.random(100) <= traffic_shaping_policy.hashHeaderWeight then
+      return true
+    end
+  end
+
   return false
 end
 

--- a/rootfs/etc/nginx/lua/balancer.lua
+++ b/rootfs/etc/nginx/lua/balancer.lua
@@ -248,7 +248,7 @@ local function route_to_alternative_balancer(balancer)
     "-", "_")
   local hash_header_value = ngx.var["http_" .. target_hash_header]
   if hash_header_value then
-    if math.random(100) <= traffic_shaping_policy.hashHeaderWeight then
+    if hash(hash_header_value) % 100 <= traffic_shaping_policy.hashHeaderWeight then
       return true
     end
   end

--- a/rootfs/etc/nginx/lua/balancer.lua
+++ b/rootfs/etc/nginx/lua/balancer.lua
@@ -17,6 +17,7 @@ local tostring = tostring
 local pairs = pairs
 local math = math
 local ngx = ngx
+local hashcode = require("balancer.hashcode").str_hash_to_uint
 
 -- measured in seconds
 -- for an Nginx worker to pick up the new list of upstream peers
@@ -248,7 +249,7 @@ local function route_to_alternative_balancer(balancer)
     "-", "_")
   local hash_header_value = ngx.var["http_" .. target_hash_header]
   if hash_header_value then
-    if hash(hash_header_value) % 100 <= traffic_shaping_policy.hashHeaderWeight then
+    if math.abs(hashcode(hash_header_value)) % 100 <= traffic_shaping_policy.hashHeaderWeight then
       return true
     end
   end

--- a/rootfs/etc/nginx/lua/balancer.lua
+++ b/rootfs/etc/nginx/lua/balancer.lua
@@ -245,12 +245,14 @@ local function route_to_alternative_balancer(balancer)
     return true
   end
 
-  local target_hash_header = util.replace_special_char(traffic_shaping_policy.hashHeader,
-    "-", "_")
-  local hash_header_value = ngx.var["http_" .. target_hash_header]
-  if hash_header_value then
-    if math.abs(hashcode(hash_header_value)) % 100 <= traffic_shaping_policy.hashHeaderWeight then
-      return true
+  if traffic_shaping_policy.hashHeader then
+    local target_hash_header = util.replace_special_char(traffic_shaping_policy.hashHeader,
+      "-", "_")
+    local hash_header_value = ngx.var["http_" .. target_hash_header]
+    if hash_header_value then
+      if math.abs(hashcode(hash_header_value)) % 100 <= traffic_shaping_policy.hashHeaderWeight then
+        return true
+      end
     end
   end
 

--- a/rootfs/etc/nginx/lua/balancer/hashcode.lua
+++ b/rootfs/etc/nginx/lua/balancer/hashcode.lua
@@ -1,6 +1,6 @@
 local _M = {}
 
-function _M.str_hash_to_uint(str)
+function _M.str_hash_to_int(str)
     local h = 0
     local l = #str
     if l > 0 then

--- a/rootfs/etc/nginx/lua/balancer/hashcode.lua
+++ b/rootfs/etc/nginx/lua/balancer/hashcode.lua
@@ -1,0 +1,12 @@
+function str_hash_to_uint(str)
+    local h = 0
+    local l = #str
+    if l > 0 then
+        local i = 0
+        while i < l do
+            h = 31 * h + string.byte(str,i+1);
+            i = i + 1
+        end
+    end
+    return h
+end

--- a/rootfs/etc/nginx/lua/balancer/hashcode.lua
+++ b/rootfs/etc/nginx/lua/balancer/hashcode.lua
@@ -4,7 +4,7 @@ function str_hash_to_uint(str)
     if l > 0 then
         local i = 0
         while i < l do
-            h = 31 * h + string.byte(str,i+1);
+            h = 31 * h + string.byte(str, i + 1);
             i = i + 1
         end
     end

--- a/rootfs/etc/nginx/lua/balancer/hashcode.lua
+++ b/rootfs/etc/nginx/lua/balancer/hashcode.lua
@@ -1,4 +1,6 @@
-function str_hash_to_uint(str)
+local _M = {}
+
+function _M.str_hash_to_uint(str)
     local h = 0
     local l = #str
     if l > 0 then
@@ -10,3 +12,5 @@ function str_hash_to_uint(str)
     end
     return h
 end
+
+return _M

--- a/rootfs/etc/nginx/lua/test/balancer_test.lua
+++ b/rootfs/etc/nginx/lua/test/balancer_test.lua
@@ -303,6 +303,22 @@ describe("Balancer", function()
             request_header_value = "bEn",
             expected_result = true,
           },
+          {
+            case_title = "returns true when header matches and weight is 0",
+            header_name = "canaryHeader",
+            header_weight = 0,
+            request_header_name = "canaryHeader",
+            request_header_value = "bEn",
+            expected_result = false,
+          },
+          {
+            case_title = "returns false when header not matches",
+            header_name = "canaryHeaderNotMatchs",
+            header_weight = 100,
+            request_header_name = "canaryHeader",
+            request_header_value = "bEn",
+            expected_result = false,
+          },
         }
 
         for _, test_pattern in pairs(test_patterns) do

--- a/rootfs/etc/nginx/lua/test/balancer_test.lua
+++ b/rootfs/etc/nginx/lua/test/balancer_test.lua
@@ -319,6 +319,24 @@ describe("Balancer", function()
             request_header_value = "bEn",
             expected_result = false,
           },
+          {
+            -- hashcode("bEn") % 100 is 27
+            case_title = "returns true when header matches but the weight of header value is less than hashHeaderWeight",
+            header_name = "canaryHeader",
+            header_weight = 28,
+            request_header_name = "canaryHeader",
+            request_header_value = "bEn",
+            expected_result = true,
+          },
+          {
+            -- hashcode("bEn") % 100 is 27
+            case_title = "returns false when header matches but the weight of header value is more than or equal hashHeaderWeight",
+            header_name = "canaryHeader",
+            header_weight = 27,
+            request_header_name = "canaryHeader",
+            request_header_value = "bEn",
+            expected_result = false,
+          },
         }
 
         for _, test_pattern in pairs(test_patterns) do

--- a/rootfs/etc/nginx/lua/test/balancer_test.lua
+++ b/rootfs/etc/nginx/lua/test/balancer_test.lua
@@ -291,6 +291,35 @@ describe("Balancer", function()
         end
       end)
     end)
+
+    context("canary by header hash weight", function()
+      it("returns correct result for given header", function()
+        local test_patterns = {
+          {
+            case_title = "returns true when header matches and weight is 100",
+            header_name = "canaryHeader",
+            header_weight = 100,
+            request_header_name = "canaryHeader",
+            request_header_value = "bEn",
+            expected_result = true,
+          },
+        }
+
+        for _, test_pattern in pairs(test_patterns) do
+          mock_ngx({ var = {
+            ["http_" .. test_pattern.request_header_name] = test_pattern.request_header_value,
+            request_uri = "/"
+          }})
+          reset_balancer()
+          backend.trafficShapingPolicy.hashHeader = test_pattern.header_name
+          backend.trafficShapingPolicy.hashHeaderWeight = test_pattern.header_weight
+          balancer.sync_backend(backend)
+          assert.message("\nTest data pattern: " .. test_pattern.case_title)
+          .equal(test_pattern.expected_result, balancer.route_to_alternative_balancer(_balancer))
+          reset_ngx()
+        end
+      end)
+    end)
   end)
 
   describe("sync_backend()", function()


### PR DESCRIPTION
Weighted Consistent Hashing
 consider that
1. route 30% requests to canary backends just like what canary-weight did
2.the requests of a single user/device route to primary backends or canary backends randomly,  it cause unconsistency

add two annotations
1. canary-by-hash-header
the http request header name, if the request carry it, map the header value to [0-99]
2. canary-by-hash-header-weight
0 ~ 100% percent requests to canary backends

show case
header('username=bEn');  bEn always visit  canary 
header('username=Join'); Join always visit primary

detailed test cases are added into rootfs/etc/nginx/lua/test/balancer_test.lua
