### PR TITLE
Allowing mod-security to be enabled from the controller

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -149,16 +149,17 @@ http {
     {{ if $all.Cfg.EnableModsecurity }}
     modsecurity on;
 
-    modsecurity_rules_file /etc/nginx/modsecurity/modsecurity.conf;
-
-    {{ if $all.Cfg.EnableOWASPCoreRules }}
-    modsecurity_rules_file /etc/nginx/owasp-modsecurity-crs/nginx-modsecurity.conf;
-    {{ else if (not (empty $all.Cfg.ModsecuritySnippet)) }}
+    {{ if (not (empty $all.Cfg.ModsecuritySnippet)) }}
     modsecurity_rules '
       {{ $all.Cfg.ModsecuritySnippet }}
     ';
     {{ end }}
 
+    modsecurity_rules_file /etc/nginx/modsecurity/modsecurity.conf;
+
+    {{ if $all.Cfg.EnableOWASPCoreRules }}
+    modsecurity_rules_file /etc/nginx/owasp-modsecurity-crs/nginx-modsecurity.conf;
+    {{ end }}
     {{ end }}
 
     {{ if $cfg.UseGeoIP }}

--- a/test/e2e/annotations/modsecurity.go
+++ b/test/e2e/annotations/modsecurity.go
@@ -216,4 +216,81 @@ var _ = framework.DescribeAnnotation("modsecurity owasp", func() {
 			Expect().
 			Status(http.StatusForbidden)
 	})
+
+	ginkgo.It("should enable modsecurity when enable-owasp-modsecurity-crs is set to true", func() {
+		host := "modsecurity.foo.com"
+		nameSpace := f.Namespace
+
+		snippet := `SecRuleEngine On
+		SecRequestBodyAccess On
+		SecAuditEngine RelevantOnly
+		SecAuditLogParts ABIJDEFHZ
+		SecAuditLog /dev/stdout
+		SecAuditLogType Serial
+		SecRule REQUEST_HEADERS:User-Agent \"block-ua\" \"log,deny,id:107,status:403,msg:\'UA blocked\'\"`
+
+		annotations := map[string]string{
+			"nginx.ingress.kubernetes.io/modsecurity-snippet": snippet,
+		}
+
+		ing := framework.NewSingleIngress(host, "/", host, nameSpace, framework.EchoService, 80, annotations)
+		f.EnsureIngress(ing)
+
+		f.SetNginxConfigMapData(map[string]string{
+			"enable-modsecurity":  "true",
+			"enable-owasp-modsecurity-crs": "true",
+		})
+
+
+		f.WaitForNginxServer(host,
+			func(server string) bool {
+				return strings.Contains(server, "SecRuleEngine On")
+			})
+
+		f.HTTPTestClient().
+			GET("/").
+			WithHeader("Host", host).
+			WithHeader("User-Agent", "block-ua").
+			Expect().
+			Status(http.StatusForbidden)
+	})
+
+	ginkgo.It("should enable modsecurity through the config map", func() {
+		host := "modsecurity.foo.com"
+		nameSpace := f.Namespace
+
+		snippet := `SecRequestBodyAccess On
+		SecAuditEngine RelevantOnly
+		SecAuditLogParts ABIJDEFHZ
+		SecAuditLog /dev/stdout
+		SecAuditLogType Serial
+		SecRule REQUEST_HEADERS:User-Agent \"block-ua\" \"log,deny,id:107,status:403,msg:\'UA blocked\'\"`
+
+		annotations := map[string]string{
+			"nginx.ingress.kubernetes.io/modsecurity-snippet": snippet,
+		}
+
+		ing := framework.NewSingleIngress(host, "/", host, nameSpace, framework.EchoService, 80, annotations)
+		f.EnsureIngress(ing)
+
+		expectedComment := "SecRuleEngine On"
+
+		f.SetNginxConfigMapData(map[string]string{
+			"enable-modsecurity":  "true",
+			"enable-owasp-modsecurity-crs": "true",
+			"modsecurity-snippet": expectedComment,
+		})
+
+		f.WaitForNginxServer(host,
+			func(server string) bool {
+				return true
+			})
+
+		f.HTTPTestClient().
+			GET("/").
+			WithHeader("Host", host).
+			WithHeader("User-Agent", "block-ua").
+			Expect().
+			Status(http.StatusForbidden)
+	})
 })


### PR DESCRIPTION
Opening a new PR as the other [one](https://github.com/kubernetes/ingress-nginx/pull/6589) was too messy.

As it stands, ModSecurity can only be taken off of DetectionOnly mode through Ingress resources. It would be nice to be able to enable it through the Ingress controller so it can be active across the cluster.

## What this PR does / why we need it:
This change aims to allow users to enable ModSecurity from their Nginx controller.
I began trying to fix this by what was outlined [here](https://github.com/kubernetes/ingress-nginx/issues/6307#issuecomment-714211944).
I also restructured it so it would fix [this](this) issue. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## How Has This Been Tested?
I ran the local automated test and build an image which I used to see if the issue had been fixed and added tests that check to verify that it is enabled when added to the controller.


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

