### PR TITLE
Fix crl not reload when crl got updated in the ca secret

### DIFF
--- a/internal/ingress/controller/store/store.go
+++ b/internal/ingress/controller/store/store.go
@@ -457,8 +457,8 @@ func New(
 							klog.ErrorS(err, "could not find Ingress in local store", "ingress", ingKey)
 							continue
 						}
-						store.syncIngress(ing)
 						store.syncSecrets(ing)
+						store.syncIngress(ing)
 					}
 					updateCh.In() <- Event{
 						Type: UpdateEvent,

--- a/internal/ingress/types_equals.go
+++ b/internal/ingress/types_equals.go
@@ -549,6 +549,9 @@ func (s1 *SSLCert) Equal(s2 *SSLCert) bool {
 	if s1.CASHA != s2.CASHA {
 		return false
 	}
+	if s1.CRLSHA != s2.CRLSHA {
+		return false
+	}
 	if s1.PemSHA != s2.PemSHA {
 		return false
 	}

--- a/internal/ingress/types_equals_test.go
+++ b/internal/ingress/types_equals_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestEqualConfiguration(t *testing.T) {
@@ -139,6 +140,156 @@ func TestIntElementsMatch(t *testing.T) {
 		result := compareInts(testCase.listA, testCase.listB)
 		if result != testCase.expected {
 			t.Errorf("expected %v but returned %v (%v - %v)", testCase.expected, result, testCase.listA, testCase.listB)
+		}
+	}
+}
+
+func TestSSLCertMatch(t *testing.T) {
+	now := time.Now()
+	cert := &SSLCert{
+		UID:        "1",
+		Name:       "nameA",
+		Namespace:  "namespaceA",
+		CASHA:      "CASHA_A",
+		CN:         []string{"CommonNameA"},
+		CRLSHA:     "CRLSHA_A",
+		PemSHA:     "PemSHA_A",
+		PemCertKey: "PemKeyA",
+		ExpireTime: now,
+	}
+
+	testCases := []struct {
+		sslCertA *SSLCert
+		sslCertB *SSLCert
+		expected bool
+	}{
+		{cert, cert, true},
+		{
+			cert,
+			&SSLCert{
+				UID:        "1",
+				Name:       "nameA",
+				Namespace:  "namespaceA",
+				CASHA:      "CASHA_A",
+				CN:         []string{"CommonNameA"},
+				CRLSHA:     "CRLSHA_A",
+				PemSHA:     "PemSHA_A",
+				PemCertKey: "PemKeyA",
+				ExpireTime: now,
+			},
+			true,
+		},
+		{
+			cert,
+			&SSLCert{
+				UID:        "1",
+				Name:       "nameA",
+				Namespace:  "namespaceA",
+				CASHA:      "CASHA_New",
+				CN:         []string{"CommonNameA"},
+				CRLSHA:     "CRLSHA_A",
+				PemSHA:     "PemSHA_A",
+				PemCertKey: "PemKeyA",
+				ExpireTime: now,
+			},
+			false,
+		},
+		{
+			cert,
+			&SSLCert{
+				UID:        "1",
+				Name:       "nameA",
+				Namespace:  "namespaceA",
+				CASHA:      "CASHA_A",
+				CN:         []string{"CommonNameA"},
+				CRLSHA:     "CRLSHA_NEW",
+				PemSHA:     "PemSHA_A",
+				PemCertKey: "PemKeyA",
+				ExpireTime: now,
+			},
+			false,
+		},
+		{
+			cert,
+			&SSLCert{
+				UID:        "1",
+				Name:       "nameA",
+				Namespace:  "namespaceA",
+				CASHA:      "CASHA_A",
+				CN:         []string{"CommonNameA"},
+				CRLSHA:     "CRLSHA_A",
+				PemSHA:     "PemSHA_New",
+				PemCertKey: "PemKeyA",
+				ExpireTime: now,
+			},
+			false,
+		},
+		{
+			cert,
+			&SSLCert{
+				UID:        "1",
+				Name:       "nameA",
+				Namespace:  "namespaceA",
+				CASHA:      "CASHA_A",
+				CN:         []string{"CommonNameNew"},
+				CRLSHA:     "CRLSHA_A",
+				PemSHA:     "PemSHA_A",
+				PemCertKey: "PemKeyA",
+				ExpireTime: now,
+			},
+			false,
+		},
+		{
+			cert,
+			&SSLCert{
+				UID:        "1",
+				Name:       "nameA",
+				Namespace:  "namespaceA",
+				CASHA:      "CASHA_A",
+				CN:         []string{"CommonNameA"},
+				CRLSHA:     "CRLSHA_A",
+				PemSHA:     "PemSHA_A",
+				PemCertKey: "PemKeyA",
+				ExpireTime: now.Add(time.Minute),
+			},
+			false,
+		},
+		{
+			cert,
+			&SSLCert{
+				UID:        "1",
+				Name:       "nameA",
+				Namespace:  "namespaceA",
+				CASHA:      "CASHA_A",
+				CN:         []string{"CommonNameA"},
+				CRLSHA:     "CRLSHA_A",
+				PemSHA:     "PemSHA_A",
+				PemCertKey: "PemKeyNew",
+				ExpireTime: now,
+			},
+			false,
+		},
+		{
+			cert,
+			&SSLCert{
+				UID:        "2",
+				Name:       "nameA",
+				Namespace:  "namespaceA",
+				CASHA:      "CASHA_A",
+				CN:         []string{"CommonNameA"},
+				CRLSHA:     "CRLSHA_A",
+				PemSHA:     "PemSHA_A",
+				PemCertKey: "PemKeyA",
+				ExpireTime: now,
+			},
+			false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		result := testCase.sslCertA.Equal(testCase.sslCertB)
+		if result != testCase.expected {
+			t.Errorf("expected %v but returned %v (%v - %v)", testCase.expected, result, testCase.sslCertA, testCase.sslCertB)
 		}
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR fixes the issue where nginx did not get reloaded when certificate revocation list (crl) within a client-ca secret is updated. This is because:
* the [equal function](https://github.com/kubernetes/ingress-nginx/blob/master/internal/ingress/types_equals.go#L542) of SSLCert didn't check for CRLSHA when updating the SSL secret [here](https://github.com/kubernetes/ingress-nginx/blob/master/internal/ingress/controller/store/backend_ssl.go#L54)
* `store.syncIngress(ing)` got called before `store.syncSecrets(ing)` in the secret update [event handler function](https://github.com/kubernetes/ingress-nginx/blob/master/internal/ingress/controller/store/store.go#L460). Calling the store.syncIngress before calling store.syncSecret on ca-secret update would make ingress controller to build nginx conf template based on the [old local stored SSLCert](https://github.com/kubernetes/ingress-nginx/blob/master/internal/ingress/controller/store/store.go#L817). Normally this is not an issue when ca-secret only contains ca.crt, however an edge case is introduced when ca.crt is added inside the secret ca-secret. For example, a person created ca-secret with only ca.crt data field and then later on it updates the secret to include ca.crl. nginx controller would create a nginx config file with the old SSLCert and then the actual content of the SSLCert will now be finally synced. 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes # https://github.com/kubernetes/ingress-nginx/issues/4904
-->
fixes https://github.com/kubernetes/ingress-nginx/issues/4904

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have also tested it manually by:
1. Deploying ingress nginx controller to to a k8s cluster.
```
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: busybox
  namespace: anthony-test
  annotations:
    ingress.kubernetes.io/auth-tls-verify-client: "on"
    ingress.kubernetes.io/auth-tls-secret: "test-ns/ca-secret"
    ingress.kubernetes.io/auth-tls-verify-depth: "3"
spec:
   ...
```
2. create k8s secret 
```
 kubectl create secret generic ca-secret --from-file=ca.crt=ca.crt --save-config --dry-run -o yaml | kubectl apply -f -
```
3. curl-ed the ing endpoint with a tls.crt and tls.key and received a 200.
4. revoked the certificate and generate a CRL 
5. updated k8s secret with CRL
```
kubectl create secret generic ca-secret --from-file=ca.crt=ca.crt --from-file=ca.crl=ca.crl --save-config --dry-run -o yaml | kubectl apply -f -
```
6. Received a `400 The SSL certificate` error from curling the ing endpoint with the revoked tls.crt and tls.key.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
