### PR TITLE
Add datadog environment as a configuration option

### DIFF
--- a/docs/user-guide/nginx-configuration/configmap.md
+++ b/docs/user-guide/nginx-configuration/configmap.md
@@ -140,8 +140,9 @@ The following table shows a configuration option's name, type, and the default v
 |[jaeger-trace-baggage-header-prefix](#jaeger-trace-baggage-header-prefix)|string|uberctx-|
 |[datadog-collector-host](#datadog-collector-host)|string|""|
 |[datadog-collector-port](#datadog-collector-port)|int|8126|
-|[datadog-service-name](#datadog-service-name)|service|"nginx"|
-|[datadog-operation-name-override](#datadog-operation-name-override)|service|"nginx.handle"|
+|[datadog-service-name](#datadog-service-name)|string|"nginx"|
+|[datadog-environment](#datadog-environment)|string|"prod"|
+|[datadog-operation-name-override](#datadog-operation-name-override)|string|"nginx.handle"|
 |[datadog-priority-sampling](#datadog-priority-sampling)|bool|"true"|
 |[datadog-sample-rate](#datadog-sample-rate)|float|1.0|
 |[main-snippet](#main-snippet)|string|""|
@@ -860,6 +861,10 @@ Specifies the port to use when uploading traces. _**default:**_ 8126
 ## datadog-service-name
 
 Specifies the service name to use for any traces created. _**default:**_ nginx
+
+## datadog-environment
+
+Specifies the environment this trace belongs to. _**default:**_ prod
 
 ## datadog-operation-name-override
 

--- a/docs/user-guide/third-party-addons/opentracing.md
+++ b/docs/user-guide/third-party-addons/opentracing.md
@@ -92,6 +92,9 @@ datadog-collector-port
 # specifies the service name to use for any traces created, Default: nginx
 datadog-service-name
 
+# specifies the environment this trace belongs to, Default: prod
+datadog-environment
+
 # specifies the operation name to use for any traces collected, Default: nginx.handle
 datadog-operation-name-override
 

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -584,6 +584,10 @@ type Configuration struct {
 	// Default: 8126
 	DatadogCollectorPort int `json:"datadog-collector-port"`
 
+	// DatadogEnvironment specifies the environment this trace belongs to.
+	// Default: prod
+	DatadogEnvironment string `json:"datadog-environment"`
+
 	// DatadogServiceName specifies the service name to use for any traces created
 	// Default: nginx
 	DatadogServiceName string `json:"datadog-service-name"`
@@ -823,6 +827,7 @@ func NewDefault() Configuration {
 		JaegerSamplerPort:            5778,
 		JaegerSamplerHost:            "http://127.0.0.1",
 		DatadogServiceName:           "nginx",
+		DatadogEnvironment:           "prod",
 		DatadogCollectorPort:         8126,
 		DatadogOperationNameOverride: "nginx.handle",
 		DatadogSampleRate:            1.0,

--- a/internal/ingress/controller/nginx.go
+++ b/internal/ingress/controller/nginx.go
@@ -1046,6 +1046,7 @@ const datadogTmpl = `{
   "service": "{{ .DatadogServiceName }}",
   "agent_host": "{{ .DatadogCollectorHost }}",
   "agent_port": {{ .DatadogCollectorPort }},
+  "environment": "{{ .DatadogEnvironment }}",
   "operation_name_override": "{{ .DatadogOperationNameOverride }}",
   "sample_rate": {{ .DatadogSampleRate }},
   "dd.priority.sampling": {{ .DatadogPrioritySampling }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Add `datadog-environment` as a configuration to specify what environment traces belong to. Exposes the configuration from the datadog opentracing plugin: https://github.com/DataDog/dd-opentracing-cpp/blob/master/include/datadog/opentracing.h#L39-L41

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
