### PR TITLE
feat: allow volume-type emptyDir in controller podsecuritypolicy

### DIFF
--- a/charts/ingress-nginx/templates/controller-psp.yaml
+++ b/charts/ingress-nginx/templates/controller-psp.yaml
@@ -20,7 +20,7 @@ spec:
   # Allow core volume types.
   volumes:
     - 'configMap'
-    #- 'emptyDir'
+    - 'emptyDir'
     #- 'projected'
     - 'secret'
     #- 'downwardAPI'


### PR DESCRIPTION
## What this PR does / why we need it:
When adding ingress-nginx to [linkerd2 servicemesh](https://linkerd.io/), the linkerd2-proxy sidecar container wants to create a volume of type emptyDir. If we can't update the controller psp, cluster admins would have to create a separate, out-of-chart, psp for ingress-nginx. Considering that adding emptyDir as an allowed volume type does not pose a/any risk to the controller integrity, I hope it is agreeable to expand the psp.

emptyDir volumes are also already allowed for the [default backend](https://github.com/kubernetes/ingress-nginx/blob/master/charts/ingress-nginx/templates/default-backend-psp.yaml)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
N/A

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [] All new and existing tests passed.
