### PR TITLE
Numerals in podAnnotations in quotes #6315

### DIFF
--- a/charts/ingress-nginx/Chart.yaml
+++ b/charts/ingress-nginx/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: ingress-nginx
-version: 3.6.0
+version: 3.7.0
 appVersion: 0.40.2
 home: https://github.com/kubernetes/ingress-nginx
 description: Ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer

--- a/charts/ingress-nginx/ci/daemonset-podannotations-values.yaml
+++ b/charts/ingress-nginx/ci/daemonset-podannotations-values.yaml
@@ -1,0 +1,13 @@
+controller:
+  kind: DaemonSet
+  admissionWebhooks:
+    enabled: false
+  metrics:
+    enabled: true
+  service:
+    type: ClusterIP
+  podAnnotations:
+    prometheus.io/path: /metrics
+    prometheus.io/port: "10254"
+    prometheus.io/scheme: http
+    prometheus.io/scrape: "true"

--- a/charts/ingress-nginx/ci/deployment-podannotations-values.yaml
+++ b/charts/ingress-nginx/ci/deployment-podannotations-values.yaml
@@ -1,0 +1,12 @@
+controller:
+  admissionWebhooks:
+    enabled: false
+  metrics:
+    enabled: true
+  service:
+    type: ClusterIP
+  podAnnotations:
+    prometheus.io/path: /metrics
+    prometheus.io/port: "10254"
+    prometheus.io/scheme: http
+    prometheus.io/scrape: "true"

--- a/charts/ingress-nginx/templates/controller-daemonset.yaml
+++ b/charts/ingress-nginx/templates/controller-daemonset.yaml
@@ -26,7 +26,10 @@ spec:
   template:
     metadata:
     {{- if .Values.controller.podAnnotations }}
-      annotations: {{ toYaml .Values.controller.podAnnotations | nindent 8 }}
+      annotations: 
+      {{- range $key, $value := .Values.controller.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}      
     {{- end }}
       labels:
         {{- include "ingress-nginx.selectorLabels" . | nindent 8 }}

--- a/charts/ingress-nginx/templates/controller-deployment.yaml
+++ b/charts/ingress-nginx/templates/controller-deployment.yaml
@@ -30,7 +30,10 @@ spec:
   template:
     metadata:
     {{- if .Values.controller.podAnnotations }}
-      annotations: {{ toYaml .Values.controller.podAnnotations | nindent 8 }}
+      annotations: 
+      {{- range $key, $value := .Values.controller.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
     {{- end }}
       labels:
         {{- include "ingress-nginx.selectorLabels" . | nindent 8 }}


### PR DESCRIPTION
What this PR does / why we need it:

`podAnnotations` that include numerals (like `prometheus.io/port: "9100"`) need quotes or they trigger the  kubernetes/kubernetes#82296 . 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes

fixes #6315

## How Has This Been Tested?

Locally on my machine

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
