### PR TITLE
Add controller.podAnnonationConfigChecksum config

### DIFF
--- a/charts/ingress-nginx/Chart.yaml
+++ b/charts/ingress-nginx/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: ingress-nginx
-version: 3.8.0
+version: 3.8.1
 appVersion: 0.41.0
 home: https://github.com/kubernetes/ingress-nginx
 description: Ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer

--- a/charts/ingress-nginx/templates/controller-deployment.yaml
+++ b/charts/ingress-nginx/templates/controller-deployment.yaml
@@ -29,10 +29,13 @@ spec:
   minReadySeconds: {{ .Values.controller.minReadySeconds }}
   template:
     metadata:
-    {{- if .Values.controller.podAnnotations }}
+    {{- if or .Values.controller.podAnnotations .Values.controller.podAnnotationConfigChecksum }}
       annotations: 
       {{- range $key, $value := .Values.controller.podAnnotations }}
         {{ $key }}: {{ $value | quote }}
+      {{- end }}
+      {{- if .Values.controller.podAnnotationConfigChecksum }}
+        checksum/config: {{ tpl (toYaml .Values.controller) . | sha256sum }}
       {{- end }}
     {{- end }}
       labels:

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -257,6 +257,10 @@ controller:
   ##
   podAnnotations: {}
 
+  # Add Config Checksum to pod Annotations
+  # This will trigger Rolling Updates on configuration changes
+  podAnnotationConfigChecksum: false
+
   replicaCount: 1
 
   minAvailable: 1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This flag adds an annotation with a checksum/config in pod template metadata that will trigger a Rolling Update when configuration (in ConfigMap) changes.
Ref: https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments

This Pull Request is completely based on a Pull Request done in the deprecated repository: https://github.com/helm/charts/pull/22998

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->
N/A

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I've used the chart attribute `controller.config.http-snippet` to test this behavior.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
