### PR TITLE
Canary supports Weighted Consistent Hashing

### DIFF
--- a/internal/ingress/annotations/canary/main.go
+++ b/internal/ingress/annotations/canary/main.go
@@ -30,14 +30,14 @@ type canary struct {
 
 // Config returns the configuration rules for setting up the Canary
 type Config struct {
-	Enabled       bool
-	Weight        int
-	Header        string
-	HeaderValue   string
-	HeaderPattern string
-	Cookie        string
-	HashHeader        string
-	HashHeaderWeight        int
+	Enabled          bool
+	Weight           int
+	Header           string
+	HeaderValue      string
+	HeaderPattern    string
+	Cookie           string
+	HashHeader       string
+	HashHeaderWeight int
 }
 
 // NewParser parses the ingress for canary related annotations

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -756,6 +756,8 @@ func (n *NGINXController) createUpstreams(data []*ingress.Ingress, du *ingress.B
 					HeaderValue:   anns.Canary.HeaderValue,
 					HeaderPattern: anns.Canary.HeaderPattern,
 					Cookie:        anns.Canary.Cookie,
+					HashHeader:        anns.Canary.HashHeader,
+					HashHeaderWeight:        anns.Canary.HashHeaderWeight,
 				}
 			}
 
@@ -820,6 +822,8 @@ func (n *NGINXController) createUpstreams(data []*ingress.Ingress, du *ingress.B
 						HeaderValue:   anns.Canary.HeaderValue,
 						HeaderPattern: anns.Canary.HeaderPattern,
 						Cookie:        anns.Canary.Cookie,
+						HashHeader:        anns.Canary.HashHeader,
+						HashHeaderWeight:        anns.Canary.HashHeaderWeight,
 					}
 				}
 

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -751,13 +751,13 @@ func (n *NGINXController) createUpstreams(data []*ingress.Ingress, du *ingress.B
 			if anns.Canary.Enabled {
 				upstreams[defBackend].NoServer = true
 				upstreams[defBackend].TrafficShapingPolicy = ingress.TrafficShapingPolicy{
-					Weight:        anns.Canary.Weight,
-					Header:        anns.Canary.Header,
-					HeaderValue:   anns.Canary.HeaderValue,
-					HeaderPattern: anns.Canary.HeaderPattern,
-					Cookie:        anns.Canary.Cookie,
-					HashHeader:        anns.Canary.HashHeader,
-					HashHeaderWeight:        anns.Canary.HashHeaderWeight,
+					Weight:           anns.Canary.Weight,
+					Header:           anns.Canary.Header,
+					HeaderValue:      anns.Canary.HeaderValue,
+					HeaderPattern:    anns.Canary.HeaderPattern,
+					Cookie:           anns.Canary.Cookie,
+					HashHeader:       anns.Canary.HashHeader,
+					HashHeaderWeight: anns.Canary.HashHeaderWeight,
 				}
 			}
 
@@ -817,13 +817,13 @@ func (n *NGINXController) createUpstreams(data []*ingress.Ingress, du *ingress.B
 				if anns.Canary.Enabled {
 					upstreams[name].NoServer = true
 					upstreams[name].TrafficShapingPolicy = ingress.TrafficShapingPolicy{
-						Weight:        anns.Canary.Weight,
-						Header:        anns.Canary.Header,
-						HeaderValue:   anns.Canary.HeaderValue,
-						HeaderPattern: anns.Canary.HeaderPattern,
-						Cookie:        anns.Canary.Cookie,
-						HashHeader:        anns.Canary.HashHeader,
-						HashHeaderWeight:        anns.Canary.HashHeaderWeight,
+						Weight:           anns.Canary.Weight,
+						Header:           anns.Canary.Header,
+						HeaderValue:      anns.Canary.HeaderValue,
+						HeaderPattern:    anns.Canary.HeaderPattern,
+						Cookie:           anns.Canary.Cookie,
+						HashHeader:       anns.Canary.HashHeader,
+						HashHeaderWeight: anns.Canary.HashHeaderWeight,
 					}
 				}
 

--- a/internal/ingress/types.go
+++ b/internal/ingress/types.go
@@ -123,6 +123,11 @@ type TrafficShapingPolicy struct {
 	HeaderPattern string `json:"headerPattern"`
 	// Cookie on which to redirect requests to this backend
 	Cookie string `json:"cookie"`
+	// HashHeader on which to redirect requests to this backend
+	// hash(the value of Header) % 100 ,Weight (0-100) of traffic to redirect to the backend
+	HashHeader string `json:"hashHeader"`
+	//HashHeaderWeight 20 means 20%
+	HashHeaderWeight int `json:"hashHeaderWeight"`
 }
 
 // HashInclude defines if a field should be used or not to calculate the hash

--- a/internal/ingress/types_equals.go
+++ b/internal/ingress/types_equals.go
@@ -257,6 +257,12 @@ func (tsp1 TrafficShapingPolicy) Equal(tsp2 TrafficShapingPolicy) bool {
 	if tsp1.Cookie != tsp2.Cookie {
 		return false
 	}
+	if tsp1.HashHeader != tsp2.HashHeader {
+		return false
+	}
+	if tsp1.HashHeaderWeight != tsp2.HashHeaderWeight {
+		return false
+	}
 
 	return true
 }

--- a/rootfs/etc/nginx/lua/balancer/hashcode.lua
+++ b/rootfs/etc/nginx/lua/balancer/hashcode.lua
@@ -1,0 +1,16 @@
+local _M = {}
+
+function _M.str_hash_to_int(str)
+    local h = 0
+    local l = #str
+    if l > 0 then
+        local i = 0
+        while i < l do
+            h = 31 * h + string.byte(str, i + 1);
+            i = i + 1
+        end
+    end
+    return h
+end
+
+return _M


### PR DESCRIPTION
Weighted Consistent Hashing
consider that
1.route 30% requests to canary backends just like what canary-weight did
2.the requests of a single user/device route to primary backends or canary backends randomly, it cause unconsistency

add two annotations
1.canary-by-hash-header
the http request header name, if the request carry it, map the header value to [0-99]
2.canary-by-hash-header-weight
0 ~ 100% percent requests to canary backends

detailed test cases are added into rootfs/etc/nginx/lua/test/balancer_test.lua