### PR TITLE
Reject ingresses that use the default annotation if a custom one was provided

### DIFF
--- a/cmd/nginx/flags.go
+++ b/cmd/nginx/flags.go
@@ -126,7 +126,7 @@ Requires the update-status parameter.`)
 		enableSSLPassthrough = flags.Bool("enable-ssl-passthrough", false,
 			`Enable SSL Passthrough.`)
 
-		annotationsPrefix = flags.String("annotations-prefix", "nginx.ingress.kubernetes.io",
+		annotationsPrefix = flags.String("annotations-prefix", parser.DefaultAnnotationsPrefix,
 			`Prefix of the Ingress annotations specific to the NGINX controller.`)
 
 		enableSSLChainCompletion = flags.Bool("enable-ssl-chain-completion", false,

--- a/internal/ingress/annotations/parser/main.go
+++ b/internal/ingress/annotations/parser/main.go
@@ -28,9 +28,12 @@ import (
 	"k8s.io/ingress-nginx/internal/ingress/errors"
 )
 
+// DefaultAnnotationsPrefix defines the common prefix used in the nginx ingress controller
+const DefaultAnnotationsPrefix = "nginx.ingress.kubernetes.io"
+
 var (
-	// AnnotationsPrefix defines the common prefix used in the nginx ingress controller
-	AnnotationsPrefix = "nginx.ingress.kubernetes.io"
+	// AnnotationsPrefix is the mutable attribute that the controller explicitly refers to
+	AnnotationsPrefix = DefaultAnnotationsPrefix
 )
 
 // IngressAnnotation has a method to parse annotations located in Ingress

--- a/internal/ingress/controller/controller_test.go
+++ b/internal/ingress/controller/controller_test.go
@@ -42,6 +42,7 @@ import (
 	"k8s.io/ingress-nginx/internal/ingress"
 	"k8s.io/ingress-nginx/internal/ingress/annotations"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/canary"
+	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/proxyssl"
 	"k8s.io/ingress-nginx/internal/ingress/controller/config"
 	ngx_config "k8s.io/ingress-nginx/internal/ingress/controller/config"
@@ -240,6 +241,18 @@ func TestCheckIngress(t *testing.T) {
 			}
 			if nginx.CheckIngress(ing) == nil {
 				t.Errorf("with a new ingress with an error, an error should be returned")
+			}
+		})
+
+		t.Run("When the default annotation prefix is used despite an override", func(t *testing.T) {
+			parser.AnnotationsPrefix = "ingress.kubernetes.io"
+			ing.ObjectMeta.Annotations["nginx.ingress.kubernetes.io/backend-protocol"] = "GRPC"
+			nginx.command = testNginxTestCommand{
+				t:   t,
+				err: nil,
+			}
+			if nginx.CheckIngress(ing) == nil {
+				t.Errorf("with a custom annotation prefix, ingresses using the default should be rejected")
 			}
 		})
 


### PR DESCRIPTION
## What this PR does / why we need it:
My team has seen many instances of people using the default `nginx.ingress.kubernetes.io` annotation prefix, but our deployment has a custom prefix defined. Due to this, annotations are silently ignored and the dev might not notice their faulty ingress. This PR will reject such ingresses and suggest they use the custom prefix instead.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?
There is a new case in `controller_test::TestCheckIngress` to ensure that `CheckIngress()` returns an error appropriately. I also started a local deploy with Kind (`make dev-env`), changed the prefix in the Deployment by adding `--annotations-prefix=timmy.ingress.kubernetes.io`, and added an ingress that used the default annotation prefix. It failed as expected.

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
