### PR TITLE
Fix forwarding of auth-response-headers to gRPC backends

### DIFF
--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -565,7 +565,7 @@ func shouldApplyGlobalAuth(input interface{}, globalExternalAuthURL string) bool
 	return false
 }
 
-func buildAuthResponseHeaders(headers []string) []string {
+func buildAuthResponseHeaders(proxySetHeader string, headers []string) []string {
 	res := []string{}
 
 	if len(headers) == 0 {
@@ -576,7 +576,7 @@ func buildAuthResponseHeaders(headers []string) []string {
 		hvar := strings.ToLower(h)
 		hvar = strings.NewReplacer("-", "_").Replace(hvar)
 		res = append(res, fmt.Sprintf("auth_request_set $authHeader%v $upstream_http_%v;", i, hvar))
-		res = append(res, fmt.Sprintf("proxy_set_header '%v' $authHeader%v;", h, i))
+		res = append(res, fmt.Sprintf("%s '%v' $authHeader%v;", proxySetHeader, h, i))
 	}
 	return res
 }
@@ -668,7 +668,7 @@ func buildProxyPass(host string, b interface{}, loc interface{}) string {
 		var xForwardedPrefix string
 
 		if len(location.XForwardedPrefix) > 0 {
-			xForwardedPrefix = fmt.Sprintf("proxy_set_header X-Forwarded-Prefix \"%s\";\n", location.XForwardedPrefix)
+			xForwardedPrefix = fmt.Sprintf("%s X-Forwarded-Prefix \"%s\";\n", proxySetHeader(location), location.XForwardedPrefix)
 		}
 
 		return fmt.Sprintf(`

--- a/internal/ingress/controller/template/template_test.go
+++ b/internal/ingress/controller/template/template_test.go
@@ -448,7 +448,7 @@ func TestBuildAuthResponseHeaders(t *testing.T) {
 		"proxy_set_header 'H-With-Caps-And-Dashes' $authHeader1;",
 	}
 
-	headers := buildAuthResponseHeaders(externalAuthResponseHeaders)
+	headers := buildAuthResponseHeaders(proxySetHeader(nil), externalAuthResponseHeaders)
 
 	if !reflect.DeepEqual(expected, headers) {
 		t.Errorf("Expected \n'%v'\nbut returned \n'%v'", expected, headers)

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -1178,7 +1178,7 @@ stream {
             auth_request        {{ $authPath }};
             auth_request_set    $auth_cookie $upstream_http_set_cookie;
             add_header          Set-Cookie $auth_cookie;
-            {{- range $line := buildAuthResponseHeaders $externalAuth.ResponseHeaders }}
+            {{- range $line := buildAuthResponseHeaders $proxySetHeader $externalAuth.ResponseHeaders }}
             {{ $line }}
             {{- end }}
             {{ end }}
@@ -1196,7 +1196,7 @@ stream {
             auth_digest {{ $location.BasicDigestAuth.Realm | quote }};
             auth_digest_user_file {{ $location.BasicDigestAuth.File }};
             {{ end }}
-            proxy_set_header Authorization "";
+            {{ $proxySetHeader }} Authorization "";
             {{ end }}
             {{ end }}
 

--- a/test/e2e/annotations/grpc.go
+++ b/test/e2e/annotations/grpc.go
@@ -27,6 +27,7 @@ import (
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/metadata"
 	core "k8s.io/api/core/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -119,6 +120,79 @@ var _ = framework.DescribeAnnotation("backend-protocol - GRPC", func() {
 
 		metadata := res.GetMetadata()
 		assert.Equal(ginkgo.GinkgoT(), metadata["content-type"].Values[0], "application/grpc")
+	})
+
+	ginkgo.It("authorization metadata should be overwritten by external auth response headers", func() {
+		f.NewGRPCBinDeployment()
+		f.NewHttpbinDeployment()
+
+		host := "echo"
+
+		svc := &core.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "grpcbin-test",
+				Namespace: f.Namespace,
+			},
+			Spec: corev1.ServiceSpec{
+				ExternalName: fmt.Sprintf("grpcbin.%v.svc.cluster.local", f.Namespace),
+				Type:         corev1.ServiceTypeExternalName,
+				Ports: []corev1.ServicePort{
+					{
+						Name:       host,
+						Port:       9000,
+						TargetPort: intstr.FromInt(9000),
+						Protocol:   "TCP",
+					},
+				},
+			},
+		}
+		f.EnsureService(svc)
+
+		err := framework.WaitForEndpoints(f.KubeClientSet, framework.DefaultTimeout, framework.HTTPBinService, f.Namespace, 1)
+		assert.Nil(ginkgo.GinkgoT(), err)
+
+		e, err := f.KubeClientSet.CoreV1().Endpoints(f.Namespace).Get(context.TODO(), framework.HTTPBinService, metav1.GetOptions{})
+		assert.Nil(ginkgo.GinkgoT(), err)
+
+		assert.GreaterOrEqual(ginkgo.GinkgoT(), len(e.Subsets), 1, "expected at least one endpoint")
+		assert.GreaterOrEqual(ginkgo.GinkgoT(), len(e.Subsets[0].Addresses), 1, "expected at least one address ready in the endpoint")
+
+		httpbinIP := e.Subsets[0].Addresses[0].IP
+
+		annotations := map[string]string{
+			"nginx.ingress.kubernetes.io/auth-url":              fmt.Sprintf("http://%s/response-headers?authorization=foo", httpbinIP),
+			"nginx.ingress.kubernetes.io/auth-response-headers": "Authorization",
+			"nginx.ingress.kubernetes.io/backend-protocol":      "GRPC",
+		}
+
+		ing := framework.NewSingleIngressWithTLS(host, "/", host, []string{host}, f.Namespace, "grpcbin-test", 9000, annotations)
+
+		f.EnsureIngress(ing)
+
+		f.WaitForNginxServer(host,
+			func(server string) bool {
+				return strings.Contains(server, "grpc_pass grpc://upstream_balancer;")
+			})
+
+		conn, _ := grpc.Dial(f.GetNginxIP()+":443",
+			grpc.WithTransportCredentials(
+				credentials.NewTLS(&tls.Config{
+					ServerName:         "echo",
+					InsecureSkipVerify: true,
+				}),
+			),
+		)
+		defer conn.Close()
+
+		client := pb.NewGRPCBinClient(conn)
+		ctx := metadata.AppendToOutgoingContext(context.Background(),
+			"authorization", "bar")
+
+		res, err := client.HeadersUnary(ctx, &pb.EmptyMessage{})
+		assert.Nil(ginkgo.GinkgoT(), err)
+
+		metadata := res.GetMetadata()
+		assert.Equal(ginkgo.GinkgoT(), "foo", metadata["authorization"].Values[0])
 	})
 
 	ginkgo.It("should return OK for service with backend protocol GRPCS", func() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
Redefining headers to gRPC backends requires the directive `grpc_set_header`, not the standard `proxy_set_header`. nginx.tmpl mostly does a good job of parameterizing this directive name and swapping in the correct name for the backend except for a few places fixed in this PR.

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When using a gRPC backend, external auth, and `auth-response-headers`, the specified header is not rewritten with the one from the auth response. The original request header is passed through unmodified. This is bad because it could allow privilege escalation through spoofed authorization headers.

Fixes #3914.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->
Fixes #3914

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added e2e test cases to exercise the `auth-response-headers` annotation with http and grpc backends. The test asserts that the header from the external auth response is the one received by the upstream service, not the original value from the request.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
