### PR TITLE
helm chart: add additional ports option for http(s) services

### DIFF
--- a/charts/ingress-nginx/templates/controller-service.yaml
+++ b/charts/ingress-nginx/templates/controller-service.yaml
@@ -46,6 +46,24 @@ spec:
       nodePort: {{ .Values.controller.service.nodePorts.http }}
     {{- end }}
   {{- end }}
+  {{- range $additional := .Values.controller.service.ports.additionalHttp }}
+    - name: {{ $additional.name }}
+      port: {{ $additional.port }}
+      protocol: TCP
+      targetPort: {{ $.Values.controller.service.targetPorts.http }}
+    {{- if $additional.nodePort }}
+      nodePort: {{ $additional.nodePort }}
+    {{- end }}
+  {{- end }}
+  {{- range $additional := .Values.controller.service.ports.additionalHttps }}
+    - name: {{ $additional.name }}
+      port: {{ $additional.port }}
+      protocol: TCP
+      targetPort: {{ $.Values.controller.service.targetPorts.https }}
+    {{- if $additional.nodePort }}
+      nodePort: {{ $additional.nodePort }}
+    {{- end }}
+  {{- end }}
   {{- if .Values.controller.service.enableHttps }}
     - name: https
       port: {{ .Values.controller.service.ports.https }}

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -337,6 +337,18 @@ controller:
       http: 80
       https: 443
 
+      additionalHttp: []
+      ## Additional ports for http service
+      #  - port: 8000
+      #    name: http-8000
+      #    nodePort: ""
+
+      additionalHttps: []
+      ## Additional ports for https service
+      #  - port: 8443
+      #    name: https-8443
+      #    nodePort: ""
+
     targetPorts:
       http: http
       https: https


### PR DESCRIPTION
## What this PR does / why we need it:

Add `additionalHttp` and `additionalHttps` option to have multiple ports for http and https.
I currently have a usecase for legacy devices which use custom port and can't be changed. The same ingress must be available for 80 and 8000.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
