### PR TITLE
Replace non-existent curl image

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -173,7 +173,7 @@ Verify with the following commands:
 
 ```console
 # start a container that contains curl
-$ kubectl run test --image=tutum/curl -- sleep 10000
+$ kubectl run test --image=curlimages/curl-- sleep 10000
 
 # check that container is running
 $ kubectl get pods


### PR DESCRIPTION
The tutum/curl image no longer exists, the official curl image from https://github.com/curl/curl-docker is curlimages/curl, and it works with the demo instructions above.

## What this PR does / why we need it:
It will ease the use of the demo, and allow for copy-pasting of working commands.

## Types of changes
Broken container image replacement

## Which issue/s this PR fixes
None that I know of.

## How Has This Been Tested?
Yes tested, works with the same instructions, only the container image needs to change.

## Checklist:
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
