### PR TITLE
[Cherry Pick 7298] Speed up admission hook by eliminating deep copy of Ingresses in CheckIngress

### DIFF
--- a/internal/ingress/controller/location.go
+++ b/internal/ingress/controller/location.go
@@ -20,10 +20,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/mitchellh/copystructure"
 	networking "k8s.io/api/networking/v1beta1"
 	"k8s.io/ingress-nginx/internal/ingress"
-	"k8s.io/klog/v2"
 )
 
 var (
@@ -73,18 +71,14 @@ func updateServerLocations(locations []*ingress.Location) []*ingress.Location {
 			continue
 		}
 
-		// copy location before any change
-		el, err := copystructure.Copy(location)
-		if err != nil {
-			klog.ErrorS(err, "copying location")
-		}
+		var el ingress.Location = *location
 
 		// normalize path. Must end in /
 		location.Path = normalizePrefixPath(location.Path)
 		newLocations = append(newLocations, location)
 
 		// add exact location
-		exactLocation := el.(*ingress.Location)
+		exactLocation := &el
 		exactLocation.PathType = &pathTypeExact
 
 		newLocations = append(newLocations, exactLocation)


### PR DESCRIPTION
Cherry-pick of #7298