### PR TITLE
Update the basic auth example

### DIFF
--- a/docs/examples/auth/basic/README.md
+++ b/docs/examples/auth/basic/README.md
@@ -115,11 +115,13 @@ accept=*/*
 connection=close
 host=foo.bar.com
 user-agent=curl/7.43.0
+x-request-id=e426c7829ef9f3b18d40730857c3eddb
 x-forwarded-for=10.2.29.1
 x-forwarded-host=foo.bar.com
 x-forwarded-port=80
 x-forwarded-proto=http
 x-real-ip=10.2.29.1
+x-scheme=http
 BODY:
 * Connection #0 to host 10.2.29.4 left intact
 -no body in request-

--- a/docs/examples/auth/basic/README.md
+++ b/docs/examples/auth/basic/README.md
@@ -112,7 +112,6 @@ server_version=nginx: 1.9.11 - lua: 10001
 
 HEADERS RECEIVED:
 accept=*/*
-authorization=Basic Zm9vOmJhcg==
 connection=close
 host=foo.bar.com
 user-agent=curl/7.43.0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:

In this PR I'm fixing the basic authentication example documentation so that it better reflects the current state.

I was expecting that Nginx-ingress should pass the `Authorization` header to pods as it's mentioned in the doc, but it looks like that has not been the case for four years now. I suspect that after this commit, https://github.com/kubernetes/ingress-nginx/commit/5effb7b4e388a92caeb84313aab36f8d2d5c9a9e Nginx-ingress doesn't pass the `Authorization` header to upstream services anymore if HTTP basic authentication is being used.

Also added `X-Request-ID` and `X-Scheme` headers to the example since, by default, ingress-nginx always sends those headers to pods. Probably that wasn't true when the doc was written.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
