### PR TITLE
Delete OCSP Response cache when certificate renewed

### DIFF
--- a/build/test-lua.sh
+++ b/build/test-lua.sh
@@ -30,6 +30,7 @@ resty \
   --shdict "configuration_data 5M" \
   --shdict "certificate_data 16M" \
   --shdict "certificate_servers 1M" \
+  --shdict "ocsp_response_cache 1M" \
   --shdict "balancer_ewma 1M" \
   --shdict "balancer_ewma_last_touched_at 1M" \
   --shdict "balancer_ewma_locks 512k" \

--- a/rootfs/etc/nginx/lua/certificate.lua
+++ b/rootfs/etc/nginx/lua/certificate.lua
@@ -182,7 +182,7 @@ local function fetch_and_cache_ocsp_response(uid, der_cert)
   end
   if forcible then
     ngx.log(ngx.NOTICE, "removed an existing item when saving OCSP response, ",
-      "consider increasing shared dictionary size for 'ocsp_reponse_cache'")
+      "consider increasing shared dictionary size for 'ocsp_response_cache'")
   end
 end
 

--- a/rootfs/etc/nginx/lua/configuration.lua
+++ b/rootfs/etc/nginx/lua/configuration.lua
@@ -102,7 +102,7 @@ local function handle_servers()
 
   for uid, cert in pairs(configuration.certificates) do
     local old_cert = certificate_data:get(uid)
-    if old_cert ~= cert then
+    if old_cert ~= nil and old_cert ~= cert then
         ocsp_response_cache:delete(uid)
     end
 

--- a/rootfs/etc/nginx/lua/configuration.lua
+++ b/rootfs/etc/nginx/lua/configuration.lua
@@ -11,6 +11,7 @@ local pairs = pairs
 local configuration_data = ngx.shared.configuration_data
 local certificate_data = ngx.shared.certificate_data
 local certificate_servers = ngx.shared.certificate_servers
+local ocsp_response_cache = ngx.shared.ocsp_response_cache
 
 local EMPTY_UID = "-1"
 
@@ -100,6 +101,11 @@ local function handle_servers()
   end
 
   for uid, cert in pairs(configuration.certificates) do
+    local old_cert = certificate_data:get(uid)
+    if old_cert ~= cert then
+        ocsp_response_cache:delete(uid)
+    end
+
     local success, set_err, forcible = certificate_data:set(uid, cert)
     if not success then
       local err_msg = string.format("error setting certificate for %s: %s\n",

--- a/rootfs/etc/nginx/lua/test/configuration_test.lua
+++ b/rootfs/etc/nginx/lua/test/configuration_test.lua
@@ -197,7 +197,7 @@ describe("Configuration", function()
 
       local s = spy.on(ngx.shared.ocsp_response_cache, "delete")
       assert.has_no.errors(configuration.handle_servers)
-      assert.spy(s).was_not_called_with(UUID)
+      assert.spy(s).was_not_called()
     end)
 
     it("should not delete ocsp_response_cache if certificate is empty", function()
@@ -212,7 +212,7 @@ describe("Configuration", function()
 
       local s = spy.on(ngx.shared.ocsp_response_cache, "delete")
       assert.has_no.errors(configuration.handle_servers)
-      assert.spy(s).was_not_called_with(UUID)
+      assert.spy(s).was_not_called()
     end)
 
     it("should delete ocsp_response_cache if certificate changed", function()


### PR DESCRIPTION
Delete OCSP Response cache when certificate renewed

## What this PR does / why we need it:

Use OCSP Stapling along with cert-manager auto-renew certificate will cause mismatch between OCSP Response and the certificate.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Which issue/s this PR fixes

## How Has This Been Tested?

```
$ make lua-test
147 successes / 0 failures / 0 errors / 0 pending : 1.62225 seconds
```

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.