### PR TITLE
Fixed markdown typo in deploy/index.md

### DIFF
--- a/docs/deploy/index.md
+++ b/docs/deploy/index.md
@@ -15,16 +15,16 @@
 
 !!! attention
     The first time the ingress controller starts, two [Jobs](https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/) create the SSL Certificate used by the admission webhook.
-    For this reason, there is an initial delay of up to two minutes until it is possible to create and validate Ingress definitions.
+    For this reason, there is an initial delay of up to two minutes until it is possible to create and validate Ingress definitions. 
 
-    You can wait until it is ready to run the next command:
+You can wait until it is ready to run the next command:
 
-    ```yaml
-    kubectl wait --namespace ingress-nginx \
-      --for=condition=ready pod \
-      --selector=app.kubernetes.io/component=controller \
-      --timeout=120s
-    ```
+```yaml
+ kubectl wait --namespace ingress-nginx \
+  --for=condition=ready pod \
+  --selector=app.kubernetes.io/component=controller \
+  --timeout=120s
+```
 
 ## Contents
 


### PR DESCRIPTION
Fixed a funky looking markdown typo.

Signed-off-by: Mathis Van Eetvelde <mathis.vaneetvelde@protonmail.com>

