### PR TITLE
Switching the check order to check the CommonName then DNSNames

### DIFF
--- a/internal/ingress/controller/certificate.go
+++ b/internal/ingress/controller/certificate.go
@@ -50,15 +50,15 @@ func verifyHostname(h string, c *x509.Certificate) error {
 
 	lowered := toLowerCaseASCII(h)
 
-	if len(c.DNSNames) > 0 {
+	//checking the CommonName then failover to checking the DNSNames aka AltNames
+	if matchHostnames(toLowerCaseASCII(c.Subject.CommonName), lowered) {
+		return nil
+	} else if len(c.DNSNames) > 0 {
 		for _, match := range c.DNSNames {
 			if matchHostnames(toLowerCaseASCII(match), lowered) {
 				return nil
 			}
 		}
-		// If Subject Alt Name is given, we ignore the common name.
-	} else if matchHostnames(toLowerCaseASCII(c.Subject.CommonName), lowered) {
-		return nil
 	}
 
 	return x509.HostnameError{Certificate: c, Host: h}


### PR DESCRIPTION
Switching the check order to check the CommonName first then failover to check DNSNames aka AltNames. Instead of checking the DNSNames only if they are there. This causes it to skip the CommonName all together.

<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
https://github.com/kubernetes/ingress-nginx/issues/6905

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
fixes #6905 

## How Has This Been Tested?
I followed the same steps in #6905 to reproduce the issue but now the request returns a valid certificate
The only thing that was changed was the order of the check. It now checks the CommonName first then the DNSNames.

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [X ] All new and existing tests passed.
