### PR TITLE
Add value for configuring a custom Diffie-Hellman parameters file

### DIFF
--- a/charts/ingress-nginx/templates/controller-configmap.yaml
+++ b/charts/ingress-nginx/templates/controller-configmap.yaml
@@ -15,6 +15,9 @@ data:
 {{- if or .Values.controller.proxySetHeaders .Values.controller.headers }}
   proxy-set-headers: {{ .Release.Namespace }}/{{ include "ingress-nginx.fullname" . }}-custom-proxy-headers
 {{- end }}
+{{- if .Values.dhParam }}
+  ssl-dh-param: {{ printf "%s/%s" .Release.Namespace (include "ingress-nginx.controller.fullname" .) }}
+{{- end }}
 {{- range $key, $value := .Values.controller.config }}
     {{ $key | nindent 2 }}: {{ $value | quote }}
 {{- end }}

--- a/charts/ingress-nginx/templates/dh-param-secret.yaml
+++ b/charts/ingress-nginx/templates/dh-param-secret.yaml
@@ -1,0 +1,10 @@
+{{- with .Values.dhParam -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "ingress-nginx.controller.fullname" $ }}
+  labels:
+    {{- include "ingress-nginx.labels" $ | nindent 4 }}
+data:
+  dhparam.pem: {{ . }}
+{{- end }}

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -731,3 +731,8 @@ tcp: {}
 ##
 udp: {}
 #  53: "kube-system/kube-dns:53"
+
+# A base64ed Diffie-Hellman parameter
+# This can be generated with: openssl dhparam 4096 2> /dev/null | base64
+# Ref: https://github.com/krmichel/ingress-nginx/blob/master/docs/examples/customization/ssl-dh-param
+dhParam:


### PR DESCRIPTION
## What this PR does / why we need it:
Currently creating the resources needed to configure Diffie-Hellman parameters requires manual configuration outside of the helm chart.  This PR makes it possible to configure the required secret and the setting in the configmap by providing a value to helm while deploying a chart 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?
I have deployed the updated chart from my fork into an EKS cluster and validated that the additional cyphers were made available

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
