### PR TITLE
canary consistency

### DIFF
--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -895,12 +895,14 @@ func (n *NGINXController) createUpstreams(data []*ingress.Ingress, du *ingress.B
 			if anns.Canary.Enabled {
 				upstreams[defBackend].NoServer = true
 				upstreams[defBackend].TrafficShapingPolicy = ingress.TrafficShapingPolicy{
-					Weight:        anns.Canary.Weight,
-					WeightTotal:   anns.Canary.WeightTotal,
-					Header:        anns.Canary.Header,
-					HeaderValue:   anns.Canary.HeaderValue,
-					HeaderPattern: anns.Canary.HeaderPattern,
-					Cookie:        anns.Canary.Cookie,
+					Weight:            anns.Canary.Weight,
+					WeightTotal:       anns.Canary.WeightTotal,
+					Header:            anns.Canary.Header,
+					HeaderValue:       anns.Canary.HeaderValue,
+					HeaderPattern:     anns.Canary.HeaderPattern,
+					Cookie:            anns.Canary.Cookie,
+					CanaryConsistency: anns.Canary.CanaryConsistency,
+					HashSeed:          anns.Canary.HashSeed,
 				}
 			}
 
@@ -967,11 +969,13 @@ func (n *NGINXController) createUpstreams(data []*ingress.Ingress, du *ingress.B
 				if anns.Canary.Enabled {
 					upstreams[name].NoServer = true
 					upstreams[name].TrafficShapingPolicy = ingress.TrafficShapingPolicy{
-						Weight:        anns.Canary.Weight,
-						Header:        anns.Canary.Header,
-						HeaderValue:   anns.Canary.HeaderValue,
-						HeaderPattern: anns.Canary.HeaderPattern,
-						Cookie:        anns.Canary.Cookie,
+						Weight:            anns.Canary.Weight,
+						Header:            anns.Canary.Header,
+						HeaderValue:       anns.Canary.HeaderValue,
+						HeaderPattern:     anns.Canary.HeaderPattern,
+						Cookie:            anns.Canary.Cookie,
+						CanaryConsistency: anns.Canary.CanaryConsistency,
+						HashSeed:          anns.Canary.HashSeed,
 					}
 				}
 

--- a/internal/ingress/types.go
+++ b/internal/ingress/types.go
@@ -128,6 +128,10 @@ type TrafficShapingPolicy struct {
 	HeaderPattern string `json:"headerPattern"`
 	// Cookie on which to redirect requests to this backend
 	Cookie string `json:"cookie"`
+	// the value can be "header" or "cookie", which one will be keeping consistency
+	CanaryConsistency string `json:"canaryConsistency"`
+	//it's optional, the different seeds can result different hashcode
+	HashSeed string `json:"hashSeed"`
 }
 
 // HashInclude defines if a field should be used or not to calculate the hash

--- a/internal/ingress/types_equals.go
+++ b/internal/ingress/types_equals.go
@@ -260,6 +260,12 @@ func (tsp1 TrafficShapingPolicy) Equal(tsp2 TrafficShapingPolicy) bool {
 	if tsp1.Cookie != tsp2.Cookie {
 		return false
 	}
+	if tsp1.CanaryConsistency != tsp2.CanaryConsistency {
+		return false
+	}
+	if tsp1.HashSeed != tsp2.HashSeed {
+		return false
+	}
 
 	return true
 }

--- a/rootfs/etc/nginx/lua/balancer/hashcode.lua
+++ b/rootfs/etc/nginx/lua/balancer/hashcode.lua
@@ -1,0 +1,17 @@
+local string = string
+local _M = {}
+
+function _M.str_hash_to_int(str)
+    local h = 0
+    local l = #str
+    if l > 0 then
+        local i = 0
+        while i < l do
+            h = 31 * h + string.byte(str, i + 1)
+            i = i + 1
+        end
+    end
+    return h
+end
+
+return _M


### PR DESCRIPTION
## Weighted Consistent Hashing
consider that
1.route 30% requests to canary backends just like what canary-weight did
2.the requests of a single user/device route to primary backends or canary backends randomly, it cause unconsistency
3.we want a single user routes to primary backends or canary backends all the time during the lifecycle

## Add two new canary annotations
**canary-consistency**
it has two option, "header" or "cookie", means 

header="userId" value="1" this userId routes to primary backends all the time
header="userId" value="2" this userId routes to canary backends all the time
or
cookie="userId" value="1" this userId routes to primary backends all the time
cookie="userId" value="2" this userId routes to canary backends all the time

**canary-hash-seed**
it's optional, it makes sure two experiments requests are different, the different seeds can result different hashcode

## three old canary annotations are reused
**canary-weight**
**canary-by-header**
**cookie**

## Compatibility
won't harm other canary strategies
but if canary-consistency is configured, other strategies won't work