### PR TITLE
Adding parameter for externalTrafficPolicy in internal controller service spec.

### DIFF
--- a/charts/ingress-nginx/Chart.yaml
+++ b/charts/ingress-nginx/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: ingress-nginx
-version: 2.14.0
+version: 2.15.0
 appVersion: 0.35.0
 home: https://github.com/kubernetes/ingress-nginx
 description: Ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer

--- a/charts/ingress-nginx/templates/controller-service-internal.yaml
+++ b/charts/ingress-nginx/templates/controller-service-internal.yaml
@@ -15,6 +15,9 @@ metadata:
   name: {{ include "ingress-nginx.controller.fullname" . }}-internal
 spec:
   type: "{{ .Values.controller.service.type }}"
+{{- if .Values.controller.service.internal.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.controller.service.internal.externalTrafficPolicy }}
+{{- end }}
   ports:
   {{- $setNodePorts := (or (eq .Values.controller.service.type "NodePort") (eq .Values.controller.service.type "LoadBalancer")) }}
   {{- if .Values.controller.service.enableHttp }}

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -349,6 +349,11 @@ controller:
       enabled: false
       annotations: {}
 
+      ## Set external traffic policy to: "Local" to preserve source IP on
+      ## providers supporting it
+      ## Ref: https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typeloadbalancer
+      # externalTrafficPolicy: ""
+
   extraContainers: []
   ## Additional containers to be added to the controller pod.
   ## See https://github.com/lemonldap-ng-controller/lemonldap-ng-controller as example.


### PR DESCRIPTION
Adding parameter for externalTrafficPolicy in internal controller service spec.

## What this PR does / why we need it:
Adding this parameter enables changing the value in the Helm chart values.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes

## How Has This Been Tested?
- Deployed the Helm chart and changed externalTrafficPolicy for internal service in the values.yaml to Local
- Internal controller service externalTrafficPolicy was set with value Local

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
