### PR TITLE
Rebase controller-service-internal on controller-service + add capability to disable ports

### DIFF
--- a/charts/ingress-nginx/CHANGELOG.md
+++ b/charts/ingress-nginx/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file documents all notable changes to [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+### 3.34.0
+
+- Rebase controller-service-internal features on controller-service
+- Add capability to disable ports in controller-service-internal
+
 ### 3.32.0
 
 - [7117] https://github.com/kubernetes/ingress-nginx/pull/7117 Add annotations for HPA

--- a/charts/ingress-nginx/Chart.yaml
+++ b/charts/ingress-nginx/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ingress-nginx
 # When the version is modified, make sure the artifacthub.io/changes list is updated
 # Also update CHANGELOG.md
-version: 3.33.0
+version: 3.34.0
 appVersion: 0.47.0
 home: https://github.com/kubernetes/ingress-nginx
 description: Ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer
@@ -21,4 +21,5 @@ annotations:
   # List of changes for the release in artifacthub.io
   # https://artifacthub.io/packages/helm/ingress-nginx/ingress-nginx?modal=changelog
   artifacthub.io/changes: |
-    - Update nginx to v1.20.1
+    - Rebase controller-service-internal features on controller-service
+    - Add capability to disable ports in controller-service-internal

--- a/charts/ingress-nginx/templates/controller-service-internal.yaml
+++ b/charts/ingress-nginx/templates/controller-service-internal.yaml
@@ -15,6 +15,12 @@ metadata:
   name: {{ include "ingress-nginx.controller.fullname" . }}-internal
 spec:
   type: "{{ .Values.controller.service.type }}"
+{{- if .Values.controller.service.internal.clusterIP }}
+  clusterIP: {{ .Values.controller.service.internal.clusterIP }}
+{{- end }}
+{{- if .Values.controller.service.internal.externalIPs }}
+  externalIPs: {{ toYaml .Values.controller.service.internal.externalIPs | nindent 4 }}
+{{- end }}
 {{- if .Values.controller.service.internal.loadBalancerIP }}
   loadBalancerIP: {{ .Values.controller.service.internal.loadBalancerIP }}
 {{- end }}
@@ -24,9 +30,16 @@ spec:
 {{- if .Values.controller.service.internal.externalTrafficPolicy }}
   externalTrafficPolicy: {{ .Values.controller.service.internal.externalTrafficPolicy }}
 {{- end }}
+{{- if .Values.controller.service.internal.sessionAffinity }}
+  sessionAffinity: {{ .Values.controller.service.internal.sessionAffinity }}
+{{- end }}
+{{- if .Values.controller.service.internal.healthCheckNodePort }}
+  healthCheckNodePort: {{ .Values.controller.service.internal.healthCheckNodePort }}
+{{- end }}
   ports:
   {{- $setNodePorts := (or (eq .Values.controller.service.type "NodePort") (eq .Values.controller.service.type "LoadBalancer")) }}
-  {{- if .Values.controller.service.enableHttp }}
+  # Ugly if statement to replace default function limitation (https://github.com/helm/helm/issues/3308)
+  {{- if or .Values.controller.service.internal.enableHttp (and (not (hasKey .Values.controller.service.internal "enableHttp")) .Values.controller.service.enableHttp) }}
     - name: http
       port: {{ .Values.controller.service.ports.http }}
       protocol: TCP
@@ -35,13 +48,39 @@ spec:
       nodePort: {{ .Values.controller.service.nodePorts.http }}
     {{- end }}
   {{- end }}
-  {{- if .Values.controller.service.enableHttps }}
+  {{- if or .Values.controller.service.internal.enableHttps (and (not (hasKey .Values.controller.service.internal "enableHttps")) .Values.controller.service.enableHttps) }}
     - name: https
       port: {{ .Values.controller.service.ports.https }}
       protocol: TCP
       targetPort: {{ .Values.controller.service.targetPorts.https }}
     {{- if (and $setNodePorts (not (empty .Values.controller.service.nodePorts.https))) }}
       nodePort: {{ .Values.controller.service.nodePorts.https }}
+    {{- end }}
+  {{- end }}
+  {{- if or .Values.controller.service.internal.enableTcp (and (not (hasKey .Values.controller.service.internal "enableTcp")) .Values.controller.service.enableTcp) }}
+    {{- range $key, $value := .Values.tcp }}
+      - name: {{ $key }}-tcp
+        port: {{ $key }}
+        protocol: TCP
+        targetPort: {{ $key }}-tcp
+      {{- if $.Values.controller.service.nodePorts.tcp }}
+      {{- if index $.Values.controller.service.nodePorts.tcp $key }}
+        nodePort: {{ index $.Values.controller.service.nodePorts.tcp $key }}
+      {{- end }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+  {{- if or .Values.controller.service.internal.enableUdp (and (not (hasKey .Values.controller.service.internal "enableUdp")) .Values.controller.service.enableUdp) }}
+    {{- range $key, $value := .Values.udp }}
+      - name: {{ $key }}-udp
+        port: {{ $key }}
+        protocol: UDP
+        targetPort: {{ $key }}-udp
+      {{- if $.Values.controller.service.nodePorts.udp }}
+      {{- if index $.Values.controller.service.nodePorts.udp $key }}
+        nodePort: {{ index $.Values.controller.service.nodePorts.udp $key }}
+      {{- end }}
+      {{- end }}
     {{- end }}
   {{- end }}
   selector:

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -438,9 +438,15 @@ controller:
 
     ## Enables an additional internal load balancer (besides the external one).
     ## Annotations are mandatory for the load balancer to come up. Varies with the cloud service.
+    ## By default internal load balancer is configured like the external one. You can choose to disable
+    ## parts with enableHttp, enableHttps, enableUdp, enableTcp
     internal:
       enabled: false
       annotations: {}
+      # enableHttp: false
+      # enableHttps: false
+      # enableUdp: false
+      # enableTcp: false
 
       # loadBalancerIP: ""
 


### PR DESCRIPTION
The goal is to provide similar features on internal and external controller services.

## What this PR does / why we need it:
I need to create an internal loadbalancer with custom TCP port but without http enabled (only on external one).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?
```
controller:
  service:
    internal:
      enabled: true
      annotations:
        service.beta.kubernetes.io/aws-load-balancer-internal: "true"
      enableHttp: false
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
