### PR TITLE
chart: add `topologySpreadConstraint` to controller

### DIFF
--- a/charts/ingress-nginx/Chart.yaml
+++ b/charts/ingress-nginx/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: ingress-nginx
-version: 2.15.0
+version: 2.16.0
 appVersion: 0.35.0
 home: https://github.com/kubernetes/ingress-nginx
 description: Ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer

--- a/charts/ingress-nginx/templates/controller-daemonset.yaml
+++ b/charts/ingress-nginx/templates/controller-daemonset.yaml
@@ -224,6 +224,9 @@ spec:
     {{- if .Values.controller.affinity }}
       affinity: {{ toYaml .Values.controller.affinity | nindent 8 }}
     {{- end }}
+    {{- if .Values.controller.topologySpreadConstraints }}
+      topologySpreadConstraints: {{ toYaml .Values.controller.topologySpreadConstraints | nindent 8 }}
+    {{- end }}
       serviceAccountName: {{ template "ingress-nginx.serviceAccountName" . }}
       terminationGracePeriodSeconds: {{ .Values.controller.terminationGracePeriodSeconds }}
     {{- if (or .Values.controller.customTemplate.configMapName .Values.controller.extraVolumeMounts .Values.controller.admissionWebhooks.enabled .Values.controller.extraVolumes) }}

--- a/charts/ingress-nginx/templates/controller-deployment.yaml
+++ b/charts/ingress-nginx/templates/controller-deployment.yaml
@@ -228,6 +228,9 @@ spec:
     {{- if .Values.controller.affinity }}
       affinity: {{ toYaml .Values.controller.affinity | nindent 8 }}
     {{- end }}
+    {{- if .Values.controller.topologySpreadConstraints }}
+      topologySpreadConstraints: {{ toYaml .Values.controller.topologySpreadConstraints | nindent 8 }}
+    {{- end }}
       serviceAccountName: {{ template "ingress-nginx.serviceAccountName" . }}
       terminationGracePeriodSeconds: {{ .Values.controller.terminationGracePeriodSeconds }}
     {{- if (or .Values.controller.customTemplate.configMapName .Values.controller.extraVolumeMounts .Values.controller.admissionWebhooks.enabled .Values.controller.extraVolumes) }}

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -209,6 +209,17 @@ controller:
     #         - controller
     #     topologyKey: "kubernetes.io/hostname"
 
+  ## Topology spread constraints rely on node labels to identify the topology domain(s) that each Node is in.
+  ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+  ##
+  topologySpreadConstraints: []
+    # - maxSkew: 1
+    #   topologyKey: failure-domain.beta.kubernetes.io/zone
+    #   whenUnsatisfiable: DoNotSchedule
+    #   labelSelector:
+    #     matchLabels:
+    #       app.kubernetes.io/instance: ingress-nginx-internal
+
   ## terminationGracePeriodSeconds
   ## wait up to five minutes for the drain of connections
   ##


### PR DESCRIPTION
## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Adding `topologySpreadConstraint` will help solve on how to describe a deployment that should be located across zone availability in a cluster.
Reduces cost by avoiding to enable cross zone loadbalancing in AWS when using `externalTrafficPolicy: Local`

Not sure it makes sense to add to defaultbackend or controller.daemonset. I can add it though if desired.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
fixes #6055 

## How Has This Been Tested?
Testing a deployment of 3 replicas with a 2 worker setup in AWS.
And using this
```yaml
      topologySpreadConstraints:
      - labelSelector:
          matchLabels:
            app.kubernetes.io/instance: ingress-nginx-internal
        maxSkew: 1
        topologyKey: failure-domain.beta.kubernetes.io/zone
        whenUnsatisfiable: DoNotSchedule
```

In a setup with cluster autoscaler it does not trigger a scale up as the desired worker is 2.

```
Events:
  Type     Reason             Age                 From                Message
  ----     ------             ----                ----                -------
  Warning  FailedScheduling   57s (x5 over 5m8s)  default-scheduler   0/5 nodes are available: 2 node(s) didn't match pod topology spread constraints, 3 node(s) had taint {node-role.kubernetes.io/master: }, that the pod didn't tolerate.
  Normal   NotTriggerScaleUp  4s (x29 over 5m6s)  cluster-autoscaler  pod didn't trigger scale-up (it wouldn't fit if a new node is added): 1 node(s) didn't match pod topology spread constraints, 3 max node group size reached
```

```
kubectl --namespace ingress-nginx-internal get pods
NAME                                                READY   STATUS    RESTARTS   AGE
ingress-nginx-internal-controller-b4f79b67d-4ltg6   0/1     Pending   0          6m22s
ingress-nginx-internal-controller-b4f79b67d-nzgss   1/1     Running   0          6m22s
ingress-nginx-internal-controller-b4f79b67d-rtbjd   1/1     Running   0          13m
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
