### PR TITLE
Issue #7153: Add note about matching host names in TLS user guide

### DIFF
--- a/docs/user-guide/tls.md
+++ b/docs/user-guide/tls.md
@@ -18,6 +18,10 @@ kubectl create secret tls ${CERT_NAME} --key ${KEY_FILE} --cert ${CERT_FILE}
 
 The resulting secret will be of type `kubernetes.io/tls`.
 
+## Host names
+
+Ensure that the relevant [ingress rules specify a matching host name](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls).
+
 ## Default SSL Certificate
 
 NGINX provides the option to configure a server as a catch-all with


### PR DESCRIPTION
See Issue #7153. Assumed that `ingress.spec.rules.host` could be a wildcard given that [general Ingress documentation](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules) states:

> An optional host. In this example, no host is specified, so the rule applies to all inbound HTTP traffic through the IP address specified.

Later in the TLS section, [it states](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls):

> Keep in mind that TLS will not work on the default rule because the certificates would have to be issued for all the possible sub-domains. Therefore, hosts in the tls section need to explicitly match the host in the rules section.

This wasn't immediately obvious because describing the ingress states that "TLS [is] terminating" the specified host. For example:

```
TLS:
  test-api-certificate-key terminates example.myplaceonline.com
Rules:
  Host        Path  Backends
  ----        ----  --------
  *           
              /test/(.*)   helloworldweb:80 (10.244.0.254:80)
```

I think this is worthy of noting in the user guide.

## Which issue/s this PR fixes

fixes #7153

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
