### PR TITLE
DRAFT: adding higher than 10 second buckets for request_duration_seconds

### DIFF
--- a/internal/ingress/metric/collectors/socket.go
+++ b/internal/ingress/metric/collectors/socket.go
@@ -156,6 +156,7 @@ func NewSocketCollector(pod, namespace, class string, metricsPerHost bool) (*Soc
 				Help:        "The request processing time in milliseconds",
 				Namespace:   PrometheusNamespace,
 				ConstLabels: constLabels,
+				Buckets:     []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 20, 30, 60},
 			},
 			requestTags,
 		),


### PR DESCRIPTION
I don't have time to jump through the hoops necessary to try to get something like this merged into mainline, which I assume there will be otherwise it would make no sense why no one has done this before.  If anyone has time/interest to carry this please do it.  Will refer to my comment from an open issue in just a second...