### PR TITLE
Admission: Skip validation checks if an ingress is marked as deleted

### DIFF
--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -214,6 +214,11 @@ func (n *NGINXController) CheckIngress(ing *networking.Ingress) error {
 		return nil
 	}
 
+	// Skip checks if the ingress is marked as deleted
+	if !ing.DeletionTimestamp.IsZero() {
+		return nil
+	}
+
 	if !class.IsValid(ing) {
 		klog.Warningf("ignoring ingress %v in %v based on annotation %v", ing.Name, ing.ObjectMeta.Namespace, class.IngressKey)
 		return nil

--- a/internal/ingress/controller/controller_test.go
+++ b/internal/ingress/controller/controller_test.go
@@ -294,6 +294,16 @@ func TestCheckIngress(t *testing.T) {
 			}
 		})
 	})
+
+	t.Run("When the ingress is marked as deleted", func(t *testing.T) {
+		ing.DeletionTimestamp = &metav1.Time{
+			Time: time.Now(),
+		}
+
+		if nginx.CheckIngress(ing) != nil {
+			t.Errorf("when the ingress is marked as deleted, no error should be returned")
+		}
+	})
 }
 
 func TestMergeAlternativeBackends(t *testing.T) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We have an internal controller that registers ingresses into our routing layer, we add finalizers to all ingresses that have been registered with the routing layer. 

We use finalizers for cleanup/garbage collection as recommended here: https://book.kubebuilder.io/reference/using-finalizers.html:

> Finalizers allow controllers to implement asynchronous pre-delete hooks. Let’s say you create an external resource (such as a storage bucket) for each object of your API type, and you want to delete the associated external resource on object’s deletion from Kubernetes, you can use a finalizer to do that.
>
> The key point to note is that a finalizer causes “delete” on the object to become an “update” to set deletion timestamp. Presence of deletion timestamp on the object indicates that it is being deleted. Otherwise, without finalizers, a delete shows up as a reconcile where the object is missing from the cache.


We have been running into an issue where our controller is unable to remove its finalizer because the admission webhook rejects the `update` call. This happens when a single deploy creates a new ingress with the same paths while deleting an older one. 

Since a finalizer turns `delete` events into `update` events but with the deletion timestamp set on the object, our controller **has to remove** the finalizer for the ingress object to be deleted by Kubernetes or otherwise the ingress will stick around forever


Logs:
```
sample-controller-b47b4787b-fhqkn sample-controller {"level":"error","ts":1622816911.4505384,"logger":"sample.controller.ingress","msg":"removing finalizer","reconciler group":"networking.k8s.io","reconciler kind":"Ingress","name":"web-fake","namespace":"foobar","error":"admission webhook \"validate.nginx.ingress.kubernetes.io\" denied the request: host \"foo.bar.com\" and path \"/fake/graphql\" is already defined in ingress foobar/web-public"}
sample-controller-b47b4787b-fhqkn sample-controller {"level":"error","ts":1622816911.4506292,"logger":"sample.controller.ingress","msg":"Reconciler error","reconciler group":"networking.k8s.io","reconciler kind":"Ingress","name":"web-fake","namespace":"foobar","error":"admission webhook \"validate.nginx.ingress.kubernetes.io\" denied the request: host \"foo.bar.com\" and path \"/fake/graphql\" is already defined in ingress foobar/web-public"}
```


This PR handles this edge case by returning early in `CheckIngress` if an ingress is marked as deleted

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## How Has This Been Tested?

Added a test case where the `DeletionTimestamp` is non zero and asserting against no errors being returned by `CheckIngress`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
