### PR TITLE
Label mismatch for PodAffinity,PodAntiAffinity

### DIFF
--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -194,7 +194,7 @@ controller:
     #         - key: app.kubernetes.io/instance
     #           operator: In
     #           values:
-    #           - ingress-nginx
+    #           - nginx
     #         - key: app.kubernetes.io/component
     #           operator: In
     #           values:
@@ -213,7 +213,7 @@ controller:
     #       - key: app.kubernetes.io/instance
     #         operator: In
     #         values:
-    #         - ingress-nginx
+    #         - nginx
     #       - key: app.kubernetes.io/component
     #         operator: In
     #         values:


### PR DESCRIPTION
Label for app.kubernetes.io/instance is nginx instead of ingress-nginx

<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
