### PR TITLE
canary supports Weighted Consistent Hashing

### DIFF
--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -756,6 +756,8 @@ func (n *NGINXController) createUpstreams(data []*ingress.Ingress, du *ingress.B
 					HeaderValue:   anns.Canary.HeaderValue,
 					HeaderPattern: anns.Canary.HeaderPattern,
 					Cookie:        anns.Canary.Cookie,
+					HashHeader:        anns.Canary.HashHeader,
+					HashHeaderWeight:        anns.Canary.HashHeaderWeight,
 				}
 			}
 
@@ -820,6 +822,8 @@ func (n *NGINXController) createUpstreams(data []*ingress.Ingress, du *ingress.B
 						HeaderValue:   anns.Canary.HeaderValue,
 						HeaderPattern: anns.Canary.HeaderPattern,
 						Cookie:        anns.Canary.Cookie,
+						HashHeader:        anns.Canary.HashHeader,
+						HashHeaderWeight:        anns.Canary.HashHeaderWeight,
 					}
 				}
 

--- a/internal/ingress/types.go
+++ b/internal/ingress/types.go
@@ -123,6 +123,11 @@ type TrafficShapingPolicy struct {
 	HeaderPattern string `json:"headerPattern"`
 	// Cookie on which to redirect requests to this backend
 	Cookie string `json:"cookie"`
+	// HashHeader on which to redirect requests to this backend
+	// hash(the value of Header) % 100 ,Weight (0-100) of traffic to redirect to the backend
+	HashHeader string `json:"hashHeader"`
+	//HashHeaderWeight 20 means 20%
+	HashHeaderWeight int `json:"hashHeaderWeight"`
 }
 
 // HashInclude defines if a field should be used or not to calculate the hash

--- a/rootfs/etc/nginx/lua/balancer/hashcode.lua
+++ b/rootfs/etc/nginx/lua/balancer/hashcode.lua
@@ -1,0 +1,16 @@
+local _M = {}
+
+function _M.str_hash_to_int(str)
+    local h = 0
+    local l = #str
+    if l > 0 then
+        local i = 0
+        while i < l do
+            h = 31 * h + string.byte(str, i + 1);
+            i = i + 1
+        end
+    end
+    return h
+end
+
+return _M


### PR DESCRIPTION
Weighted Consistent Hashing
consider that
1.route 30% requests to canary backends just like what canary-weight did
2.the requests of a single user/device route to primary backends or canary backends randomly, it cause unconsistency

add two annotations
1.canary-by-hash-header
the http request header name, if the request carry it, map the header value to [0-99]
2.canary-by-hash-header-weight
0 ~ 100% percent requests to canary backends

show case
header('username=bEn'); bEn always visit canary
header('username=Join'); Join always visit primary

detailed test cases are added into rootfs/etc/nginx/lua/test/balancer_test.lua