### PR TITLE
Fix sum value of nginx process connections

### DIFF
--- a/deploy/grafana/dashboards/nginx.json
+++ b/deploy/grafana/dashboards/nginx.json
@@ -206,7 +206,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(avg_over_time(nginx_ingress_controller_nginx_process_connections{controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$namespace\"}[2m]))",
+          "expr": "sum(avg_over_time(nginx_ingress_controller_nginx_process_connections{controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$namespace\",state=\"active\"}[2m]))",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,


### PR DESCRIPTION
## What this PR does / why we need it:
Fixes displayed grafana value for nginx process connections.

nginx_ingress_controller_nginx_process_connections returns four elements
for each pod, one for each "state" (active, reading, waiting, writing).

The value of the element with state "active" is the sum of the other
three elements of other states:

active = reading + waiting + writing

So sum() returns a value that is 2x of the actual amount of connections.
To fix this we simply select elements with state "active".

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
