### PR TITLE
baremetal docs: fix example IP address

### DIFF
--- a/docs/deploy/baremetal.md
+++ b/docs/deploy/baremetal.md
@@ -77,7 +77,7 @@ are created in the iptables NAT table and the node with the selected IP address 
 the ports configured in the LoadBalancer Service:
 
 ```console
-$ curl -D- http://203.0.113.3 -H 'Host: myapp.example.com'
+$ curl -D- http://203.0.113.10 -H 'Host: myapp.example.com'
 HTTP/1.1 200 OK
 Server: nginx/1.15.2
 ```


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
The example given in the baremetal docs for MetalLB had an incorrect IP address that causes some confusion. The curl example should use the IP of the ingress controller, not a node in the cluster.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
