### PR TITLE
Allow Helm Chart to customize admission webhook's annotations, timeoutSeconds, namespaceSelector, objectSelector and cert files locations

### DIFF
--- a/charts/ingress-nginx/Chart.yaml
+++ b/charts/ingress-nginx/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: ingress-nginx
-version: 3.4.1
+version: 3.5.0
 appVersion: 0.40.2
 home: https://github.com/kubernetes/ingress-nginx
 description: Ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer

--- a/charts/ingress-nginx/templates/admission-webhooks/validating-webhook.yaml
+++ b/charts/ingress-nginx/templates/admission-webhooks/validating-webhook.yaml
@@ -4,6 +4,9 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
+  {{- if .Values.controller.admissionWebhooks.annotations }}
+  annotations: {{ toYaml .Values.controller.admissionWebhooks.annotations | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: admission-webhook
@@ -31,4 +34,13 @@ webhooks:
         namespace: {{ .Release.Namespace }}
         name: {{ include "ingress-nginx.controller.fullname" . }}-admission
         path: /networking/v1beta1/ingresses
+    {{- if .Values.controller.admissionWebhooks.timeoutSeconds }}
+    timeoutSeconds: {{ .Values.controller.admissionWebhooks.timeoutSeconds }}
+    {{- end }}
+    {{- if .Values.controller.admissionWebhooks.namespaceSelector }}
+    namespaceSelector: {{ toYaml .Values.controller.admissionWebhooks.namespaceSelector | nindent 6 }}
+    {{- end }}
+    {{- if .Values.controller.admissionWebhooks.objectSelector }}
+    objectSelector: {{ toYaml .Values.controller.admissionWebhooks.objectSelector | nindent 6 }}
+    {{- end }}
 {{- end }}

--- a/charts/ingress-nginx/templates/controller-daemonset.yaml
+++ b/charts/ingress-nginx/templates/controller-daemonset.yaml
@@ -92,8 +92,8 @@ spec:
           {{- end }}
           {{- if .Values.controller.admissionWebhooks.enabled }}
             - --validating-webhook=:{{ .Values.controller.admissionWebhooks.port }}
-            - --validating-webhook-certificate=/usr/local/certificates/cert
-            - --validating-webhook-key=/usr/local/certificates/key
+            - --validating-webhook-certificate={{ .Values.controller.admissionWebhooks.certificate }}
+            - --validating-webhook-key={{ .Values.controller.admissionWebhooks.key }}
           {{- end }}
           {{- if .Values.controller.maxmindLicenseKey }}
             - --maxmind-license-key={{ .Values.controller.maxmindLicenseKey }}

--- a/charts/ingress-nginx/templates/controller-deployment.yaml
+++ b/charts/ingress-nginx/templates/controller-deployment.yaml
@@ -96,8 +96,8 @@ spec:
           {{- end }}
           {{- if .Values.controller.admissionWebhooks.enabled }}
             - --validating-webhook=:{{ .Values.controller.admissionWebhooks.port }}
-            - --validating-webhook-certificate=/usr/local/certificates/cert
-            - --validating-webhook-key=/usr/local/certificates/key
+            - --validating-webhook-certificate={{ .Values.controller.admissionWebhooks.certificate }}
+            - --validating-webhook-key={{ .Values.controller.admissionWebhooks.key }}
           {{- end }}
           {{- if .Values.controller.maxmindLicenseKey }}
             - --maxmind-license-key={{ .Values.controller.maxmindLicenseKey }}

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -406,9 +406,15 @@ controller:
   #   command: ['sh', '-c', 'until nslookup myservice; do echo waiting for myservice; sleep 2; done;']
 
   admissionWebhooks:
+    annotations: {}
     enabled: true
     failurePolicy: Fail
+    # timeoutSeconds: 10
     port: 8443
+    certificate: "/usr/local/certificates/cert"
+    key: "/usr/local/certificates/key"
+    namespaceSelector: {}
+    objectSelector: {}
 
     service:
       annotations: {}

--- a/hack/generate-deploy-scripts.sh
+++ b/hack/generate-deploy-scripts.sh
@@ -53,7 +53,7 @@ $(cat ${OUTPUT_FILE})" > ${OUTPUT_FILE}
 
 # Cloud - generic
 OUTPUT_FILE="${DIR}/deploy/static/provider/cloud/deploy.yaml"
-cat << EOF | helm template $RELEASE_NAME ${DIR}/charts/ingress-nginx --namespace $NAMESPACE --namespace $NAMESPACE --values - | $DIR/hack/add-namespace.py $NAMESPACE > ${OUTPUT_FILE}
+cat << EOF | helm template $RELEASE_NAME ${DIR}/charts/ingress-nginx --namespace $NAMESPACE --values - | $DIR/hack/add-namespace.py $NAMESPACE > ${OUTPUT_FILE}
 controller:
   service:
     type: LoadBalancer

--- a/test/e2e-image/namespace-overlays/admission/values.yaml
+++ b/test/e2e-image/namespace-overlays/admission/values.yaml
@@ -25,6 +25,8 @@ controller:
 
   admissionWebhooks:
     enabled: true
+    certificate: "/usr/local/certificates/cert"
+    key: "/usr/local/certificates/key"
 
 defaultBackend:
   enabled: false


### PR DESCRIPTION
This PR allows Helm Chart to customize admission webhook's annotations, timeoutSeconds, namespaceSelector, objectSelector and cert files locations. 

## What this PR does / why we need it:
This PR adds following capabilities to the ingress-nginx Helm Chart:
* Allow  users to set annotations, timeoutSeconds, namespaceSelector and objectSelector on ValidatingWebhookConfiguration 
* Allow users to customize values of `--validating-webhook-certificate` and `--validating-webhook-key` in Deployment and DaemontSet.
* Fixed a duplicated command line argument `--namespace $NAMESPACE` in `generate-deploy-scripts.sh`

Why:
* We use cert-manager to manage webhook certs and it relies on an annotation on the ValidatingWebhookConfiguration resource, which currently cannot be set.
* The other improvement is making `timeoutSeconds` customizable, since it's a super useful setting.
* I also made namespaceSelector and objectSelector configurable due to it could be handy in big clusters.
* The last improvement is that during testing, I found there is a  a duplicated command line argument `--namespace $NAMESPACE` in `generate-deploy-scripts.sh`, so I just went ahead and fixed it.
https://github.com/kubernetes/ingress-nginx/blob/9c94d772fb708d401a9f27239b45d0c4fbf32cc9/hack/generate-deploy-scripts.sh#L56
* In general, it's nicer to be able to customize resource as much as possible.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?
* I ran the e2e test.
* I ran the e2e test for helm-charts.
* I ran `generate-deploy-scripts.sh` to make sure generated static yamls has the correct webhook related values.
* I also ran `helm install -n ingress-nginx-internal --dry-run ingress-nginx ./charts/ingress-nginx/` before and after my change with different sets values and verified via the diff results that annotations and timeoutSeconds are added correctly when specified and are not added when not specified. 

With new value like: 
``` yaml
  admissionWebhooks:
    annotations:
      foo: bar
      hello: world
    enabled: true
    failurePolicy: Fail
    timeoutSeconds: 30
    port: 8443
    certificate: "/usr/local/certificates/tls.crt"
    key: "/usr/local/certificates/tls.key"
    namespaceSelector:
      matchLabels:
        needValidation: true
    objectSelector: 
      matchExpressions:
      - key: owner
        operator: NotIn
        values:
        - noValidation
```
The new outputs are:
1) in `ValidatingWebhookConfiguration` resource
``` yaml
apiVersion: admissionregistration.k8s.io/v1
kind: ValidatingWebhookConfiguration
metadata:
  annotations: 
    foo: bar
    hello: world
  labels:
    helm.sh/chart: ingress-nginx-3.5.0
    app.kubernetes.io/name: ingress-nginx
    app.kubernetes.io/instance: ingress-nginx
    app.kubernetes.io/version: "0.40.2"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: admission-webhook
  name: ingress-nginx-admission
webhooks:
  - name: validate.nginx.ingress.kubernetes.io
    rules:
      - apiGroups:
          - networking.k8s.io
        apiVersions:
          - v1beta1
          - v1
        operations:
          - CREATE
          - UPDATE
        resources:
          - ingresses
    failurePolicy: Fail
    sideEffects: None
    admissionReviewVersions:
      - v1
    clientConfig:
      service:
        namespace: ingress-nginx-internal
        name: ingress-nginx-controller-admission
        path: /networking/v1beta1/ingresses
    timeoutSeconds: 30
    namespaceSelector:
      matchLabels:
        needValidation: true
    objectSelector: 
      matchExpressions:
      - key: owner
        operator: NotIn
        values:
        - noValidation
```
2) In `Deployment` or `DaemonSet` resource
``` yaml
         args:
            ...
            - --validating-webhook-certificate=/usr/local/certificates/tls.crt
            - --validating-webhook-key=/usr/local/certificates/tls.key
```

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
