### PR TITLE
Enable namespace for Service object

### DIFF
--- a/charts/ingress-nginx/templates/controller-service.yaml
+++ b/charts/ingress-nginx/templates/controller-service.yaml
@@ -13,6 +13,9 @@ metadata:
     {{- toYaml .Values.controller.service.labels | nindent 4 }}
   {{- end }}
   name: {{ include "ingress-nginx.controller.fullname" . }}
+{{- if .Values.controller.service.namespace }}
+  namespace: {{ .Values.controller.service.namespace }}
+{{- end }}
 spec:
   type: {{ .Values.controller.service.type }}
 {{- if .Values.controller.service.clusterIP }}

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -303,6 +303,7 @@ controller:
 
   service:
     enabled: true
+    namespace: ""
 
     annotations: {}
     labels: {}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In Kuberentes I want to be able to deploy NGINX controller to certain namespace and all of its functionalities limited only to this namespace. Nearly everything can be achieved via combination of currently offered setters (e.g. --set controller.scope.enabled=true --set controller.scope.namespace=namespace ...) but after defining all limitations, Service is deployed to default namespace. Therefore whole deployment is failing because other Resources cannot find Service in desired namespace. Adding possibility of deploying Service to chosen namespace solves the problem. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have successfully deployed LoadBalancer type of Service (integrated with OpenStack) to certain namespace and  by connecting with NGINX (in that namespace) I am able to expose TCP/UDP services even though my cluster is on private network. This is useful if there are more people using the cluster and everyone has his own namespace but needs to expose services to external world. 

Helm command to deploy to namespace:
`helm install my-ingress ingress-nginx/ingress-nginx -n $NAMESPACE  --kube-context=$KUBE_CONTEXT  --set controller.admissionWebhooks.enabled=false --set tcp.8080="$NAMESPACE/alpha:91" --set controller.scope.enabled=true --set controller.scope.namespace=$NAMESPACE --set rbac.create=false --set rbac.scope=true --set serviceAccount.create=false  --set controller.service.namespace=$NAMESPACE`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
