### PR TITLE
updating test-runner/echo in code, docs fixup

### DIFF
--- a/build/run-in-docker.sh
+++ b/build/run-in-docker.sh
@@ -34,7 +34,7 @@ function cleanup {
 }
 trap cleanup EXIT
 
-E2E_IMAGE=${E2E_IMAGE:-k8s.gcr.io/ingress-nginx/e2e-test-runner:v20210104-g81a8d5cd8@sha256:bfd55f589ea998f961825a9d09158d766cf621d1b8fc5d8c905aba07d9794e08}
+E2E_IMAGE=${E2E_IMAGE:-k8s.gcr.io/ingress-nginx/e2e-test-runner:v20210326-gb52c538bb@sha256:b1b684ac3cc6a1ba68611707467fe2c9fe1c9c4a60f85e19ee10ea14b5343432}
 
 DOCKER_OPTS=${DOCKER_OPTS:-}
 DOCKER_IN_DOCKER_ENABLED=${DOCKER_IN_DOCKER_ENABLED:-}

--- a/docs/e2e-tests.md
+++ b/docs/e2e-tests.md
@@ -449,18 +449,19 @@
 
 - [Check limit-rate config](https://github.com/kubernetes/ingress-nginx/tree/master/test/e2e/settings/limit_rate.go#L36)
 
-### [Configure OpenTracing](https://github.com/kubernetes/ingress-nginx/tree/master/test/e2e/settings/opentracing.go#L43)
+### [Configure OpenTracing](https://github.com/kubernetes/ingress-nginx/tree/master/test/e2e/settings/opentracing.go#L47)
 
-- [should not exists opentracing directive](https://github.com/kubernetes/ingress-nginx/tree/master/test/e2e/settings/opentracing.go#L53)
-- [should exists opentracing directive when is enabled](https://github.com/kubernetes/ingress-nginx/tree/master/test/e2e/settings/opentracing.go#L66)
-- [should not exists opentracing_operation_name directive when is empty](https://github.com/kubernetes/ingress-nginx/tree/master/test/e2e/settings/opentracing.go#L80)
-- [should exists opentracing_operation_name directive when is configured](https://github.com/kubernetes/ingress-nginx/tree/master/test/e2e/settings/opentracing.go#L95)
-- [should not exists opentracing_location_operation_name directive when is empty](https://github.com/kubernetes/ingress-nginx/tree/master/test/e2e/settings/opentracing.go#L110)
-- [should exists opentracing_location_operation_name directive when is configured](https://github.com/kubernetes/ingress-nginx/tree/master/test/e2e/settings/opentracing.go#L125)
-- [should enable opentracing using zipkin](https://github.com/kubernetes/ingress-nginx/tree/master/test/e2e/settings/opentracing.go#L140)
-- [should enable opentracing using jaeger](https://github.com/kubernetes/ingress-nginx/tree/master/test/e2e/settings/opentracing.go#L152)
-- [should enable opentracing using jaeger with sampler host](https://github.com/kubernetes/ingress-nginx/tree/master/test/e2e/settings/opentracing.go#L164)
-- [should enable opentracing using datadog](https://github.com/kubernetes/ingress-nginx/tree/master/test/e2e/settings/opentracing.go#L177)
+- [should not exists opentracing directive](https://github.com/kubernetes/ingress-nginx/tree/master/test/e2e/settings/opentracing.go#L57)
+- [should exists opentracing directive when is enabled](https://github.com/kubernetes/ingress-nginx/tree/master/test/e2e/settings/opentracing.go#L70)
+- [should not exists opentracing_operation_name directive when is empty](https://github.com/kubernetes/ingress-nginx/tree/master/test/e2e/settings/opentracing.go#L84)
+- [should exists opentracing_operation_name directive when is configured](https://github.com/kubernetes/ingress-nginx/tree/master/test/e2e/settings/opentracing.go#L99)
+- [should not exists opentracing_location_operation_name directive when is empty](https://github.com/kubernetes/ingress-nginx/tree/master/test/e2e/settings/opentracing.go#L114)
+- [should exists opentracing_location_operation_name directive when is configured](https://github.com/kubernetes/ingress-nginx/tree/master/test/e2e/settings/opentracing.go#L129)
+- [should enable opentracing using zipkin](https://github.com/kubernetes/ingress-nginx/tree/master/test/e2e/settings/opentracing.go#L144)
+- [should enable opentracing using jaeger](https://github.com/kubernetes/ingress-nginx/tree/master/test/e2e/settings/opentracing.go#L156)
+- [should enable opentracing using jaeger with sampler host](https://github.com/kubernetes/ingress-nginx/tree/master/test/e2e/settings/opentracing.go#L168)
+- [should propagate the w3c header when configured with jaeger](https://github.com/kubernetes/ingress-nginx/tree/master/test/e2e/settings/opentracing.go#L181)
+- [should enable opentracing using datadog](https://github.com/kubernetes/ingress-nginx/tree/master/test/e2e/settings/opentracing.go#L225)
 
 ### [use-forwarded-headers](https://github.com/kubernetes/ingress-nginx/tree/master/test/e2e/settings/forwarded_headers.go#L30)
 

--- a/docs/user-guide/nginx-configuration/configmap.md
+++ b/docs/user-guide/nginx-configuration/configmap.md
@@ -134,6 +134,7 @@ The following table shows a configuration option's name, type, and the default v
 |[jaeger-collector-port](#jaeger-collector-port)|int|6831|
 |[jaeger-endpoint](#jaeger-endpoint)|string|""|
 |[jaeger-service-name](#jaeger-service-name)|string|"nginx"|
+|[jaeger-propagation-format](#jaeger-propagation-format)|string|"jaeger"|
 |[jaeger-sampler-type](#jaeger-sampler-type)|string|"const"|
 |[jaeger-sampler-param](#jaeger-sampler-param)|string|"1"|
 |[jaeger-sampler-host](#jaeger-sampler-host)|string|"http://127.0.0.1"|

--- a/test/e2e-image/Dockerfile
+++ b/test/e2e-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM k8s.gcr.io/ingress-nginx/e2e-test-runner:v20210104-g81a8d5cd8@sha256:bfd55f589ea998f961825a9d09158d766cf621d1b8fc5d8c905aba07d9794e08 AS BASE
+FROM k8s.gcr.io/ingress-nginx/e2e-test-runner:v20210326-gb52c538bb@sha256:b1b684ac3cc6a1ba68611707467fe2c9fe1c9c4a60f85e19ee10ea14b5343432 AS BASE
 
 FROM alpine:3.12
 

--- a/test/e2e/framework/deployment.go
+++ b/test/e2e/framework/deployment.go
@@ -52,7 +52,7 @@ func (f *Framework) NewEchoDeploymentWithReplicas(replicas int) {
 // replicas is configurable and
 // name is configurable
 func (f *Framework) NewEchoDeploymentWithNameAndReplicas(name string, replicas int) {
-	deployment := newDeployment(name, f.Namespace, "k8s.gcr.io/ingress-nginx/e2e-test-echo@sha256:d34944a61a65382e9a81f5e28e981187b419b9d579322277c5a98c2857fd7c5e", 80, int32(replicas),
+	deployment := newDeployment(name, f.Namespace, "k8s.gcr.io/ingress-nginx/e2e-test-echo@sha256:b13e44f7bb6852b90633957e743e4a2b34f32f1694da556a9131b43950b8b2b1", 80, int32(replicas),
 		nil,
 		[]corev1.VolumeMount{},
 		[]corev1.Volume{},


### PR DESCRIPTION
Some docs changes were mixed while updating the nginx base image and jaeger client support, so this PR adds those.
As well, updating the e2e-test-runner image in run-in-docker.sh & the e2e-image Dockerfile, and the echoserver used in e2e tests.

(aside from the last 2 lines in e2e-tests.md where I added one, I just changed the line numbers in the links)