### PR TITLE
Documentation: minikube - ingress-nginx instead of kube-system namespace

### DIFF
--- a/docs/deploy/index.md
+++ b/docs/deploy/index.md
@@ -177,9 +177,6 @@ kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/cont
 
 ### Verify installation
 
-!!! info
-    In minikube the ingress addon is installed in the namespace **kube-system** instead of ingress-nginx
-
 To check if the ingress controller pods have started, run the following command:
 
 ```console


### PR DESCRIPTION
## What this PR does / why we need it:
The latest version of the ingress addon is now installed in the namespace `ingress-nginx` and not in `kube-system`.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?
Setting up ingress with the latest version of Minikube.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
