### PR TITLE
Add new Dockerfile label org.opencontainers.image.revision

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ E2E_NODES ?= 8
 E2E_CHECK_LEAKS ?=
 
 REPO_INFO ?= $(shell git config --get remote.origin.url)
-GIT_COMMIT ?= git-$(shell git rev-parse --short HEAD)
+COMMIT_SHA ?= git-$(shell git rev-parse --short HEAD)
 
 PKG = k8s.io/ingress-nginx
 
@@ -65,6 +65,7 @@ image: clean-image ## Build image for a particular arch.
 		--build-arg BASE_IMAGE="$(BASE_IMAGE)" \
 		--build-arg VERSION="$(TAG)" \
 		--build-arg TARGETARCH="$(ARCH)" \
+		--build-arg COMMIT_SHA="$(COMMIT_SHA)" \
 		-t $(REGISTRY)/controller:$(TAG) rootfs
 
 .PHONY: clean-image
@@ -77,7 +78,7 @@ build:  ## Build ingress controller, debug tool and pre-stop hook.
 	@build/run-in-docker.sh \
 		PKG=$(PKG) \
 		ARCH=$(ARCH) \
-		GIT_COMMIT=$(GIT_COMMIT) \
+		COMMIT_SHA=$(COMMIT_SHA) \
 		REPO_INFO=$(REPO_INFO) \
 		TAG=$(TAG) \
 		GOBUILD_FLAGS=$(GOBUILD_FLAGS) \
@@ -88,7 +89,7 @@ build-plugin:  ## Build ingress-nginx krew plugin.
 	@build/run-in-docker.sh \
 		PKG=$(PKG) \
 		ARCH=$(ARCH) \
-		GIT_COMMIT=$(GIT_COMMIT) \
+		COMMIT_SHA=$(COMMIT_SHA) \
 		REPO_INFO=$(REPO_INFO) \
 		TAG=$(TAG) \
 		GOBUILD_FLAGS=$(GOBUILD_FLAGS) \
@@ -108,7 +109,7 @@ test:  ## Run go unit tests.
 	@build/run-in-docker.sh \
 		PKG=$(PKG) \
 		ARCH=$(ARCH) \
-		GIT_COMMIT=$(GIT_COMMIT) \
+		COMMIT_SHA=$(COMMIT_SHA) \
 		REPO_INFO=$(REPO_INFO) \
 		TAG=$(TAG) \
 		GOBUILD_FLAGS=$(GOBUILD_FLAGS) \
@@ -213,4 +214,5 @@ release: ensure-buildx clean
 		--platform $(subst $(SPACE),$(COMMA),$(PLATFORMS)) \
 		--build-arg BASE_IMAGE="$(BASE_IMAGE)" \
 		--build-arg VERSION="$(TAG)" \
+		--build-arg COMMIT_SHA="$(COMMIT_SHA)" \
 		-t $(REGISTRY)/controller:$(TAG) rootfs

--- a/build/build-plugin.sh
+++ b/build/build-plugin.sh
@@ -26,7 +26,7 @@ declare -a mandatory
 mandatory=(
   PKG
   ARCH
-  GIT_COMMIT
+  COMMIT_SHA
   REPO_INFO
   TAG
 )
@@ -56,7 +56,7 @@ function build_for_arch(){
     "${GOBUILD_FLAGS}" \
     -ldflags "-s -w \
       -X ${PKG}/version.RELEASE=${TAG} \
-      -X ${PKG}/version.COMMIT=${GIT_COMMIT} \
+      -X ${PKG}/version.COMMIT=${COMMIT_SHA} \
       -X ${PKG}/version.REPO=${REPO_INFO}" \
     -o "${release}/kubectl-ingress_nginx${extension}" "${PKG}/cmd/plugin"
 

--- a/build/build.sh
+++ b/build/build.sh
@@ -26,7 +26,7 @@ declare -a mandatory
 mandatory=(
   PKG
   ARCH
-  GIT_COMMIT
+  COMMIT_SHA
   REPO_INFO
   TAG
 )
@@ -49,20 +49,20 @@ export GOARCH=${ARCH}
 go build \
   -ldflags "-s -w \
     -X ${PKG}/version.RELEASE=${TAG} \
-    -X ${PKG}/version.COMMIT=${GIT_COMMIT} \
+    -X ${PKG}/version.COMMIT=${COMMIT_SHA} \
     -X ${PKG}/version.REPO=${REPO_INFO}" \
   -o "rootfs/bin/${ARCH}/nginx-ingress-controller" "${PKG}/cmd/nginx"
 
 go build \
   -ldflags "-s -w \
     -X ${PKG}/version.RELEASE=${TAG} \
-    -X ${PKG}/version.COMMIT=${GIT_COMMIT} \
+    -X ${PKG}/version.COMMIT=${COMMIT_SHA} \
     -X ${PKG}/version.REPO=${REPO_INFO}" \
   -o "rootfs/bin/${ARCH}/dbg" "${PKG}/cmd/dbg"
 
 go build \
   -ldflags "-s -w \
     -X ${PKG}/version.RELEASE=${TAG} \
-    -X ${PKG}/version.COMMIT=${GIT_COMMIT} \
+    -X ${PKG}/version.COMMIT=${COMMIT_SHA} \
     -X ${PKG}/version.REPO=${REPO_INFO}" \
   -o "rootfs/bin/${ARCH}/wait-shutdown" "${PKG}/cmd/waitshutdown"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -8,7 +8,6 @@ steps:
     entrypoint: bash
     env:
       - DOCKER_CLI_EXPERIMENTAL=enabled
-      - GIT_COMMIT=$_GIT_TAG
       - REGISTRY=gcr.io/k8s-staging-ingress-nginx
       - REPO_INFO=https://github.com/kubernetes/ingress-nginx
       - HOME=/root

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -18,6 +18,7 @@ FROM ${BASE_IMAGE}
 
 ARG TARGETARCH
 ARG VERSION
+ARG COMMIT_SHA
 
 LABEL org.opencontainers.image.title="NGINX Ingress Controller for Kubernetes"
 LABEL org.opencontainers.image.documentation="https://kubernetes.github.io/ingress-nginx/"
@@ -25,6 +26,7 @@ LABEL org.opencontainers.image.source="https://github.com/kubernetes/ingress-ngi
 LABEL org.opencontainers.image.vendor="The Kubernetes Authors"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 LABEL org.opencontainers.image.version="${VERSION}"
+LABEL org.opencontainers.image.revision="${COMMIT_SHA}"
 
 WORKDIR  /etc/nginx
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:

Add a new label to track the commit from which the image is built.
The rename of the env variable is to reuse an existing one in cloud build

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
