### PR TITLE
Allow users adding extraRoleRules and extraClusterRoleRules in RBAC

### DIFF
--- a/charts/ingress-nginx/templates/clusterrole.yaml
+++ b/charts/ingress-nginx/templates/clusterrole.yaml
@@ -73,4 +73,7 @@ rules:
       - get
       - list
       - watch
+{{- if .Values.rbac.extraClusterRoleRules }}
+  {{- toYaml .Values.rbac.extraClusterRoleRules | nindent 2 }}
+{{- end }}
 {{- end }}

--- a/charts/ingress-nginx/templates/controller-role.yaml
+++ b/charts/ingress-nginx/templates/controller-role.yaml
@@ -87,6 +87,9 @@ rules:
     verbs:
       - create
       - patch
+{{- if .Values.rbac.extraRoleRules }}
+  {{- toYaml .Values.rbac.extraRoleRules | nindent 2 }}
+{{- end }}
 {{- if .Values.podSecurityPolicy.enabled }}
   - apiGroups:      [{{ template "podSecurityPolicy.apiGroup" . }}]
     resources:      ['podsecuritypolicies']

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -642,6 +642,10 @@ defaultBackend:
 rbac:
   create: true
   scope: false
+  # Extra RBAC rules for role used by the ingress controller
+  extraRoleRules: []
+  # Extra RBAC rules for cluster role used by the ingress controller
+  extraClusterRoleRules: []
 
 # If true, create & use Pod Security Policy resources
 # https://kubernetes.io/docs/concepts/policy/pod-security-policy/


### PR DESCRIPTION
Allow users adding extraRoleRules and extraClusterRoleRules in RBAC

## What this PR does / why we need it:
Sometimes we would like to grant the Ingress Pod extra permissions that are used by extraInitContainers and extraContainers. 
It would be convenient to bake it into the helm chart.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?
* I have run e2e test locally
* I have manually run `helm template` with the new values
```
rbac:
  create: true
  scope: false
  extraRoleRules:
    - apiGroups:
        - ""
      resources:
        - pod
      verbs:
        - delete
    - apiGroups:
        - "test"
      resources: ["test"]
      verbs: ["create", "get", "list"]
  extraClusterRoleRules:
    - apiGroups:
        - "testtest"
      resources:
        - test
      verbs:
        - delete
```
which results in
```
  - apiGroups:
    - ""
    resources:
    - pod
    verbs:
    - delete
  - apiGroups:
    - test
    resources:
    - test
    verbs:
    - create
    - get
    - list

```
and
```
  - apiGroups:
    - testtest
    resources:
    - test
    verbs:
    - delete
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
