### PR TITLE
Fix typo in 0.40 breaking changes

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -122,8 +122,8 @@ _Changes:_
 
 _Breaking Changes:_
 
-Kubernetes v1.16 or higher is required.
-Only ValidatingWebhookConfiguration AdmissionReviewVersions v1 is supported.
+- Kubernetes v1.14 or higher is required.
+- Only ValidatingWebhookConfiguration AdmissionReviewVersions v1 is supported.
 
 Following the [Ingress extensions/v1beta1](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16) deprecation, please use `networking.k8s.io/v1beta1` or `networking.k8s.io/v1` (Kubernetes v1.19 or higher) for new Ingress definitions
 


### PR DESCRIPTION
There seems to be a typo in the changelog for version 0.40, it says kubernetes 1.16 is the lowest required version, but it seems to be [1.14](https://github.com/kubernetes/ingress-nginx/blob/master/cmd/nginx/main.go#L111)


