### PR TITLE
Update deploy-tls-termination.yaml

### DIFF
--- a/deploy/static/provider/aws/deploy-tls-termination.yaml
+++ b/deploy/static/provider/aws/deploy-tls-termination.yaml
@@ -401,7 +401,7 @@ spec:
               containerPort: 80
               protocol: TCP
             - name: https
-              containerPort: 80
+              containerPort: 443
               protocol: TCP
             - name: tohttps
               containerPort: 2443


### PR DESCRIPTION
If a port named http and https are set with the same actual port number then the second one may win under some circumstances leading to no port named http. Without a port named http the service:

```
- name: https
      port: 443
      protocol: TCP
      targetPort: http
```

will fail to find a targetPort of http to route to and take down your site. I have confirmed this behavior if the file is passed through kustomize (because kustomize sees the second definition as overriding the first). If applied directly to the cluster without kustomize then the first one will win but there won't actually be a port named https in the end.

<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
