### PR TITLE
Adding quotes in the serviceAccount name in Helm values. 

### DIFF
--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -608,7 +608,7 @@ defaultBackend:
 
   serviceAccount:
     create: true
-    name:
+    name: ""
   ## Additional environment variables to set for defaultBackend pods
   extraEnvs: []
 
@@ -708,7 +708,7 @@ podSecurityPolicy:
 
 serviceAccount:
   create: true
-  name:
+  name: ""
 
 ## Optional array of imagePullSecrets containing private registry credentials
 ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/


### PR DESCRIPTION
- Replacing empty serviceAccount name with quotes.

## What this PR does / why we need it:
It is just generic values improvement. The current values work but I think having quotes like all other empty values makes more sense than having empty values.

## Types of changes
Values improvement. 

## Which issue/s this PR fixes
None

## How Has This Been Tested?
Helm chart deployed with both empty quotes and value in place and works as expected. 

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
