### PR TITLE
Fix panic in ingress class validation

### DIFF
--- a/internal/ingress/annotations/class/main.go
+++ b/internal/ingress/annotations/class/main.go
@@ -63,5 +63,8 @@ func IsValid(ing *networking.Ingress) bool {
 	}
 
 	// 4. with IngressClass
-	return k8s.IngressClass.Name == *ing.Spec.IngressClassName
+	if ing.Spec.IngressClassName != nil {
+		return k8s.IngressClass.Name == *ing.Spec.IngressClassName
+	}
+	return false
 }


### PR DESCRIPTION
## What this PR does / why we need it:
If an Ingress had no class annotation, nor IngressClassName  at all, and an IngressClass resource was created for the ingress-nginx there was a panic when the controller tried to check the IngressClassName of the Ingress.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes

## How Has This Been Tested?
unit testing

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
