### PR TITLE
[docs]: proxy-real-ip-cidr, mention default and comma-separated behavior

### DIFF
--- a/docs/user-guide/nginx-configuration/configmap.md
+++ b/docs/user-guide/nginx-configuration/configmap.md
@@ -458,7 +458,8 @@ Sets the bucket size for the [map variables hash tables](http://nginx.org/en/doc
 
 ## proxy-real-ip-cidr
 
-If use-forwarded-headers or use-proxy-protocol is enabled, proxy-real-ip-cidr defines the default the IP/network address of your external load balancer.
+If `use-forwarded-headers` or `use-proxy-protocol` is enabled, `proxy-real-ip-cidr` defines the default IP/network address of your external load balancer. Can be a comma-separated list of CIDR blocks.
+_**default:**_ "0.0.0.0/0"
 
 ## proxy-set-headers
 


### PR DESCRIPTION

## What this PR does / why we need it:
Mention default setting and comma-separated list behavior.

Helps clarify behavior added in https://github.com/kubernetes/ingress-nginx/pull/921.

## Types of changes
- [x] Super tiny docs fix

## Which issue/s this PR fixes
None, sorry!

## How Has This Been Tested?
None, docs.

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [n/a] I have added tests to cover my changes.
- [n/a] All new and existing tests passed.
