### PR TITLE
Use net.Listen func to ensure the port is free

### DIFF
--- a/internal/net/net.go
+++ b/internal/net/net.go
@@ -29,12 +29,12 @@ func IsIPV6(ip _net.IP) bool {
 
 // IsPortAvailable checks if a TCP port is available or not
 func IsPortAvailable(p int) bool {
-	conn, err := _net.Dial("tcp", fmt.Sprintf(":%v", p))
+	ln, err := _net.Listen("tcp", fmt.Sprintf(":%v", p))
 	if err != nil {
-		return true
+		return false
 	}
-	defer conn.Close()
-	return false
+	defer ln.Close()
+	return true
 }
 
 // IsIPv6Enabled checks if IPV6 is enabled or not and we have


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fro the issue, I meet the problem here #6988  ; and I fixed it after I change the judgment method.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
#6988 
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I make a image and deploy it in my cluster which I meet the problem in the issue, then the problem disappeared. I reboot some node, and the problem no happen again.
My [image link (docker hub)](https://hub.docker.com/layers/boxjan/k8s-staging-ingress-nginx-controller/v0.45.0-dev.1/images/sha256-ceb738a70c75fa1fe69e0db7816a6fd85a8addd3d6bbad4c152bc0a56cbfca08?context=explore)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
