### PR TITLE
adding e2e test and making sure it fails before I make the change

### DIFF
--- a/test/e2e/annotations/modsecurity.go
+++ b/test/e2e/annotations/modsecurity.go
@@ -216,4 +216,44 @@ var _ = framework.DescribeAnnotation("modsecurity owasp", func() {
 			Expect().
 			Status(http.StatusForbidden)
 	})
+
+		ginkgo.It("should enable modsecurity when enable-owasp-modsecurity-crs is set to true", func() {
+		host := "modsecurity.foo.com"
+		nameSpace := f.Namespace
+
+		snippet := `SecRuleEngine On
+		SecRequestBodyAccess On
+		SecAuditEngine RelevantOnly
+		SecAuditLogParts ABIJDEFHZ
+		SecAuditLog /dev/stdout
+		SecAuditLogType Serial
+		SecRule REQUEST_HEADERS:User-Agent \"block-ua\" \"log,deny,id:107,status:403,msg:\'UA blocked\'\"`
+
+		annotations := map[string]string{
+			"nginx.ingress.kubernetes.io/modsecurity-snippet": snippet,
+		}
+
+		ing := framework.NewSingleIngress(host, "/", host, nameSpace, framework.EchoService, 80, annotations)
+		f.EnsureIngress(ing)
+
+		f.SetNginxConfigMapData(map[string]string{
+			"enable-modsecurity": "true",
+			"enable-owasp-modsecurity-crs": "true"},
+		)
+
+
+		f.WaitForNginxServer(host,
+			func(server string) bool {
+				return strings.Contains(server, "SecRuleEngine On")
+			})
+
+		f.HTTPTestClient().
+			GET("/").
+			WithHeader("Host", host).
+			WithHeader("User-Agent", "block-ua").
+			Expect().
+			Status(http.StatusForbidden)
+	})
+
+
 })


### PR DESCRIPTION
As it stands, ModSecurity snippets can only be applied if owasp rules are set to false.

## What this PR does / why we need it:
This aims to allow snippets to be set when OWASP rules are set to true as outlined [here](https://github.com/kubernetes/ingress-nginx/issues/4902#issuecomment-598331053) issue.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?
I ran the local automated test and build and image which I used to see if the issue had been fixed.

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

