### PR TITLE
Update the suggested port to point to the port of the service not pods

### DIFF
--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -493,7 +493,7 @@ controller:
     service:
       annotations: {}
       # prometheus.io/scrape: "true"
-      # prometheus.io/port: "10254"
+      # prometheus.io/port: "9913"
 
       # clusterIP: ""
 


### PR DESCRIPTION
## What this PR does / why we need it:
The suggested port to uncomment is incorrect in that if a consumer of the chart uncomments these lines, the prometheus exporter will be unable to connect to the service as by [default](https://github.com/kubernetes/ingress-nginx/blob/master/charts/ingress-nginx/values.yaml#L507) 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?
Deployed to a local cluster with prometheus installed.

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
