### PR TITLE
Allow customisation of redirect URL parameter in external auth redirects

### DIFF
--- a/docs/user-guide/nginx-configuration/annotations.md
+++ b/docs/user-guide/nginx-configuration/annotations.md
@@ -440,6 +440,8 @@ Additionally it is possible to set:
   `<Method>` to specify the HTTP method to use.
 * `nginx.ingress.kubernetes.io/auth-signin`:
   `<SignIn_URL>` to specify the location of the error page.
+* `nginx.ingress.kubernetes.io/auth-signin-redirect-param`:
+  `<SignIn_URL>` to specify the URL parameter in the error page which should contain the original URL for a failed signin request.
 * `nginx.ingress.kubernetes.io/auth-response-headers`:
   `<Response_Header_1, ..., Response_Header_n>` to specify headers to pass to backend once authentication request completes.
 * `nginx.ingress.kubernetes.io/auth-proxy-set-headers`:

--- a/docs/user-guide/nginx-configuration/configmap.md
+++ b/docs/user-guide/nginx-configuration/configmap.md
@@ -176,6 +176,7 @@ The following table shows a configuration option's name, type, and the default v
 |[global-auth-url](#global-auth-url)|string|""|
 |[global-auth-method](#global-auth-method)|string|""|
 |[global-auth-signin](#global-auth-signin)|string|""|
+|[global-auth-signin-redirect-param](#global-auth-signin-redirect-param)|string|"rd"|
 |[global-auth-response-headers](#global-auth-response-headers)|string|""|
 |[global-auth-request-redirect](#global-auth-request-redirect)|string|""|
 |[global-auth-snippet](#global-auth-snippet)|string|""|
@@ -1047,6 +1048,12 @@ _**default:**_ ""
 Sets the location of the error page for an existing service that provides authentication for all the locations.
 Similar to the Ingress rule annotation `nginx.ingress.kubernetes.io/auth-signin`.
 _**default:**_ ""
+
+## global-auth-signin-redirect-param
+
+Sets the query parameter in the error page signin URL which contains the original URL of the request that failed authentication.
+Similar to the Ingress rule annotation `nginx.ingress.kubernetes.io/auth-signin-redirect-param`.
+_**default:**_ "rd"
 
 ## global-auth-response-headers
 

--- a/internal/ingress/annotations/authreq/main.go
+++ b/internal/ingress/annotations/authreq/main.go
@@ -35,15 +35,16 @@ import (
 type Config struct {
 	URL string `json:"url"`
 	// Host contains the hostname defined in the URL
-	Host              string            `json:"host"`
-	SigninURL         string            `json:"signinUrl"`
-	Method            string            `json:"method"`
-	ResponseHeaders   []string          `json:"responseHeaders,omitempty"`
-	RequestRedirect   string            `json:"requestRedirect"`
-	AuthSnippet       string            `json:"authSnippet"`
-	AuthCacheKey      string            `json:"authCacheKey"`
-	AuthCacheDuration []string          `json:"authCacheDuration"`
-	ProxySetHeaders   map[string]string `json:"proxySetHeaders,omitempty"`
+	Host                   string            `json:"host"`
+	SigninURL              string            `json:"signinUrl"`
+	SigninURLRedirectParam string            `json:"signinUrlRedirectParam,omitempty"`
+	Method                 string            `json:"method"`
+	ResponseHeaders        []string          `json:"responseHeaders,omitempty"`
+	RequestRedirect        string            `json:"requestRedirect"`
+	AuthSnippet            string            `json:"authSnippet"`
+	AuthCacheKey           string            `json:"authCacheKey"`
+	AuthCacheDuration      []string          `json:"authCacheDuration"`
+	ProxySetHeaders        map[string]string `json:"proxySetHeaders,omitempty"`
 }
 
 // DefaultCacheDuration is the fallback value if no cache duration is provided
@@ -64,6 +65,9 @@ func (e1 *Config) Equal(e2 *Config) bool {
 		return false
 	}
 	if e1.SigninURL != e2.SigninURL {
+		return false
+	}
+	if e1.SigninURLRedirectParam != e2.SigninURLRedirectParam {
 		return false
 	}
 	if e1.Method != e2.Method {
@@ -174,6 +178,11 @@ func (a authReq) Parse(ing *networking.Ingress) (interface{}, error) {
 		klog.V(3).InfoS("auth-signin annotation is undefined and will not be set")
 	}
 
+	signInRedirectParam, err := parser.GetStringAnnotation("auth-signin-redirect-param", ing)
+	if err != nil {
+		klog.V(3).Infof("auth-signin-redirect-param annotation is undefined and will not be set")
+	}
+
 	authSnippet, err := parser.GetStringAnnotation("auth-snippet", ing)
 	if err != nil {
 		klog.V(3).InfoS("auth-snippet annotation is undefined and will not be set")
@@ -230,16 +239,17 @@ func (a authReq) Parse(ing *networking.Ingress) (interface{}, error) {
 	requestRedirect, _ := parser.GetStringAnnotation("auth-request-redirect", ing)
 
 	return &Config{
-		URL:               urlString,
-		Host:              authURL.Hostname(),
-		SigninURL:         signIn,
-		Method:            authMethod,
-		ResponseHeaders:   responseHeaders,
-		RequestRedirect:   requestRedirect,
-		AuthSnippet:       authSnippet,
-		AuthCacheKey:      authCacheKey,
-		AuthCacheDuration: authCacheDuration,
-		ProxySetHeaders:   proxySetHeaders,
+		URL:                    urlString,
+		Host:                   authURL.Hostname(),
+		SigninURL:              signIn,
+		SigninURLRedirectParam: signInRedirectParam,
+		Method:                 authMethod,
+		ResponseHeaders:        responseHeaders,
+		RequestRedirect:        requestRedirect,
+		AuthSnippet:            authSnippet,
+		AuthCacheKey:           authCacheKey,
+		AuthCacheDuration:      authCacheDuration,
+		ProxySetHeaders:        proxySetHeaders,
 	}, nil
 }
 

--- a/internal/ingress/annotations/authreq/main_test.go
+++ b/internal/ingress/annotations/authreq/main_test.go
@@ -72,30 +72,33 @@ func TestAnnotations(t *testing.T) {
 	ing.SetAnnotations(data)
 
 	tests := []struct {
-		title           string
-		url             string
-		signinURL       string
-		method          string
-		requestRedirect string
-		authSnippet     string
-		authCacheKey    string
-		expErr          bool
+		title                  string
+		url                    string
+		signinURL              string
+		signinURLRedirectParam string
+		method                 string
+		requestRedirect        string
+		authSnippet            string
+		authCacheKey           string
+		expErr                 bool
 	}{
-		{"empty", "", "", "", "", "", "", true},
-		{"no scheme", "bar", "bar", "", "", "", "", true},
-		{"invalid host", "http://", "http://", "", "", "", "", true},
-		{"invalid host (multiple dots)", "http://foo..bar.com", "http://foo..bar.com", "", "", "", "", true},
-		{"valid URL", "http://bar.foo.com/external-auth", "http://bar.foo.com/external-auth", "", "", "", "", false},
-		{"valid URL - send body", "http://foo.com/external-auth", "http://foo.com/external-auth", "POST", "", "", "", false},
-		{"valid URL - send body", "http://foo.com/external-auth", "http://foo.com/external-auth", "GET", "", "", "", false},
-		{"valid URL - request redirect", "http://foo.com/external-auth", "http://foo.com/external-auth", "GET", "http://foo.com/redirect-me", "", "", false},
-		{"auth snippet", "http://foo.com/external-auth", "http://foo.com/external-auth", "", "", "proxy_set_header My-Custom-Header 42;", "", false},
-		{"auth cache ", "http://foo.com/external-auth", "http://foo.com/external-auth", "", "", "", "$foo$bar", false},
+		{"empty", "", "", "", "", "", "", "", true},
+		{"no scheme", "bar", "bar", "", "", "", "", "", true},
+		{"invalid host", "http://", "http://", "", "", "", "", "", true},
+		{"invalid host (multiple dots)", "http://foo..bar.com", "http://foo..bar.com", "", "", "", "", "", true},
+		{"valid URL", "http://bar.foo.com/external-auth", "http://bar.foo.com/external-auth", "", "", "", "", "", false},
+		{"valid URL - send body", "http://foo.com/external-auth", "http://foo.com/external-auth", "", "POST", "", "", "", false},
+		{"valid URL - send body", "http://foo.com/external-auth", "http://foo.com/external-auth", "", "GET", "", "", "", false},
+		{"valid URL - request redirect", "http://foo.com/external-auth", "http://foo.com/external-auth", "", "GET", "http://foo.com/redirect-me", "", "", false},
+		{"auth snippet", "http://foo.com/external-auth", "http://foo.com/external-auth", "", "", "", "proxy_set_header My-Custom-Header 42;", "", false},
+		{"auth cache ", "http://foo.com/external-auth", "http://foo.com/external-auth", "", "", "", "", "$foo$bar", false},
+		{"redirect param", "http://bar.foo.com/external-auth", "http://bar.foo.com/external-auth", "origUrl", "", "", "", "", false},
 	}
 
 	for _, test := range tests {
 		data[parser.GetAnnotationWithPrefix("auth-url")] = test.url
 		data[parser.GetAnnotationWithPrefix("auth-signin")] = test.signinURL
+		data[parser.GetAnnotationWithPrefix("auth-signin-redirect-param")] = test.signinURLRedirectParam
 		data[parser.GetAnnotationWithPrefix("auth-method")] = fmt.Sprintf("%v", test.method)
 		data[parser.GetAnnotationWithPrefix("auth-request-redirect")] = test.requestRedirect
 		data[parser.GetAnnotationWithPrefix("auth-snippet")] = test.authSnippet
@@ -121,6 +124,9 @@ func TestAnnotations(t *testing.T) {
 		}
 		if u.SigninURL != test.signinURL {
 			t.Errorf("%v: expected \"%v\" but \"%v\" was returned", test.title, test.signinURL, u.SigninURL)
+		}
+		if u.SigninURLRedirectParam != test.signinURLRedirectParam {
+			t.Errorf("%v: expected \"%v\" but \"%v\" was returned", test.title, test.signinURLRedirectParam, u.SigninURLRedirectParam)
 		}
 		if u.Method != test.method {
 			t.Errorf("%v: expected \"%v\" but \"%v\" was returned", test.title, test.method, u.Method)

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -704,7 +704,7 @@ func NewDefault() Configuration {
 	defNginxStatusIpv4Whitelist = append(defNginxStatusIpv4Whitelist, "127.0.0.1")
 	defNginxStatusIpv6Whitelist = append(defNginxStatusIpv6Whitelist, "::1")
 	defProxyDeadlineDuration := time.Duration(5) * time.Second
-	defGlobalExternalAuth := GlobalExternalAuth{"", "", "", "", append(defResponseHeaders, ""), "", "", "", []string{}, map[string]string{}}
+	defGlobalExternalAuth := GlobalExternalAuth{"", "", "", "", "", append(defResponseHeaders, ""), "", "", "", []string{}, map[string]string{}}
 
 	cfg := Configuration{
 		AllowBackendServerHeader:         false,
@@ -888,13 +888,14 @@ type ListenPorts struct {
 type GlobalExternalAuth struct {
 	URL string `json:"url"`
 	// Host contains the hostname defined in the URL
-	Host              string            `json:"host"`
-	SigninURL         string            `json:"signinUrl"`
-	Method            string            `json:"method"`
-	ResponseHeaders   []string          `json:"responseHeaders,omitempty"`
-	RequestRedirect   string            `json:"requestRedirect"`
-	AuthSnippet       string            `json:"authSnippet"`
-	AuthCacheKey      string            `json:"authCacheKey"`
-	AuthCacheDuration []string          `json:"authCacheDuration"`
-	ProxySetHeaders   map[string]string `json:"proxySetHeaders,omitempty"`
+	Host                   string            `json:"host"`
+	SigninURL              string            `json:"signinUrl"`
+	SigninURLRedirectParam string            `json:"signinUrlRedirectParam"`
+	Method                 string            `json:"method"`
+	ResponseHeaders        []string          `json:"responseHeaders,omitempty"`
+	RequestRedirect        string            `json:"requestRedirect"`
+	AuthSnippet            string            `json:"authSnippet"`
+	AuthCacheKey           string            `json:"authCacheKey"`
+	AuthCacheDuration      []string          `json:"authCacheDuration"`
+	ProxySetHeaders        map[string]string `json:"proxySetHeaders,omitempty"`
 }

--- a/internal/ingress/controller/template/configmap.go
+++ b/internal/ingress/controller/template/configmap.go
@@ -37,31 +37,32 @@ import (
 )
 
 const (
-	customHTTPErrors          = "custom-http-errors"
-	skipAccessLogUrls         = "skip-access-log-urls"
-	whitelistSourceRange      = "whitelist-source-range"
-	proxyRealIPCIDR           = "proxy-real-ip-cidr"
-	bindAddress               = "bind-address"
-	httpRedirectCode          = "http-redirect-code"
-	blockCIDRs                = "block-cidrs"
-	blockUserAgents           = "block-user-agents"
-	blockReferers             = "block-referers"
-	proxyStreamResponses      = "proxy-stream-responses"
-	hideHeaders               = "hide-headers"
-	nginxStatusIpv4Whitelist  = "nginx-status-ipv4-whitelist"
-	nginxStatusIpv6Whitelist  = "nginx-status-ipv6-whitelist"
-	proxyHeaderTimeout        = "proxy-protocol-header-timeout"
-	workerProcesses           = "worker-processes"
-	globalAuthURL             = "global-auth-url"
-	globalAuthMethod          = "global-auth-method"
-	globalAuthSignin          = "global-auth-signin"
-	globalAuthResponseHeaders = "global-auth-response-headers"
-	globalAuthRequestRedirect = "global-auth-request-redirect"
-	globalAuthSnippet         = "global-auth-snippet"
-	globalAuthCacheKey        = "global-auth-cache-key"
-	globalAuthCacheDuration   = "global-auth-cache-duration"
-	luaSharedDictsKey         = "lua-shared-dicts"
-	plugins                   = "plugins"
+	customHTTPErrors              = "custom-http-errors"
+	skipAccessLogUrls             = "skip-access-log-urls"
+	whitelistSourceRange          = "whitelist-source-range"
+	proxyRealIPCIDR               = "proxy-real-ip-cidr"
+	bindAddress                   = "bind-address"
+	httpRedirectCode              = "http-redirect-code"
+	blockCIDRs                    = "block-cidrs"
+	blockUserAgents               = "block-user-agents"
+	blockReferers                 = "block-referers"
+	proxyStreamResponses          = "proxy-stream-responses"
+	hideHeaders                   = "hide-headers"
+	nginxStatusIpv4Whitelist      = "nginx-status-ipv4-whitelist"
+	nginxStatusIpv6Whitelist      = "nginx-status-ipv6-whitelist"
+	proxyHeaderTimeout            = "proxy-protocol-header-timeout"
+	workerProcesses               = "worker-processes"
+	globalAuthURL                 = "global-auth-url"
+	globalAuthMethod              = "global-auth-method"
+	globalAuthSignin              = "global-auth-signin"
+	globalAuthSigninRedirectParam = "global-auth-signin-redirect-param"
+	globalAuthResponseHeaders     = "global-auth-response-headers"
+	globalAuthRequestRedirect     = "global-auth-request-redirect"
+	globalAuthSnippet             = "global-auth-snippet"
+	globalAuthCacheKey            = "global-auth-cache-key"
+	globalAuthCacheDuration       = "global-auth-cache-duration"
+	luaSharedDictsKey             = "lua-shared-dicts"
+	plugins                       = "plugins"
 )
 
 var (
@@ -75,6 +76,7 @@ var (
 		"certificate_servers":           5,
 		"ocsp_response_cache":           5, // keep this same as certificate_servers
 	}
+	defaultGlobalAuthRedirectParam = "rd"
 )
 
 const (
@@ -251,6 +253,19 @@ func ReadConfig(src map[string]string) config.Configuration {
 			klog.Warningf("Global auth location denied - %v.", "global-auth-signin setting is undefined and will not be set")
 		} else {
 			to.GlobalExternalAuth.SigninURL = val
+		}
+	}
+
+	// Verify that the configured global external authorization error page redirection URL parameter is set and valid. if not, set the default value
+	if val, ok := conf[globalAuthSigninRedirectParam]; ok {
+		delete(conf, globalAuthSigninRedirectParam)
+
+		redirectParam := strings.TrimSpace(val)
+		dummySigninURL, _ := parser.StringToURL(fmt.Sprintf("%s?%s=dummy", to.GlobalExternalAuth.SigninURL, redirectParam))
+		if dummySigninURL == nil {
+			klog.Warningf("Global auth redirect parameter denied - %v.", "global-auth-signin-redirect-param setting is invalid and will not be set")
+		} else {
+			to.GlobalExternalAuth.SigninURLRedirectParam = redirectParam
 		}
 	}
 

--- a/internal/ingress/controller/template/configmap_test.go
+++ b/internal/ingress/controller/template/configmap_test.go
@@ -229,6 +229,28 @@ func TestGlobalExternalAuthSigninParsing(t *testing.T) {
 	}
 }
 
+func TestGlobalExternalAuthSigninRedirectParamParsing(t *testing.T) {
+	testCases := map[string]struct {
+		param  string
+		signin string
+		expect string
+	}{
+		"no param":      {"", "http://bar.foo.com/auth-error-page", ""},
+		"valid param":   {"orig", "http://bar.foo.com/auth-error-page", "orig"},
+		"no signin url": {"orig", "", ""},
+	}
+
+	for n, tc := range testCases {
+		cfg := ReadConfig(map[string]string{
+			"global-auth-signin":                tc.signin,
+			"global-auth-signin-redirect-param": tc.param,
+		})
+		if cfg.GlobalExternalAuth.SigninURLRedirectParam != tc.expect {
+			t.Errorf("Testing %v. Expected \"%v\" but \"%v\" was returned", n, tc.expect, cfg.GlobalExternalAuth.SigninURLRedirectParam)
+		}
+	}
+}
+
 func TestGlobalExternalAuthResponseHeadersParsing(t *testing.T) {
 	testCases := map[string]struct {
 		headers string

--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -50,9 +50,10 @@ import (
 )
 
 const (
-	slash         = "/"
-	nonIdempotent = "non_idempotent"
-	defBufferSize = 65535
+	slash                      = "/"
+	nonIdempotent              = "non_idempotent"
+	defBufferSize              = 65535
+	defAuthSigninRedirectParam = "rd"
 )
 
 // TemplateWriter is the interface to render a template
@@ -903,18 +904,21 @@ func buildForwardedFor(input interface{}) string {
 	return fmt.Sprintf("$http_%v", ffh)
 }
 
-func buildAuthSignURL(authSignURL string) string {
+func buildAuthSignURL(authSignURL, authRedirectParam string) string {
 	u, _ := url.Parse(authSignURL)
 	q := u.Query()
+	if authRedirectParam == "" {
+		authRedirectParam = defaultGlobalAuthRedirectParam
+	}
 	if len(q) == 0 {
-		return fmt.Sprintf("%v?rd=$pass_access_scheme://$http_host$escaped_request_uri", authSignURL)
+		return fmt.Sprintf("%v?%v=$pass_access_scheme://$http_host$escaped_request_uri", authSignURL, authRedirectParam)
 	}
 
-	if q.Get("rd") != "" {
+	if q.Get(authRedirectParam) != "" {
 		return authSignURL
 	}
 
-	return fmt.Sprintf("%v&rd=$pass_access_scheme://$http_host$escaped_request_uri", authSignURL)
+	return fmt.Sprintf("%v&%v=$pass_access_scheme://$http_host$escaped_request_uri", authSignURL, authRedirectParam)
 }
 
 func buildAuthSignURLLocation(location, authSignURL string) string {

--- a/internal/ingress/controller/template/template_test.go
+++ b/internal/ingress/controller/template/template_test.go
@@ -766,16 +766,19 @@ func TestFilterRateLimits(t *testing.T) {
 
 func TestBuildAuthSignURL(t *testing.T) {
 	cases := map[string]struct {
-		Input, Output string
+		Input, RedirectParam, Output string
 	}{
-		"default url":       {"http://google.com", "http://google.com?rd=$pass_access_scheme://$http_host$escaped_request_uri"},
-		"with random field": {"http://google.com?cat=0", "http://google.com?cat=0&rd=$pass_access_scheme://$http_host$escaped_request_uri"},
-		"with rd field":     {"http://google.com?cat&rd=$request", "http://google.com?cat&rd=$request"},
+		"default url and redirect":              {"http://google.com", "rd", "http://google.com?rd=$pass_access_scheme://$http_host$escaped_request_uri"},
+		"default url and custom redirect":       {"http://google.com", "orig", "http://google.com?orig=$pass_access_scheme://$http_host$escaped_request_uri"},
+		"with random field":                     {"http://google.com?cat=0", "rd", "http://google.com?cat=0&rd=$pass_access_scheme://$http_host$escaped_request_uri"},
+		"with random field and custom redirect": {"http://google.com?cat=0", "orig", "http://google.com?cat=0&orig=$pass_access_scheme://$http_host$escaped_request_uri"},
+		"with rd field":                         {"http://google.com?cat&rd=$request", "rd", "http://google.com?cat&rd=$request"},
+		"with orig field":                       {"http://google.com?cat&orig=$request", "orig", "http://google.com?cat&orig=$request"},
 	}
 	for k, tc := range cases {
-		res := buildAuthSignURL(tc.Input)
+		res := buildAuthSignURL(tc.Input, tc.RedirectParam)
 		if res != tc.Output {
-			t.Errorf("%s: called buildAuthSignURL('%s'); expected '%v' but returned '%v'", k, tc.Input, tc.Output, res)
+			t.Errorf("%s: called buildAuthSignURL('%s','%s'); expected '%v' but returned '%v'", k, tc.Input, tc.RedirectParam, tc.Output, res)
 		}
 	}
 }

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -1040,7 +1040,7 @@ stream {
 
             add_header Set-Cookie $auth_cookie;
 
-            return 302 {{ buildAuthSignURL $externalAuth.SigninURL }};
+            return 302 {{ buildAuthSignURL $externalAuth.SigninURL $externalAuth.SigninURLRedirectParam }};
         }
         {{ end }}
         {{ end }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
Currently for external authentication, if the `auth-signin` annotation or `global-auth-signin` ConfigMap property is set, 401 responses from the external auth server will generate URLs of the form: `<auth-signin-url>?rd=<request-url>`, where `rd=` is hardcoded. This can be problematic for external authentication services that expect a different parameter. This PR updates the external auth annotations and ConfigMap entries to make this parameter configurable. The default is set to `rd` to ensure backwards compatibility with existing ingress definitions.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Updated the unit tests and e2e tests to test the changes, then ran the following successfully:
```
make test
FOCUS="auth" make kind-e2e-test
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
