### PR TITLE
Set use-forwarded-headers to true for digitalocean

### DIFF
--- a/deploy/static/provider/do/deploy.yaml
+++ b/deploy/static/provider/do/deploy.yaml
@@ -37,6 +37,7 @@ metadata:
   namespace: ingress-nginx
 data:
   use-proxy-protocol: 'true'
+  use-forwarded-headers: 'true'
 ---
 # Source: ingress-nginx/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
## What this PR does / why we need it:

When using DO, use-proxy-protocol is set to true by default. This means
use-forwarded-headers also has to be set to true otherwise requests will get
caught in a 308 redirect loop.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes

I found some related closed issues, but none that are open.

## How Has This Been Tested?

I tested this on a DigitalOcean Kubernetes cluster by applying:
https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v0.43.0/deploy/static/provider/do/deploy.yaml
I also used cert-manager and external-dns.
I created a Deployment and an Ingress. 
I made a request and Safari display the "too many redirects" error message.
I added the `use-forwarded-headers: true` setting to the ingress-nginx ConfigMap.
I made another request and the website was displayed.

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
