### PR TITLE
Adds controller.service.customPorts to templates/controller-service a…

### DIFF
--- a/charts/ingress-nginx/templates/controller-service.yaml
+++ b/charts/ingress-nginx/templates/controller-service.yaml
@@ -77,6 +77,9 @@ spec:
     {{- end }}
     {{- end }}
   {{- end }}
+  {{- if .Values.controller.service.customPorts }}
+{{ toYaml .Values.controller.service.customPorts | indent 4 }}
+  {{- end }}
   selector:
     {{- include "ingress-nginx.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: controller

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -325,6 +325,13 @@ controller:
       http: 80
       https: 443
 
+    ## Add custom listen ports to the controller service
+    #customPorts:
+    #  - name: 8080-http
+    #    port: 8080
+    #    targetPort: http
+    #    protocol: TCP
+
     targetPorts:
       http: http
       https: https


### PR DESCRIPTION
Adds support for configuring customPorts in controller service

<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
Currently only tcp/udp port->specific namespace/serivce is possible. This adds the ability to configure a more generic port -> other port supported by nginx. This was solved in a previous PR to the old stable repo.

<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/helm/charts/pull/12979/files

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local generation of templates using helm CLI and a values.yaml.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
