### PR TITLE
update release docs with build.sh SHA requirements

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,11 @@
-1. [nginx](https://github.com/kubernetes/ingress-nginx/tree/master/images/nginx)
+1. [NGINX](https://github.com/kubernetes/ingress-nginx/tree/master/images/nginx)
 
 * Open pull request
+  
+If you are updating any component in [build.sh](images/nginx/rootfs/build.sh) please also update the SHA256 checksum of that component as 
+  well, the cloud build will fail with an exit 10 if not.  
+Example [NGINX_VERSION](images/nginx/rootfs/build.sh#L21),
+[SHA256](images/nginx/rootfs/build.sh#L124) 
 * Merge
 * Wait for [cloud build](https://console.cloud.google.com/cloud-build/builds?project=k8s-staging-ingress-nginx)
 


### PR DESCRIPTION
When updating base components like the NGINX version to use, the build shell script checks the SHA256 of that component. This PR adds this to the release doc for future committers to be aware of. 

## Which issue/s this PR fixes

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
