### PR TITLE
Fix MaxWorkerOpenFiles calculation on high cores nodes

### DIFF
--- a/docs/user-guide/nginx-configuration/configmap.md
+++ b/docs/user-guide/nginx-configuration/configmap.md
@@ -451,7 +451,7 @@ _**default:**_ 16384
 ## max-worker-open-files
 
 Sets the [maximum number of files](http://nginx.org/en/docs/ngx_core_module.html#worker_rlimit_nofile) that can be opened by each worker process.
-The default of 0 means "max open files (system's limit) / [worker-processes](#worker-processes) - 1024".
+The default of 0 means "max open files (system's limit) - 1024".
 _**default:**_ 0
 
 ## map-hash-bucket-size

--- a/internal/ingress/controller/nginx.go
+++ b/internal/ingress/controller/nginx.go
@@ -512,12 +512,7 @@ func (n NGINXController) generateTemplate(cfg ngx_config.Configuration, ingressC
 	if cfg.MaxWorkerOpenFiles == 0 {
 		// the limit of open files is per worker process
 		// and we leave some room to avoid consuming all the FDs available
-		wp, err := strconv.Atoi(cfg.WorkerProcesses)
-		klog.V(3).InfoS("Worker processes", "count", wp)
-		if err != nil {
-			wp = 1
-		}
-		maxOpenFiles := (rlimitMaxNumFiles() / wp) - 1024
+		maxOpenFiles := rlimitMaxNumFiles() - 1024
 		klog.V(3).InfoS("Maximum number of open file descriptors", "value", maxOpenFiles)
 		if maxOpenFiles < 1024 {
 			// this means the value of RLIMIT_NOFILE is too low.

--- a/test/e2e/settings/global_options.go
+++ b/test/e2e/settings/global_options.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package settings
+
+import (
+	"fmt"
+	"strings"
+	"syscall"
+
+	"github.com/onsi/ginkgo"
+	"k8s.io/ingress-nginx/test/e2e/framework"
+)
+
+var _ = framework.IngressNginxDescribe("global-options", func() {
+	f := framework.NewDefaultFramework("global-options")
+
+	ginkgo.It("should have worker_rlimit_nofile option", func() {
+		f.WaitForNginxConfiguration(func(server string) bool {
+			return strings.Contains(server, fmt.Sprintf("worker_rlimit_nofile %d;", rlimitMaxNumFiles()-1024))
+
+		})
+	})
+
+	ginkgo.It("should have worker_rlimit_nofile option and be independent on amount of worker processes", func() {
+		f.SetNginxConfigMapData(map[string]string{
+			"worker-processes": "11",
+		})
+
+		f.WaitForNginxConfiguration(func(server string) bool {
+			return strings.Contains(server, "worker_processes 11;") &&
+				strings.Contains(server, fmt.Sprintf("worker_rlimit_nofile %d;", rlimitMaxNumFiles()-1024))
+		})
+	})
+})
+
+// rlimitMaxNumFiles returns hard limit for RLIMIT_NOFILE
+func rlimitMaxNumFiles() int {
+	var rLimit syscall.Rlimit
+	err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rLimit)
+	if err != nil {
+		return 0
+	}
+	return int(rLimit.Max)
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

Re-open of my stale PR #5627.
Added tests and fixed doc.

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Default MaxWorkerOpenFiles (`max-worker-open-files`) value becomes too low on high spec nodes with multiple of cores.
As workaround it always possible to provide exact value through configMap: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#max-worker-open-files

Currently max opened files is calculated based on `RLIMIT_NOFILE` divided on amount of working processes.
https://github.com/kubernetes/ingress-nginx/blob/07b70f68bd9b4367c5266ec2cb068f97e4a5b40a/internal/ingress/controller/nginx.go#L539-L544

Working processes is calculated based on amount of cores.
https://github.com/kubernetes/ingress-nginx/blob/bef2efc4f303b728b9f5ef9326fbcd25376d5e6b/internal/ingress/controller/config/config.go#L751

Our example:
```
$ sysctl fs.file-max
fs.file-max = 6506158
$ ulimit -Sn
65536
$ ulimit -Hn
65536
$ lscpu  | grep 'CPU(s)' | head -n 1
CPU(s):              40
```

As a result, we have `65536  / 40 - 1024 = 614.4`. This is less than `1024`, so `1024` is actually used. 
This value is too small for single worker on heavy loaded server with thousands total connections.

Since RLIMIT_NOFILE is already a value per single process, there's no need divide by worker_processes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->
* #5627 - my previous stale PR about the same
* #2055 - similar problem
* #2157 - similar problem
* #2050 (this tries use Global value of max opened files)
* #2241 (this reverts that change and per-process value of max opened files)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
E2e test

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
