### PR TITLE
Skip host metrics only if --metrics-per-host is enabled

### DIFF
--- a/internal/ingress/metric/collectors/socket.go
+++ b/internal/ingress/metric/collectors/socket.go
@@ -230,8 +230,8 @@ func (sc *SocketCollector) handleMessage(msg []byte) {
 	}
 
 	for _, stats := range statsBatch {
-		if !sc.hosts.Has(stats.Host) {
-			klog.V(3).Infof("skiping metric for host %v that is not being served", stats.Host)
+		if sc.metricsPerHost && !sc.hosts.Has(stats.Host) {
+			klog.V(3).Infof("skiping metric for host %v that is not being served and metrics-per-host is enabled", stats.Host)
 			continue
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In current implementation, metrics from a request if skipped, if hostname does not exist in host list specified in ingress manifest. As a result, if no host is specified in manifest, no request metrics will be recorded.
A switch `--metrics-per-host` exists to control whether host label is attached to metric or not.

This PR will make the restrict the skip case to happen only if `--metrics-per-host` is true (the default).
i.e. if `--metrics-per-host=false` is specified, requests from all hostname will have their metrics recorded.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
#5755 
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Unittest/e2e
- Personal usage

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
