### PR TITLE
allow proxy-ssl-* annotations without proxy-ssl-secret

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -1344,13 +1344,25 @@ stream {
             # Location denied. Reason: {{ $location.Denied | quote }}
             return 503;
             {{ end }}
+
+            {{ if not (empty $location.ProxySSL.Verify) }}
+            proxy_ssl_verify                        {{ $location.ProxySSL.Verify }};
+            {{ if eq $location.ProxySSL.Verify "on" }}
             {{ if not (empty $location.ProxySSL.CAFileName) }}
             # PEM sha: {{ $location.ProxySSL.CASHA }}
             proxy_ssl_trusted_certificate           {{ $location.ProxySSL.CAFileName }};
-            proxy_ssl_ciphers                       {{ $location.ProxySSL.Ciphers }};
-            proxy_ssl_protocols                     {{ $location.ProxySSL.Protocols }};
-            proxy_ssl_verify                        {{ $location.ProxySSL.Verify }};
+            {{ else }}
+            proxy_ssl_trusted_certificate           /etc/ssl/cert.pem;
+            {{ end }}
             proxy_ssl_verify_depth                  {{ $location.ProxySSL.VerifyDepth }};
+            {{ end }}
+            {{ end }}
+
+            {{ if not (empty $location.ProxySSL.Ciphers) }}
+            proxy_ssl_ciphers                       {{ $location.ProxySSL.Ciphers }};
+            {{ end }}
+            {{ if not (empty $location.ProxySSL.Protocols) }}
+            proxy_ssl_protocols                     {{ $location.ProxySSL.Protocols }};
             {{ end }}
 
             {{ if not (empty $location.ProxySSL.ProxySSLName) }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

Allow the various proxy-ssl-* directives to be set independently.

## What this PR does / why we need it:

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Currently they are only applied if proxy-ssl-secret is set. However, not all proxy backends require mTLS, so making such a secret in this cases does not make any sense.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

fixes #6728

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
