### PR TITLE
Adding global ssl auth

### DIFF
--- a/internal/ingress/annotations/authtls/main.go
+++ b/internal/ingress/annotations/authtls/main.go
@@ -106,7 +106,7 @@ func (a authTLS) Parse(ing *networking.Ingress) (interface{}, error) {
 		config.AuthSSLCert = *authCert
 	} else {
 		// Only enabled global ssl auth validation when auth-tls-verify-client is
-		// set to either `on|optional|optional_no_ca` and that GlobalSSLClientCertificate is set
+		// set to either `on|optional|optional_no_ca` and that auth-tls-secret is not set
 		authTLSVerifyClient, err := parser.GetStringAnnotation("auth-tls-verify-client", ing)
 		if err != nil || !validationEnabledClientRegex.MatchString(authTLSVerifyClient) {
 			return &Config{}, nil

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -739,6 +739,10 @@ type Configuration struct {
 	// GlobalRateLimitStatucCode determines the HTTP status code to return
 	// when limit is exceeding during global rate limiting.
 	GlobalRateLimitStatucCode int `json:"global-rate-limit-status-code"`
+
+	GlobalSSLClientCertificate string `json:"global-ssl-client-certificate"`
+
+	GlobalSSLCRL string `json:"global"`
 }
 
 // NewDefault returns the default nginx configuration
@@ -895,6 +899,8 @@ func NewDefault() Configuration {
 		GlobalRateLimitMemcachedMaxIdleTimeout: 10000,
 		GlobalRateLimitMemcachedPoolSize:       50,
 		GlobalRateLimitStatucCode:              429,
+		GlobalSSLClientCertificate:             "",
+		GlobalSSLCRL:                           "",
 	}
 
 	if klog.V(5).Enabled() {

--- a/internal/ingress/controller/controller_test.go
+++ b/internal/ingress/controller/controller_test.go
@@ -98,6 +98,14 @@ func (fakeIngressStore) GetAuthCertificate(string) (*resolver.AuthSSLCert, error
 	return nil, fmt.Errorf("test error")
 }
 
+func (fakeIngressStore) GetGlobalAuthCertificate() (*resolver.AuthSSLCert, error) {
+	return nil, fmt.Errorf("test error")
+}
+
+func (fakeIngressStore) GetGlobalSSLClientCertificatePath() string {
+	return ""
+}
+
 func (fakeIngressStore) GetDefaultBackend() defaults.Backend {
 	return defaults.Backend{}
 }

--- a/internal/ingress/controller/template/configmap.go
+++ b/internal/ingress/controller/template/configmap.go
@@ -61,6 +61,8 @@ const (
 	globalAuthSnippet             = "global-auth-snippet"
 	globalAuthCacheKey            = "global-auth-cache-key"
 	globalAuthCacheDuration       = "global-auth-cache-duration"
+	globalSSLClientCertificate    = "global-ssl-client-certificate"
+	globalSSLCRL                  = "global-ssl-crl"
 	luaSharedDictsKey             = "lua-shared-dicts"
 	plugins                       = "plugins"
 )
@@ -311,6 +313,20 @@ func ReadConfig(src map[string]string) config.Configuration {
 			klog.Warningf("Global auth location denied - %s", err)
 		}
 		to.GlobalExternalAuth.AuthCacheDuration = cacheDurations
+	}
+
+	if val, ok := conf[globalSSLClientCertificate]; ok {
+		delete(conf, globalSSLClientCertificate)
+		if val != "" {
+			to.GlobalSSLClientCertificate = val
+		}
+	}
+
+	if val, ok := conf[globalSSLCRL]; ok {
+		delete(conf, globalSSLCRL)
+		if val != "" {
+			to.GlobalSSLCRL = val
+		}
 	}
 
 	// Verify that the configured timeout is parsable as a duration. if not, set the default value

--- a/internal/ingress/resolver/main.go
+++ b/internal/ingress/resolver/main.go
@@ -39,6 +39,10 @@ type Resolver interface {
 	//   ca.crl: contains the revocation list used for authentication
 	GetAuthCertificate(string) (*AuthSSLCert, error)
 
+	GetGlobalSSLClientCertificatePath() string
+
+	GetGlobalAuthCertificate() (*AuthSSLCert, error)
+
 	// GetService searches for services containing the namespace and name using a the character /
 	GetService(string) (*apiv1.Service, error)
 }

--- a/internal/ingress/resolver/mock.go
+++ b/internal/ingress/resolver/mock.go
@@ -46,6 +46,14 @@ func (m Mock) GetAuthCertificate(string) (*AuthSSLCert, error) {
 	return nil, nil
 }
 
+func (m Mock) GetGlobalAuthCertificate() (*AuthSSLCert, error) {
+	return nil, nil
+}
+
+func (m Mock) GetGlobalSSLClientCertificatePath() string {
+	return ""
+}
+
 // GetService searches for services contenating the namespace and name using a the character /
 func (m Mock) GetService(string) (*apiv1.Service, error) {
 	return nil, nil

--- a/test/e2e/annotations/authtlsglobal.go
+++ b/test/e2e/annotations/authtlsglobal.go
@@ -1,0 +1,208 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package annotations
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/onsi/ginkgo"
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/ingress-nginx/internal/file"
+	"k8s.io/ingress-nginx/test/e2e/framework"
+)
+
+var _ = framework.DescribeAnnotation("auth-tls-global", func() {
+	f := framework.NewDefaultFramework("authtlsglobal")
+
+	ginkgo.BeforeEach(func() {
+		f.NewEchoDeploymentWithReplicas(2)
+	})
+
+	ginkgo.It("should use auth tls secret even when global ssl auth is set", func() {
+		globalSecretName := "auth-tls-global-secret"
+		host := "authtls.foo.com"
+		globalAuthConfig := configureIngressWithGlobalSSLAuth(f, host, globalSecretName)
+
+		f.UpdateNginxConfigMapData("global-ssl-client-certificate", "/etc/ingress-controller/ssl/global-auth-ssl/ca.crt")
+		nameSpace := f.Namespace
+
+		clientConfig, err := framework.CreateIngressMASecret(
+			f.KubeClientSet,
+			host,
+			host,
+			nameSpace)
+		assert.Nil(ginkgo.GinkgoT(), err)
+
+		annotations := map[string]string{
+			"nginx.ingress.kubernetes.io/auth-tls-secret":        nameSpace + "/" + host,
+			"nginx.ingress.kubernetes.io/auth-tls-verify-client": "on",
+		}
+
+		f.EnsureIngress(framework.NewSingleIngressWithTLS(host, "/", host, []string{host}, nameSpace, framework.EchoService, 80, annotations))
+		assertSslClientCertificateConfig(f, host, "on", "1")
+
+		framework.Sleep(30 * time.Minute)
+		ioutil.WriteFile("/etc/ssl/nginx-host", []byte(f.GetURL(framework.HTTPS)), file.ReadWriteByUser)
+
+		f.HTTPTestClientWithTLSConfig(&tls.Config{ServerName: host, InsecureSkipVerify: true}).
+			GET("/").
+			WithURL(f.GetURL(framework.HTTPS)).
+			WithHeader("Host", host).
+			Expect().
+			Status(http.StatusBadRequest)
+
+		f.HTTPTestClientWithTLSConfig(clientConfig).
+			GET("/").
+			WithURL(f.GetURL(framework.HTTPS)).
+			WithHeader("Host", host).
+			Expect().
+			Status(http.StatusOK)
+
+		f.HTTPTestClientWithTLSConfig(globalAuthConfig).
+			GET("/").
+			WithURL(f.GetURL(framework.HTTPS)).
+			WithHeader("Host", host).
+			Expect().
+			Status(http.StatusBadRequest)
+	})
+
+	ginkgo.It("should use global ssl auth when auth-tls-verify-client is set to on and auth-tls-secret is not defined", func() {
+		host := "authtls.foo.com"
+		globalSecretName := "auth-tls-global-secret"
+		nameSpace := f.Namespace
+		globalAuthConfig := configureIngressWithGlobalSSLAuth(f, host, globalSecretName)
+
+		f.UpdateNginxConfigMapData("global-ssl-client-certificate", "/ssl/global-auth-ssl/ca.crt")
+
+		clientConfig, err := framework.CreateIngressMASecret(
+			f.KubeClientSet,
+			host,
+			host,
+			nameSpace)
+		assert.Nil(ginkgo.GinkgoT(), err)
+
+		annotations := map[string]string{
+			"nginx.ingress.kubernetes.io/auth-tls-verify-client": "on",
+		}
+
+		f.EnsureIngress(framework.NewSingleIngressWithTLS(host, "/", host, []string{host}, nameSpace, framework.EchoService, 80, annotations))
+		f.WaitForNginxServer(host,
+			func(server string) bool {
+				return strings.Contains(server, "ssl_client_certificate /ssl/global-auth-ssl/ca.crt;") &&
+					strings.Contains(server, "ssl_verify_client on;")
+			})
+
+		ioutil.WriteFile("/etc/ssl/nginx-host", []byte(f.GetURL(framework.HTTPS)), file.ReadWriteByUser)
+		// framework.Sleep(20 * time.Minute)
+
+		f.HTTPTestClientWithTLSConfig(&tls.Config{ServerName: host, InsecureSkipVerify: true}).
+			GET("/").
+			WithURL(f.GetURL(framework.HTTPS)).
+			WithHeader("Host", host).
+			Expect().
+			Status(http.StatusBadRequest)
+
+		f.HTTPTestClientWithTLSConfig(clientConfig).
+			GET("/").
+			WithURL(f.GetURL(framework.HTTPS)).
+			WithHeader("Host", host).
+			Expect().
+			Status(http.StatusBadRequest)
+
+		f.HTTPTestClientWithTLSConfig(globalAuthConfig).
+			GET("/").
+			WithURL(f.GetURL(framework.HTTPS)).
+			WithHeader("Host", host).
+			Expect().
+			Status(http.StatusOK)
+
+	})
+
+	ginkgo.It("should not use global ssl auth when auth-tls-verify-client is not defined", func() {
+		host := "authtls.foo.com"
+		globalSecretName := "auth-tls-global-secret"
+		configureIngressWithGlobalSSLAuth(f, host, globalSecretName)
+
+		f.UpdateNginxConfigMapData("global-ssl-client-certificate", "/ssl/global-auth-ssl/ca.crt")
+
+		ing := framework.NewSingleIngress(host, "/", host, f.Namespace, framework.EchoService, 80, nil)
+		f.EnsureIngress(ing)
+
+		f.WaitForNginxServer(host,
+			func(server string) bool {
+				return strings.Contains(server, "server_name auth")
+			})
+
+		f.HTTPTestClient().
+			GET("/").
+			WithHeader("Host", host).
+			Expect().
+			Status(http.StatusOK).
+			Body().Contains(fmt.Sprintf("host=%v", host))
+	})
+})
+
+func configureIngressWithGlobalSSLAuth(f *framework.Framework, host string, globalSecretName string) *tls.Config {
+	globalAuthConfig, err := framework.CreateIngressMASecret(
+		f.KubeClientSet,
+		host,
+		globalSecretName,
+		f.Namespace)
+	assert.Nil(ginkgo.GinkgoT(), err)
+
+	globalAuthVolume := []corev1.Volume{
+		{
+			Name: "global-auth-ssl",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: globalSecretName,
+				},
+			},
+		},
+	}
+
+	globalAuthVolumeMount := []corev1.VolumeMount{
+		{
+			Name:      "global-auth-ssl",
+			MountPath: "/ssl/global-auth-ssl",
+			ReadOnly:  true,
+		},
+	}
+	err = f.UpdateIngressControllerDeployment(func(deployment *appsv1.Deployment) error {
+		volumes := deployment.Spec.Template.Spec.Volumes
+		volumes = append(volumes, globalAuthVolume...)
+		deployment.Spec.Template.Spec.Volumes = volumes
+
+		volumeMounts := deployment.Spec.Template.Spec.Containers[0].VolumeMounts
+		volumeMounts = append(volumeMounts, globalAuthVolumeMount...)
+		deployment.Spec.Template.Spec.Containers[0].VolumeMounts = volumeMounts
+		assert.Nil(ginkgo.GinkgoT(), err, "updating deployment")
+		_, err := f.KubeClientSet.AppsV1().Deployments(f.Namespace).Update(context.TODO(), deployment, metav1.UpdateOptions{})
+		return err
+	})
+	assert.Nil(ginkgo.GinkgoT(), err, "updating ingress controller deployment")
+	return globalAuthConfig
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR allows us to:
* configure global SSL auth through config map
* only enable global SSL auth when 
    * `auth-tls-verify-client` is set to `on|optional|optional_no_ca` 
    * and `auth-tls-secret` is not set 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
