### PR TITLE
add string split function to template funcMap

### DIFF
--- a/docs/user-guide/nginx-configuration/custom-template.md
+++ b/docs/user-guide/nginx-configuration/custom-template.md
@@ -30,6 +30,7 @@ In addition to the built-in functions provided by the Go package the following f
 - hasSuffix: [strings.HasSuffix](https://golang.org/pkg/strings/#HasSuffix)
 - toUpper: [strings.ToUpper](https://golang.org/pkg/strings/#ToUpper)
 - toLower: [strings.ToLower](https://golang.org/pkg/strings/#ToLower)
+- split: [strings.Split](https://golang.org/pkg/strings/#Split)
 - quote: wraps a string in double quotes
 - buildLocation: helps to build the NGINX Location section in each server
 - buildProxyPass: builds the reverse proxy configuration

--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -152,6 +152,7 @@ var (
 		"buildDenyVariable":               buildDenyVariable,
 		"getenv":                          os.Getenv,
 		"contains":                        strings.Contains,
+		"split":                           strings.Split,
 		"hasPrefix":                       strings.HasPrefix,
 		"hasSuffix":                       strings.HasSuffix,
 		"trimSpace":                       strings.TrimSpace,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently, golang text template does not support strings split operator natively. Add `strings.Split` to `funcMap`  as `split`.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
