### PR TITLE
delete redundant NGINX config about X-Forwarded-Proto

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -391,14 +391,6 @@ http {
 
     {{ end }}
 
-    {{ if $cfg.UseForwardedHeaders }}
-    map $http_x_forwarded_proto $full_x_forwarded_proto {
-        default $http_x_forwarded_proto;
-        "" $scheme;
-    }
-
-    {{ end }}
-
     # Create a variable that contains the literal $ character.
     # This works because the geo module will not resolve variables.
     geo $literal_dollar {
@@ -1216,13 +1208,9 @@ stream {
             {{ else }}
             {{ $proxySetHeader }} X-Forwarded-For        $remote_addr;
             {{ end }}
-            {{ if $all.Cfg.UseForwardedHeaders }}
-            {{ $proxySetHeader }} X-Forwarded-Proto      $full_x_forwarded_proto;
-            {{ else }}
-            {{ $proxySetHeader }} X-Forwarded-Proto      $pass_access_scheme;
-            {{ end }}
             {{ $proxySetHeader }} X-Forwarded-Host       $best_http_host;
             {{ $proxySetHeader }} X-Forwarded-Port       $pass_port;
+            {{ $proxySetHeader }} X-Forwarded-Proto      $pass_access_scheme;
             {{ if $all.Cfg.ProxyAddOriginalURIHeader }}
             {{ $proxySetHeader }} X-Original-URI         $request_uri;
             {{ end }}

--- a/test/e2e/settings/forwarded_headers.go
+++ b/test/e2e/settings/forwarded_headers.go
@@ -48,7 +48,7 @@ var _ = framework.DescribeSetting("use-forwarded-headers", func() {
 		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return strings.Contains(server, "server_name forwarded-headers") &&
-					strings.Contains(server, "proxy_set_header X-Forwarded-Proto $full_x_forwarded_proto;")
+					strings.Contains(server, "proxy_set_header X-Forwarded-Proto $pass_access_scheme;")
 			})
 
 		ginkgo.By("ensuring single values are parsed correctly")


### PR DESCRIPTION
## What this PR does / why we need it:
Revert the unnecessary PR https://github.com/kubernetes/ingress-nginx/pull/4958. If what is said in that PR was true, our assertion at https://github.com/niedbalski/ingress-nginx/blob/1d1b857cb7b641777919d4b1c2e488a293a93619/test/e2e/settings/forwarded_headers.go#L68 would be failing. Or am I missing something here?

Always using `$pass_access_scheme` is sufficient because its value is adjusted based on `use-forwarded-headers` setting in https://github.com/kubernetes/ingress-nginx/blob/4dd206b31af977a484bd7b9f52a8f6c5367cd17e/rootfs/etc/nginx/lua/lua_ingress.lua#L119.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
