### PR TITLE
Improve HandleAdmission resiliency

### DIFF
--- a/internal/admission/controller/main.go
+++ b/internal/admission/controller/main.go
@@ -64,9 +64,6 @@ func (ia *IngressAdmission) HandleAdmission(obj runtime.Object) (runtime.Object,
 
 	review, isV1 := obj.(*admissionv1.AdmissionReview)
 
-	status := &admissionv1.AdmissionResponse{}
-	status.UID = review.Request.UID
-
 	if !isV1 {
 		outputVersion = admissionv1beta1.SchemeGroupVersion
 		reviewv1beta1, isv1beta1 := obj.(*admissionv1beta1.AdmissionReview)
@@ -79,9 +76,12 @@ func (ia *IngressAdmission) HandleAdmission(obj runtime.Object) (runtime.Object,
 	}
 
 	if review.Request.Resource != networkingV1Beta1Resource && review.Request.Resource != networkingV1Resource {
-		return nil, fmt.Errorf("rejecting admission review because the request does not contains an Ingress resource but %s with name %s in namespace %s",
+		return nil, fmt.Errorf("rejecting admission review because the request does not contain an Ingress resource but %s with name %s in namespace %s",
 			review.Request.Resource.String(), review.Request.Name, review.Request.Namespace)
 	}
+
+	status := &admissionv1.AdmissionResponse{}
+	status.UID = review.Request.UID
 
 	ingress := networking.Ingress{}
 

--- a/internal/admission/controller/main_test.go
+++ b/internal/admission/controller/main_test.go
@@ -25,6 +25,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/json"
+	"k8s.io/kubernetes/pkg/apis/extensions"
 )
 
 const testIngressName = "testIngressName"
@@ -62,6 +63,20 @@ func TestHandleAdmission(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatalf("with a non ingress resource, the check should not pass")
+	}
+
+	result, err = adm.HandleAdmission(nil)
+	if err == nil {
+		t.Fatalf("with a nil AdmissionReview request, the check should not pass")
+	}
+
+	result, err = adm.HandleAdmission(&admissionv1.AdmissionReview{
+		Request: &admissionv1.AdmissionRequest{
+			Resource: v1.GroupVersionResource{Group: extensions.GroupName, Version: "v1beta1", Resource: "ingresses"},
+		},
+	})
+	if err == nil {
+		t.Fatalf("with extensions/v1beta1 Ingress resource, the check should not pass")
 	}
 
 	result, err = adm.HandleAdmission(&admissionv1.AdmissionReview{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

While testing ingress-nginx v0.40.1 on Kubernetes v1.17.12, with extensions/v1beta1 Ingress, somehow nil ended up being handed over to HandleAdmission, and controller panicked.

```
2020/10/05 15:50:37 http: panic serving 10.6.1.61:35040: runtime error: invalid memory address or nil pointer dereference
goroutine 344 [running]:
net/http.(*conn).serve.func1(0xc00017ca00)
	net/http/server.go:1801 +0x147
panic(0x1941ce0, 0x28d4200)
	runtime/panic.go:975 +0x3e9
k8s.io/ingress-nginx/internal/admission/controller.(*IngressAdmission).HandleAdmission(0xc000519c10, 0x1d9aa00, 0xc000a21620, 0x600, 0x0, 0x0, 0x0)
	k8s.io/ingress-nginx/internal/admission/controller/main.go:68 +0x91
k8s.io/ingress-nginx/internal/admission/controller.(*AdmissionControllerServer).ServeHTTP(0xc000519c20, 0x1dd23c0, 0xc000102380, 0xc000124900)
	k8s.io/ingress-nginx/internal/admission/controller/server.go:82 +0x24c
net/http.serverHandler.ServeHTTP(0xc000103960, 0x1dd23c0, 0xc000102380, 0xc000124900)
	net/http/server.go:2843 +0xa3
net/http.(*conn).serve(0xc00017ca00, 0x1dd5d40, 0xc0000cdcc0)
	net/http/server.go:1925 +0x8ad
created by net/http.(*Server).Serve
	net/http/server.go:2969 +0x36c
```


This PR at least makes the controller more resilient. PR also adds a test case that extensions/v1beta1 validation is not supported / gets rejected; migration to networking.k8s.io/v1beta1 or networking.k8s.io/v1 is advised instead.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
