### PR TITLE
Fix KEDA autoscaler resource

### DIFF
--- a/charts/ingress-nginx/CHANGELOG.md
+++ b/charts/ingress-nginx/CHANGELOG.md
@@ -4,6 +4,11 @@ This file documents all notable changes to [ingress-nginx](https://github.com/ku
 
 ### Unreleased
 
+### 3.20.1
+
+- Do not create KEDA in case of DaemonSets.
+- Fix KEDA v2 definition
+
 ### 3.20.0
 
 - [] [#6730](https://github.com/kubernetes/ingress-nginx/pull/6730) Do not create HPA for defaultBackend if not enabled.

--- a/charts/ingress-nginx/Chart.yaml
+++ b/charts/ingress-nginx/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ingress-nginx
 # When the version is modified, make sure the artifacthub.io/changes list is updated
 # Also update CHANGELOG.md
-version: 3.20.0
+version: 3.20.1
 appVersion: 0.43.0
 home: https://github.com/kubernetes/ingress-nginx
 description: Ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer
@@ -21,4 +21,5 @@ annotations:
   # List of changes for the release in artifacthub.io
   # https://artifacthub.io/packages/helm/ingress-nginx/ingress-nginx?modal=changelog
   artifacthub.io/changes: |
-    - Do not create HPA for defaultbackend if not enabled.
+    - Do not create KEDA in case of DaemonSets.
+    - Fix KEDA v2 definition

--- a/charts/ingress-nginx/templates/controller-keda.yaml
+++ b/charts/ingress-nginx/templates/controller-keda.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.controller.keda.enabled }}
+{{- if and .Values.controller.keda.enabled (or (eq .Values.controller.kind "Deployment") (eq .Values.controller.kind "Both")) -}}
 # https://keda.sh/docs/
 
 apiVersion: {{ .Values.controller.keda.apiVersion }}
@@ -11,7 +11,11 @@ metadata:
 
 spec:
   scaleTargetRef:
+{{- if eq .Values.controller.keda.apiVersion "keda.k8s.io/v1alpha1" }}
     deploymentName: {{ include "ingress-nginx.controller.fullname" . }}
+{{- else if eq .Values.controller.keda.apiVersion "keda.sh/v1alpha1" }}
+    name: {{ include "ingress-nginx.controller.fullname" . }}
+{{- end }}
   pollingInterval: {{ .Values.controller.keda.pollingInterval }}
   cooldownPeriod: {{ .Values.controller.keda.cooldownPeriod }}
   minReplicaCount: {{ .Values.controller.keda.minReplicas }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
Currently the chart creates invalid "ScaledObject" resource in case of using KEDA v2 api version ("keda.sh/v1alpha1"). Property "**spec.scaleTargetRef.deploymentName**" is changed to a "**spec.scaleTargetRef.name**" in this version ([KEDA migration guide](https://keda.sh/docs/2.0/migration/#scaling-of-deployments)).
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?
Tested manually by templating and deploying "ScaledObject" resource to a KEDA v2 enabled cluster.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
