### PR TITLE
Update OSFileWatcher to support symlinks

### DIFF
--- a/internal/watch/file_watcher.go
+++ b/internal/watch/file_watcher.go
@@ -18,7 +18,9 @@ package watch
 
 import (
 	"log"
+	"os"
 	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/fsnotify/fsnotify"
@@ -60,15 +62,31 @@ func (f *OSFileWatcher) watch() error {
 	}
 	f.watcher = watcher
 
+	realFile, err := filepath.EvalSymlinks(f.file)
+	if err != nil {
+		return err
+	}
+
 	dir, file := path.Split(f.file)
 	go func(file string) {
 		for {
 			select {
 			case event := <-watcher.Events:
-				if (event.Op&fsnotify.Write == fsnotify.Write ||
-					event.Op&fsnotify.Create == fsnotify.Create) &&
-					strings.HasSuffix(event.Name, file) {
-					f.onEvent()
+				if event.Op&fsnotify.Create == fsnotify.Create ||
+					event.Op&fsnotify.Write == fsnotify.Write {
+					if finfo, err := os.Lstat(event.Name); err != nil {
+						log.Printf("can not lstat file: %v\n", err)
+					} else if finfo.Mode()&os.ModeSymlink != 0 {
+						if currentRealFile, err := filepath.EvalSymlinks(f.file); err == nil &&
+							currentRealFile != realFile {
+							f.onEvent()
+							realFile = currentRealFile
+						}
+						continue
+					}
+					if strings.HasSuffix(event.Name, file) {
+						f.onEvent()
+					}
 				}
 			case err := <-watcher.Errors:
 				if err != nil {


### PR DESCRIPTION
This PR modifies the wrapper around fsnotify's file Watcher to watch symlinks in a custom manner such that if the symlink itself triggers an event and the target has been updated since the last event, the event should be called.

## What this PR does / why we need it:
This PR is needed because fsnotify auto-resolves symlinks internally. fsnotify/fsnotify#199 provides a little bit of context on their internals/decisions. The problem that results from this is that any watcher on a file which is a kubernetes secret will not detect updates, due to the symlink nature of them. Here's a glimpse of an example directory:
```bash
bash-5.0$ pwd
/run/secrets/webhook-certs
bash-5.0$ ls -l
total 0
lrwxrwxrwx    1 root     root            13 Sep  8 20:00 ca.crt -> ..data/ca.crt
lrwxrwxrwx    1 root     root            14 Sep  8 20:00 tls.crt -> ..data/tls.crt
lrwxrwxrwx    1 root     root            14 Sep  8 20:00 tls.key -> ..data/tls.key
bash-5.0$ ls -l ..data
lrwxrwxrwx    1 root     root            31 Sep  8 20:36 ..data -> ..2020_09_08_20_36_52.438041338
```
This change will allow for libraries that auto-update secrets (such as `cert-manager` for webhook server certs in the above example) to work without interference.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?
- Added a unit test case that creates a symlink to file A, creates file B, deletes and replaces the symlink to point to file B instead, and ensures that the watcher raises the expected events.
- Ran locally using the `kind` deploy manifest, deleted and recreated the `ingress-validation-admission` secret and confirmed that the validation webhook server reloaded the TLS files as expected.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
