### PR TITLE
Support Keda Autoscaling

### DIFF
--- a/charts/ingress-nginx/CHANGELOG.md
+++ b/charts/ingress-nginx/CHANGELOG.md
@@ -4,6 +4,10 @@ This file documents all notable changes to [ingress-nginx](https://github.com/ku
 
 ### Unreleased
 
+### 3.11.0
+
+- Support Keda Autoscaling
+
 ### 3.10.1
 
 - Fix regression introduced in 0.41.0 with external authentication

--- a/charts/ingress-nginx/Chart.yaml
+++ b/charts/ingress-nginx/Chart.yaml
@@ -16,4 +16,4 @@ engine: gotpl
 kubeVersion: ">=1.16.0-0"
 annotations:
   artifacthub.io/changes: |
-    - Update ingress-nginx image to v0.41.2
+    - Support Keda Autoscaling

--- a/charts/ingress-nginx/Chart.yaml
+++ b/charts/ingress-nginx/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: ingress-nginx
-version: 3.10.1
+version: 3.11.0
 appVersion: 0.41.2
 home: https://github.com/kubernetes/ingress-nginx
 description: Ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer

--- a/charts/ingress-nginx/templates/controller-hpa.yaml
+++ b/charts/ingress-nginx/templates/controller-hpa.yaml
@@ -1,4 +1,6 @@
 {{- if and .Values.controller.autoscaling.enabled (or (eq .Values.controller.kind "Deployment") (eq .Values.controller.kind "Both")) -}}
+{{- if not .Values.controller.keda.enabled }}
+
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -34,3 +36,5 @@ spec:
 {{- toYaml . | nindent 2 }}
   {{- end }}
 {{- end }}
+{{- end }}
+

--- a/charts/ingress-nginx/templates/controller-keda.yaml
+++ b/charts/ingress-nginx/templates/controller-keda.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.controller.keda.enabled }}
+# https://keda.sh/docs/
+
+apiVersion: {{ .Values.controller.keda.apiVersion }}
+kind: ScaledObject
+metadata:
+  labels:
+    {{- include "ingress-nginx.labels" . | nindent 4 }}
+    app.kubernetes.io/component: controller
+  name: {{ include "ingress-nginx.controller.fullname" . }}
+
+spec:
+  scaleTargetRef:
+    deploymentName: {{ include "ingress-nginx.controller.fullname" . }}
+  pollingInterval: {{ .Values.controller.keda.pollingInterval }}
+  cooldownPeriod: {{ .Values.controller.keda.cooldownPeriod }}
+  minReplicaCount: {{ .Values.controller.keda.minReplicas }}
+  maxReplicaCount: {{ .Values.controller.keda.maxReplicas }}
+  triggers:
+{{- with .Values.controller.keda.triggers }}
+{{ toYaml . | indent 2 }}
+{{ end }}
+  advanced:
+    restoreToOriginalReplicaCount: {{ .Values.controller.keda.restoreToOriginalReplicaCount }}
+{{- if .Values.controller.keda.behavior }}
+    horizontalPodAutoscalerConfig:
+      behavior:
+{{ with .Values.controller.keda.behavior -}}
+{{ toYaml . | indent 8 }}
+{{ end }}
+
+{{- end }}
+{{- end }}

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -273,6 +273,7 @@ controller:
       cpu: 100m
       memory: 90Mi
 
+  # Mutually exclusive with keda autoscaling
   autoscaling:
     enabled: false
     minReplicas: 1
@@ -290,6 +291,40 @@ controller:
   #     target:
   #       type: AverageValue
   #       averageValue: 10000m
+
+  # Mutually exclusive with hpa autoscaling
+  keda:
+    apiVersion: "keda.sh/v1alpha1"
+  # apiVersion changes with keda 1.x vs 2.x
+  # 2.x = keda.sh/v1alpha1
+  # 1.x = keda.k8s.io/v1alpha1
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 11
+    pollingInterval: 30
+    cooldownPeriod: 300
+    restoreToOriginalReplicaCount: false
+    triggers: []
+ #     - type: prometheus
+ #       metadata:
+ #         serverAddress: http://<prometheus-host>:9090
+ #         metricName: http_requests_total
+ #         threshold: '100'
+ #         query: sum(rate(http_requests_total{deployment="my-deployment"}[2m]))
+
+    behavior: {}
+ #     scaleDown:
+ #       stabilizationWindowSeconds: 300
+ #       policies:
+ #       - type: Pods
+ #         value: 1
+ #         periodSeconds: 180
+ #     scaleUp:
+ #       stabilizationWindowSeconds: 300
+ #       policies:
+ #       - type: Pods
+ #         value: 2
+ #         periodSeconds: 60
 
   ## Enable mimalloc as a drop-in replacement for malloc.
   ## ref: https://github.com/microsoft/mimalloc


### PR DESCRIPTION
Keda autoscaling is exclusive with regular hpa scaling.
If both are set to true, keda takes precedence.

<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
This change allows for scaling ingress controllers based on arbitrary prometheus metrics, such as http requests per second, or host level metrics such as conntrack table utilization.

## Types of changes
- [x ] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?

Local helm rendering produces valid keda configurations.
Enabling both keda and hpa autoscaling results in solely keda configurations.

## Checklist:
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly. In-line comments in the values file
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
