### PR TITLE
Add opentracing operation name settings

### DIFF
--- a/docs/user-guide/nginx-configuration/configmap.md
+++ b/docs/user-guide/nginx-configuration/configmap.md
@@ -121,6 +121,8 @@ The following table shows a configuration option's name, type, and the default v
 |[proxy-add-original-uri-header](#proxy-add-original-uri-header)|bool|"false"|
 |[generate-request-id](#generate-request-id)|bool|"true"|
 |[enable-opentracing](#enable-opentracing)|bool|"false"|
+|[opentracing-operation-name](#opentracing-operation-name)|string|""|
+|[opentracing-location-operation-name](#opentracing-location-operation-name)|string|""|
 |[zipkin-collector-host](#zipkin-collector-host)|string|""|
 |[zipkin-collector-port](#zipkin-collector-port)|int|9411|
 |[zipkin-service-name](#zipkin-service-name)|string|"nginx"|
@@ -772,6 +774,18 @@ Enables the nginx Opentracing extension. _**default:**_ is disabled
 
 _References:_
 [https://github.com/opentracing-contrib/nginx-opentracing](https://github.com/opentracing-contrib/nginx-opentracing)
+
+## opentracing-operation-name
+
+Specifies a custom name for the server span. _**default:**_ is empty
+
+For example, set to "HTTP $request_method $uri".
+
+## opentracing-location-operation-name
+
+Specifies a custom name for the location span. _**default:**_ is empty
+
+For example, set to "HTTP $request_method $uri".
 
 ## zipkin-collector-host
 

--- a/docs/user-guide/third-party-addons/opentracing.md
+++ b/docs/user-guide/third-party-addons/opentracing.md
@@ -39,6 +39,12 @@ have been tested.
 
 Other optional configuration options:
 ```
+# specifies the name to use for the server span
+opentracing-operation-name
+
+# specifies specifies the name to use for the location span
+opentracing-location-operation-name
+
 # specifies the port to use when uploading traces, Default: 9411
 zipkin-collector-port
 

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -503,6 +503,12 @@ type Configuration struct {
 	// By default this is disabled
 	EnableOpentracing bool `json:"enable-opentracing"`
 
+	// OpentracingOperationName specifies a custom name for the server span
+	OpentracingOperationName string `json:"opentracing-operation-name"`
+
+	// OpentracingOperationName specifies a custom name for the location span
+	OpentracingLocationOperationName string `json:"opentracing-location-operation-name"`
+
 	// ZipkinCollectorHost specifies the host to use when uploading traces
 	ZipkinCollectorHost string `json:"zipkin-collector-host"`
 

--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -970,6 +970,13 @@ func buildOpentracing(c interface{}, s interface{}) string {
 
 	buf.WriteString("\r\n")
 
+	if cfg.OpentracingOperationName != "" {
+		buf.WriteString(fmt.Sprintf("opentracing_operation_name \"%s\";\n", cfg.OpentracingOperationName))
+	}
+	if cfg.OpentracingLocationOperationName != "" {
+		buf.WriteString(fmt.Sprintf("opentracing_location_operation_name \"%s\";\n", cfg.OpentracingLocationOperationName))
+	}
+
 	return buf.String()
 }
 

--- a/internal/ingress/controller/template/template_test.go
+++ b/internal/ingress/controller/template/template_test.go
@@ -1193,6 +1193,21 @@ func TestBuildOpenTracing(t *testing.T) {
 		t.Errorf("Expected '%v' but returned '%v'", expected, actual)
 	}
 
+	cfgOpenTracing := config.Configuration{
+		EnableOpentracing:                true,
+		DatadogCollectorHost:             "datadog-host.com",
+		OpentracingOperationName:         "my-operation-name",
+		OpentracingLocationOperationName: "my-location-operation-name",
+	}
+	expected = "opentracing_load_tracer /usr/local/lib64/libdd_opentracing.so /etc/nginx/opentracing.json;\r\n"
+	expected += "opentracing_operation_name \"my-operation-name\";\n"
+	expected += "opentracing_location_operation_name \"my-location-operation-name\";\n"
+	actual = buildOpentracing(cfgOpenTracing, []*ingress.Server{})
+
+	if expected != actual {
+		t.Errorf("Expected '%v' but returned '%v'", expected, actual)
+	}
+
 }
 
 func TestEnforceRegexModifier(t *testing.T) {

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -276,16 +276,6 @@ http {
     limit_req_status                {{ $cfg.LimitReqStatusCode }};
     limit_conn_status               {{ $cfg.LimitConnStatusCode }};
 
-    {{ if $cfg.EnableOpentracing }}
-    opentracing on;
-    {{ if not (empty $cfg.OpentracingOperationName) }}
-    opentracing_operation_name "{{ $cfg.OpentracingOperationName }}";
-    {{ end }}
-    {{ if not (empty $cfg.OpentracingLocationOperationName) }}
-    opentracing_location_operation_name "{{ $cfg.OpentracingLocationOperationName }}";
-    {{ end }}
-    {{ end }}
-
     {{ buildOpentracing $cfg $servers }}
 
     include /etc/nginx/mime.types;

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -276,6 +276,16 @@ http {
     limit_req_status                {{ $cfg.LimitReqStatusCode }};
     limit_conn_status               {{ $cfg.LimitConnStatusCode }};
 
+    {{ if $cfg.EnableOpentracing }}
+    opentracing on;
+    {{ if not (empty $cfg.OpentracingOperationName) }}
+    opentracing_operation_name "{{ $cfg.OpentracingOperationName }}";
+    {{ end }}
+    {{ if not (empty $cfg.OpentracingLocationOperationName) }}
+    opentracing_location_operation_name "{{ $cfg.OpentracingLocationOperationName }}";
+    {{ end }}
+    {{ end }}
+
     {{ buildOpentracing $cfg $servers }}
 
     include /etc/nginx/mime.types;

--- a/test/e2e/settings/opentracing.go
+++ b/test/e2e/settings/opentracing.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package settings
+
+import (
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+
+	"k8s.io/ingress-nginx/test/e2e/framework"
+)
+
+var _ = framework.IngressNginxDescribe("Configure OpenTracing", func() {
+	f := framework.NewDefaultFramework("enable-opentracing")
+	enableOpentracing := "enable-opentracing"
+	opentracingOperationName := "opentracing-operation-name"
+	opentracingLocationOperationName := "opentracing-location-operation-name"
+
+	BeforeEach(func() {
+		f.NewEchoDeployment()
+	})
+
+	AfterEach(func() {
+	})
+
+	It("should not exists opentracing directive", func() {
+		f.UpdateNginxConfigMapData(enableOpentracing, "false")
+
+		f.EnsureIngress(framework.NewSingleIngress(enableOpentracing, "/", enableOpentracing, f.Namespace, "http-svc", 80, nil))
+
+		f.WaitForNginxConfiguration(
+			func(cfg string) bool {
+				return !strings.Contains(cfg, "opentracing on")
+			})
+	})
+
+	It("should exists opentracing directive when is enabled", func() {
+		f.UpdateNginxConfigMapData(enableOpentracing, "true")
+
+		f.EnsureIngress(framework.NewSingleIngress(enableOpentracing, "/", enableOpentracing, f.Namespace, "http-svc", 80, nil))
+
+		f.WaitForNginxConfiguration(
+			func(cfg string) bool {
+				return strings.Contains(cfg, "opentracing on")
+			})
+	})
+
+	It("should not exists opentracing_operation_name directive when is empty", func() {
+		f.UpdateNginxConfigMapData(enableOpentracing, "true")
+		f.UpdateNginxConfigMapData(opentracingOperationName, "")
+
+		f.EnsureIngress(framework.NewSingleIngress(enableOpentracing, "/", enableOpentracing, f.Namespace, "http-svc", 80, nil))
+
+		f.WaitForNginxConfiguration(
+			func(cfg string) bool {
+				return !strings.Contains(cfg, "opentracing_operation_name")
+			})
+	})
+
+	It("should exists opentracing_operation_name directive when is configured", func() {
+		f.UpdateNginxConfigMapData(enableOpentracing, "true")
+		f.UpdateNginxConfigMapData(opentracingOperationName, "HTTP $request_method $uri")
+
+		f.EnsureIngress(framework.NewSingleIngress(enableOpentracing, "/", enableOpentracing, f.Namespace, "http-svc", 80, nil))
+
+		f.WaitForNginxConfiguration(
+			func(cfg string) bool {
+				return strings.Contains(cfg, "opentracing_operation_name \"HTTP $request_method $uri\"")
+			})
+	})
+
+	It("should not exists opentracing_operation_name directive when is empty", func() {
+		f.UpdateNginxConfigMapData(enableOpentracing, "true")
+		f.UpdateNginxConfigMapData(opentracingLocationOperationName, "")
+
+		f.EnsureIngress(framework.NewSingleIngress(enableOpentracing, "/", enableOpentracing, f.Namespace, "http-svc", 80, nil))
+
+		f.WaitForNginxConfiguration(
+			func(cfg string) bool {
+				return !strings.Contains(cfg, "opentracing_location_operation_name")
+			})
+	})
+
+	It("should exists opentracing_operation_name directive when is configured", func() {
+		f.UpdateNginxConfigMapData(enableOpentracing, "true")
+		f.UpdateNginxConfigMapData(opentracingLocationOperationName, "HTTP $request_method $uri")
+
+		f.EnsureIngress(framework.NewSingleIngress(enableOpentracing, "/", enableOpentracing, f.Namespace, "http-svc", 80, nil))
+
+		f.WaitForNginxConfiguration(
+			func(cfg string) bool {
+				return strings.Contains(cfg, "opentracing_location_operation_name \"HTTP $request_method $uri\"")
+			})
+	})
+})

--- a/test/e2e/settings/opentracing.go
+++ b/test/e2e/settings/opentracing.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ package settings
 import (
 	"strings"
 
-	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo"
 
 	"k8s.io/ingress-nginx/test/e2e/framework"
 )
@@ -27,17 +27,18 @@ import (
 var _ = framework.IngressNginxDescribe("Configure OpenTracing", func() {
 	f := framework.NewDefaultFramework("enable-opentracing")
 	enableOpentracing := "enable-opentracing"
+	zipkinCollectorHost := "zipkin-collector-host"
 	opentracingOperationName := "opentracing-operation-name"
 	opentracingLocationOperationName := "opentracing-location-operation-name"
 
-	BeforeEach(func() {
+	ginkgo.BeforeEach(func() {
 		f.NewEchoDeployment()
 	})
 
-	AfterEach(func() {
+	ginkgo.AfterEach(func() {
 	})
 
-	It("should not exists opentracing directive", func() {
+	ginkgo.It("should not exists opentracing directive", func() {
 		f.UpdateNginxConfigMapData(enableOpentracing, "false")
 
 		f.EnsureIngress(framework.NewSingleIngress(enableOpentracing, "/", enableOpentracing, f.Namespace, "http-svc", 80, nil))
@@ -48,8 +49,9 @@ var _ = framework.IngressNginxDescribe("Configure OpenTracing", func() {
 			})
 	})
 
-	It("should exists opentracing directive when is enabled", func() {
+	ginkgo.It("should exists opentracing directive when is enabled", func() {
 		f.UpdateNginxConfigMapData(enableOpentracing, "true")
+		f.UpdateNginxConfigMapData(zipkinCollectorHost, "127.0.0.1")
 
 		f.EnsureIngress(framework.NewSingleIngress(enableOpentracing, "/", enableOpentracing, f.Namespace, "http-svc", 80, nil))
 
@@ -59,8 +61,9 @@ var _ = framework.IngressNginxDescribe("Configure OpenTracing", func() {
 			})
 	})
 
-	It("should not exists opentracing_operation_name directive when is empty", func() {
+	ginkgo.It("should not exists opentracing_operation_name directive when is empty", func() {
 		f.UpdateNginxConfigMapData(enableOpentracing, "true")
+		f.UpdateNginxConfigMapData(zipkinCollectorHost, "127.0.0.1")
 		f.UpdateNginxConfigMapData(opentracingOperationName, "")
 
 		f.EnsureIngress(framework.NewSingleIngress(enableOpentracing, "/", enableOpentracing, f.Namespace, "http-svc", 80, nil))
@@ -71,8 +74,9 @@ var _ = framework.IngressNginxDescribe("Configure OpenTracing", func() {
 			})
 	})
 
-	It("should exists opentracing_operation_name directive when is configured", func() {
+	ginkgo.It("should exists opentracing_operation_name directive when is configured", func() {
 		f.UpdateNginxConfigMapData(enableOpentracing, "true")
+		f.UpdateNginxConfigMapData(zipkinCollectorHost, "127.0.0.1")
 		f.UpdateNginxConfigMapData(opentracingOperationName, "HTTP $request_method $uri")
 
 		f.EnsureIngress(framework.NewSingleIngress(enableOpentracing, "/", enableOpentracing, f.Namespace, "http-svc", 80, nil))
@@ -83,8 +87,9 @@ var _ = framework.IngressNginxDescribe("Configure OpenTracing", func() {
 			})
 	})
 
-	It("should not exists opentracing_operation_name directive when is empty", func() {
+	ginkgo.It("should not exists opentracing_location_operation_name directive when is empty", func() {
 		f.UpdateNginxConfigMapData(enableOpentracing, "true")
+		f.UpdateNginxConfigMapData(zipkinCollectorHost, "127.0.0.1")
 		f.UpdateNginxConfigMapData(opentracingLocationOperationName, "")
 
 		f.EnsureIngress(framework.NewSingleIngress(enableOpentracing, "/", enableOpentracing, f.Namespace, "http-svc", 80, nil))
@@ -95,8 +100,9 @@ var _ = framework.IngressNginxDescribe("Configure OpenTracing", func() {
 			})
 	})
 
-	It("should exists opentracing_operation_name directive when is configured", func() {
+	ginkgo.It("should exists opentracing_location_operation_name directive when is configured", func() {
 		f.UpdateNginxConfigMapData(enableOpentracing, "true")
+		f.UpdateNginxConfigMapData(zipkinCollectorHost, "127.0.0.1")
 		f.UpdateNginxConfigMapData(opentracingLocationOperationName, "HTTP $request_method $uri")
 
 		f.EnsureIngress(framework.NewSingleIngress(enableOpentracing, "/", enableOpentracing, f.Namespace, "http-svc", 80, nil))


### PR DESCRIPTION
## What this PR does / why we need it:
Based on stale PR #4118
In order to set custom span names for server and location span use the following config items in the configmap:
```
opentracing-operation-name: "HTTP $request_method $uri"
opentracing-location-operation-name: "HTTP $request_method $uri"
```

## Which issue/s this PR fixes

fixes #5829
fixes #4116

## How Has This Been Tested?
Original PR had some E2E tests. Modified them to make them load a tracer (Zipkin in this case, this is required for nginx to not crash)

## Checklist:
- [ x] My change requires a change to the documentation.
- [ x] I have updated the documentation accordingly.
- [ x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ x] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
