### PR TITLE
canary support Weighted Consistent Hashing

### DIFF
--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -751,11 +751,14 @@ func (n *NGINXController) createUpstreams(data []*ingress.Ingress, du *ingress.B
 			if anns.Canary.Enabled {
 				upstreams[defBackend].NoServer = true
 				upstreams[defBackend].TrafficShapingPolicy = ingress.TrafficShapingPolicy{
-					Weight:        anns.Canary.Weight,
-					Header:        anns.Canary.Header,
-					HeaderValue:   anns.Canary.HeaderValue,
-					HeaderPattern: anns.Canary.HeaderPattern,
-					Cookie:        anns.Canary.Cookie,
+					Weight:           anns.Canary.Weight,
+					Header:           anns.Canary.Header,
+					HeaderValue:      anns.Canary.HeaderValue,
+					HeaderPattern:    anns.Canary.HeaderPattern,
+					Cookie:           anns.Canary.Cookie,
+					HashHeader:       anns.Canary.HashHeader,
+					HashHeaderWeight: anns.Canary.HashHeaderWeight,
+					HashHeaderSeed:   anns.Canary.HashHeaderSeed,
 				}
 			}
 
@@ -815,11 +818,14 @@ func (n *NGINXController) createUpstreams(data []*ingress.Ingress, du *ingress.B
 				if anns.Canary.Enabled {
 					upstreams[name].NoServer = true
 					upstreams[name].TrafficShapingPolicy = ingress.TrafficShapingPolicy{
-						Weight:        anns.Canary.Weight,
-						Header:        anns.Canary.Header,
-						HeaderValue:   anns.Canary.HeaderValue,
-						HeaderPattern: anns.Canary.HeaderPattern,
-						Cookie:        anns.Canary.Cookie,
+						Weight:           anns.Canary.Weight,
+						Header:           anns.Canary.Header,
+						HeaderValue:      anns.Canary.HeaderValue,
+						HeaderPattern:    anns.Canary.HeaderPattern,
+						Cookie:           anns.Canary.Cookie,
+						HashHeader:       anns.Canary.HashHeader,
+						HashHeaderWeight: anns.Canary.HashHeaderWeight,
+						HashHeaderSeed:   anns.Canary.HashHeaderSeed,
 					}
 				}
 

--- a/internal/ingress/types.go
+++ b/internal/ingress/types.go
@@ -123,6 +123,13 @@ type TrafficShapingPolicy struct {
 	HeaderPattern string `json:"headerPattern"`
 	// Cookie on which to redirect requests to this backend
 	Cookie string `json:"cookie"`
+	// HashHeader on which to redirect requests to this backend
+	// hash(the value of Header) % 100 ,Weight (0-100) of traffic to redirect to the backend
+	HashHeader string `json:"hashHeader"`
+	//HashHeaderWeight 20 means 20%
+	HashHeaderWeight int `json:"hashHeaderWeight"`
+	//it's optional, the different seeds can result different hashcode
+	HashHeaderSeed string `json:"hashHeaderSeed"`
 }
 
 // HashInclude defines if a field should be used or not to calculate the hash

--- a/internal/ingress/types_equals.go
+++ b/internal/ingress/types_equals.go
@@ -257,6 +257,15 @@ func (tsp1 TrafficShapingPolicy) Equal(tsp2 TrafficShapingPolicy) bool {
 	if tsp1.Cookie != tsp2.Cookie {
 		return false
 	}
+	if tsp1.HashHeader != tsp2.HashHeader {
+		return false
+	}
+	if tsp1.HashHeaderWeight != tsp2.HashHeaderWeight {
+		return false
+	}
+	if tsp1.HashHeaderSeed != tsp2.HashHeaderSeed {
+		return false
+	}
 
 	return true
 }

--- a/rootfs/etc/nginx/lua/balancer.lua
+++ b/rootfs/etc/nginx/lua/balancer.lua
@@ -17,6 +17,7 @@ local tostring = tostring
 local pairs = pairs
 local math = math
 local ngx = ngx
+local hashcode = require("balancer.hashcode").str_hash_to_int
 
 -- measured in seconds
 -- for an Nginx worker to pick up the new list of upstream peers
@@ -242,6 +243,22 @@ local function route_to_alternative_balancer(balancer)
 
   if math.random(100) <= traffic_shaping_policy.weight then
     return true
+  end
+
+  if traffic_shaping_policy.hashHeader then
+    local target_hash_header = util.replace_special_char(traffic_shaping_policy.hashHeader,
+      "-", "_")
+    local hash_header_value = ngx.var["http_" .. target_hash_header]
+    if hash_header_value then
+      local seed = traffic_shaping_policy.hashHeaderSeed
+      if not seed then
+        seed = ""
+      end
+      local hash_value = math.abs(hashcode(hash_header_value..seed))
+      if hash_value % 100 < traffic_shaping_policy.hashHeaderWeight then
+        return true
+      end
+    end
   end
 
   return false

--- a/rootfs/etc/nginx/lua/balancer/hashcode.lua
+++ b/rootfs/etc/nginx/lua/balancer/hashcode.lua
@@ -1,0 +1,17 @@
+local string = string
+local _M = {}
+
+function _M.str_hash_to_int(str)
+    local h = 0
+    local l = #str
+    if l > 0 then
+        local i = 0
+        while i < l do
+            h = 31 * h + string.byte(str, i + 1);
+            i = i + 1
+        end
+    end
+    return h
+end
+
+return _M


### PR DESCRIPTION
## Weighted Consistent Hashing
consider that
1.route 30% requests to canary backends just like what canary-weight did
2.the requests of a single user/device route to primary backends or canary backends randomly, it cause unconsistency

## Add three new canary annotations
**canary-by-hash-header**
the http request header, if the request carry it, map the header value to [0-99]
**canary-by-hash-header-weight**
0 ~ 100% percent requests to canary backends
**canary-by-hash-header-seed**
it's optional, it makes sure two experiments requests are different, the different seeds can result different hashcode

## Compatibility
won't harm other canary strategy

## Test
detailed test cases are added into rootfs/etc/nginx/lua/test/balancer_test.lua