### PR TITLE
Move ocsp_response_cache:delete after certificate_data:set

### DIFF
--- a/rootfs/etc/nginx/lua/configuration.lua
+++ b/rootfs/etc/nginx/lua/configuration.lua
@@ -101,13 +101,19 @@ local function handle_servers()
   end
 
   for uid, cert in pairs(configuration.certificates) do
+    -- don't delete the cache here, certificate_data[uid] is not replaced yet.
+    -- there is small chance that nginx worker still get the old certificate,
+    -- then fetch and cache the old OCSP Response
     local old_cert = certificate_data:get(uid)
-    if old_cert ~= nil and old_cert ~= cert then
-        ocsp_response_cache:delete(uid)
-    end
+    local is_renew = (old_cert ~= nil and old_cert ~= cert)
 
     local success, set_err, forcible = certificate_data:set(uid, cert)
-    if not success then
+    if success then
+        -- delete ocsp cache after certificate_data:set succeed
+        if is_renew then
+            ocsp_response_cache:delete(uid)
+        end
+    else
       local err_msg = string.format("error setting certificate for %s: %s\n",
         uid, tostring(set_err))
       table.insert(err_buf, err_msg)


### PR DESCRIPTION
Move ocsp_response_cache:delete after certificate_data:set

## What this PR does / why we need it:

There is a potential concurrency problem.

So in /configurations/servers:

+ after ocsp_response_cache:delete(uid)
+ before certificate_data:set(uid)

Since the two steps are not atomic operation, there is a small chance that some nginx worker missed the cache and read the old certificate, then fetch and cache the old ocsp_response again.

This PR change the sequence of the two operations.

However this PR is not perfect. There might be some requests still served by mismatch certificate and OCSP Response(between certificate_data:set and ocsp_response_cache:delete), but the impact is much more smaller than origin implementation.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Which issue/s this PR fixes

## How Has This Been Tested?

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
