### PR TITLE
Add global-auth-signin-snippet and auth-signin-snippet

### DIFF
--- a/docs/user-guide/nginx-configuration/annotations.md
+++ b/docs/user-guide/nginx-configuration/annotations.md
@@ -420,6 +420,8 @@ Additionally it is possible to set:
   `<Method>` to specify the HTTP method to use.
 * `nginx.ingress.kubernetes.io/auth-signin`:
   `<SignIn_URL>` to specify the location of the error page.
+* `nginx.ingress.kubernetes.io/auth-signin-snippet`:
+  `<SignIn_URL_Snippet>` to specify a custom snippet in the location of the error page.  
 * `nginx.ingress.kubernetes.io/auth-response-headers`:
   `<Response_Header_1, ..., Response_Header_n>` to specify headers to pass to backend once authentication request completes.
 * `nginx.ingress.kubernetes.io/auth-proxy-set-headers`:

--- a/docs/user-guide/nginx-configuration/configmap.md
+++ b/docs/user-guide/nginx-configuration/configmap.md
@@ -173,6 +173,7 @@ The following table shows a configuration option's name, type, and the default v
 |[global-auth-url](#global-auth-url)|string|""|
 |[global-auth-method](#global-auth-method)|string|""|
 |[global-auth-signin](#global-auth-signin)|string|""|
+|[global-auth-signin-snippet](#global-auth-signin-snippet)|string|""|
 |[global-auth-response-headers](#global-auth-response-headers)|string|""|
 |[global-auth-request-redirect](#global-auth-request-redirect)|string|""|
 |[global-auth-snippet](#global-auth-snippet)|string|""|
@@ -1027,6 +1028,13 @@ _**default:**_ ""
 
 Sets the location of the error page for an existing service that provides authentication for all the locations.
 Similar to the Ingress rule annotation `nginx.ingress.kubernetes.io/auth-signin`.
+_**default:**_ ""
+
+## global-auth-signin-snippet
+
+Sets a custom snippet to use in the location that serves the error page for an existing service that provides authentication for all the locations.
+Applied to all the locations.
+Similar to the Ingress rule annotation `nginx.ingress.kubernetes.io/auth-signin-snippet`.
 _**default:**_ ""
 
 ## global-auth-response-headers

--- a/internal/ingress/annotations/authreq/main.go
+++ b/internal/ingress/annotations/authreq/main.go
@@ -37,6 +37,7 @@ type Config struct {
 	// Host contains the hostname defined in the URL
 	Host              string            `json:"host"`
 	SigninURL         string            `json:"signinUrl"`
+	SigninURLSnippet  string     		`json:"signinUrlSnippet"`
 	Method            string            `json:"method"`
 	ResponseHeaders   []string          `json:"responseHeaders,omitempty"`
 	RequestRedirect   string            `json:"requestRedirect"`
@@ -83,6 +84,10 @@ func (e1 *Config) Equal(e2 *Config) bool {
 	}
 
 	if e1.AuthCacheKey != e2.AuthCacheKey {
+		return false
+	}
+
+	if e1.SigninURLSnippet != e2.SigninURLSnippet {
 		return false
 	}
 
@@ -174,6 +179,11 @@ func (a authReq) Parse(ing *networking.Ingress) (interface{}, error) {
 		klog.V(3).Infof("auth-signin annotation is undefined and will not be set")
 	}
 
+	signInSnippet, err := parser.GetStringAnnotation("auth-signin-snippet", ing)
+	if err != nil {
+		klog.V(3).Infof("auth-signin-snippet annotation is undefined and will not be set")
+	}
+
 	authSnippet, err := parser.GetStringAnnotation("auth-snippet", ing)
 	if err != nil {
 		klog.V(3).Infof("auth-snippet annotation is undefined and will not be set")
@@ -233,6 +243,7 @@ func (a authReq) Parse(ing *networking.Ingress) (interface{}, error) {
 		URL:               urlString,
 		Host:              authURL.Hostname(),
 		SigninURL:         signIn,
+		SigninURLSnippet:  signInSnippet,
 		Method:            authMethod,
 		ResponseHeaders:   responseHeaders,
 		RequestRedirect:   requestRedirect,

--- a/internal/ingress/annotations/authreq/main.go
+++ b/internal/ingress/annotations/authreq/main.go
@@ -37,7 +37,7 @@ type Config struct {
 	// Host contains the hostname defined in the URL
 	Host              string            `json:"host"`
 	SigninURL         string            `json:"signinUrl"`
-	SigninURLSnippet  string     		`json:"signinUrlSnippet"`
+	SigninURLSnippet  string            `json:"signinUrlSnippet"`
 	Method            string            `json:"method"`
 	ResponseHeaders   []string          `json:"responseHeaders,omitempty"`
 	RequestRedirect   string            `json:"requestRedirect"`

--- a/internal/ingress/annotations/authreq/main_test.go
+++ b/internal/ingress/annotations/authreq/main_test.go
@@ -72,15 +72,15 @@ func TestAnnotations(t *testing.T) {
 	ing.SetAnnotations(data)
 
 	tests := []struct {
-		title           string
-		url             string
-		signinURL       string
-		signinURLSnippet       string
-		method          string
-		requestRedirect string
-		authSnippet     string
-		authCacheKey    string
-		expErr          bool
+		title            string
+		url              string
+		signinURL        string
+		signinURLSnippet string
+		method           string
+		requestRedirect  string
+		authSnippet      string
+		authCacheKey     string
+		expErr           bool
 	}{
 		{"empty", "", "", "", "", "", "", "", true},
 		{"no scheme", "bar", "bar", "", "", "", "", "", true},

--- a/internal/ingress/annotations/authreq/main_test.go
+++ b/internal/ingress/annotations/authreq/main_test.go
@@ -75,27 +75,30 @@ func TestAnnotations(t *testing.T) {
 		title           string
 		url             string
 		signinURL       string
+		signinURLSnippet       string
 		method          string
 		requestRedirect string
 		authSnippet     string
 		authCacheKey    string
 		expErr          bool
 	}{
-		{"empty", "", "", "", "", "", "", true},
-		{"no scheme", "bar", "bar", "", "", "", "", true},
-		{"invalid host", "http://", "http://", "", "", "", "", true},
-		{"invalid host (multiple dots)", "http://foo..bar.com", "http://foo..bar.com", "", "", "", "", true},
-		{"valid URL", "http://bar.foo.com/external-auth", "http://bar.foo.com/external-auth", "", "", "", "", false},
-		{"valid URL - send body", "http://foo.com/external-auth", "http://foo.com/external-auth", "POST", "", "", "", false},
-		{"valid URL - send body", "http://foo.com/external-auth", "http://foo.com/external-auth", "GET", "", "", "", false},
-		{"valid URL - request redirect", "http://foo.com/external-auth", "http://foo.com/external-auth", "GET", "http://foo.com/redirect-me", "", "", false},
-		{"auth snippet", "http://foo.com/external-auth", "http://foo.com/external-auth", "", "", "proxy_set_header My-Custom-Header 42;", "", false},
-		{"auth cache ", "http://foo.com/external-auth", "http://foo.com/external-auth", "", "", "", "$foo$bar", false},
+		{"empty", "", "", "", "", "", "", "", true},
+		{"no scheme", "bar", "bar", "", "", "", "", "", true},
+		{"invalid host", "http://", "http://", "", "", "", "", "", true},
+		{"invalid host (multiple dots)", "http://foo..bar.com", "http://foo..bar.com", "", "", "", "", "", true},
+		{"valid URL", "http://bar.foo.com/external-auth", "http://bar.foo.com/external-auth", "", "", "", "", "", false},
+		{"valid URL - send body", "http://foo.com/external-auth", "http://foo.com/external-auth", "", "POST", "", "", "", false},
+		{"valid URL - send body", "http://foo.com/external-auth", "http://foo.com/external-auth", "", "GET", "", "", "", false},
+		{"valid URL - request redirect", "http://foo.com/external-auth", "http://foo.com/external-auth", "", "GET", "http://foo.com/redirect-me", "", "", false},
+		{"auth snippet", "http://foo.com/external-auth", "http://foo.com/external-auth", "", "", "", "proxy_set_header My-Custom-Header 42;", "", false},
+		{"auth cache ", "http://foo.com/external-auth", "http://foo.com/external-auth", "", "", "", "", "$foo$bar", false},
+		{"signin snippet", "http://foo.com/external-auth", "http://foo.com/external-auth", "proxy_set_header My-Custom-Header 42;", "", "", "", "", false},
 	}
 
 	for _, test := range tests {
 		data[parser.GetAnnotationWithPrefix("auth-url")] = test.url
 		data[parser.GetAnnotationWithPrefix("auth-signin")] = test.signinURL
+		data[parser.GetAnnotationWithPrefix("auth-signin-snippet")] = test.signinURLSnippet
 		data[parser.GetAnnotationWithPrefix("auth-method")] = fmt.Sprintf("%v", test.method)
 		data[parser.GetAnnotationWithPrefix("auth-request-redirect")] = test.requestRedirect
 		data[parser.GetAnnotationWithPrefix("auth-snippet")] = test.authSnippet
@@ -121,6 +124,9 @@ func TestAnnotations(t *testing.T) {
 		}
 		if u.SigninURL != test.signinURL {
 			t.Errorf("%v: expected \"%v\" but \"%v\" was returned", test.title, test.signinURL, u.SigninURL)
+		}
+		if u.SigninURLSnippet != test.signinURLSnippet {
+			t.Errorf("%v: expected \"%v\" but \"%v\" was returned", test.title, test.signinURLSnippet, u.SigninURLSnippet)
 		}
 		if u.Method != test.method {
 			t.Errorf("%v: expected \"%v\" but \"%v\" was returned", test.title, test.method, u.Method)

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -691,7 +691,7 @@ func NewDefault() Configuration {
 	defNginxStatusIpv4Whitelist = append(defNginxStatusIpv4Whitelist, "127.0.0.1")
 	defNginxStatusIpv6Whitelist = append(defNginxStatusIpv6Whitelist, "::1")
 	defProxyDeadlineDuration := time.Duration(5) * time.Second
-	defGlobalExternalAuth := GlobalExternalAuth{"", "", "", "", append(defResponseHeaders, ""), "", "", "", []string{}, map[string]string{}}
+	defGlobalExternalAuth := GlobalExternalAuth{"", "", "", "", "", append(defResponseHeaders, ""), "", "", "", []string{}, map[string]string{}}
 
 	cfg := Configuration{
 		AllowBackendServerHeader:         false,
@@ -876,6 +876,7 @@ type GlobalExternalAuth struct {
 	// Host contains the hostname defined in the URL
 	Host              string            `json:"host"`
 	SigninURL         string            `json:"signinUrl"`
+	SigninURLSnippet  string            `json:"signinUrlSnippet"`
 	Method            string            `json:"method"`
 	ResponseHeaders   []string          `json:"responseHeaders,omitempty"`
 	RequestRedirect   string            `json:"requestRedirect"`

--- a/internal/ingress/controller/template/configmap.go
+++ b/internal/ingress/controller/template/configmap.go
@@ -55,6 +55,7 @@ const (
 	globalAuthURL             = "global-auth-url"
 	globalAuthMethod          = "global-auth-method"
 	globalAuthSignin          = "global-auth-signin"
+	globalAuthSigninSnippet   = "global-auth-signin-snippet"
 	globalAuthResponseHeaders = "global-auth-response-headers"
 	globalAuthRequestRedirect = "global-auth-request-redirect"
 	globalAuthSnippet         = "global-auth-snippet"
@@ -284,6 +285,11 @@ func ReadConfig(src map[string]string) config.Configuration {
 	if val, ok := conf[globalAuthCacheKey]; ok {
 		delete(conf, globalAuthCacheKey)
 		to.GlobalExternalAuth.AuthCacheKey = val
+	}
+
+	if val, ok := conf[globalAuthSigninSnippet]; ok {
+		delete(conf, globalAuthSigninSnippet)
+		to.GlobalExternalAuth.SigninURLSnippet = val
 	}
 
 	// Verify that the configured global external authorization cache duration is valid

--- a/internal/ingress/controller/template/configmap_test.go
+++ b/internal/ingress/controller/template/configmap_test.go
@@ -286,6 +286,23 @@ func TestGlobalExternalAuthSnippetParsing(t *testing.T) {
 	}
 }
 
+func TestGlobalExternalSigninURLSnippetParsing(t *testing.T) {
+	testCases := map[string]struct {
+		signinURLSnippet string
+		expect      string
+	}{
+		"empty":        {"", ""},
+		"auth snippet": {"proxy_set_header My-Custom-Header 42;", "proxy_set_header My-Custom-Header 42;"},
+	}
+
+	for n, tc := range testCases {
+		cfg := ReadConfig(map[string]string{"global-auth-signin-snippet": tc.signinURLSnippet})
+		if cfg.GlobalExternalAuth.SigninURLSnippet != tc.expect {
+			t.Errorf("Testing %v. Expected \"%v\" but \"%v\" was returned", n, tc.expect, cfg.GlobalExternalAuth.SigninURLSnippet)
+		}
+	}
+}
+
 func TestGlobalExternalAuthCacheDurationParsing(t *testing.T) {
 	testCases := map[string]struct {
 		durations string

--- a/internal/ingress/controller/template/configmap_test.go
+++ b/internal/ingress/controller/template/configmap_test.go
@@ -289,7 +289,7 @@ func TestGlobalExternalAuthSnippetParsing(t *testing.T) {
 func TestGlobalExternalSigninURLSnippetParsing(t *testing.T) {
 	testCases := map[string]struct {
 		signinURLSnippet string
-		expect      string
+		expect           string
 	}{
 		"empty":        {"", ""},
 		"auth snippet": {"proxy_set_header My-Custom-Header 42;", "proxy_set_header My-Custom-Header 42;"},

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -1026,6 +1026,8 @@ stream {
         location {{ buildAuthSignURLLocation $location.Path $externalAuth.SigninURL }} {
             internal;
 
+            {{ $externalAuth.SigninURLSnippet }}
+
             add_header Set-Cookie $auth_cookie;
 
             return 302 {{ buildAuthSignURL $externalAuth.SigninURL }};

--- a/test/e2e/settings/global_external_auth.go
+++ b/test/e2e/settings/global_external_auth.go
@@ -214,6 +214,25 @@ var _ = framework.DescribeSetting("[Security] global-auth-url", func() {
 				})
 		})
 
+		ginkgo.It(`should add custom error page when global-auth-signin and global-auth-signin-snippet url are configured`, func() {
+
+			globalExternalAuthSigninSetting := "global-auth-signin"
+			globalExternalAuthSignin := "http://foo.com/global-error-page"
+			globalExternalAuthSigninSnippetSetting := "global-auth-signin-snippet"
+			globalExternalAuthSigninSnippet := "ThisIsASnippet"
+
+			ginkgo.By("Adding a global-auth-signin to configMap")
+			f.UpdateNginxConfigMapData(globalExternalAuthSigninSetting, globalExternalAuthSignin)
+
+			ginkgo.By("global-auth-signin-snippet")
+			f.UpdateNginxConfigMapData(globalExternalAuthSigninSnippetSetting, globalExternalAuthSigninSnippet)
+
+			f.WaitForNginxServer(host,
+				func(server string) bool {
+					return strings.Contains(server, "proxy_set_header ThisIsSnippet 42;")
+				})
+		})
+
 		ginkgo.It(`should add auth headers when global-auth-response-headers is configured`, func() {
 
 			globalExternalAuthResponseHeadersSetting := "global-auth-response-headers"

--- a/test/e2e/settings/global_external_auth.go
+++ b/test/e2e/settings/global_external_auth.go
@@ -224,7 +224,7 @@ var _ = framework.DescribeSetting("[Security] global-auth-url", func() {
 			ginkgo.By("Adding a global-auth-signin to configMap")
 			f.UpdateNginxConfigMapData(globalExternalAuthSigninSetting, globalExternalAuthSignin)
 
-			ginkgo.By("global-auth-signin-snippet")
+			ginkgo.By("Adding a global-auth-signin-snippet to configMap")
 			f.UpdateNginxConfigMapData(globalExternalAuthSigninSnippetSetting, globalExternalAuthSigninSnippet)
 
 			f.WaitForNginxServer(host,

--- a/test/e2e/settings/global_external_auth.go
+++ b/test/e2e/settings/global_external_auth.go
@@ -219,7 +219,7 @@ var _ = framework.DescribeSetting("[Security] global-auth-url", func() {
 			globalExternalAuthSigninSetting := "global-auth-signin"
 			globalExternalAuthSignin := "http://foo.com/global-error-page"
 			globalExternalAuthSigninSnippetSetting := "global-auth-signin-snippet"
-			globalExternalAuthSigninSnippet := "ThisIsASnippet"
+			globalExternalAuthSigninSnippet := "proxy_set_header ThisIsSnippet 42;"
 
 			ginkgo.By("Adding a global-auth-signin to configMap")
 			f.UpdateNginxConfigMapData(globalExternalAuthSigninSetting, globalExternalAuthSignin)


### PR DESCRIPTION
This introduces 2 new annotations `auth-signin-snippet` and `global-auth-signin-snippet`. This allows adding snippets into the external signin location.

## What this PR does / why we need it:
I wanted to return 401 response for json requests (or grpc requests) and 302 redirect for interactive requests. This was not possible to do without modifying the template. This PR allows defining such snippets both on global scope and locally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
N/A

## How Has This Been Tested?
I've added tests replicating the ones that were in place for `global-auth-snippet`.
Tested my use case manually in local environment to validate it works as expected.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
