### PR TITLE
Add configurable serviceMonitor metricRelabelling and targetLabels

### DIFF
--- a/charts/ingress-nginx/Chart.yaml
+++ b/charts/ingress-nginx/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: ingress-nginx
-version: 2.11.3
+version: 2.12.0
 appVersion: 0.34.1
 home: https://github.com/kubernetes/ingress-nginx
 description: Ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer

--- a/charts/ingress-nginx/templates/controller-servicemonitor.yaml
+++ b/charts/ingress-nginx/templates/controller-servicemonitor.yaml
@@ -19,12 +19,21 @@ spec:
     {{- if .Values.controller.metrics.serviceMonitor.honorLabels }}
       honorLabels: true
     {{- end }}
+    {{- if .Values.controller.metrics.serviceMonitor.metricRelabelings }}
+      metricRelabelings: {{ toYaml .Values.controller.metrics.serviceMonitor.metricRelabelings | nindent 8 }}
+    {{- end }}
 {{- if .Values.controller.metrics.serviceMonitor.namespaceSelector }}
   namespaceSelector: {{ toYaml .Values.controller.metrics.serviceMonitor.namespaceSelector | nindent 4 }}
 {{ else }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}
+{{- end }}
+{{- if .Values.controller.metrics.serviceMonitor.targetLabels }}
+  targetLabels:
+  {{- range .Values.controller.metrics.serviceMonitor.targetLabels }}
+    - {{ . }}
+  {{- end }}
 {{- end }}
   selector:
     matchLabels:

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -426,6 +426,8 @@ controller:
       #   any: true
       scrapeInterval: 30s
       # honorLabels: true
+      targetLabels: []
+      metricRelabelings: []
 
     prometheusRule:
       enabled: false


### PR DESCRIPTION
Signed-off-by: Calvin Bui <3604363+calvinbui@users.noreply.github.com>

<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Originally opened in https://github.com/helm/charts/pull/23527

**Target Labels**:  Adds the serviceMonitor `targetLabels` key as documented in the [Prometheus Operator API](https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#servicemonitorspec)

**Metric Relabelings**: Adds the ServiceMonitor metricRelabelings key as documented in the [Prometheus Operator API](https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint). Used for adding, dropping or renaming labels at ingestion time, or to drop entire metrics that are not useful.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Ran `helm template . -f values.yaml` with default values and add then with `targetLabels` and `metricRelabelings`

```yaml
...
      targetLabels:
        - name
        - server
      metricRelabelings:
        - action: replace
          regex: nginx_ingress_.*;.+
          replacement: ""
          sourceLabels:
          - __name__
          - pod
          targetLabel: pod
...
```

This produced the YAML files as expected:

```yaml
# Source: ingress-nginx/templates/controller-servicemonitor.yaml
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  name: RELEASE-NAME-ingress-nginx-controller
  labels:
    helm.sh/chart: ingress-nginx-2.12.0
    app.kubernetes.io/name: ingress-nginx
    app.kubernetes.io/instance: RELEASE-NAME

    app.kubernetes.io/version: "0.34.1"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: controller
spec:
  endpoints:
    - port: metrics
      interval: 30s
      metricRelabelings:
        - action: replace
          regex: nginx_ingress_.*;.+
          replacement: ""
          sourceLabels:
          - __name__
          - pod
          targetLabel: pod
  namespaceSelector:
    matchNames:
      - default
  targetLabels:
    - name
    - server
  selector:
    matchLabels:
      app.kubernetes.io/name: ingress-nginx
      app.kubernetes.io/instance: RELEASE-NAME
      app.kubernetes.io/component: controller
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
