### PR TITLE
Return unique addresses from service

### DIFF
--- a/internal/ingress/status/status.go
+++ b/internal/ingress/status/status.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 
 	pool "gopkg.in/go-playground/pool.v3"
@@ -339,26 +340,26 @@ func statusAddressFromService(service string, kubeClient clientset.Interface) ([
 	case apiv1.ServiceTypeClusterIP:
 		return []string{svc.Spec.ClusterIP}, nil
 	case apiv1.ServiceTypeNodePort:
-		addresses := []string{}
+		addresses := sets.NewString()
 		if svc.Spec.ExternalIPs != nil {
-			addresses = append(addresses, svc.Spec.ExternalIPs...)
+			addresses.Insert(svc.Spec.ExternalIPs...)
 		} else {
-			addresses = append(addresses, svc.Spec.ClusterIP)
+			addresses.Insert(svc.Spec.ClusterIP)
 		}
-		return addresses, nil
+		return addresses.List(), nil
 	case apiv1.ServiceTypeLoadBalancer:
-		addresses := []string{}
+		addresses := sets.NewString()
 		for _, ip := range svc.Status.LoadBalancer.Ingress {
 			if ip.IP == "" {
-				addresses = append(addresses, ip.Hostname)
+				addresses.Insert(ip.Hostname)
 			} else {
-				addresses = append(addresses, ip.IP)
+				addresses.Insert(ip.IP)
 			}
 		}
 
-		addresses = append(addresses, svc.Spec.ExternalIPs...)
+		addresses.Insert(svc.Spec.ExternalIPs...)
 
-		return addresses, nil
+		return addresses.List(), nil
 	}
 
 	return nil, fmt.Errorf("unable to extract IP address/es from service %v", service)

--- a/internal/ingress/status/status_test.go
+++ b/internal/ingress/status/status_test.go
@@ -483,6 +483,34 @@ func TestRunningAddresessWithPublishService(t *testing.T) {
 			[]string{"10.0.0.1", "foo"},
 			false,
 		},
+		"service type LoadBalancer with same externalIP and ingress IP": {
+			testclient.NewSimpleClientset(
+				&apiv1.ServiceList{Items: []apiv1.Service{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "foo",
+							Namespace: apiv1.NamespaceDefault,
+						},
+						Spec: apiv1.ServiceSpec{
+							Type:        apiv1.ServiceTypeLoadBalancer,
+							ExternalIPs: []string{"10.0.0.1"},
+						},
+						Status: apiv1.ServiceStatus{
+							LoadBalancer: apiv1.LoadBalancerStatus{
+								Ingress: []apiv1.LoadBalancerIngress{
+									{
+										IP: "10.0.0.1",
+									},
+								},
+							},
+						},
+					},
+				},
+				},
+			),
+			[]string{"10.0.0.1"},
+			false,
+		},
 		"invalid service type": {
 			testclient.NewSimpleClientset(
 				&apiv1.ServiceList{Items: []apiv1.Service{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When the `ExternalIP` of a Service and `status.loadBalancer.ingress.ip` has the same value, the ingress controller assigns duplicate IPs to the ingress. 
This behaviour was noticed while using [inlets-operator](https://github.com/inlets/inlets-operator) to provision  a VM load balancer for service of type LoadBalancer. 

Even though it might be a corner case, I felt it makes sense to assign only unique IPs to the ingress. Having duplicate IPs in the ingress also affects other services which deal with the IPs e.g. external-dns.

Example snippet from `service` (IP addresses have been changed)
```
...
spec:
  externalIPs:
  - 10.15.10.15
  externalTrafficPolicy: Cluster
...
  type: LoadBalancer
status:
  loadBalancer:
    ingress:
    - ip: 10.15.10.15
```

Example snippet of affected `ingress` 
```
...
spec:
  rules:
  - host: hello.dev.example.com
    http:
      paths:
      - backend:
          serviceName: hello-world
          servicePort: 80
        path: /
        pathType: Prefix
status:
  loadBalancer:
    ingress:
    - ip: 10.15.10.15
    - ip: 10.15.10.15
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have added a test case for the method returning a unique list. 

I also tested the controller by building an image, and running it in a kubernetes environment along side a service with the same values for `externalIP` and `status.loadBalancer.ingress.ip`. The controller now only assigns unique IPs to the ingress. 
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
