### PR TITLE
Fix buggy retry logic in syncIngress()

### DIFF
--- a/cmd/nginx/flags.go
+++ b/cmd/nginx/flags.go
@@ -173,6 +173,9 @@ Takes the form "<host>:port". If not provided, no admission controller is starte
 		statusUpdateInterval = flags.Int("status-update-interval", status.UpdateInterval, "Time interval in seconds in which the status should check if an update is required. Default is 60 seconds")
 
 		shutdownGracePeriod = flags.Int("shutdown-grace-period", 0, "Seconds to wait after receiving the shutdown signal, before stopping the nginx process.")
+
+		dynamicConfigurationRetries = flags.Int("dynamic-configuration-retries", 15,
+			`Number of times to retry failed dynamic configuration before failing to sync an ingress.`)
 	)
 
 	flags.StringVar(&nginx.MaxmindMirror, "maxmind-mirror", "", `Maxmind mirror url (example: http://geoip.local/databases`)
@@ -293,10 +296,11 @@ https://blog.maxmind.com/2019/12/18/significant-changes-to-accessing-and-using-g
 			HTTPS:    *httpsPort,
 			SSLProxy: *sslProxyPort,
 		},
-		DisableCatchAll:           *disableCatchAll,
-		ValidationWebhook:         *validationWebhook,
-		ValidationWebhookCertPath: *validationWebhookCert,
-		ValidationWebhookKeyPath:  *validationWebhookKey,
+		DisableCatchAll:             *disableCatchAll,
+		ValidationWebhook:           *validationWebhook,
+		ValidationWebhookCertPath:   *validationWebhookCert,
+		ValidationWebhookKeyPath:    *validationWebhookKey,
+		DynamicConfigurationRetries: *dynamicConfigurationRetries,
 	}
 
 	if *apiserverHost != "" {

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -178,7 +178,7 @@ func (n *NGINXController) syncIngress(interface{}) error {
 	retry := wait.Backoff{
 		Steps:    15,
 		Duration: 1 * time.Second,
-		Factor:   0.8,
+		Factor:   1.2,
 		Jitter:   0.1,
 	}
 

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -108,6 +108,8 @@ type Configuration struct {
 	MonitorMaxBatchSize int
 
 	ShutdownGracePeriod int
+
+	DynamicConfigurationRetries int
 }
 
 // GetPublishService returns the Service used to set the load-balancer status of Ingresses.
@@ -176,7 +178,7 @@ func (n *NGINXController) syncIngress(interface{}) error {
 	}
 
 	retry := wait.Backoff{
-		Steps:    15,
+		Steps:    1 + n.cfg.DynamicConfigurationRetries,
 		Duration: time.Second,
 		Factor:   1.3,
 		Jitter:   0.1,

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -177,8 +177,8 @@ func (n *NGINXController) syncIngress(interface{}) error {
 
 	retry := wait.Backoff{
 		Steps:    15,
-		Duration: 1 * time.Second,
-		Factor:   1.2,
+		Duration: time.Second,
+		Factor:   1.3,
 		Jitter:   0.1,
 	}
 


### PR DESCRIPTION
## What this PR does / why we need it:
NGINXController.syncIngress in internal/ingress/controller/controller.go is clearly intended to do retries with exponential backoff when calling configureDynamically(). However, due to what seems to be a bug, it won't do any retries. This bugfix contribution fixes that bug, so NGINXController.syncIngress will start doing retries according to the retry policy that seems to have been the original intent.

Per the documentation for wait.ExponentialBackoff, this function "stops and returns as soon as [...] the condition check returns true or an error". The previous implementation of the condition check always returned either true (success) or an error (failure) -- as such, retries would never actually trigger.

We've had issues with this "retry" loop on a real deployment on multiple occasions. This manifests as the nginx-controller failing to get healthy and getting stuck in a crashloop for minutes or hours with an errors akin to this:

    Unexpected failure reconfiguring NGINX:
    "requeuing" err="Post \"http://127.0.0.1:10246/configuration/backends\": dial tcp 127.0.0.1:10246: connect: connection refused" key="initial-sync"

The hope is that this bugfix will resolve this existing crash-on-startup bug by allowing more time (as much time as originally intended) for port 10246 to start listening.

Since the amount of time required will depend on configuration size, as noted in the pre-existing comment, I've also added a flag to control the number of retries.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes

might fix #4742

Also referenced in the comments of this one: https://github.com/kubernetes/ingress-nginx/issues/4629#issuecomment-537524234

## How Has This Been Tested?
I ran "make test", and everything seemed to pass. (On my development Linux laptop.)

I don't have enough context in the code to know how to easily write a unit test for this. If the reviewers want to require one, pointers on how to set up a test to call a callback function from configureDynamically() would be appreciated.

Update: I attempted to test on a testing cluster. I added lots of ingresses (164 ingresses) and restarted the nginx-controller pods -- first with a control version, then with an image including this patch. I was able to reproduce the "connection refused" error as noted above and as such got to see the retries working. However, in the stress test conditions, even 15 retries were not enough and I ultimately got "Unexpected failure reconfiguring NGINX" again. I was also unable to reproduce the crash _loop_ (both with the control version and the patch) -- both the control version and the patch came up after a few minutes on the second attempt.

The control version I used was: k8s.gcr.io/ingress-nginx/controller:v0.45.0@sha256:c4390c53f348c3bd4e60a5dd6a11c35799ae78c49388090140b9d72ccede1755 

This testing attempt also uncovered a secondary bug: 15 retries take around 5 seconds because the Factor is set to 0.8, meaning this is a rarely-seen example of exponential backoff where the retry delay gets shorter and shorter. That's almost certainly not what was intended. I'll set it to 1.2 instead.

Update 2: tried again with the fixed backoff factor and overall more lax settings. In my stress test conditions, the controller came up after 67 seconds. I've suggested bumping the factor to 1.3 so that this apparently-realistic-if-overloaded scenario can finish successfully. Really, though -- perhaps the retry budget here should be somehow configurable? (Added a flag.)
 
## Checklist:
- [X] My change requires a change to the documentation. (If we're adding a flag, should document it.)
- [ ] I have updated the documentation accordingly. (Waiting to see whether reviewers think this warrants a flag. If so, please point me to the docs that should be updated.)
- [X] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
