### PR TITLE
resolving host before enabling tracing

### DIFF
--- a/internal/ingress/controller/template/template_test.go
+++ b/internal/ingress/controller/template/template_test.go
@@ -1175,7 +1175,7 @@ func TestBuildOpenTracing(t *testing.T) {
 
 	cfgJaeger := config.Configuration{
 		EnableOpentracing:   true,
-		JaegerCollectorHost: "jaeger-host.com",
+		JaegerCollectorHost: "jaeger.lvh.me",
 	}
 	expected = "opentracing_load_tracer /usr/local/lib/libjaegertracing_plugin.so /etc/nginx/opentracing.json;\r\n"
 	actual = buildOpentracing(cfgJaeger, []*ingress.Server{})
@@ -1186,7 +1186,7 @@ func TestBuildOpenTracing(t *testing.T) {
 
 	cfgZipkin := config.Configuration{
 		EnableOpentracing:   true,
-		ZipkinCollectorHost: "zipkin-host.com",
+		ZipkinCollectorHost: "zipkin.lvh.me",
 	}
 	expected = "opentracing_load_tracer /usr/local/lib/libzipkin_opentracing_plugin.so /etc/nginx/opentracing.json;\r\n"
 	actual = buildOpentracing(cfgZipkin, []*ingress.Server{})
@@ -1197,10 +1197,31 @@ func TestBuildOpenTracing(t *testing.T) {
 
 	cfgDatadog := config.Configuration{
 		EnableOpentracing:    true,
-		DatadogCollectorHost: "datadog-host.com",
+		DatadogCollectorHost: "datadog.lvh.me",
 	}
 	expected = "opentracing_load_tracer /usr/local/lib64/libdd_opentracing.so /etc/nginx/opentracing.json;\r\n"
 	actual = buildOpentracing(cfgDatadog, []*ingress.Server{})
+
+	cfgBadhost := config.Configuration{
+		EnableOpentracing:   true,
+		ZipkinCollectorHost: "foobar.nonsense",
+	}
+	expected = ""
+	actual = buildOpentracing(cfgBadhost, []*ingress.Server{})
+
+	cfgUseIP := config.Configuration{
+		EnableOpentracing:   true,
+		ZipkinCollectorHost: "127.0.0.1",
+	}
+	expected = "opentracing_load_tracer /usr/local/lib/libzipkin_opentracing_plugin.so /etc/nginx/opentracing.json;\r\n"
+	actual = buildOpentracing(cfgUseIP, []*ingress.Server{})
+
+	cfgUseProtocol := config.Configuration{
+		EnableOpentracing:   true,
+		ZipkinCollectorHost: "https://zipkin.lvh.me",
+	}
+	expected = "opentracing_load_tracer /usr/local/lib/libzipkin_opentracing_plugin.so /etc/nginx/opentracing.json;\r\n"
+	actual = buildOpentracing(cfgUseProtocol, []*ingress.Server{})
 
 	if expected != actual {
 		t.Errorf("Expected '%v' but returned '%v'", expected, actual)
@@ -1208,7 +1229,7 @@ func TestBuildOpenTracing(t *testing.T) {
 
 	cfgJaegerEndpoint := config.Configuration{
 		EnableOpentracing: true,
-		JaegerEndpoint:    "http://jaeger-collector.com:14268/api/traces",
+		JaegerEndpoint:    "http://jaeger.lvh.me:14268/api/traces",
 	}
 	expected = "opentracing_load_tracer /usr/local/lib/libjaegertracing_plugin.so /etc/nginx/opentracing.json;\r\n"
 	actual = buildOpentracing(cfgJaegerEndpoint, []*ingress.Server{})
@@ -1217,9 +1238,20 @@ func TestBuildOpenTracing(t *testing.T) {
 		t.Errorf("Expected '%v' but returned '%v'", expected, actual)
 	}
 
+	cfgInvalidJaegerEndpoint := config.Configuration{
+		EnableOpentracing: true,
+		JaegerEndpoint:    "invalid-foobar.com", // Jaeger client expects full endpoint so this fails fast
+	}
+	expected = ""
+	actual = buildOpentracing(cfgInvalidJaegerEndpoint, []*ingress.Server{})
+
+	if expected != actual {
+		t.Errorf("Expected '%v' but returned '%v'", expected, actual)
+	}
+
 	cfgOpenTracing := config.Configuration{
 		EnableOpentracing:                true,
-		DatadogCollectorHost:             "datadog-host.com",
+		DatadogCollectorHost:             "datadog.lvh.me",
 		OpentracingOperationName:         "my-operation-name",
 		OpentracingLocationOperationName: "my-location-operation-name",
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
While testing a new Jaeger C++ client, @miry found that configuring tracing with a domain that doesn't resolve causes ingress-nginx to fail bootup. This tries to resolve the domain in Go before letting the tracing client libraries do it and cause fatal errors. If it can't resolve, it simply won't enable tracing.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Updated the old test cases to use `localhost` since that should always resolve (and not hit this error), and added a new test case to ensure that an invalid domain causes an error and doesn't write to the template file.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
