### PR TITLE
Add scope configuration check.

### DIFF
--- a/charts/ingress-nginx/templates/clusterrole.yaml
+++ b/charts/ingress-nginx/templates/clusterrole.yaml
@@ -1,4 +1,10 @@
-{{- if and .Values.rbac.create (not .Values.rbac.scope) -}}
+{{- if .Values.rbac.create }}
+
+{{- if and .Values.rbac.scope (not .Values.controller.scope.enabled) -}}
+  {{ required "Invalid configuration: 'rbac.scope' should be equal to 'controller.scope.enabled' (true/false)." (index (dict) ".") }}
+{{- end }}
+
+{{- if not .Values.rbac.scope -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -72,4 +78,6 @@ rules:
       - get
       - list
       - watch
+{{- end }}
+
 {{- end }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

A specific configuration of scope variables result in errors in runtime.

| config | Helm render | Kubernetes runtime |
|-|-|-|
| `helm template charts/ingress-nginx \`<br>&nbsp;&nbsp;`--output-dir=_manifests \`<br>&nbsp;&nbsp;`--set=controller.scope.enabled=true \`<br>&nbsp;&nbsp;`--set=rbac.scope=true` | :white_check_mark: | :white_check_mark: |
| `helm template charts/ingress-nginx \`<br>&nbsp;&nbsp;`--output-dir=_manifests \`<br>&nbsp;&nbsp;`--set=controller.scope.enabled=false \`<br>&nbsp;&nbsp;`--set=rbac.scope=false ` | :white_check_mark: | :white_check_mark: |
| `helm template charts/ingress-nginx \`<br>&nbsp;&nbsp;`--output-dir=_manifests \`<br>&nbsp;&nbsp;`--set=controller.scope.enabled=true \`<br>&nbsp;&nbsp;`--set=rbac.scope=false ` | :white_check_mark: | :white_check_mark: |
| `helm template charts/ingress-nginx \`<br>&nbsp;&nbsp;`--output-dir=_manifests \`<br>&nbsp;&nbsp;`--set=controller.scope.enabled=false \`<br>&nbsp;&nbsp;`--set=rbac.scope=true` | ✔️  | :x: |

### Reproduction

```console
$ helm install nginx-ingress charts/ingress-nginx \
    --set=controller.scope.enabled=false \
    --set=rbac.scope=true
```
results in runtime in

```console
$ kubectl logs -f nginx-ingress-controller-5566dbf6f-cr4ms

 ❌ Failed to watch *v1beta1.Ingress: failed to list *v1beta1.Ingress: ingresses.networking.k8s.io is forbidden: User "system:serviceaccount:default:nginx-ingress" cannot list resource "ingresses" in API group "networking.k8s.io" at the cluster scope
```

By checking these config incompatibility during rendering the chart we can catch this early on.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```console
$ helm template charts/ingress-nginx \
    --output-dir=_manifests \
    --set=controller.scope.enabled=false \
    --set=rbac.scope=true

  Invalid configuration: 'rbac.scope' should be equal to 'controller.scope.enabled' (true/false).
```

| config | Helm render | Kubernetes runtime |
|-|-|-|
| `helm template charts/ingress-nginx \`<br>&nbsp;&nbsp;`--output-dir=_manifests \`<br>&nbsp;&nbsp;`--set=controller.scope.enabled=true \`<br>&nbsp;&nbsp;`--set=rbac.scope=true` | :white_check_mark: | :white_check_mark: |
| `helm template charts/ingress-nginx \`<br>&nbsp;&nbsp;`--output-dir=_manifests \`<br>&nbsp;&nbsp;`--set=controller.scope.enabled=false \`<br>&nbsp;&nbsp;`--set=rbac.scope=false ` | :white_check_mark: | :white_check_mark: |
| `helm template charts/ingress-nginx \`<br>&nbsp;&nbsp;`--output-dir=_manifests \`<br>&nbsp;&nbsp;`--set=controller.scope.enabled=true \`<br>&nbsp;&nbsp;`--set=rbac.scope=false ` | :white_check_mark: | :white_check_mark: |
| `helm template charts/ingress-nginx \`<br>&nbsp;&nbsp;`--output-dir=_manifests \`<br>&nbsp;&nbsp;`--set=controller.scope.enabled=false \`<br>&nbsp;&nbsp;`--set=rbac.scope=true` | ✖️  | |


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] ~~My change requires a change to the documentation.~~
- [ ] ~~I have updated the documentation accordingly.~~
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] ~~I have added tests to cover my changes.~~
- [x] All ~~new and~~ existing tests passed.

