### PR TITLE
Lower webhook timeout for digital ocean

### DIFF
--- a/deploy/static/provider/do/deploy.yaml
+++ b/deploy/static/provider/do/deploy.yaml
@@ -441,6 +441,7 @@ webhooks:
         namespace: ingress-nginx
         name: ingress-nginx-controller-admission
         path: /networking/v1/ingresses
+    timeoutSeconds: 29
 ---
 # Source: ingress-nginx/templates/admission-webhooks/job-patch/serviceaccount.yaml
 apiVersion: v1

--- a/hack/generate-deploy-scripts.sh
+++ b/hack/generate-deploy-scripts.sh
@@ -163,6 +163,8 @@ controller:
       service.beta.kubernetes.io/do-loadbalancer-enable-proxy-protocol: "true"
   config:
     use-proxy-protocol: "true"
+  admissionWebhooks:
+    timeoutSeconds: 29
 
 EOF
 


### PR DESCRIPTION
## What this PR does / why we need it:

Fixes issue for Digital Ocean users where cluster cannot be upgrade safely due to clusterlint error, which warns that webhook timeouts are too high.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
fixes #7318


## How Has This Been Tested?

- I've added the webhook timeout on my local copy of v0.46  
  https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v0.46.0/deploy/static/provider/do/deploy.yaml
- I've then run the cluster upgrade check
- The previously shown error is gone. (see issue for screenshot of error).

![image](https://user-images.githubusercontent.com/53926/124380622-f0188300-dcbd-11eb-90e3-58dc36e9ccab.png)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly. (n/a)
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

This is a simple change that will save DigitalOcean users a couple of hours digging into why their cluster won't upgrade.
I hope we can keep administrative overhead to a minimum.