### PR TITLE
Make setup instructions for Docker Desktop general

### DIFF
--- a/docs/deploy/index.md
+++ b/docs/deploy/index.md
@@ -29,7 +29,7 @@
 ## Contents
 
 - [Provider Specific Steps](#provider-specific-steps)
-  - [Docker for Mac](#docker-for-mac)
+  - [Docker Desktop](#docker-desktop)
   - [minikube](#minikube)
   - [microk8s](#microk8s)
   - [AWS](#aws)
@@ -44,9 +44,12 @@
 
 ### Provider Specific Steps
 
-#### Docker for Mac
+#### Docker Desktop
 
-Kubernetes is available in Docker for Mac (from [version 18.06.0-ce](https://docs.docker.com/docker-for-mac/release-notes/#stable-releases-of-2018))
+Kubernetes is available in Docker Desktop
+
+- Mac, from [version 18.06.0-ce](https://docs.docker.com/docker-for-mac/release-notes/#stable-releases-of-2018)
+- Windows, from [version 18.06.0-ce](https://docs.docker.com/docker-for-windows/release-notes/#docker-community-edition-18060-ce-win70-2018-07-25)
 
 ```console
 kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v0.44.0/deploy/static/provider/cloud/deploy.yaml


### PR DESCRIPTION
The same setup instruction for Mac also works on Windows 10. I tested on my own Windows 10 setup. Some other people on the Internet also pointed it out. I think Docker Desktop is supposed to provide feature parity between these platforms. So, I think we can rely on Docker Desktop to keep the behaviour and allow the same instructions to work on both platforms.

## What this PR does / why we need it:

Update the setup instruction for Docker Desktop for Mac & Windows.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #6878
-->

## How Has This Been Tested?
Tried on my own Windows setup.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
