### PR TITLE
Add custom annotations example to documentation

### DIFF
--- a/docs/examples/customization/custom-annotations/README.md
+++ b/docs/examples/customization/custom-annotations/README.md
@@ -1,0 +1,56 @@
+# Custom annotations
+
+Demonstrates how to use arbitrary ingress annotations, and notably custom ones.
+
+In this example, we wish to conditionally add an ingress-specific request header (only if not already set by client).
+This could be done with a Lua block:
+
+```lua
+rewrite_by_lua_block {
+  headers = ngx.req.get_headers()
+  if not headers["foo"] then
+    ngx.req.set_header["foo"] = "bar"
+  end
+}
+```
+
+We might try to add it via [configuration snippets](../configuration-snippets/README.md), only to find out that configuration reloads fail due to duplicate `rewrite_by_lua_block` directives, as another one is already present in the default template.
+
+To work around this issue, we must find a way to insert ingress-specific configuration inside the default `rewrite_by_lua_block` directive.
+
+## Plugins: a poor solution
+
+We could write a Lua plugin, using a `ngx.var.host` filter to determine which headers to add in `rewrite()` (akin to the [`hello_world` plugin example](../../../../rootfs/etc/nginx/lua/plugins/hello_world)). However, this separates an ingress definition from its headers, which is inelegant and poorly maintainable.
+
+## Custom annotations: the right solution
+
+We can access raw ingress data in NGINX templates via the already defined `$ing` variable:
+
+```nginx
+{{ $ing := (getIngressInformation $location.Ingress $server.Hostname $location.Path) }}
+```
+
+This enables us to craft a [custom template](../../../user-guide/nginx-configuration/custom-template.md), where we access custom annotations in the default `rewrite_by_lua_block` directive:
+
+```nginx
+rewrite_by_lua_block {
+  ... -- default template config
+
+  -- Custom headers
+  {{ if index $ing.Annotations "my-annotations/custom-headers" }}
+  {{ index $ing.Annotations "my-annotations/custom-headers" }}
+  {{ end }}
+}
+```
+
+It is then possible to insert conditional headers directly in an ingress definition (see [ingress.yaml](ingress.yaml) for full ingress definition):
+
+```yaml
+my-annotations/custom-headers: |
+  headers = ngx.req.get_headers()
+  if not headers["foo"] then
+    ngx.req.set_header["foo"] = "bar"
+  end
+```
+
+Hopefully this gives you some ideas to play with custom annotations :)

--- a/docs/examples/customization/custom-annotations/ingress.yaml
+++ b/docs/examples/customization/custom-annotations/ingress.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: nginx-custom-annotations
+  annotations:
+    my-annotations/custom-headers: |
+      headers = ngx.req.get_headers()
+      if not headers["foo"] then
+        ngx.req.set_header["foo"] = "bar"
+      end
+spec:
+  rules:
+    - host: custom.annotations.com
+      http:
+        paths:
+          - backend:
+              serviceName: http-svc
+              servicePort: 80
+            path: /

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -11,6 +11,7 @@ Auth | [Client certificate authentication](auth/client-certs/README.md) | secure
 Auth | [External authentication plugin](auth/external-auth/README.md) | defer to an external authentication service | Intermediate
 Auth | [OAuth external auth](auth/oauth-external-auth/README.md) | TODO | TODO
 Customization | [Configuration snippets](customization/configuration-snippets/README.md) | customize nginx location configuration using annotations | Advanced
+Customization | [Custom annotations](customization/custom-annotations/README.md) | process custom ingress annotations using custom templates | Advanced
 Customization | [Custom configuration](customization/custom-configuration/README.md) | TODO | TODO
 Customization | [Custom DH parameters for perfect forward secrecy](customization/ssl-dh-param/README.md) | TODO | TODO
 Customization | [Custom errors](customization/custom-errors/README.md) | serve custom error pages from the default backend | Intermediate

--- a/docs/user-guide/nginx-configuration/custom-template.md
+++ b/docs/user-guide/nginx-configuration/custom-template.md
@@ -52,3 +52,16 @@ TODO:
 - serverConfig:
 - isLocationAllowed:
 - isValidClientBodyBufferSize:
+
+## Accessing raw ingress data from custom templates
+
+It is possible to access raw ingress data from custom templates with the help of `getIngressInformation`.
+This function is already called at the top of the `location` directive:
+
+```nginx
+{{ $ing := (getIngressInformation $location.Ingress $server.Hostname $location.Path) }}
+```
+
+`$ing` can then be used as you please to process raw ingress data, for example `$ing.Annotations`.
+
+An example leveraging custom annotations to conditionally add headers (only if not already set by client) can be found [here](../../examples/customization/custom-annotations/README.md).

--- a/rootfs/etc/nginx/lua/plugins/README.md
+++ b/rootfs/etc/nginx/lua/plugins/README.md
@@ -17,7 +17,7 @@ By defining functions with the following names, you can run your custom Lua code
  - `header_filter`: this is called when backend response header is received, it is useful for modifying response headers
  - `log`: this is called when request processing is commpleted and response is delivered to the client
 
-Check this [`hello_world`](https://github.com/kubernetes/ingress-nginx/tree/master/rootfs/etc/nginx/lua/plugins/hello_world) plugin as a simple example or refer to [OpenID Connect integration](https://github.com/ElvinEfendi/ingress-nginx-openidc/tree/master/rootfs/etc/nginx/lua/plugins/openidc) for more advanced usage.
+Check this [`hello_world`](hello_world) plugin as a simple example or refer to [OpenID Connect integration](https://github.com/ElvinEfendi/ingress-nginx-openidc/tree/master/rootfs/etc/nginx/lua/plugins/openidc) for more advanced usage.
 
 Do not forget to write tests for your plugin.
 


### PR DESCRIPTION
## What this PR does / why we need it:

This demonstrates how to leverage custom templates to access raw ingress data, and notably custom annotations.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

None of the above: documentation only.

## How Has This Been Tested?

By looking at the doc of this branch over at [my fork](https://github.com/Skymirrh/ingress-nginx/tree/documentation/custom-annotations).

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
