### PR TITLE
allow kb granularity for lua shared dicts

### DIFF
--- a/docs/user-guide/nginx-configuration/configmap.md
+++ b/docs/user-guide/nginx-configuration/configmap.md
@@ -1046,6 +1046,12 @@ For example following will set default `certificate_data` dictionary to `100M` a
 lua-shared-dicts: "certificate_data: 100, my_custom_plugin: 5"
 ```
 
+You can optionally set a size unit to allow for kilobyte-granularity. Allowed units are 'm' or 'k' (case-insensitive), and it defaults to MB if no unit is provided. Here is a similar example, but the `my_custom_plugin` dict is only 512KB.
+
+```
+lua-shared-dicts: "certificate_data: 100, my_custom_plugin: 512k"
+```
+
 _References:_
 [http://nginx.org/en/docs/http/ngx_http_core_module.html#limit_rate_after](http://nginx.org/en/docs/http/ngx_http_core_module.html#limit_rate_after)
 

--- a/internal/ingress/controller/nginx.go
+++ b/internal/ingress/controller/nginx.go
@@ -230,7 +230,7 @@ type NGINXController struct {
 	// runningConfig contains the running configuration in the Backend
 	runningConfig *ingress.Configuration
 
-	t ngx_template.TemplateWriter
+	t ngx_template.Writer
 
 	resolver []net.IP
 

--- a/internal/ingress/controller/template/configmap_test.go
+++ b/internal/ingress/controller/template/configmap_test.go
@@ -344,27 +344,32 @@ func TestLuaSharedDictsParsing(t *testing.T) {
 		{
 			name:   "configuration_data only",
 			entry:  map[string]string{"lua-shared-dicts": "configuration_data:5"},
-			expect: map[string]int{"configuration_data": 5},
+			expect: map[string]int{"configuration_data": 5120},
 		},
 		{
 			name:   "certificate_data only",
 			entry:  map[string]string{"lua-shared-dicts": "certificate_data: 4"},
-			expect: map[string]int{"certificate_data": 4},
+			expect: map[string]int{"certificate_data": 4096},
 		},
 		{
 			name:   "custom dicts",
 			entry:  map[string]string{"lua-shared-dicts": "configuration_data:   10, my_random_dict:15 ,   another_example:2"},
-			expect: map[string]int{"configuration_data": 10, "my_random_dict": 15, "another_example": 2},
+			expect: map[string]int{"configuration_data": 10240, "my_random_dict": 15360, "another_example": 2048},
 		},
 		{
 			name:   "invalid size value should be ignored",
-			entry:  map[string]string{"lua-shared-dicts": "mydict: 10, invalid_dict: 1a"},
-			expect: map[string]int{"mydict": 10},
+			entry:  map[string]string{"lua-shared-dicts": "mydict: 10, invalid_dict: 1a, bad_mb_dict:10mb"},
+			expect: map[string]int{"mydict": 10240},
 		},
 		{
 			name:   "dictionary size can not be larger than 200",
-			entry:  map[string]string{"lua-shared-dicts": "mydict: 10, invalid_dict: 201"},
-			expect: map[string]int{"mydict": 10},
+			entry:  map[string]string{"lua-shared-dicts": "mydict: 10, invalid_dict: 201, invalid_kb: 204801k"},
+			expect: map[string]int{"mydict": 10240},
+		},
+		{
+			name:   "specified units are interpreted properly",
+			entry:  map[string]string{"lua-shared-dicts": "kb_dict_a: 512k, mb_dict_a: 30m, kb_dict_b:16K, mb_dict_b:4M"},
+			expect: map[string]int{"kb_dict_a": 512, "mb_dict_a": 30720, "kb_dict_b": 16, "mb_dict_b": 4096},
 		},
 	}
 
@@ -415,6 +420,79 @@ func TestSplitAndTrimSpace(t *testing.T) {
 		data := splitAndTrimSpace(tc.input, ",")
 		if !reflect.DeepEqual(data, tc.expect) {
 			t.Errorf("Testing %v. Expected \"%v\" but \"%v\" was returned", tc.name, tc.expect, data)
+		}
+	}
+}
+
+func TestDictStrToKb(t *testing.T) {
+	testCases := []struct {
+		name   string
+		input  string
+		expect int
+	}{
+		{
+			name:   "unitless int size converted to kb",
+			input:  "50",
+			expect: 51200,
+		},
+		{
+			name:   "lowercase k accepted",
+			input:  "512k",
+			expect: 512,
+		},
+		{
+			name:   "uppercase K accepted",
+			input:  "512K",
+			expect: 512,
+		},
+		{
+			name:   "lowercase m accepted",
+			input:  "10m",
+			expect: 10240,
+		},
+		{
+			name:   "uppercase M accepted",
+			input:  "10M",
+			expect: 10240,
+		},
+		{
+			name:   "trailing characters fail",
+			input:  "50kb",
+			expect: -1,
+		},
+		{
+			name:   "leading characters fail",
+			input:  " 50k",
+			expect: -1,
+		},
+	}
+	for _, tc := range testCases {
+		if size := dictStrToKb(tc.input); size != tc.expect {
+			t.Errorf("Testing %v. Expected \"%v\" but \"%v\" was returned", tc.name, tc.expect, size)
+		}
+	}
+}
+
+func TestDictKbToStr(t *testing.T) {
+	testCases := []struct {
+		name   string
+		input  int
+		expect string
+	}{
+		{
+			name:   "mod 1024 reports as M",
+			input:  5120,
+			expect: "5M",
+		},
+		{
+			name:   "non-mod 1024 reports as K",
+			input:  5001,
+			expect: "5001K",
+		},
+	}
+	for _, tc := range testCases {
+		if sizeStr := dictKbToStr(tc.input); sizeStr != tc.expect {
+			t.Errorf("Testing %v. Expected \"%v\" but \"%v\" was returned", tc.name, tc.expect, sizeStr)
 		}
 	}
 }

--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -61,8 +61,8 @@ const (
 	stateComment
 )
 
-// TemplateWriter is the interface to render a template
-type TemplateWriter interface {
+// Writer is the interface to render a template
+type Writer interface {
 	Write(conf config.TemplateConfig) ([]byte, error)
 }
 
@@ -330,7 +330,8 @@ func buildLuaSharedDictionaries(c interface{}, s interface{}) string {
 	}
 
 	for name, size := range cfg.LuaSharedDicts {
-		out = append(out, fmt.Sprintf("lua_shared_dict %s %dM", name, size))
+		sizeStr := dictKbToStr(size)
+		out = append(out, fmt.Sprintf("lua_shared_dict %s %s", name, sizeStr))
 	}
 
 	sort.Strings(out)
@@ -342,16 +343,16 @@ func luaConfigurationRequestBodySize(c interface{}) string {
 	cfg, ok := c.(config.Configuration)
 	if !ok {
 		klog.Errorf("expected a 'config.Configuration' type but %T was returned", c)
-		return "100" // just a default number
+		return "100M" // just a default number
 	}
 
 	size := cfg.LuaSharedDicts["configuration_data"]
 	if size < cfg.LuaSharedDicts["certificate_data"] {
 		size = cfg.LuaSharedDicts["certificate_data"]
 	}
-	size = size + 1
+	size = size + 1024
 
-	return fmt.Sprintf("%d", size)
+	return dictKbToStr(size)
 }
 
 // configForLua returns some general configuration as Lua table represented as string

--- a/internal/ingress/controller/template/template_test.go
+++ b/internal/ingress/controller/template/template_test.go
@@ -195,7 +195,7 @@ func TestBuildLuaSharedDictionaries(t *testing.T) {
 	// config lua dict
 	cfg := config.Configuration{
 		LuaSharedDicts: map[string]int{
-			"configuration_data": 10, "certificate_data": 20,
+			"configuration_data": 10240, "certificate_data": 20480,
 		},
 	}
 	actual := buildLuaSharedDictionaries(cfg, invalidType)
@@ -236,13 +236,13 @@ func TestBuildLuaSharedDictionaries(t *testing.T) {
 func TestLuaConfigurationRequestBodySize(t *testing.T) {
 	cfg := config.Configuration{
 		LuaSharedDicts: map[string]int{
-			"configuration_data": 10, "certificate_data": 20,
+			"configuration_data": 10240, "certificate_data": 20480,
 		},
 	}
 
 	size := luaConfigurationRequestBodySize(cfg)
-	if size != "21" {
-		t.Errorf("expected the size to be 20 but got: %v", size)
+	if size != "21M" {
+		t.Errorf("expected the size to be 21M but got: %v", size)
 	}
 }
 

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -676,8 +676,8 @@ http {
         }
 
         location /configuration {
-            client_max_body_size                    {{ luaConfigurationRequestBodySize $cfg }}m;
-            client_body_buffer_size                 {{ luaConfigurationRequestBodySize $cfg }}m;
+            client_max_body_size                    {{ luaConfigurationRequestBodySize $cfg }};
+            client_body_buffer_size                 {{ luaConfigurationRequestBodySize $cfg }};
             proxy_buffering                         off;
 
             content_by_lua_block {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Lua shared dicts can be configured via Configmaps, but it enforces a megabyte granularity. This PR adds regex parsing to allow an appended "k" or "m" (case-insensitive) to specify the size unit of the shared dict. If no unit is specified, it will default to the old behaviour of using megabytes. If for example a user wanted to add many shared dicts of only 16k size, this PR would make sure they don't all use the previous minimum size of 1MB, which could become a considerable memory optimization.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- I updated old tests for this feature to conform to the new unit formatting I set
- I wrote new unit tests for the utility functions I introduced

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

PS: I changed `TemplateWriter` to `Writer` because my go-lint plugin told me to.