### PR TITLE
Adding parameter for externalTrafficPolicy in controller service spec.

### DIFF
--- a/charts/ingress-nginx/templates/controller-service.yaml
+++ b/charts/ingress-nginx/templates/controller-service.yaml
@@ -14,6 +14,7 @@ metadata:
   name: {{ include "ingress-nginx.controller.fullname" . }}
 spec:
   type: {{ .Values.controller.service.type }}
+  externalTrafficPolicy: {{ .Values.controller.service.externalTrafficPolicy }}
 {{- if .Values.controller.service.clusterIP }}
   clusterIP: {{ .Values.controller.service.clusterIP }}
 {{- end }}

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -323,6 +323,8 @@ controller:
 
     type: LoadBalancer
 
+    externalTrafficPolicy: Cluster
+
     # type: NodePort
     # nodePorts:
     #   http: 32080


### PR DESCRIPTION
Adding parameter for externalTrafficPolicy in controller service spec.

## What this PR does / why we need it:
Adding this parameter enables changing the value in the Helm chart values.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
-


## How Has This Been Tested?
- Deployed the Helm chart and changed externalTrafficPolicy in the values.yaml to Local
- Controller service externalTrafficPolicy was set with value Local

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
