### PR TITLE
Fix controller service annotations

### DIFF
--- a/charts/ingress-nginx/templates/controller-service.yaml
+++ b/charts/ingress-nginx/templates/controller-service.yaml
@@ -2,9 +2,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-{{- if .Values.controller.service.annotations }}
-  annotations: {{ toYaml .Values.controller.service.annotations | nindent 4 }}
-{{- end }}
+  annotations:
+  {{- range $key, $value := .Values.controller.service.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: controller


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
Currently 
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)


## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->
```bash
Error: UPGRADE FAILED: unable to decode \"\": resource.metadataOnlyObject.ObjectMeta: v1.ObjectMeta.Annotations: ReadString: expects \" or n, but found t, error found in #10 byte of ...|nternal\":true},\"labe|..., bigger context ...|beta.kubernetes.io/azure-load-balancer-internal\":true},\"labels\":{\"app.kubernetes.io/component\":\"cont|..."], "stdout": "", "stdout_lines": []
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
values.yaml
```yaml
controller:
  service:
    annotations:
      service.beta.kubernetes.io/azure-load-balancer-internal: true
    externalTrafficPolicy: Local
```
Run helm install
```bash
helm  upgrade -i  \              
    --wait --atomic  \
    -f values.yaml \
     nginx-ingress charts/ingress-nginx
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [x] All new and existing tests passed.
