### PR TITLE
Fix liveness and readiness probe path in daemonset chart

### DIFF
--- a/charts/ingress-nginx/Chart.yaml
+++ b/charts/ingress-nginx/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: ingress-nginx
-version: 3.7.0
+version: 3.7.1
 appVersion: 0.40.2
 home: https://github.com/kubernetes/ingress-nginx
 description: Ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer

--- a/charts/ingress-nginx/templates/controller-daemonset.yaml
+++ b/charts/ingress-nginx/templates/controller-daemonset.yaml
@@ -138,7 +138,7 @@ spec:
           {{- end }}
           livenessProbe:
             httpGet:
-              path: /healthz
+              path: {{ .Values.controller.healthCheckPath }}
               port: {{ .Values.controller.livenessProbe.port }}
               scheme: HTTP
             initialDelaySeconds: {{ .Values.controller.livenessProbe.initialDelaySeconds }}
@@ -148,7 +148,7 @@ spec:
             failureThreshold: {{ .Values.controller.livenessProbe.failureThreshold }}
           readinessProbe:
             httpGet:
-              path: /healthz
+              path: {{ .Values.controller.healthCheckPath }}
               port: {{ .Values.controller.readinessProbe.port }}
               scheme: HTTP
             initialDelaySeconds: {{ .Values.controller.readinessProbe.initialDelaySeconds }}


### PR DESCRIPTION
Fix liveness and readiness probe path in daemonset chart

## What this PR does / why we need it:
This PR makes the path field on both readiness and liveness probe of the DaemonSet chart `{{ .Values.controller.healthCheckPath }}`. instead of a hardcoded value `healthz`.
This is already the case in Deployment chart,  but not in DaemonSet.

https://github.com/kubernetes/ingress-nginx/blob/a6d603566be31da03b61014cbd1ae0d31a19694f/charts/ingress-nginx/templates/controller-deployment.yaml#L145

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?
I ran test locally and use `helm template` command to validate the field is correct locally.
 
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
