### PR TITLE
add --status-port flag to dbg

### DIFF
--- a/cmd/dbg/main.go
+++ b/cmd/dbg/main.go
@@ -108,6 +108,8 @@ func main() {
 	}
 	rootCmd.AddCommand(confCmd)
 
+	rootCmd.PersistentFlags().IntVar(&nginx.StatusPort, "status-port", 10246, `Port to use for the lua HTTP endpoint configuration.`)
+
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When config custom status port for ingress controller, dbg will not working since use default status port(10246) to connect nginx. 
```
Get "http://127.0.0.1:10246/configuration/backends": dial tcp 127.0.0.1:10246: connect: connection refused
```
So we should support `--status-port` flag in dbg too.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)