### PR TITLE
Speed up admission hook by eliminating deep copy of Ingresses in CheckIngress

### DIFF
--- a/internal/ingress/controller/location.go
+++ b/internal/ingress/controller/location.go
@@ -20,10 +20,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/mitchellh/copystructure"
 	networking "k8s.io/api/networking/v1"
 	"k8s.io/ingress-nginx/internal/ingress"
-	"k8s.io/klog/v2"
 )
 
 var (
@@ -73,18 +71,14 @@ func updateServerLocations(locations []*ingress.Location) []*ingress.Location {
 			continue
 		}
 
-		// copy location before any change
-		el, err := copystructure.Copy(location)
-		if err != nil {
-			klog.ErrorS(err, "copying location")
-		}
+		var el ingress.Location = *location
 
 		// normalize path. Must end in /
 		location.Path = normalizePrefixPath(location.Path)
 		newLocations = append(newLocations, location)
 
 		// add exact location
-		exactLocation := el.(*ingress.Location)
+		exactLocation := &el
 		exactLocation.PathType = &pathTypeExact
 
 		newLocations = append(newLocations, exactLocation)


### PR DESCRIPTION
On big k8s clusters with a lot of Ingresses web admission hook may be too slow.
For example in my real developing k8s cluster with have nginx ingress controller which contains 120 server sections (hosts) and 5271 location sections (endpoints) and have 19MB size as nginx text config.

On such big config amission hook for each ingress update becomes too slow, it lasts about 7 seconds now on setup described above (k8s inside aws ec2).

Sometimes when somebody install helm charts, which contains many ingresses admission hooks must be evaluated many times in a row and we got error from master about admission hook time out (of 30s).

This PR decrease timings for setup described above by 3s.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Performance improvement

## Which issue/s this PR fixes
fixes #7297

## How Has This Been Tested?
e2e test: https://gist.github.com/cgorbit/431086b0e78f1a8b75cd497235ae8d51
Also tested in runtime of developer's k8s cluster at work.

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
