### PR TITLE
feat: add option to set worker_rlimit_core

### DIFF
--- a/docs/user-guide/nginx-configuration/configmap.md
+++ b/docs/user-guide/nginx-configuration/configmap.md
@@ -102,6 +102,7 @@ The following table shows a configuration option's name, type, and the default v
 |[gzip-level](#gzip-level)|int|1|
 |[gzip-types](#gzip-types)|string|"application/atom+xml application/javascript application/x-javascript application/json application/rss+xml application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/svg+xml image/x-icon text/css text/javascript text/plain text/x-component"|
 |[worker-processes](#worker-processes)|string|`<Number of CPUs>`|
+|[worker-rlimit-core](#worker-rlimit-core)|string|empty|
 |[worker-cpu-affinity](#worker-cpu-affinity)|string|""|
 |[worker-shutdown-timeout](#worker-shutdown-timeout)|string|"240s"|
 |[load-balance](#load-balance)|string|"round_robin"|
@@ -661,6 +662,10 @@ _**default:**_ `application/atom+xml application/javascript application/x-javasc
 
 Sets the number of [worker processes](http://nginx.org/en/docs/ngx_core_module.html#worker_processes).
 The default of "auto" means number of available CPU cores.
+
+## worker-rlimit-core
+
+Sets the limit on the [largest size of a core file](http://nginx.org/en/docs/ngx_core_module.html#worker_rlimit_core).
 
 ## worker-cpu-affinity
 

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -432,6 +432,10 @@ type Configuration struct {
 	// http://nginx.org/en/docs/ngx_core_module.html#worker_processes
 	WorkerProcesses string `json:"worker-processes,omitempty"`
 
+	// WorkerRlimitCore Changes the limit on the largest size of a core file (RLIMIT_CORE) for worker processes.
+	// http://nginx.org/en/docs/ngx_core_module.html#worker_rlimit_core
+	WorkerRlimitCore string `json:"worker-rlimit-core,omitempty"`
+
 	// Defines a timeout for a graceful shutdown of worker processes
 	// http://nginx.org/en/docs/ngx_core_module.html#worker_shutdown_timeout
 	WorkerShutdownTimeout string `json:"worker-shutdown-timeout,omitempty"`

--- a/internal/ingress/controller/template/configmap.go
+++ b/internal/ingress/controller/template/configmap.go
@@ -52,6 +52,7 @@ const (
 	nginxStatusIpv6Whitelist      = "nginx-status-ipv6-whitelist"
 	proxyHeaderTimeout            = "proxy-protocol-header-timeout"
 	workerProcesses               = "worker-processes"
+	workerRlimitCore              = "worker-rlimit-core"
 	globalAuthURL                 = "global-auth-url"
 	globalAuthMethod              = "global-auth-method"
 	globalAuthSignin              = "global-auth-signin"
@@ -353,6 +354,11 @@ func ReadConfig(src map[string]string) config.Configuration {
 		}
 
 		delete(conf, workerProcesses)
+	}
+
+	if val, ok := conf[workerRlimitCore]; ok {
+		to.WorkerRlimitCore = val
+		delete(conf, workerRlimitCore)
 	}
 
 	if val, ok := conf[plugins]; ok {

--- a/internal/ingress/controller/template/configmap_test.go
+++ b/internal/ingress/controller/template/configmap_test.go
@@ -69,6 +69,7 @@ func TestMergeConfigMapToStruct(t *testing.T) {
 		"gzip-types":                    "text/html",
 		"proxy-real-ip-cidr":            "1.1.1.1/8,2.2.2.2/24",
 		"bind-address":                  "1.1.1.1,2.2.2.2,3.3.3,2001:db8:a0b:12f0::1,3731:54:65fe:2::a7,33:33:33::33::33",
+		"worker-rlimit-core":            "100M",
 		"worker-shutdown-timeout":       "99s",
 		"nginx-status-ipv4-whitelist":   "127.0.0.1,10.0.0.0/24",
 		"nginx-status-ipv6-whitelist":   "::1,2001::/16",
@@ -92,6 +93,7 @@ func TestMergeConfigMapToStruct(t *testing.T) {
 	def.ProxyRealIPCIDR = []string{"1.1.1.1/8", "2.2.2.2/24"}
 	def.BindAddressIpv4 = []string{"1.1.1.1", "2.2.2.2"}
 	def.BindAddressIpv6 = []string{"[2001:db8:a0b:12f0::1]", "[3731:54:65fe:2::a7]"}
+	def.WorkerRlimitCore = "100M"
 	def.WorkerShutdownTimeout = "99s"
 	def.NginxStatusIpv4Whitelist = []string{"127.0.0.1", "10.0.0.0/24"}
 	def.NginxStatusIpv6Whitelist = []string{"::1", "2001::/16"}

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -45,6 +45,9 @@ worker_cpu_affinity {{ $cfg.WorkerCPUAffinity }};
 {{ end }}
 
 worker_rlimit_nofile {{ $cfg.MaxWorkerOpenFiles }};
+{{ if $cfg.WorkerRlimitCore }}
+worker_rlimit_core {{ $cfg.WorkerRlimitCore }};
+{{ end }}
 
 {{/* http://nginx.org/en/docs/ngx_core_module.html#worker_shutdown_timeout */}}
 {{/* avoid waiting too long during a reload */}}


### PR DESCRIPTION
## What this PR does / why we need it:
Allows setting worker_rlimit_core, without this there is not really a way to disable core dump files, which can fill up disk.
It doesn't fix, but related to https://github.com/kubernetes/ingress-nginx/issues/7080

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
Build the image and deployed in our environment (eks, k8s 1.18, deployed via helm). Set the option in helm under `controller.config`, applied, verified the container launches and the nginx config included
```
worker_rlimit_core 0;
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Not sure if there are other tests somewhere that I should update/could add to? Let me know if anything is missing.