### PR TITLE
Typo

### DIFF
--- a/charts/ingress-nginx/README.md
+++ b/charts/ingress-nginx/README.md
@@ -101,7 +101,7 @@ Parameter | Description | Default
 `controller.publishService.pathOverride` | override of the default publish-service name | `""`
 `controller.service.annotations` | annotations for controller service | `{}`
 `controller.service.labels` | labels for controller service | `{}`
-`controller.service.enabled` | if disabled no service will be created. This is especially useful when `controller.kind` is set to `DaemonSet` and `controller.hostPorts.enabled` is `true` | true
+`controller.service.enabled` | if disabled no service will be created. This is especially useful when `controller.kind` is set to `DaemonSet` and `controller.hostPort.enabled` is `true` | true
 `controller.service.clusterIP` | internal controller cluster service IP (set to `"-"` to pass an empty value) | `nil`
 `controller.service.omitClusterIP` | (Deprecated) To omit the `clusterIP` from the controller service | `false`
 `controller.service.externalIPs` | controller service external IP addresses. Do not set this when `controller.hostNetwork` is set to `true` and `kube-proxy` is used as there will be a port-conflict for port `80` | `[]`


### PR DESCRIPTION
Typo in documentation. Should be `hostPort` since no `hostPorts` exist.