### PR TITLE
Add support for hostIP to NGINX ingress

### DIFF
--- a/charts/ingress-nginx/CHANGELOG.md
+++ b/charts/ingress-nginx/CHANGELOG.md
@@ -7,6 +7,10 @@ This file documents all notable changes to [ingress-nginx](https://github.com/ku
 - [#7092](https://github.com/kubernetes/ingress-nginx/pull/7092) Removes the possibility of using localhost in ExternalNames as endpoints
 
 
+### 3.30.0
+
+- Added the possibility to configure `hostIP` on ports exposed by NGINX.
+
 ### 3.29.0
 
 - [X] [#6945](https://github.com/kubernetes/ingress-nginx/pull/7020) Add option to specify job label for ServiceMonitor

--- a/charts/ingress-nginx/templates/controller-daemonset.yaml
+++ b/charts/ingress-nginx/templates/controller-daemonset.yaml
@@ -166,6 +166,9 @@ spec:
               protocol: TCP
               {{- if $.Values.controller.hostPort.enabled }}
               hostPort: {{ index $.Values.controller.hostPort.ports $key | default $value }}
+              {{- with (index $.Values.controller.hostPort.ips $key) }}
+              hostIP: {{ . }}
+              {{- end }}
               {{- end }}
           {{- end }}
           {{- if .Values.controller.metrics.enabled }}
@@ -184,6 +187,9 @@ spec:
               protocol: TCP
               {{- if $.Values.controller.hostPort.enabled }}
               hostPort: {{ $key }}
+              {{- with (index $.Values.controller.hostPort.ips $key) }}
+              hostIP: {{ . }}
+              {{- end }}
               {{- end }}
           {{- end }}
           {{- range $key, $value := .Values.udp }}

--- a/charts/ingress-nginx/templates/controller-deployment.yaml
+++ b/charts/ingress-nginx/templates/controller-deployment.yaml
@@ -167,6 +167,9 @@ spec:
               protocol: TCP
               {{- if $.Values.controller.hostPort.enabled }}
               hostPort: {{ index $.Values.controller.hostPort.ports $key | default $value }}
+              {{- with (index $.Values.controller.hostPort.ips $key) }}
+              hostIP: {{ . }}
+              {{- end }}
               {{- end }}
           {{- end }}
           {{- if .Values.controller.metrics.enabled }}
@@ -185,6 +188,9 @@ spec:
               protocol: TCP
               {{- if $.Values.controller.hostPort.enabled }}
               hostPort: {{ $key }}
+              {{- with (index $.Values.controller.hostPort.ips $key) }}
+              hostIP: {{ . }}
+              {{- end }}
               {{- end }}
           {{- end }}
           {{- range $key, $value := .Values.udp }}

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -67,6 +67,10 @@ controller:
     ports:
       http: 80
       https: 443
+    # Set this option to set the hostIP on expozed ports
+    ips:
+      http: ""
+      https: ""
 
   ## Election ID to use for status update
   ##


### PR DESCRIPTION
## What this PR does / why we need it:

This PR allows the user to set `hostIP` on ports. This is a feature supported by deployments / deamonsets / ... 
While not commonly used, it has it's use cases -- namely for single node installations where one computer has multiple IP addresses (e.g. public and private) and you want the controller to listen on one of those only.

## Types of changes
- [ ] ~Bug fix (non-breaking change which fixes an issue)~ 
- [X] ~New feature (non-breaking change which adds functionality)~
- [ ] ~Breaking change (fix or feature that would cause existing functionality to change)~

## Which issue/s this PR fixes

N/A

## How Has This Been Tested?

A local deployment was made from `helm repo add https://bokysan.github.io/ingress-nginx` and it works as expected

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My change requires a change to the documentation. (Although I haven't found any other documentation than what's visible in `values.yml`)
- [X] I have updated the documentation accordingly. (`values.yml` description has been updated)
- [X] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
