### PR TITLE
Remove "Development" from Welcome page

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,7 +72,6 @@ nav:
       - How it works: "how-it-works.md"
       - Troubleshooting: "troubleshooting.md"
       - kubectl plugin: "kubectl-plugin.md"
-      - Development: "development.md"
   - Deployment:
       - Installation Guide: "deploy/index.md"
       - Bare-metal considerations: "deploy/baremetal.md"


### PR DESCRIPTION
## What this PR does / why we need it:
The development.md file does not exist. Clicking on "Development" link
on the Welcome page returns a 404. We already have a Developer Guide.
Having the Development page should not be required. Hence, I am
proposing that we remove it.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
  functionality to change)

  ## Checklist:
  <!--- Go over all the following points, and put an `x` in all the
  boxes that apply. -->
  <!--- If you're unsure about any of these, don't hesitate to ask.
  We're here to help! -->
  - [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
  - [x] I've read the
  [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md)
    guide
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.

Duplicate of #7150 . Adding this separately to check if the cla signing has worked. Will close #7150 if it has.