### PR TITLE
Added role binding for 'ingress-nginx-admission' to PSP example (#6018)

### DIFF
--- a/docs/examples/psp/psp.yaml
+++ b/docs/examples/psp/psp.yaml
@@ -70,3 +70,6 @@ subjects:
 - kind: ServiceAccount
   name: ingress-nginx
   namespace: ingress-nginx
+- kind: ServiceAccount
+  name: ingress-nginx-admission
+  namespace: ingress-nginx


### PR DESCRIPTION
## What this PR does / why we need it:
The `ingress-nginx-admission` account is launched by default, and there is no role binding applied to it for PSP. It might also be desired to add, or document, one for the `ingress-nginx-backend` service account when the backend is toggled.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #6018
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
