### PR TITLE
Update controller-poddisruptionbudget.yaml

### DIFF
--- a/charts/ingress-nginx/templates/controller-poddisruptionbudget.yaml
+++ b/charts/ingress-nginx/templates/controller-poddisruptionbudget.yaml
@@ -1,4 +1,4 @@
-{{- if or (and .Values.controller.autoscaling.enabled (gt (.Values.controller.autoscaling.minReplicas | int) 1)) (gt (.Values.controller.replicaCount | int) 1) -}}
+{{- if or (and .Values.controller.autoscaling.enabled (gt (.Values.controller.autoscaling.minReplicas | int) 1)) (and (not .Values.controller.autoscaling.enabled) (gt (.Values.controller.replicaCount | int) 1)) }}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:


### PR DESCRIPTION
Logic was wrong. See additional check that is also part of the first OR.

<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
Without this change there is a wrongful deployment of a PDB for the controller when autoscaling is enabled.
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
This has been tested by hand as I see no chart tests for this logic.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- PDB is successfully omitted when autoscaling is enabled with `minReplicas 1`
- PDB is successfully deployed when autoscaling is enabled with `minReplicas > 1`
- PDB is successfully omitted when autoscaling is disabled with `replicaCount 1`
- PDB is successfully deployed when autoscaling is disabled with `replicaCount > 1`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
