### PR TITLE
Increase timeout for cloud build

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,6 +1,6 @@
 # See https://cloud.google.com/cloud-build/docs/build-config
 
-timeout: 1800s
+timeout: 21600s
 options:
   substitution_option: ALLOW_LOOSE
 steps:

--- a/images/nginx/cloudbuild.yaml
+++ b/images/nginx/cloudbuild.yaml
@@ -1,4 +1,4 @@
-timeout: 10800s
+timeout: 21600s
 options:
   substitution_option: ALLOW_LOOSE
   # job builds a multi-arch docker image for amd64,arm,arm64 and s390x.


### PR DESCRIPTION
## What this PR does / why we need it:

Previous builds for updating Nginx base image is taking [~3 hours to build ](https://console.cloud.google.com/cloud-build/builds;region=global/c55ca536-a70a-40d2-a8be-4fca5fc79940?project=k8s-staging-ingress-nginx)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

