### PR TITLE
Ensure `ttlSecondsAfterFinished` is set on Job resources in static deploy manifests

### DIFF
--- a/deploy/static/provider/aws/deploy-tls-termination.yaml
+++ b/deploy/static/provider/aws/deploy-tls-termination.yaml
@@ -589,6 +589,8 @@ metadata:
     app.kubernetes.io/component: admission-webhook
   namespace: ingress-nginx
 spec:
+  # Alpha feature since k8s 1.12
+  ttlSecondsAfterFinished: 0
   template:
     metadata:
       name: ingress-nginx-admission-create
@@ -637,6 +639,8 @@ metadata:
     app.kubernetes.io/component: admission-webhook
   namespace: ingress-nginx
 spec:
+  # Alpha feature since k8s 1.12
+  ttlSecondsAfterFinished: 0
   template:
     metadata:
       name: ingress-nginx-admission-patch

--- a/deploy/static/provider/aws/deploy.yaml
+++ b/deploy/static/provider/aws/deploy.yaml
@@ -576,6 +576,8 @@ metadata:
     app.kubernetes.io/component: admission-webhook
   namespace: ingress-nginx
 spec:
+  # Alpha feature since k8s 1.12
+  ttlSecondsAfterFinished: 0
   template:
     metadata:
       name: ingress-nginx-admission-create
@@ -624,6 +626,8 @@ metadata:
     app.kubernetes.io/component: admission-webhook
   namespace: ingress-nginx
 spec:
+  # Alpha feature since k8s 1.12
+  ttlSecondsAfterFinished: 0
   template:
     metadata:
       name: ingress-nginx-admission-patch

--- a/deploy/static/provider/baremetal/deploy.yaml
+++ b/deploy/static/provider/baremetal/deploy.yaml
@@ -571,6 +571,8 @@ metadata:
     app.kubernetes.io/component: admission-webhook
   namespace: ingress-nginx
 spec:
+  # Alpha feature since k8s 1.12
+  ttlSecondsAfterFinished: 0
   template:
     metadata:
       name: ingress-nginx-admission-create
@@ -619,6 +621,8 @@ metadata:
     app.kubernetes.io/component: admission-webhook
   namespace: ingress-nginx
 spec:
+  # Alpha feature since k8s 1.12
+  ttlSecondsAfterFinished: 0
   template:
     metadata:
       name: ingress-nginx-admission-patch

--- a/deploy/static/provider/cloud/deploy.yaml
+++ b/deploy/static/provider/cloud/deploy.yaml
@@ -573,6 +573,8 @@ metadata:
     app.kubernetes.io/component: admission-webhook
   namespace: ingress-nginx
 spec:
+  # Alpha feature since k8s 1.12
+  ttlSecondsAfterFinished: 0
   template:
     metadata:
       name: ingress-nginx-admission-create
@@ -621,6 +623,8 @@ metadata:
     app.kubernetes.io/component: admission-webhook
   namespace: ingress-nginx
 spec:
+  # Alpha feature since k8s 1.12
+  ttlSecondsAfterFinished: 0
   template:
     metadata:
       name: ingress-nginx-admission-patch

--- a/deploy/static/provider/do/deploy.yaml
+++ b/deploy/static/provider/do/deploy.yaml
@@ -575,6 +575,8 @@ metadata:
     app.kubernetes.io/component: admission-webhook
   namespace: ingress-nginx
 spec:
+  # Alpha feature since k8s 1.12
+  ttlSecondsAfterFinished: 0
   template:
     metadata:
       name: ingress-nginx-admission-create
@@ -623,6 +625,8 @@ metadata:
     app.kubernetes.io/component: admission-webhook
   namespace: ingress-nginx
 spec:
+  # Alpha feature since k8s 1.12
+  ttlSecondsAfterFinished: 0
   template:
     metadata:
       name: ingress-nginx-admission-patch

--- a/deploy/static/provider/exoscale/deploy.yaml
+++ b/deploy/static/provider/exoscale/deploy.yaml
@@ -581,6 +581,8 @@ metadata:
     app.kubernetes.io/component: admission-webhook
   namespace: ingress-nginx
 spec:
+  # Alpha feature since k8s 1.12
+  ttlSecondsAfterFinished: 0
   template:
     metadata:
       name: ingress-nginx-admission-create
@@ -629,6 +631,8 @@ metadata:
     app.kubernetes.io/component: admission-webhook
   namespace: ingress-nginx
 spec:
+  # Alpha feature since k8s 1.12
+  ttlSecondsAfterFinished: 0
   template:
     metadata:
       name: ingress-nginx-admission-patch

--- a/deploy/static/provider/kind/deploy.yaml
+++ b/deploy/static/provider/kind/deploy.yaml
@@ -583,6 +583,8 @@ metadata:
     app.kubernetes.io/component: admission-webhook
   namespace: ingress-nginx
 spec:
+  # Alpha feature since k8s 1.12
+  ttlSecondsAfterFinished: 0
   template:
     metadata:
       name: ingress-nginx-admission-create
@@ -631,6 +633,8 @@ metadata:
     app.kubernetes.io/component: admission-webhook
   namespace: ingress-nginx
 spec:
+  # Alpha feature since k8s 1.12
+  ttlSecondsAfterFinished: 0
   template:
     metadata:
       name: ingress-nginx-admission-patch

--- a/deploy/static/provider/scw/deploy.yaml
+++ b/deploy/static/provider/scw/deploy.yaml
@@ -575,6 +575,8 @@ metadata:
     app.kubernetes.io/component: admission-webhook
   namespace: ingress-nginx
 spec:
+  # Alpha feature since k8s 1.12
+  ttlSecondsAfterFinished: 0
   template:
     metadata:
       name: ingress-nginx-admission-create
@@ -623,6 +625,8 @@ metadata:
     app.kubernetes.io/component: admission-webhook
   namespace: ingress-nginx
 spec:
+  # Alpha feature since k8s 1.12
+  ttlSecondsAfterFinished: 0
   template:
     metadata:
       name: ingress-nginx-admission-patch

--- a/hack/generate-deploy-scripts.sh
+++ b/hack/generate-deploy-scripts.sh
@@ -27,6 +27,9 @@ DIR=$(cd $(dirname "${BASH_SOURCE}")/.. && pwd -P)
 RELEASE_NAME=ingress-nginx
 NAMESPACE=ingress-nginx
 
+# ensures `ttlSecondsAfterFinished` gets set on Job specs
+API_VERSIONS=batch/v1alpha1
+
 NAMESPACE_VAR="
 apiVersion: v1
 kind: Namespace
@@ -39,7 +42,7 @@ metadata:
 
 # Baremetal
 OUTPUT_FILE="${DIR}/deploy/static/provider/baremetal/deploy.yaml"
-cat << EOF | helm template $RELEASE_NAME ${DIR}/charts/ingress-nginx --namespace $NAMESPACE --values - | $DIR/hack/add-namespace.py $NAMESPACE > ${OUTPUT_FILE}
+cat << EOF | helm template $RELEASE_NAME ${DIR}/charts/ingress-nginx --namespace $NAMESPACE --api-versions $API_VERSIONS --values - | $DIR/hack/add-namespace.py $NAMESPACE > ${OUTPUT_FILE}
 controller:
   service:
     type: NodePort
@@ -53,7 +56,7 @@ $(cat ${OUTPUT_FILE})" > ${OUTPUT_FILE}
 
 # Cloud - generic
 OUTPUT_FILE="${DIR}/deploy/static/provider/cloud/deploy.yaml"
-cat << EOF | helm template $RELEASE_NAME ${DIR}/charts/ingress-nginx --namespace $NAMESPACE --values - | $DIR/hack/add-namespace.py $NAMESPACE > ${OUTPUT_FILE}
+cat << EOF | helm template $RELEASE_NAME ${DIR}/charts/ingress-nginx --namespace $NAMESPACE --api-versions $API_VERSIONS --values - | $DIR/hack/add-namespace.py $NAMESPACE > ${OUTPUT_FILE}
 controller:
   service:
     type: LoadBalancer
@@ -66,7 +69,7 @@ $(cat ${OUTPUT_FILE})" > ${OUTPUT_FILE}
 
 # AWS - NLB
 OUTPUT_FILE="${DIR}/deploy/static/provider/aws/deploy.yaml"
-cat << EOF | helm template $RELEASE_NAME ${DIR}/charts/ingress-nginx --namespace $NAMESPACE --values - | $DIR/hack/add-namespace.py $NAMESPACE > ${OUTPUT_FILE}
+cat << EOF | helm template $RELEASE_NAME ${DIR}/charts/ingress-nginx --namespace $NAMESPACE --api-versions $API_VERSIONS --values - | $DIR/hack/add-namespace.py $NAMESPACE > ${OUTPUT_FILE}
 controller:
   service:
     type: LoadBalancer
@@ -82,7 +85,7 @@ $(cat ${OUTPUT_FILE})" > ${OUTPUT_FILE}
 
 
 OUTPUT_FILE="${DIR}/deploy/static/provider/aws/deploy-tls-termination.yaml"
-cat << EOF | helm template $RELEASE_NAME ${DIR}/charts/ingress-nginx --namespace $NAMESPACE --values - | $DIR/hack/add-namespace.py $NAMESPACE > ${OUTPUT_FILE}
+cat << EOF | helm template $RELEASE_NAME ${DIR}/charts/ingress-nginx --namespace $NAMESPACE --api-versions $API_VERSIONS --values - | $DIR/hack/add-namespace.py $NAMESPACE > ${OUTPUT_FILE}
 controller:
   service:
     type: LoadBalancer
@@ -124,7 +127,7 @@ $(cat ${OUTPUT_FILE})" > ${OUTPUT_FILE}
 
 # Kind - https://kind.sigs.k8s.io/docs/user/ingress/
 OUTPUT_FILE="${DIR}/deploy/static/provider/kind/deploy.yaml"
-cat << EOF | helm template $RELEASE_NAME ${DIR}/charts/ingress-nginx --namespace $NAMESPACE --values - | $DIR/hack/add-namespace.py $NAMESPACE > ${OUTPUT_FILE}
+cat << EOF | helm template $RELEASE_NAME ${DIR}/charts/ingress-nginx --namespace $NAMESPACE --api-versions $API_VERSIONS --values - | $DIR/hack/add-namespace.py $NAMESPACE > ${OUTPUT_FILE}
 controller:
   updateStrategy:
     type: RollingUpdate
@@ -154,7 +157,7 @@ echo "${NAMESPACE_VAR}
 $(cat ${OUTPUT_FILE})" > ${OUTPUT_FILE}
 
 OUTPUT_FILE="${DIR}/deploy/static/provider/do/deploy.yaml"
-cat << EOF | helm template $RELEASE_NAME ${DIR}/charts/ingress-nginx --namespace $NAMESPACE --values - | $DIR/hack/add-namespace.py $NAMESPACE > ${OUTPUT_FILE}
+cat << EOF | helm template $RELEASE_NAME ${DIR}/charts/ingress-nginx --namespace $NAMESPACE --api-versions $API_VERSIONS --values - | $DIR/hack/add-namespace.py $NAMESPACE > ${OUTPUT_FILE}
 controller:
   service:
     type: LoadBalancer
@@ -171,7 +174,7 @@ echo "${NAMESPACE_VAR}
 $(cat ${OUTPUT_FILE})" > ${OUTPUT_FILE}
 
 OUTPUT_FILE="${DIR}/deploy/static/provider/scw/deploy.yaml"
-cat << EOF | helm template $RELEASE_NAME ${DIR}/charts/ingress-nginx --namespace $NAMESPACE --values - | $DIR/hack/add-namespace.py $NAMESPACE > ${OUTPUT_FILE}
+cat << EOF | helm template $RELEASE_NAME ${DIR}/charts/ingress-nginx --namespace $NAMESPACE --api-versions $API_VERSIONS --values - | $DIR/hack/add-namespace.py $NAMESPACE > ${OUTPUT_FILE}
 controller:
   service:
     type: LoadBalancer
@@ -188,7 +191,7 @@ echo "${NAMESPACE_VAR}
 $(cat ${OUTPUT_FILE})" > ${OUTPUT_FILE}
 
 OUTPUT_FILE="${DIR}/deploy/static/provider/exoscale/deploy.yaml"
-cat << EOF | helm template $RELEASE_NAME ${DIR}/charts/ingress-nginx --namespace $NAMESPACE --values - | $DIR/hack/add-namespace.py $NAMESPACE > ${OUTPUT_FILE}
+cat << EOF | helm template $RELEASE_NAME ${DIR}/charts/ingress-nginx --namespace $NAMESPACE --api-versions $API_VERSIONS --values - | $DIR/hack/add-namespace.py $NAMESPACE > ${OUTPUT_FILE}
 controller:
   kind: DaemonSet
   service:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

`Job` resources are not automatically pruned after completion which prevents in-place version upgrades when deploying from static manifests. See #7118.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

**Note:** this is only a "breaking" change in the sense that the static deploy manifests will now assume capabilities of the API version `batch/v1alpha1` are available (i.e. k8s >=1.12).

## Which issue/s this PR fixes

fixes #7118

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This change is inline with the existing functionality of the helm chart. Please see #7118 for steps on how to reproduce the original issue.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
