### PR TITLE
Separate apk-tools update from Dockerfile

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -33,6 +33,9 @@ LABEL build_id="${BUILD_ID}"
 
 WORKDIR  /etc/nginx
 
+# Need to update apk-tools first, otherwise cloud-build breaks
+RUN apk update && apk upgrade apk-tools
+
 RUN apk update \
   && apk upgrade \
   && apk add --no-cache \


### PR DESCRIPTION
## What this PR does / why we need it:
cloud build is failing due to update of apk-tools calling the process again:



## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?
Will test running cloud-build again before doing the PR test

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
