### PR TITLE
Add validation for wildcard server names

### DIFF
--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -182,6 +182,7 @@ var (
 		"buildMirrorLocations":               buildMirrorLocations,
 		"shouldLoadAuthDigestModule":         shouldLoadAuthDigestModule,
 		"shouldLoadInfluxDBModule":           shouldLoadInfluxDBModule,
+		"buildServerName":                    buildServerName,
 	}
 )
 
@@ -1458,4 +1459,16 @@ func shouldLoadInfluxDBModule(s interface{}) bool {
 	}
 
 	return false
+}
+
+// buildServerName ensures wildcard hostnames are valid
+func buildServerName(hostname string) string {
+	if !strings.HasPrefix(hostname, "*") {
+		return hostname
+	}
+
+	hostname = strings.Replace(hostname, "*.", "", 1)
+	parts := strings.Split(hostname, ".")
+
+	return `~^(?<subdomain>[\w-]+)\.` + strings.Join(parts, "\\.") + `$`
 }

--- a/internal/ingress/controller/template/template_test.go
+++ b/internal/ingress/controller/template/template_test.go
@@ -1448,3 +1448,24 @@ func TestModSecurityForLocation(t *testing.T) {
 		}
 	}
 }
+
+func TestBuildServerName(t *testing.T) {
+
+	testCases := []struct {
+		title    string
+		hostname string
+		expected string
+	}{
+		{"simple domain", "foo.bar", "foo.bar"},
+		{"simple www domain", "www.foo.bar", "www.foo.bar"},
+		{"wildcard domain", "*.foo.bar", "~^(?<subdomain>[\\w-]+)\\.foo\\.bar$"},
+		{"wildcard two levels domain", "*.sub.foo.bar", "~^(?<subdomain>[\\w-]+)\\.sub\\.foo\\.bar$"},
+	}
+
+	for _, testCase := range testCases {
+		result := buildServerName(testCase.hostname)
+		if result != testCase.expected {
+			t.Errorf("%v: expected '%v' but returned '%v'", testCase.title, testCase.expected, result)
+		}
+	}
+}

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -577,7 +577,7 @@ http {
 
     ## start server {{ $server.Hostname }}
     server {
-        server_name {{ $server.Hostname }} {{range $server.Aliases }}{{ . }} {{ end }};
+        server_name {{ buildServerName $server.Hostname }} {{range $server.Aliases }}{{ . }} {{ end }};
 
         {{ if gt (len $cfg.BlockUserAgents) 0 }}
         if ($block_ua) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes

From [NGINX docs](http://nginx.org/en/docs/http/server_names.html)

> The name “*.example.org” matches not only www.example.org but www.sub.example.org as well.

This is not valid. We should validate only one level is configured.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
