### PR TITLE
Fix definition order of modsecurity directives for controller to match PR 5315

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -148,14 +148,16 @@ http {
     {{ if $all.Cfg.EnableModsecurity }}
     modsecurity on;
 
+    {{ if (not (empty $all.Cfg.ModsecuritySnippet)) }}
+    modsecurity_rules '
+      {{ $all.Cfg.ModsecuritySnippet }}
+    ';
+    {{ end }}
+
     modsecurity_rules_file /etc/nginx/modsecurity/modsecurity.conf;
 
     {{ if $all.Cfg.EnableOWASPCoreRules }}
     modsecurity_rules_file /etc/nginx/owasp-modsecurity-crs/nginx-modsecurity.conf;
-    {{ else if (not (empty $all.Cfg.ModsecuritySnippet)) }}
-    modsecurity_rules '
-      {{ $all.Cfg.ModsecuritySnippet }}
-    ';
     {{ end }}
 
     {{ end }}


### PR DESCRIPTION
## What this PR does / why we need it:
The current behavior of modsecurity is different when applied at the controller level than the ingress level.  This PR changes the controller behavior to match the ingress behavior that was introduced in PR #5315

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
This fixes #6307 

## How Has This Been Tested?
I have built an image, pushed to docker hub, and deployed with the helm chart to a test cluster.  The deployed instance honored having the SecRuleEngine turned on and enforced a SecRule added via
controller:
  config:
    modsecurity-snippet:

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
