### PR TITLE
Adding SSL OCSP Client Certificate validation

### DIFF
--- a/docs/user-guide/nginx-configuration/annotations.md
+++ b/docs/user-guide/nginx-configuration/annotations.md
@@ -27,6 +27,7 @@ You can add these Kubernetes annotations to specific Ingress objects to customiz
 |[nginx.ingress.kubernetes.io/auth-tls-verify-client](#client-certificate-authentication)|string|
 |[nginx.ingress.kubernetes.io/auth-tls-error-page](#client-certificate-authentication)|string|
 |[nginx.ingress.kubernetes.io/auth-tls-pass-certificate-to-upstream](#client-certificate-authentication)|"true" or "false"|
+|[nginx.ingress.kubernetes.io/auth-tls-ocsp](#client-certificate-authentication)|"off" or "on" or "leaf"|
 |[nginx.ingress.kubernetes.io/auth-url](#external-authentication)|string|
 |[nginx.ingress.kubernetes.io/auth-cache-key](#external-authentication)|string|
 |[nginx.ingress.kubernetes.io/auth-cache-duration](#external-authentication)|string|
@@ -257,6 +258,8 @@ The annotations are:
   The URL/Page that user should be redirected in case of a Certificate Authentication Error
 * `nginx.ingress.kubernetes.io/auth-tls-pass-certificate-to-upstream`:
   Indicates if the received certificates should be passed or not to the upstream server in the header `ssl-client-cert`. Possible values are "true" or "false" (default).
+* `nginx.ingress.kubernetes.io/auth-tls-ocsp`:
+  Enables OCSP validation of the client certificate chain. The leaf parameter enables validation of the client certificate only. Possible values are "off" (default) or "on" or "leaf".
 
 The following headers are sent to the upstream service according to the `auth-tls-*` annotations:
 

--- a/internal/ingress/annotations/authtls/main_test.go
+++ b/internal/ingress/annotations/authtls/main_test.go
@@ -91,6 +91,7 @@ func TestAnnotations(t *testing.T) {
 	data[parser.GetAnnotationWithPrefix("auth-tls-verify-depth")] = "1"
 	data[parser.GetAnnotationWithPrefix("auth-tls-error-page")] = "ok.com/error"
 	data[parser.GetAnnotationWithPrefix("auth-tls-pass-certificate-to-upstream")] = "true"
+	data[parser.GetAnnotationWithPrefix("auth-tls-ocsp")] = "on"
 
 	ing.SetAnnotations(data)
 
@@ -124,6 +125,9 @@ func TestAnnotations(t *testing.T) {
 	}
 	if u.PassCertToUpstream != true {
 		t.Errorf("expected %v but got %v", true, u.PassCertToUpstream)
+	}
+	if u.OCSP != "on" {
+		t.Errorf("expected %v but got %v", "on", u.OCSP)
 	}
 }
 
@@ -159,6 +163,7 @@ func TestInvalidAnnotations(t *testing.T) {
 	data[parser.GetAnnotationWithPrefix("auth-tls-verify-client")] = "w00t"
 	data[parser.GetAnnotationWithPrefix("auth-tls-verify-depth")] = "abcd"
 	data[parser.GetAnnotationWithPrefix("auth-tls-pass-certificate-to-upstream")] = "nahh"
+	data[parser.GetAnnotationWithPrefix("auth-tls-ocsp")] = "1337"
 	ing.SetAnnotations(data)
 
 	i, err := NewParser(fakeSecret).Parse(ing)
@@ -179,7 +184,9 @@ func TestInvalidAnnotations(t *testing.T) {
 	if u.PassCertToUpstream != false {
 		t.Errorf("expected %v but got %v", false, u.PassCertToUpstream)
 	}
-
+	if u.OCSP != "off" {
+		t.Errorf("expected %v but got %v", "off", u.OCSP)
+	}
 }
 
 func TestEquals(t *testing.T) {
@@ -252,6 +259,15 @@ func TestEquals(t *testing.T) {
 		t.Errorf("Expected false")
 	}
 	cfg2.PassCertToUpstream = true
+
+	// Different OCSP
+	cfg1.OCSP = "leaf"
+	cfg2.OCSP = "on"
+	result = cfg1.Equal(cfg2)
+	if result != false {
+		t.Errorf("Expected false")
+	}
+	cfg2.OCSP = "leaf"
 
 	// Equal Configs
 	result = cfg1.Equal(cfg2)

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -904,6 +904,10 @@ stream {
         ssl_verify_client                       {{ $server.CertificateAuth.VerifyClient }};
         ssl_verify_depth                        {{ $server.CertificateAuth.ValidationDepth }};
 
+        {{ if not (empty $server.CertificateAuth.OCSP)}}
+        ssl_ocsp                                {{ $server.CertificateAuth.OCSP }};
+        {{ end }}
+
         {{ if not (empty $server.CertificateAuth.CRLFileName) }}
         # PEM sha: {{ $server.CertificateAuth.CRLSHA }}
         ssl_crl                                 {{ $server.CertificateAuth.CRLFileName }};


### PR DESCRIPTION
## What this PR does / why we need it:
Nginx supports the [ssl_ocsp](https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_ocsp) flag, which validates that a client certificate is currently valid and has not been revoked. There are very few business logic changes here, since the main thing we require is the setting of the `ssl_ocsp` flag to the provided value. If the value isn't correct we default to the documented default value of `off`.

I have been trying to create a e2e test that can proof this works, but adding a `OCSP responder` to the test suite has proven cumbersome and out of my area of expertise. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

fixes #6980

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I've added some basic unit testing to valid how to set the flag. I've ran e2e and unit test locally, successfully. 

I'm currently running this in 2 clusters on GCP with `ingress-nginx` deploy via the helm chart (where we patch the controller image). We then have a single ingress that verifies client certificates. We can access a service with a valid cert, then in our tools revoke the certificate and then we're not able to login.

```yaml
apiVersion: helm.fluxcd.io/v1
kind: HelmRelease
metadata:
  name: ingress-nginx
  namespace: istio-system
spec:
    ....
    controller:
      ....
      image:
        repository: gcr.io/sct-engep-portalcore-d-0/controller
       .....
```

```yaml
---
apiVersion: networking.k8s.io/v1beta1
kind: Ingress
metadata:
  annotations:
    kubernetes.io/ingress.class: nginx
    nginx.ingress.kubernetes.io/auth-tls-ocsp: "on"
    nginx.ingress.kubernetes.io/auth-tls-secret: portal/public-coffee-client
    nginx.ingress.kubernetes.io/auth-tls-verify-client: "on"
    nginx.ingress.kubernetes.io/auth-tls-verify-depth: "2"
    nginx.ingress.kubernetes.io/configuration-snippet: |
      if ($ssl_client_s_dn !~ ".*emailAddress=[a-zA-Z._-]+@joost.coffee.*") {
        return 403;
      }
  name: docs-internal
  namespace: portal
spec:
   etc....
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
