### PR TITLE
Remove the force stripping of trailing slashes

### DIFF
--- a/rootfs/etc/nginx/lua/lua_ingress.lua
+++ b/rootfs/etc/nginx/lua/lua_ingress.lua
@@ -147,11 +147,6 @@ function _M.rewrite(location_config)
 
   if redirect_to_https(location_config) then
     local request_uri = ngx.var.request_uri
-    -- do not append a trailing slash on redirects
-    if string.sub(request_uri, -1) == "/" then
-      request_uri = string.sub(request_uri, 1, -2)
-    end
-
     local uri = string_format("https://%s%s", redirect_host(), request_uri)
 
     if location_config.use_port_in_redirects then

--- a/test/e2e/annotations/forcesslredirect.go
+++ b/test/e2e/annotations/forcesslredirect.go
@@ -46,6 +46,6 @@ var _ = framework.DescribeAnnotation("force-ssl-redirect", func() {
 			WithHeader("Host", host).
 			Expect().
 			Status(http.StatusPermanentRedirect).
-			Header("Location").Equal("https://forcesslredirect.bar.com")
+			Header("Location").Equal("https://forcesslredirect.bar.com/")
 	})
 })

--- a/test/e2e/settings/tls.go
+++ b/test/e2e/settings/tls.go
@@ -221,7 +221,7 @@ var _ = framework.DescribeSetting("[SSL] TLS protocols, ciphers and headers)", f
 				WithHeader("Host", host).
 				Expect().
 				Status(http.StatusPermanentRedirect).
-				Header("Location").Equal(fmt.Sprintf("https://%v", host))
+				Header("Location").Equal(fmt.Sprintf("https://%v/", host))
 		})
 
 		ginkgo.It("should not use ports or X-Forwarded-Host during the HTTP to HTTPS redirection", func() {

--- a/test/e2e/settings/tls.go
+++ b/test/e2e/settings/tls.go
@@ -29,8 +29,8 @@ import (
 )
 
 var _ = framework.DescribeSetting("[SSL] TLS protocols, ciphers and headers)", func() {
-	f := framework.NewDefaultFramework("settings-tls")
-	host := "settings-tls"
+	f := framework.NewDefaultFramework("")
+	host := ""
 
 	ginkgo.BeforeEach(func() {
 		f.NewEchoDeployment()
@@ -195,7 +195,7 @@ var _ = framework.DescribeSetting("[SSL] TLS protocols, ciphers and headers)", f
 			// we can not use gorequest here because it flattens the duplicate headers
 			// and specifically in case of Strict-Transport-Security it ignore extra headers
 			// intead of concatenating, rightfully. And I don't know of any API it provides for getting raw headers.
-			curlCmd := fmt.Sprintf("curl -I -k --fail --silent --resolve settings-tls:443:127.0.0.1 https://settings-tls%v", "?hsts=true")
+			curlCmd := fmt.Sprintf("curl -I -k --fail --silent --resolve :443:127.0.0.1 https://%v", "?hsts=true")
 			output, err := f.ExecIngressPod(curlCmd)
 			assert.Nil(ginkgo.GinkgoT(), err)
 			assert.Contains(ginkgo.GinkgoT(), output, "strict-transport-security: max-age=86400; preload")
@@ -221,7 +221,7 @@ var _ = framework.DescribeSetting("[SSL] TLS protocols, ciphers and headers)", f
 				WithHeader("Host", host).
 				Expect().
 				Status(http.StatusPermanentRedirect).
-				Header("Location").Equal(fmt.Sprintf("https://%v", host))
+				Header("Location").Equal(fmt.Sprintf("https://%v/", host))
 		})
 
 		ginkgo.It("should not use ports or X-Forwarded-Host during the HTTP to HTTPS redirection", func() {

--- a/test/e2e/settings/tls.go
+++ b/test/e2e/settings/tls.go
@@ -221,7 +221,7 @@ var _ = framework.DescribeSetting("[SSL] TLS protocols, ciphers and headers)", f
 				WithHeader("Host", host).
 				Expect().
 				Status(http.StatusPermanentRedirect).
-				Header("Location").Equal(fmt.Sprintf("https://%v/", host))
+				Header("Location").Equal(fmt.Sprintf("https://%v", host))
 		})
 
 		ginkgo.It("should not use ports or X-Forwarded-Host during the HTTP to HTTPS redirection", func() {
@@ -242,7 +242,7 @@ var _ = framework.DescribeSetting("[SSL] TLS protocols, ciphers and headers)", f
 				WithHeader("X-Forwarded-Host", "example.com:80").
 				Expect().
 				Status(http.StatusPermanentRedirect).
-				Header("Location").Equal("https://example.com")
+				Header("Location").Equal("https://example.com/")
 		})
 	})
 })

--- a/test/e2e/ssl/http_redirect.go
+++ b/test/e2e/ssl/http_redirect.go
@@ -54,6 +54,6 @@ var _ = framework.IngressNginxDescribe("[SSL] redirect to HTTPS", func() {
 			WithHeader("Host", host).
 			Expect().
 			Status(http.StatusPermanentRedirect).
-			Header("Location").Equal("https://redirect.com")
+			Header("Location").Equal("https://redirect.com/")
 	})
 })


### PR DESCRIPTION
## What this PR does / why we need it:
Someone introduced trailing slash removal as part of the force-ssl-redirect annotations. This shouldn't be default behavior.

## Types of changes
- Reverted the trailing slash removal
