### PR TITLE
DOC FIX: fix helm update command

### DIFF
--- a/charts/ingress-nginx/README.md
+++ b/charts/ingress-nginx/README.md
@@ -14,7 +14,7 @@ This chart bootstraps an ingress-nginx deployment on a [Kubernetes](http://kuber
 
 ```console
 helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
-helm update
+helm repo update
 ```
 
 ## Install Chart


### PR DESCRIPTION
In 4ac3e1ff2c4cf3f78a57079cb48c6248d24a1fb5 helm2 support was removed. However looks like the `helm update` is not a valid command in helm3

Helm3 command to update help repo:
 https://helm.sh/docs/helm/helm_repo_update/#helm-repo-update