### PR TITLE
Bugfix: some requests fail with 503 when nginx reload

### DIFF
--- a/rootfs/etc/nginx/lua/balancer.lua
+++ b/rootfs/etc/nginx/lua/balancer.lua
@@ -107,6 +107,12 @@ local function sync_backend(backend)
     return
   end
 
+  if is_backend_with_external_name(backend) then
+    backend = resolve_external_names(backend)
+  end
+
+  backend.endpoints = format_ipv6_endpoints(backend.endpoints)
+
   local implementation = get_implementation(backend)
   local balancer = balancers[backend.name]
 
@@ -126,13 +132,13 @@ local function sync_backend(backend)
     return
   end
 
-  if is_backend_with_external_name(backend) then
-    backend = resolve_external_names(backend)
-  end
-
-  backend.endpoints = format_ipv6_endpoints(backend.endpoints)
-
   balancer:sync(backend)
+end
+
+local function sync_backends_with_external_name()
+  for _, backend_with_external_name in pairs(backends_with_external_name) do
+    sync_backend(backend_with_external_name)
+  end
 end
 
 local function sync_backends()
@@ -141,9 +147,6 @@ local function sync_backends()
   local current_timestamp = ngx.time()
   if current_timestamp - backends_last_synced_at < BACKENDS_FORCE_SYNC_INTERVAL
       and raw_backends_last_synced_at <= backends_last_synced_at then
-    for _, backend_with_external_name in pairs(backends_with_external_name) do
-      sync_backend(backend_with_external_name)
-    end
     return
   end
 
@@ -161,12 +164,13 @@ local function sync_backends()
 
   local balancers_to_keep = {}
   for _, new_backend in ipairs(new_backends) do
-    sync_backend(new_backend)
-    balancers_to_keep[new_backend.name] = balancers[new_backend.name]
     if is_backend_with_external_name(new_backend) then
       local backend_with_external_name = util.deepcopy(new_backend)
       backends_with_external_name[backend_with_external_name.name] = backend_with_external_name
+    else
+      sync_backend(new_backend)
     end
+    balancers_to_keep[new_backend.name] = true
   end
 
   for backend_name, _ in pairs(balancers) do
@@ -272,11 +276,12 @@ local function get_balancer()
 end
 
 function _M.init_worker()
-  -- when worker starts, sync backends without delay
-  -- we call it in timer because for endpoints that require
+  -- when worker starts, sync non ExternalName backends without delay
+  sync_backends()
+  -- we call sync_backends_with_external_name in timer because for endpoints that require
   -- DNS resolution it needs to use socket which is not available in
   -- init_worker phase
-  local ok, err = ngx.timer.at(0, sync_backends)
+  local ok, err = ngx.timer.at(0, sync_backends_with_external_name)
   if not ok then
     ngx.log(ngx.ERR, "failed to create timer: ", err)
   end
@@ -284,6 +289,11 @@ function _M.init_worker()
   ok, err = ngx.timer.every(BACKENDS_SYNC_INTERVAL, sync_backends)
   if not ok then
     ngx.log(ngx.ERR, "error when setting up timer.every for sync_backends: ", err)
+  end
+  ok, err = ngx.timer.every(BACKENDS_SYNC_INTERVAL, sync_backends_with_external_name)
+  if not ok then
+    ngx.log(ngx.ERR, "error when setting up timer.every for sync_backends_with_external_name: ",
+            err)
   end
 end
 


### PR DESCRIPTION
In PR [fix first backend sync](https://github.com/kubernetes/ingress-nginx/pull/5481), in order to solve the problem that ExternalName backend needs to perform dns query , so cannot directly execute sync_backends in the init_worker phase, the author introduced `timer.at(0, sync_backends)`, but `timer.at(0)` cannot guarantee that the worker completes once  `sync_backends`  before processing the http request, so there will be some requests fail with 503 in the rewrite phase after nginx reload:
```[lua]
function _M.rewrite()
  local balancer = get_balancer() -- init sync_backends not completed
  if not balancer then
    ngx.status = ngx.HTTP_SERVICE_UNAVAILABLE
    return ngx.exit(ngx.status)
  end
end
```
After we observed the above phenomenon in the production environment, we carried out the current bugfix, and verified that this patch can solve the problem.

The changes are as follows:
Separate the ExternalName backend from other backends in the process of synchronizing the backend, because the synchronization of the ExternalName backend requires dns resolution, so we should ensure that it does not affect the synchronization of the Non-ExternalName backend. After separation, in the init worker stage, we should immediately synchronize the Non-ExternalName backend, otherwise there will be some requests that fail with 503 because the balancer cannot be obtained in the rewrite stage.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)