### PR TITLE
Add file containing stable release

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -74,5 +74,7 @@ The sha is available in output from [cloud build](https://console.cloud.google.c
     * Update the version in [docs/deploy/index.md](docs/deploy/index.md)
     * Update Supported versions in the Support Versions table in the README.md 
     * Merge
+
+* Update the stable.txt file to reflect the release to be created
       
 7. Github release

--- a/stable.txt
+++ b/stable.txt
@@ -1,0 +1,1 @@
+controller-v0.47.0


### PR DESCRIPTION
A lot of users are complaining about using the static manifest that drops v1beta1 support.

We should create a file containing the stable version, to be queried in Main branch and be used in scripts to point to the right deployment manifest

Ref: #7305
