### PR TITLE
Reload nginx when L4 proxy protocol change

### DIFF
--- a/internal/ingress/types_equals.go
+++ b/internal/ingress/types_equals.go
@@ -524,6 +524,9 @@ func (l4b1 *L4Backend) Equal(l4b2 *L4Backend) bool {
 	if l4b1.Protocol != l4b2.Protocol {
 		return false
 	}
+	if l4b1.ProxyProtocol != l4b2.ProxyProtocol {
+		return false
+	}
 
 	return true
 }

--- a/internal/ingress/types_equals_test.go
+++ b/internal/ingress/types_equals_test.go
@@ -94,6 +94,24 @@ func TestL4ServiceElementsMatch(t *testing.T) {
 				{Port: 80, Endpoints: []Endpoint{{Address: "1.1.1.2"}, {Address: "1.1.1.1"}}}},
 			true,
 		},
+		{
+			[]L4Service{
+				{Port: 80, Backend: L4Backend{Name: "test", Namespace: "default", Protocol: "TCP", ProxyProtocol: ProxyProtocol{Decode: false, Encode: false}}},
+			},
+			[]L4Service{
+				{Port: 80, Backend: L4Backend{Name: "test", Namespace: "default", Protocol: "TCP", ProxyProtocol: ProxyProtocol{Decode: false, Encode: false}}},
+			},
+			true,
+		},
+		{
+			[]L4Service{
+				{Port: 80, Backend: L4Backend{Name: "test", Namespace: "default", Protocol: "TCP", ProxyProtocol: ProxyProtocol{Decode: false, Encode: false}}},
+			},
+			[]L4Service{
+				{Port: 80, Backend: L4Backend{Name: "test", Namespace: "default", Protocol: "TCP", ProxyProtocol: ProxyProtocol{Decode: false, Encode: true}}},
+			},
+			false,
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`nginx.conf` won't reload if add `PROXY` to tcp-services configmap without changing ports or service. I can still reproduce by this [comments](https://github.com/kubernetes/ingress-nginx/issues/4213#issuecomment-562304440)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
https://github.com/kubernetes/ingress-nginx/issues/4213

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Add test-case to check `L4Backend` kind of changes to test file `types_equals_test.go` and ran the end-to-end tests following the steps described in [development guide](https://github.com/kubernetes/ingress-nginx/blob/master/docs/development.md). All selected tests passed.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
