### PR TITLE
Add configuration to configure the agent URL in the datadog opentracing implementation.

### DIFF
--- a/docs/user-guide/third-party-addons/opentracing.md
+++ b/docs/user-guide/third-party-addons/opentracing.md
@@ -93,6 +93,11 @@ jaeger-tracer-baggage-header-prefix
 # specifies the port to use when uploading traces, Default 8126
 datadog-collector-port
 
+# specifies the url to use for submitting traces. If set, this will be used instead of datadog-collector-host / datadog-collector-port.
+# Must be a valid URL. The Datadog tracer supports HTTP, HTTPS and unix address schemes.
+# Examples: http://agent.datadog.svc.cluster.local:8126, https://agent, unix:///var/run/datadog, /var/run/datadog
+datadog-collector-url
+
 # specifies the service name to use for any traces created, Default: nginx
 datadog-service-name
 

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -602,6 +602,10 @@ type Configuration struct {
 	// Default: 8126
 	DatadogCollectorPort int `json:"datadog-collector-port"`
 
+	// DatadogCollectorURL specifies the URL of the datadog agent to use when uploading traces.
+	// If set will be used instead of DatadogCollectorHost/DatadogCollectorPort.
+	DatadogCollectorURL string `json:"datadog-collector-url"`
+
 	// DatadogEnvironment specifies the environment this trace belongs to.
 	// Default: prod
 	DatadogEnvironment string `json:"datadog-environment"`

--- a/internal/ingress/controller/nginx.go
+++ b/internal/ingress/controller/nginx.go
@@ -1052,8 +1052,12 @@ const jaegerTmpl = `{
 
 const datadogTmpl = `{
   "service": "{{ .DatadogServiceName }}",
+  {{ if .DatadogCollectorURL }}
+  "agent_url": "{{ .DatadogCollectorURL }}",
+  {{ else }}
   "agent_host": "{{ .DatadogCollectorHost }}",
   "agent_port": {{ .DatadogCollectorPort }},
+  {{ end }}
   "environment": "{{ .DatadogEnvironment }}",
   "operation_name_override": "{{ .DatadogOperationNameOverride }}",
   "sample_rate": {{ .DatadogSampleRate }},
@@ -1074,7 +1078,7 @@ func createOpentracingCfg(cfg ngx_config.Configuration) error {
 		if err != nil {
 			return err
 		}
-	} else if cfg.DatadogCollectorHost != "" {
+	} else if cfg.DatadogCollectorHost != "" || cfg.DatadogCollectorURL != "" {
 		tmpl, err = template.New("datadog").Parse(datadogTmpl)
 		if err != nil {
 			return err

--- a/internal/ingress/controller/template/template_test.go
+++ b/internal/ingress/controller/template/template_test.go
@@ -1401,6 +1401,73 @@ func TestShouldLoadOpentracingModule(t *testing.T) {
 	}
 }
 
+func TestIsValidDatadogCollectorURL(t *testing.T) {
+
+	// valid URLs
+	expected := true
+	value := "http://agent.datadog.svc.cluster.local:8126"
+	actual := isValidDatadogCollectorURL(value)
+	if actual != expected {
+		t.Errorf("Expected '%v' but returned '%v' for value '%v'", expected, actual, value)
+	}
+
+	value = "https://agent.datadog.svc.cluster.local"
+	actual = isValidDatadogCollectorURL(value)
+	if actual != expected {
+		t.Errorf("Expected '%v' but returned '%v' for value '%v'", expected, actual, value)
+	}
+
+	value = "/var/run/datadog"
+	actual = isValidDatadogCollectorURL(value)
+	if actual != expected {
+		t.Errorf("Expected '%v' but returned '%v' for value '%v'", expected, actual, value)
+	}
+
+	value = "unix:///var/run/datadog"
+	actual = isValidDatadogCollectorURL(value)
+	if actual != expected {
+		t.Errorf("Expected '%v' but returned '%v' for value '%v'", expected, actual, value)
+	}
+
+	// invalid ones
+	expected = false
+	value = "gopher://should.fail"
+	actual = isValidDatadogCollectorURL(value)
+	if actual != expected {
+		t.Errorf("Expected '%v' but returned '%v' for value '%v'", expected, actual, value)
+	}
+
+	value = ""
+	actual = isValidDatadogCollectorURL(value)
+	if actual != expected {
+		t.Errorf("Expected '%v' but returned '%v' for value '%v'", expected, actual, value)
+	}
+
+	value = "unix://foo:bar@should.fail/var/run/datadog"
+	actual = isValidDatadogCollectorURL(value)
+	if actual != expected {
+		t.Errorf("Expected '%v' but returned '%v' for value '%v'", expected, actual, value)
+	}
+
+	value = "unix://"
+	actual = isValidDatadogCollectorURL(value)
+	if actual != expected {
+		t.Errorf("Expected '%v' but returned '%v' for value '%v'", expected, actual, value)
+	}
+
+	value = "}}random/garbage:1234::"
+	actual = isValidDatadogCollectorURL(value)
+	if actual != expected {
+		t.Errorf("Expected '%v' but returned '%v' for value '%v'", expected, actual, value)
+	}
+
+	value = "https:///just/a/path"
+	actual = isValidDatadogCollectorURL(value)
+	if actual != expected {
+		t.Errorf("Expected '%v' but returned '%v' for value '%v'", expected, actual, value)
+	}
+}
+
 func TestModSecurityForLocation(t *testing.T) {
 	loadModule := `modsecurity on;
 `

--- a/test/e2e/settings/opentracing.go
+++ b/test/e2e/settings/opentracing.go
@@ -36,6 +36,7 @@ const (
 	// jaegerEndpoint      = "jaeger-endpoint"
 
 	datadogCollectorHost = "datadog-collector-host"
+	datadogCollectorURL  = "datadog-collector-url"
 
 	opentracingOperationName         = "opentracing-operation-name"
 	opentracingLocationOperationName = "opentracing-location-operation-name"
@@ -193,6 +194,18 @@ var _ = framework.IngressNginxDescribe("Configure OpenTracing", func() {
 		config := map[string]string{}
 		config[enableOpentracing] = "true"
 		config[datadogCollectorHost] = "http://127.0.0.1"
+		f.SetNginxConfigMapData(config)
+
+		framework.Sleep(10 * time.Second)
+		log, err := f.NginxLogs()
+		assert.Nil(ginkgo.GinkgoT(), err, "obtaining nginx logs")
+		assert.NotContains(ginkgo.GinkgoT(), log, "Unexpected failure reloading the backend", "reloading nginx after a configmap change")
+	})
+
+	ginkgo.It("should enable opentracing using datadog with an HTTP endpoint", func() {
+		config := map[string]string{}
+		config[enableOpentracing] = "true"
+		config[datadogCollectorURL] = "http://127.0.0.1/datadog/trace"
 		f.SetNginxConfigMapData(config)
 
 		framework.Sleep(10 * time.Second)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
This PR adds a configuration entry to set the [agent url](https://github.com/DataDog/dd-opentracing-cpp/blob/master/include/datadog/opentracing.h#L112) when using the DataDog tracer.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Enabled opentracing in a local kind cluster, configured to reach the DataDog agent using the new configuration entry, checked that traces appear in DataDog.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
