### PR TITLE
Add SIGCHLD handler

### DIFF
--- a/cmd/nginx/main.go
+++ b/cmd/nginx/main.go
@@ -201,11 +201,11 @@ func handleSigchld() {
 		klog.V(5).Infof("Children process terminated")
 
 		var wstatus syscall.WaitStatus
-		_, err := syscall.Wait4(-1, &wstatus, syscall.WNOHANG, nil)
-		if syscall.ECHILD == err {
-			continue
+		wpid, err := syscall.Wait4(-1, &wstatus, syscall.WNOHANG, nil)
+		for syscall.ECHILD != err {
+			klog.V(5).Infof("Children cleanup.PID: %v, wstatus: %v\n", wpid, wstatus)
+			wpid, err = syscall.Wait4(-1, &wstatus, syscall.WNOHANG, nil)
 		}
-		klog.V(5).Infof("Children cleanup. wstatus: %v\n", wstatus)
 	}
 }
 

--- a/cmd/nginx/main.go
+++ b/cmd/nginx/main.go
@@ -207,7 +207,6 @@ func handleSigchld() {
 		}
 		klog.V(5).Infof("Children cleanup. wstatus: %v\n", wstatus)
 	}
-
 }
 
 // createApiserverClient creates a new Kubernetes REST client. apiserverHost is

--- a/cmd/nginx/main_test.go
+++ b/cmd/nginx/main_test.go
@@ -133,6 +133,7 @@ func TestHandleSigchld(t *testing.T) {
 		select {
 		case <-timeoutTimer:
 			t.Error("Timeout!. Zombie process still there")
+			return
 		case <-checkZombie:
 			if _, err := os.Stat("/proc/" + strconv.Itoa(pid)); os.IsNotExist(err) {
 				t.Log("Process cleaned")

--- a/cmd/nginx/main_test.go
+++ b/cmd/nginx/main_test.go
@@ -111,32 +111,119 @@ func TestHandleSigterm(t *testing.T) {
 	}
 }
 
+func startKidProcess() (int, error) {
+	cmd := exec.Command("sleep", "5m")
+	err := cmd.Start()
+	return cmd.Process.Pid, err
+}
+
 func TestHandleSigchld(t *testing.T) {
 	go handleSigchld()
 
-	cmd := exec.Command("sleep", "5m")
-	err := cmd.Start()
-	if err != nil {
-		t.Error("Cannot start children command: ", err)
+	const children_count = 5
+	var pids []int
+	for i := 0; i < children_count; i++ {
+		pid, err := startKidProcess()
+		if err != nil {
+			t.Error("Cannot start children command: ", err)
+			return
+		}
+		pids = append(pids, pid)
 	}
-	pid := cmd.Process.Pid
+	t.Logf("Children PIDS: %v", pids)
 	time.Sleep(1 * time.Second)
 
-	err = syscall.Kill(pid, syscall.SIGKILL)
-	if err != nil {
-		t.Error("Unexpected error sending SIGKILL signal.")
+	for _, pid := range pids {
+		err := syscall.Kill(pid, syscall.SIGKILL)
+		if err != nil {
+			t.Error("Unexpected error sending SIGKILL signal.")
+		} else {
+			t.Logf("%d killed", pid)
+		}
 	}
 
 	checkZombie := time.Tick(1 * time.Second)
-	timeoutTimer := time.After(3 * time.Second)
+	timeoutTimer := time.NewTimer(5 * time.Second)
+	defer timeoutTimer.Stop()
 	for {
 		select {
-		case <-timeoutTimer:
+		case <-timeoutTimer.C:
 			t.Error("Timeout!. Zombie process still there")
 			return
 		case <-checkZombie:
-			if _, err := os.Stat("/proc/" + strconv.Itoa(pid)); os.IsNotExist(err) {
-				t.Log("Process cleaned")
+			deadChildren := 0
+			for _, pid := range pids {
+				if _, err := os.Stat("/proc/" + strconv.Itoa(pid)); os.IsNotExist(err) {
+					deadChildren += 1
+					t.Logf("Process %d die", pid)
+				}
+			}
+			if len(pids) == deadChildren {
+				t.Log("All Processes cleaned")
+				return
+			}
+		}
+	}
+}
+
+func TestHandleSigchldWithMonitoredChildren(t *testing.T) {
+	go handleSigchld()
+
+	const children_count = 5
+	var pids []int
+	pid, err := startKidProcess()
+	if err != nil {
+		t.Error("Cannot start children command: ", err)
+		return
+	}
+	pids = append(pids, pid)
+
+	monitoredCmdIsRunning := true
+	monitoredCmd := exec.Command("sleep", "5m")
+	err = monitoredCmd.Start()
+	if err != nil {
+		t.Error("Cannot start monitoed children command: ", err)
+		return
+	}
+	go func() {
+		monitoredCmd.Wait()
+		monitoredCmdIsRunning = false
+	}()
+
+	pid, err = startKidProcess()
+	if err != nil {
+		t.Error("Cannot start children command: ", err)
+		return
+	}
+	pids = append(pids, pid)
+
+	for _, pid := range pids {
+		err := syscall.Kill(pid, syscall.SIGKILL)
+		if err != nil {
+			t.Error("Unexpected error sending SIGKILL signal.")
+		} else {
+			t.Logf("%d killed", pid)
+		}
+	}
+
+	checkZombie := time.Tick(1 * time.Second)
+	timeoutTimer := time.NewTimer(5 * time.Second)
+	defer timeoutTimer.Stop()
+	for {
+		select {
+		case <-timeoutTimer.C:
+			t.Error("Timeout!. Zombie process still there")
+			return
+		case <-checkZombie:
+			deadChildren := 0
+			for _, pid := range pids {
+				if _, err := os.Stat("/proc/" + strconv.Itoa(pid)); os.IsNotExist(err) {
+					deadChildren += 1
+					t.Logf("Process %d die", pid)
+				}
+			}
+			if len(pids) == deadChildren && monitoredCmdIsRunning {
+				t.Log("All Processes cleaned and the monitored process is running fine")
 				return
 			}
 		}


### PR DESCRIPTION
NGINX Ingress controller does not have a handler to the SIGCHLD signal. Some monitor systems add companions processes to the nginx process. In the SIGCHLD handler when these processes not launched by the NGINX ingress controller die, NGINX will be able to clean them up and avoid zombie processes.

## What this PR does / why we need it:

Avoid zombie processes

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes

fixes #2807


## How Has This Been Tested?

I have a k8s cluster running with Dynatrace installed. After deploy this NGINX Ingress controller installed I just kill one of the NGINX ingress controller children processes. Usually the nginx master process.

