### PR TITLE
Add ssl-passthrough annotation to gRPC example doc

### DIFF
--- a/docs/examples/grpc/README.md
+++ b/docs/examples/grpc/README.md
@@ -48,7 +48,12 @@ inside the cluster and arrive "insecure").
 
 For your own application you may or may not want to do this.  If you prefer to
 forward encrypted traffic to your POD and terminate TLS at the gRPC server
-itself, add the ingress annotation `nginx.ingress.kubernetes.io/backend-protocol: "GRPCS"`.
+itself, add the following ingress annotations:
+
+```yaml
+nginx.ingress.kubernetes.io/backend-protocol: "GRPCS"
+nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+```
 
 ### Step 2: the kubernetes `Service`
 


### PR DESCRIPTION
## What this PR does / why we need it:
This change updates the [gRPC example documentation](https://kubernetes.github.io/ingress-nginx/examples/grpc/) to include the `nginx.ingress.kubernetes.io/ssl-passthrough` annotation if someone wishes to terminate TLS at the gRPC server level instead of at the ingress level. More context can be found in https://github.com/kubernetes/ingress-nginx/issues/5668

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
fixes #5668


## How Has This Been Tested?
I generated the documentation site locally using [`$ make live-docs`](https://github.com/kubernetes/ingress-nginx/blob/master/Makefile#L166) and checked manually that the new documentation looked correct.

![Screen Shot 2020-08-27 at 6 37 23 PM](https://user-images.githubusercontent.com/5367247/91505475-4befcf80-e895-11ea-96ee-56b9e7665030.png)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
