### PR TITLE
feat(baremetal): Add kustomization.yaml

### DIFF
--- a/deploy/static/provider/aws/kustomization.yaml
+++ b/deploy/static/provider/aws/kustomization.yaml
@@ -1,0 +1,11 @@
+# NOTE: kustomize is not supported. This file exists only to be able to reference it from bases.
+# https://kubectl.docs.kubernetes.io/pages/reference/kustomize.html#bases
+#
+# ```
+# namespace: ingress-nginx
+# bases:
+#   - github.com/kubernetes/ingress-nginx/deploy/static/provider/aws?ref=master
+# ```
+
+resources:
+  - deploy.yaml

--- a/deploy/static/provider/baremetal/kustomization.yaml
+++ b/deploy/static/provider/baremetal/kustomization.yaml
@@ -1,0 +1,11 @@
+# NOTE: kustomize is not supported. This file exists only to be able to reference it from bases.
+# https://kubectl.docs.kubernetes.io/pages/reference/kustomize.html#bases
+#
+# ```
+# namespace: ingress-nginx
+# bases:
+#   - github.com/kubernetes/ingress-nginx/deploy/static/provider/baremetal?ref=master
+# ```
+
+resources:
+  - deploy.yaml

--- a/deploy/static/provider/cloud/kustomization.yaml
+++ b/deploy/static/provider/cloud/kustomization.yaml
@@ -1,0 +1,11 @@
+# NOTE: kustomize is not supported. This file exists only to be able to reference it from bases.
+# https://kubectl.docs.kubernetes.io/pages/reference/kustomize.html#bases
+#
+# ```
+# namespace: ingress-nginx
+# bases:
+#   - github.com/kubernetes/ingress-nginx/deploy/static/provider/cloud?ref=master
+# ```
+
+resources:
+  - deploy.yaml

--- a/deploy/static/provider/do/kustomization.yaml
+++ b/deploy/static/provider/do/kustomization.yaml
@@ -1,0 +1,11 @@
+# NOTE: kustomize is not supported. This file exists only to be able to reference it from bases.
+# https://kubectl.docs.kubernetes.io/pages/reference/kustomize.html#bases
+#
+# ```
+# namespace: ingress-nginx
+# bases:
+#   - github.com/kubernetes/ingress-nginx/deploy/static/provider/do?ref=master
+# ```
+
+resources:
+  - deploy.yaml

--- a/deploy/static/provider/kind/kustomization.yaml
+++ b/deploy/static/provider/kind/kustomization.yaml
@@ -1,0 +1,11 @@
+# NOTE: kustomize is not supported. This file exists only to be able to reference it from bases.
+# https://kubectl.docs.kubernetes.io/pages/reference/kustomize.html#bases
+#
+# ```
+# namespace: ingress-nginx
+# bases:
+#   - github.com/kubernetes/ingress-nginx/deploy/static/provider/kind?ref=master
+# ```
+
+resources:
+  - deploy.yaml


### PR DESCRIPTION
With this change, one can [use kustomize](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization/) to deploy ingress-nginx on bare-metal clusters. Example:

```
# kustomization.yml

namespace: ingress-nginx

bases:
  - github.com/kubernetes/ingress-nginx/deploy/static/provider/baremetal?ref=master
```

Usage: In the same folder run: `$ kubectl apply -k .`
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

```
# kustomization.yml

namespace: ingress-nginx

bases:
  - github.com/haslersn/ingress-nginx/deploy/static/provider/baremetal?ref=baremetal/kustomize
```
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
