### PR TITLE
Add documentation for ssl passthrough with L4 routing

### DIFF
--- a/docs/user-guide/tls.md
+++ b/docs/user-guide/tls.md
@@ -57,6 +57,11 @@ passthrough proxy port (default: 442), which proxies the request to the default 
     Unlike HTTP backends, traffic to Passthrough backends is sent to the *clusterIP* of the backing Service instead of
     individual Endpoints.
 
+!!! note
+    If you route traffic directly to the controller without using the proxy_protocol, nginx will set the real-ip to the $remote_addr. The $remote_addr contains 127.0.0.1 as value, as this is the local TCP proxy address. 
+    In order to use the actual source ip connecting to the local TCP proxy, the following flags need to be added in the configuration [ConfigMap][ConfigMap].:  
+    `enable-real-ip: true` and `forwarded-for-header: proxy_protocol`
+
 ## HTTP Strict Transport Security
 
 HTTP Strict Transport Security (HSTS) is an opt-in security enhancement specified


### PR DESCRIPTION
Added the documentation that ensures the correct IP address is used when enabling the local TCP Proxy accepting traffic directly from the firewall

<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Which issue/s this PR fixes
https://github.com/kubernetes/ingress-nginx/issues/6301
https://github.com/kubernetes/ingress-nginx/issues/6163
https://github.com/kubernetes/ingress-nginx/issues/4941

## How Has This Been Tested?
Configure a standard nginx controller with --ssl-passthrough,
Route traffic directly to the ingress controller (without proxy_protocol)
With the default configuration the logs show 127.0.0.1 as remote_addr
With the extra configuration flags, the logs show the correct remote_addr

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
