### PR TITLE
Update catch-all ingress requirement logic

### DIFF
--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -224,6 +224,10 @@ func (n *NGINXController) CheckIngress(ing *networking.Ingress) error {
 		return nil
 	}
 
+	if n.cfg.DisableCatchAll && ing.Spec.Backend != nil {
+		return fmt.Errorf("This deployment is trying to create a catch-all ingress while DisableCatchAll flag is set to true. Remove '.spec.backend' or set DisableCatchAll flag to false.")
+	}
+
 	if parser.AnnotationsPrefix != parser.DefaultAnnotationsPrefix {
 		for key := range ing.ObjectMeta.GetAnnotations() {
 			if strings.HasPrefix(key, fmt.Sprintf("%s/", parser.DefaultAnnotationsPrefix)) {

--- a/internal/ingress/controller/controller_test.go
+++ b/internal/ingress/controller/controller_test.go
@@ -256,6 +256,28 @@ func TestCheckIngress(t *testing.T) {
 			}
 		})
 
+		t.Run("When a new catch-all ingress is being created despite catch-alls being disabled ", func(t *testing.T) {
+			nginx.command = testNginxTestCommand{
+				t:   t,
+				err: nil,
+			}
+			nginx.cfg.DisableCatchAll = true
+
+			ing.Spec.Backend = &networking.IngressBackend{
+				ServiceName: "http-svc",
+				ServicePort: intstr.IntOrString{
+					IntVal: 80,
+				},
+			}
+
+			if nginx.CheckIngress(ing) == nil {
+				t.Errorf("with a new catch-all ingress and catch-alls disable, should return error")
+			}
+
+			// set back to nil for next test
+			ing.Spec.Backend = nil
+		})
+
 		t.Run("When the ingress is in a different namespace than the watched one", func(t *testing.T) {
 			nginx.command = testNginxTestCommand{
 				t:   t,

--- a/internal/ingress/controller/controller_test.go
+++ b/internal/ingress/controller/controller_test.go
@@ -257,6 +257,9 @@ func TestCheckIngress(t *testing.T) {
 		})
 
 		t.Run("When a new catch-all ingress is being created despite catch-alls being disabled ", func(t *testing.T) {
+			backendBefore := ing.Spec.Backend
+			disableCatchAllBefore := nginx.cfg.DisableCatchAll
+
 			nginx.command = testNginxTestCommand{
 				t:   t,
 				err: nil,
@@ -274,8 +277,9 @@ func TestCheckIngress(t *testing.T) {
 				t.Errorf("with a new catch-all ingress and catch-alls disable, should return error")
 			}
 
-			// set back to nil for next test
-			ing.Spec.Backend = nil
+			// reset backend and catch-all flag
+			ing.Spec.Backend = backendBefore
+			nginx.cfg.DisableCatchAll = disableCatchAllBefore
 		})
 
 		t.Run("When the ingress is in a different namespace than the watched one", func(t *testing.T) {

--- a/internal/ingress/controller/store/store.go
+++ b/internal/ingress/controller/store/store.go
@@ -328,7 +328,7 @@ func New(
 			return
 		}
 
-		if isCatchAllIngress(ing.Spec) && disableCatchAll {
+		if hasCatchAllIngress(ing.Spec) && disableCatchAll {
 			klog.InfoS("Ignoring delete for catch-all because of --disable-catch-all", "ingress", klog.KObj(ing))
 			return
 		}
@@ -353,7 +353,7 @@ func New(
 				return
 			}
 
-			if isCatchAllIngress(ing.Spec) && disableCatchAll {
+			if hasCatchAllIngress(ing.Spec) && disableCatchAll {
 				klog.InfoS("Ignoring add for catch-all ingress because of --disable-catch-all", "ingress", klog.KObj(ing))
 				return
 			}
@@ -377,7 +377,7 @@ func New(
 			validOld := class.IsValid(oldIng)
 			validCur := class.IsValid(curIng)
 			if !validOld && validCur {
-				if isCatchAllIngress(curIng.Spec) && disableCatchAll {
+				if hasCatchAllIngress(curIng.Spec) && disableCatchAll {
 					klog.InfoS("ignoring update for catch-all ingress because of --disable-catch-all", "ingress", klog.KObj(curIng))
 					return
 				}
@@ -389,7 +389,7 @@ func New(
 				ingDeleteHandler(old)
 				return
 			} else if validCur && !reflect.DeepEqual(old, cur) {
-				if isCatchAllIngress(curIng.Spec) && disableCatchAll {
+				if hasCatchAllIngress(curIng.Spec) && disableCatchAll {
 					klog.InfoS("ignoring update for catch-all ingress and delete old one because of --disable-catch-all", "ingress", klog.KObj(curIng))
 					ingDeleteHandler(old)
 					return
@@ -624,10 +624,10 @@ func New(
 	return store
 }
 
-// isCatchAllIngress returns whether or not an ingress produces a
+// hasCatchAllIngress returns whether or not an ingress produces a
 // catch-all server, and so should be ignored when --disable-catch-all is set
-func isCatchAllIngress(spec networkingv1beta1.IngressSpec) bool {
-	return spec.Backend != nil && len(spec.Rules) == 0
+func hasCatchAllIngress(spec networkingv1beta1.IngressSpec) bool {
+	return spec.Backend != nil
 }
 
 // syncIngress parses ingress annotations converting the value of the

--- a/internal/ingress/controller/store/store.go
+++ b/internal/ingress/controller/store/store.go
@@ -328,7 +328,7 @@ func New(
 			return
 		}
 
-		if hasCatchAllIngress(ing.Spec) && disableCatchAll {
+		if hasCatchAllIngressRule(ing.Spec) && disableCatchAll {
 			klog.InfoS("Ignoring delete for catch-all because of --disable-catch-all", "ingress", klog.KObj(ing))
 			return
 		}
@@ -353,7 +353,7 @@ func New(
 				return
 			}
 
-			if hasCatchAllIngress(ing.Spec) && disableCatchAll {
+			if hasCatchAllIngressRule(ing.Spec) && disableCatchAll {
 				klog.InfoS("Ignoring add for catch-all ingress because of --disable-catch-all", "ingress", klog.KObj(ing))
 				return
 			}
@@ -377,7 +377,7 @@ func New(
 			validOld := class.IsValid(oldIng)
 			validCur := class.IsValid(curIng)
 			if !validOld && validCur {
-				if hasCatchAllIngress(curIng.Spec) && disableCatchAll {
+				if hasCatchAllIngressRule(curIng.Spec) && disableCatchAll {
 					klog.InfoS("ignoring update for catch-all ingress because of --disable-catch-all", "ingress", klog.KObj(curIng))
 					return
 				}
@@ -389,7 +389,7 @@ func New(
 				ingDeleteHandler(old)
 				return
 			} else if validCur && !reflect.DeepEqual(old, cur) {
-				if hasCatchAllIngress(curIng.Spec) && disableCatchAll {
+				if hasCatchAllIngressRule(curIng.Spec) && disableCatchAll {
 					klog.InfoS("ignoring update for catch-all ingress and delete old one because of --disable-catch-all", "ingress", klog.KObj(curIng))
 					ingDeleteHandler(old)
 					return
@@ -624,9 +624,9 @@ func New(
 	return store
 }
 
-// hasCatchAllIngress returns whether or not an ingress produces a
+// hasCatchAllIngressRule returns whether or not an ingress produces a
 // catch-all server, and so should be ignored when --disable-catch-all is set
-func hasCatchAllIngress(spec networkingv1beta1.IngressSpec) bool {
+func hasCatchAllIngressRule(spec networkingv1beta1.IngressSpec) bool {
 	return spec.Backend != nil
 }
 


### PR DESCRIPTION
## What this PR does / why we need it:
When filtering ingresses for the `--disable-catch-all` flag, we determine an ingress is a catch-all if it has a backend spec and no rules spec (`spec.Backend != nil` and `len(spec.Rules) == 0`). However this is currently not true because an ingress with the following spec is able to override the default backend.
```
spec:
  backend:
    serviceName: http-svc
    servicePort: 80
  rules:
  - host: foo.com
    http:
      paths:
      - backend:
          serviceName: http-svc
          servicePort: 80
        pathType: ImplementationSpecific
```

This PR removes the `len(spec.Rules) == 0` check used to filter ingresses for the `--disable-catch-all` flag

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
