### PR TITLE
fix: discover mounted geoip db files

### DIFF
--- a/cmd/nginx/flags.go
+++ b/cmd/nginx/flags.go
@@ -308,13 +308,15 @@ https://blog.maxmind.com/2019/12/18/significant-changes-to-accessing-and-using-g
 	}
 
 	var err error
-	if (nginx.MaxmindLicenseKey != "" || nginx.MaxmindMirror != "") && nginx.MaxmindEditionIDs != "" {
+	if nginx.MaxmindEditionIDs != "" {
 		if err = nginx.ValidateGeoLite2DBEditions(); err != nil {
 			return false, nil, err
 		}
-		klog.InfoS("downloading maxmind GeoIP2 databases")
-		if err = nginx.DownloadGeoLite2DB(nginx.MaxmindRetriesCount, nginx.MaxmindRetriesTimeout); err != nil {
-			klog.ErrorS(err, "unexpected error downloading GeoIP2 database")
+		if nginx.MaxmindLicenseKey != "" || nginx.MaxmindMirror != "" {
+			klog.InfoS("downloading maxmind GeoIP2 databases")
+			if err = nginx.DownloadGeoLite2DB(nginx.MaxmindRetriesCount, nginx.MaxmindRetriesTimeout); err != nil {
+				klog.ErrorS(err, "unexpected error downloading GeoIP2 database")
+			}
 		}
 		config.MaxmindEditionFiles = nginx.MaxmindEditionFiles
 	}

--- a/cmd/nginx/flags.go
+++ b/cmd/nginx/flags.go
@@ -318,7 +318,7 @@ https://blog.maxmind.com/2019/12/18/significant-changes-to-accessing-and-using-g
 				klog.ErrorS(err, "unexpected error downloading GeoIP2 database")
 			}
 		}
-		config.MaxmindEditionFiles = nginx.MaxmindEditionFiles
+		config.MaxmindEditionFiles = &nginx.MaxmindEditionFiles
 	}
 
 	return false, config, err

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -925,7 +925,7 @@ type TemplateConfig struct {
 	ListenPorts              *ListenPorts
 	PublishService           *apiv1.Service
 	EnableMetrics            bool
-	MaxmindEditionFiles      []string
+	MaxmindEditionFiles      *[]string
 	MonitorMaxBatchSize      int
 
 	PID        string

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -105,7 +105,7 @@ type Configuration struct {
 	ValidationWebhookKeyPath  string
 
 	GlobalExternalAuth  *ngx_config.GlobalExternalAuth
-	MaxmindEditionFiles []string
+	MaxmindEditionFiles *[]string
 
 	MonitorMaxBatchSize int
 

--- a/internal/nginx/maxmind.go
+++ b/internal/nginx/maxmind.go
@@ -71,6 +71,7 @@ func GeoLite2DBExists() bool {
 	for _, dbName := range strings.Split(MaxmindEditionIDs, ",") {
 		filename := dbName + dbExtension
 		if !fileExists(path.Join(geoIPPath, filename)) {
+			klog.Error(filename, " not found")
 			return false
 		}
 		files = append(files, filename)

--- a/internal/nginx/maxmind.go
+++ b/internal/nginx/maxmind.go
@@ -222,7 +222,7 @@ func ValidateGeoLite2DBEditions() error {
 	return nil
 }
 
-func fileExists(filePath string) bool {
+func _fileExists(filePath string) bool {
 	info, err := os.Stat(filePath)
 	if os.IsNotExist(err) {
 		return false
@@ -230,3 +230,5 @@ func fileExists(filePath string) bool {
 
 	return !info.IsDir()
 }
+
+var fileExists = _fileExists

--- a/internal/nginx/maxmind.go
+++ b/internal/nginx/maxmind.go
@@ -64,12 +64,18 @@ const (
 
 // GeoLite2DBExists checks if the required databases for
 // the GeoIP2 NGINX module are present in the filesystem
+// and indexes the discovered databases for iteration in
+// the config.
 func GeoLite2DBExists() bool {
+	files := []string{}
 	for _, dbName := range strings.Split(MaxmindEditionIDs, ",") {
-		if !fileExists(path.Join(geoIPPath, dbName+dbExtension)) {
+		filename := dbName + dbExtension
+		if !fileExists(path.Join(geoIPPath, filename)) {
 			return false
 		}
+		files = append(files, filename)
 	}
+	MaxmindEditionFiles = files
 
 	return true
 }
@@ -101,7 +107,6 @@ func DownloadGeoLite2DB(attempts int, period time.Duration) error {
 			if dlError != nil {
 				break
 			}
-			MaxmindEditionFiles = append(MaxmindEditionFiles, dbName+dbExtension)
 		}
 
 		lastErr = dlError

--- a/internal/nginx/maxmind_test.go
+++ b/internal/nginx/maxmind_test.go
@@ -56,7 +56,7 @@ func TestGeoLite2DBExists(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			resetForTesting()
 			// mimics assignment in flags.go
-			config := MaxmindEditionFiles
+			config := &MaxmindEditionFiles
 
 			if tt.setup != nil {
 				tt.setup()
@@ -67,8 +67,8 @@ func TestGeoLite2DBExists(t *testing.T) {
 			if !reflect.DeepEqual(MaxmindEditionFiles, tt.wantFiles) {
 				t.Errorf("nginx.MaxmindEditionFiles = %v, want %v", MaxmindEditionFiles, tt.wantFiles)
 			}
-			if !reflect.DeepEqual(config, tt.wantFiles) {
-				t.Errorf("config.MaxmindEditionFiles = %v, want %v", config, tt.wantFiles)
+			if !reflect.DeepEqual(*config, tt.wantFiles) {
+				t.Errorf("config.MaxmindEditionFiles = %v, want %v", *config, tt.wantFiles)
 			}
 		})
 	}

--- a/internal/nginx/maxmind_test.go
+++ b/internal/nginx/maxmind_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nginx
+
+import (
+	"reflect"
+	"testing"
+)
+
+func resetForTesting() {
+	fileExists = _fileExists
+	MaxmindLicenseKey = ""
+	MaxmindEditionIDs = ""
+	MaxmindEditionFiles = []string{}
+	MaxmindMirror = ""
+}
+
+func TestGeoLite2DBExists(t *testing.T) {
+	tests := []struct {
+		name      string
+		setup     func()
+		want      bool
+		wantFiles []string
+	}{
+		{
+			name:      "empty",
+			wantFiles: []string{},
+		},
+		{
+			name: "existing files",
+			setup: func() {
+				MaxmindEditionIDs = "GeoLite2-City,GeoLite2-ASN"
+				fileExists = func(string) bool {
+					return true
+				}
+			},
+			want:      true,
+			wantFiles: []string{"GeoLite2-City.mmdb", "GeoLite2-ASN.mmdb"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetForTesting()
+			// mimics assignment in flags.go
+			config := MaxmindEditionFiles
+
+			if tt.setup != nil {
+				tt.setup()
+			}
+			if got := GeoLite2DBExists(); got != tt.want {
+				t.Errorf("GeoLite2DBExists() = %v, want %v", got, tt.want)
+			}
+			if !reflect.DeepEqual(MaxmindEditionFiles, tt.wantFiles) {
+				t.Errorf("nginx.MaxmindEditionFiles = %v, want %v", MaxmindEditionFiles, tt.wantFiles)
+			}
+			if !reflect.DeepEqual(config, tt.wantFiles) {
+				t.Errorf("config.MaxmindEditionFiles = %v, want %v", config, tt.wantFiles)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The [docs](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#use-geoip2) say:
> it is possible to use a volume to mount the files `/etc/nginx/geoip/GeoLite2-City.mmdb` and `/etc/nginx/geoip/GeoLite2-ASN.mmdb`, avoiding the overhead of the download.

however, this was not possible because the config only iterated over downloaded geoip db files:
https://github.com/kubernetes/ingress-nginx/blob/93070faaff8443db3b800c69b31e3ba17e593582/rootfs/etc/nginx/template/nginx.tmpl#L177 
`MaxmindEditionFiles` is only set in `DownloadGeoLite2DB()`:
https://github.com/kubernetes/ingress-nginx/blob/93070faaff8443db3b800c69b31e3ba17e593582/internal/nginx/maxmind.go#L61-L72

## What this PR does / why we need it:
This PR fixes #6012 by initializing `nginx.MaxmindEditionFiles` with the files in `/etc/nginx/geoip`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
fixes #6012

## How Has This Been Tested?
New e2e test case included in PR asserts that an existing GeoIP db file is loaded and results in the `geoip2` section being included in the config.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
