### PR TITLE
Option to always use fake certificate for Nginx default server

### DIFF
--- a/cmd/nginx/flags.go
+++ b/cmd/nginx/flags.go
@@ -98,6 +98,9 @@ namespaces are watched if this parameter is left empty.`)
 			`Secret containing a SSL certificate to be used by the default HTTPS server (catch-all).
 Takes the form "namespace/name".`)
 
+		defServerUseFake = flags.Bool("default-server-uses-fake-certificate", false,
+			`If set, the default server will use the fake certificate instead of the default SSL certificate.`)
+
 		defHealthzURL = flags.String("health-check-path", "/healthz",
 			`URL path of the health check endpoint.
 Configured inside the NGINX status server. All requests received on the port
@@ -264,28 +267,29 @@ https://blog.maxmind.com/2019/12/18/significant-changes-to-accessing-and-using-g
 	ngx_config.EnableSSLChainCompletion = *enableSSLChainCompletion
 
 	config := &controller.Configuration{
-		APIServerHost:          *apiserverHost,
-		KubeConfigFile:         *kubeConfigFile,
-		UpdateStatus:           *updateStatus,
-		ElectionID:             *electionID,
-		EnableProfiling:        *profiling,
-		EnableMetrics:          *enableMetrics,
-		MetricsPerHost:         *metricsPerHost,
-		MonitorMaxBatchSize:    *monitorMaxBatchSize,
-		EnableSSLPassthrough:   *enableSSLPassthrough,
-		ResyncPeriod:           *resyncPeriod,
-		DefaultService:         *defaultSvc,
-		Namespace:              *watchNamespace,
-		ConfigMapName:          *configMap,
-		TCPConfigMapName:       *tcpConfigMapName,
-		UDPConfigMapName:       *udpConfigMapName,
-		DefaultSSLCertificate:  *defSSLCertificate,
-		PublishService:         *publishSvc,
-		PublishStatusAddress:   *publishStatusAddress,
-		UpdateStatusOnShutdown: *updateStatusOnShutdown,
-		ShutdownGracePeriod:    *shutdownGracePeriod,
-		UseNodeInternalIP:      *useNodeInternalIP,
-		SyncRateLimit:          *syncRateLimit,
+		APIServerHost:            *apiserverHost,
+		KubeConfigFile:           *kubeConfigFile,
+		UpdateStatus:             *updateStatus,
+		ElectionID:               *electionID,
+		EnableProfiling:          *profiling,
+		EnableMetrics:            *enableMetrics,
+		MetricsPerHost:           *metricsPerHost,
+		MonitorMaxBatchSize:      *monitorMaxBatchSize,
+		EnableSSLPassthrough:     *enableSSLPassthrough,
+		ResyncPeriod:             *resyncPeriod,
+		DefaultService:           *defaultSvc,
+		Namespace:                *watchNamespace,
+		ConfigMapName:            *configMap,
+		TCPConfigMapName:         *tcpConfigMapName,
+		UDPConfigMapName:         *udpConfigMapName,
+		DefaultSSLCertificate:    *defSSLCertificate,
+		DefaultServerUseFakeCert: *defServerUseFake,
+		PublishService:           *publishSvc,
+		PublishStatusAddress:     *publishStatusAddress,
+		UpdateStatusOnShutdown:   *updateStatusOnShutdown,
+		ShutdownGracePeriod:      *shutdownGracePeriod,
+		UseNodeInternalIP:        *useNodeInternalIP,
+		SyncRateLimit:            *syncRateLimit,
 		ListenPorts: &ngx_config.ListenPorts{
 			Default:  *defServerPort,
 			Health:   *healthzPort,

--- a/docs/user-guide/cli-arguments.md
+++ b/docs/user-guide/cli-arguments.md
@@ -15,6 +15,7 @@ They are set in the container spec of the `nginx-ingress-controller` Deployment 
 | `--default-backend-service`        | Service used to serve HTTP requests not matching any known server name (catch-all). Takes the form "namespace/name". The controller configures NGINX to forward requests to the first port of this Service. |
 | `--default-server-port`            | Port to use for exposing the default server (catch-all). (default 8181) |
 | `--default-ssl-certificate`        | Secret containing a SSL certificate to be used by the default HTTPS server (catch-all). Takes the form "namespace/name". |
+| `--default-server-uses-fake-certificate`        | The default Nginx server will serve the fake certificate instead of what is specified in `--default-ssl-certificate`|
 | `--disable-catch-all`              | Disable support for catch-all Ingresses |
 | `--election-id`                    | Election id to use for Ingress status updates. (default "ingress-controller-leader") |
 | `--enable-metrics`                 | Enables the collection of NGINX metrics (default true) |

--- a/docs/user-guide/tls.md
+++ b/docs/user-guide/tls.md
@@ -37,6 +37,15 @@ add `--default-ssl-certificate=default/foo-tls` in the `nginx-controller` deploy
 The default certificate will also be used for ingress `tls:` sections that do not
 have a `secretName` option.
 
+You may want your default Nginx server to not expose your
+default-ssl-certificate to all requests.  You want any Ingress without a
+`secretName` (or invalid `secretName`) to use the `default-ssl-certificate`,
+but not serve that up to requests without a matching Server Name Indication.
+For this situation, add `--default-server-uses-fake-certificate`. This will
+keep the hostnames of your default certificate hidden to bots or attackers that
+only know your IP address.
+
+
 ## SSL Passthrough
 
 The [`--enable-ssl-passthrough`](cli-arguments.md) flag enables the SSL Passthrough feature, which is disabled by

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -72,7 +72,8 @@ type Configuration struct {
 	// +optional
 	UDPConfigMapName string
 
-	DefaultSSLCertificate string
+	DefaultSSLCertificate    string
+	DefaultServerUseFakeCert bool
 
 	// +optional
 	PublishService       string
@@ -1031,9 +1032,13 @@ func (n *NGINXController) createServers(data []*ingress.Ingress,
 
 	// initialize default server and root location
 	pathTypePrefix := networking.PathTypePrefix
+	defaultServerCert := n.getDefaultSSLCertificate()
+	if n.cfg.DefaultServerUseFakeCert {
+		defaultServerCert = n.cfg.FakeCertificate
+	}
 	servers[defServerName] = &ingress.Server{
 		Hostname: defServerName,
-		SSLCert:  n.getDefaultSSLCertificate(),
+		SSLCert:  defaultServerCert,
 		Locations: []*ingress.Location{
 			{
 				Path:         rootLocation,

--- a/test/e2e/settings/default_ssl_certificate.go
+++ b/test/e2e/settings/default_ssl_certificate.go
@@ -124,6 +124,7 @@ var _ = framework.IngressNginxDescribe("[SSL] [Flag] default-ssl-certificate", f
 		})
 
 		ginkgo.By("making sure the default ssl certificate is being used when accessing ingress")
+		tlsConfig.ServerName = host
 		f.HTTPTestClientWithTLSConfig(tlsConfig).
 			GET("/").
 			WithURL(f.GetURL(framework.HTTPS)).


### PR DESCRIPTION


## What this PR does / why we need it:
The `--default-ssl-certificate` currently becomes used in two distinct areas:
1) It's the default cert used for any Ingress that has no tls.secretName, and for any Ingress whose tls.secretName points to a Secret that does not exist.
2) It's the cert used in the default Nginx server, e.g. the `server{}` entry with `listen ... default_server` defined.

This PR adds a new CLI arg `--default-server-uses-fake-certificate` that breaks out 2) above, so that the default nginx server will always still instead use the fake certificate.

`--default-ssl-certificate` is today sometimes used as a [means to share a TLS secret across namespaces](https://cert-manager.io/docs/faq/kubed/#serving-a-wildcard-to-ingress-resources-in-different-namespaces-default-ssl-certificate). At the same time however, it's undesirable for that cert to be served to non-SNI requests that merely hit :443 on a particular IP address. The default cert can reveal sensitive information, particularly what hostnames are served by the server.

By adding `--default-server-uses-fake-certificate`, the default Nginx server will instead serve up the fake generated self-signed certificate instead of the one specified by `--default-ssl-certificate`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
N/A

## How Has This Been Tested?
e2e test has been added to verify that the fake certificate is used in cases where the Host/ServerName is not supplied, and the default cert is used in cases where it matches a valid ingress.

Also tested interactively on a live cluster under similar conditions.

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
