### PR TITLE
fix: use exponential backoff policy to listen on `nginx.StatusPort` in unit test cases

### DIFF
--- a/internal/ingress/controller/checker_test.go
+++ b/internal/ingress/controller/checker_test.go
@@ -18,7 +18,6 @@ package controller
 
 import (
 	"fmt"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -46,7 +45,7 @@ func TestNginxCheck(t *testing.T) {
 
 			mux := http.NewServeMux()
 
-			listener, err := net.Listen("tcp", fmt.Sprintf(":%v", nginx.StatusPort))
+			listener, err := tryListen("tcp", fmt.Sprintf(":%v", nginx.StatusPort))
 			if err != nil {
 				t.Fatalf("creating tcp listener: %s", err)
 			}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Currently, unit test cases are run parallelly, however, some test cases might listen on the Nginx status port (`10246`) simultaneously, which broken their running.

In this Pull Request, an exponential backoff policy is applied in these unit test cases, considering these test cases won't run continuously for a long while, it should be effective.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

#7127 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
