### PR TITLE
Add helm chart options to expose metrics service as NodePort

### DIFF
--- a/charts/ingress-nginx/Chart.yaml
+++ b/charts/ingress-nginx/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: ingress-nginx
-version: 3.1.0
+version: 3.2.0
 appVersion: 0.35.0
 home: https://github.com/kubernetes/ingress-nginx
 description: Ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer

--- a/charts/ingress-nginx/templates/controller-service-metrics.yaml
+++ b/charts/ingress-nginx/templates/controller-service-metrics.yaml
@@ -26,10 +26,17 @@ spec:
 {{- if .Values.controller.metrics.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges: {{ toYaml .Values.controller.metrics.service.loadBalancerSourceRanges | nindent 4 }}
 {{- end }}
+{{- if .Values.controller.metrics.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.controller.metrics.service.externalTrafficPolicy }}
+{{- end }}
   ports:
     - name: metrics
       port: {{ .Values.controller.metrics.service.servicePort }}
       targetPort: metrics
+    {{- $setNodePorts := (or (eq .Values.controller.metrics.service.type "NodePort") (eq .Values.controller.metrics.service.type "LoadBalancer")) }}
+    {{- if (and $setNodePorts (not (empty .Values.controller.metrics.service.nodePort))) }}
+      nodePort: {{ .Values.controller.metrics.service.nodePort }}
+    {{- end }}
   selector:
     {{- include "ingress-nginx.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: controller

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -454,6 +454,8 @@ controller:
       loadBalancerSourceRanges: []
       servicePort: 9913
       type: ClusterIP
+      # externalTrafficPolicy: ""
+      # nodePort: ""
 
     serviceMonitor:
       enabled: false


### PR DESCRIPTION
## What this PR does / why we need it:
This PR allows to set `externalTrafficPolicy` and `nodePort` of the metrics service.

This allows to use the ingress controller health endpoint in an external haproxy check.
`externalTrafficPolicy: Local` is necessary to get the health info of the controller running on the queried node.
 
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?
- `helm template` with different values (default configuration does not change)
- applied to local kubernetes cluster

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
