### PR TITLE
prometheus & grafana - fix for usage docs

### DIFF
--- a/deploy/grafana/kustomization.yaml
+++ b/deploy/grafana/kustomization.yaml
@@ -9,4 +9,3 @@ resources:
 - service.yaml
 images:
 - name: grafana/grafana
-  newTag: 6.1.6

--- a/deploy/prometheus/kustomization.yaml
+++ b/deploy/prometheus/kustomization.yaml
@@ -12,7 +12,6 @@ resources:
 - service.yaml
 images:
 - name: prom/prometheus
-  newTag: v2.3.2
 configMapGenerator:
 - name: prometheus-configuration
   files:

--- a/docs/user-guide/monitoring.md
+++ b/docs/user-guide/monitoring.md
@@ -7,79 +7,137 @@ This tutorial will show you how to install [Prometheus](https://prometheus.io/) 
 
 ## Before You Begin
 
-The NGINX Ingress controller should already be deployed according to the deployment instructions [here](../deploy/index.md).
+- The NGINX Ingress controller should already be deployed according to the deployment instructions [here](../deploy/index.md).
 
-Note that the kustomize bases used in this tutorial are stored in the [deploy](https://github.com/kubernetes/ingress-nginx/tree/master/deploy) folder of the GitHub repository [kubernetes/ingress-nginx](https://github.com/kubernetes/ingress-nginx).
+- The controller should be configured for exporting metrics. This requires 3 configurations to the controller. These configurations are :
+  1. controller.metrics.enabled=true
+  2. controller.podAnnotations."prometheus.io/scrape"="true"
+  3. controller.podAnnotations."prometheus.io/port"="10254"
+
+  - The easiest way to configure the controller for metrics is via helm upgrade. Assuming you have installed the ingress-nginx controller as a helm release named ingresscontroller0, then you can simply type the command show below :
+  ```
+  helm upgrade ingresscontroller0 ingress-nginx/ingress-nginx \
+  --namespace ingress-nginx \
+  --set controller.metrics.enabled=true \
+  --set-string controller.podAnnotations."prometheus\.io/scrape"="true" \
+  --set-string controller.podAnnotations."prometheus\.io/port"="10254"
+  ```
+  - You can validate that the controller is configured for metrics by looking at the values of the installed release, like this ;
+  ```
+  helm get values ingress-controller --namespace ingress-nginx
+  ```
+  - You should be able to see the values shown below ;
+  ```
+  ..
+  controller:
+    metrics:
+      enabled: true
+      service:
+        annotations:
+          prometheus.io/port: "10254"
+          prometheus.io/scrape: "true" 
+  ..
+  ```
+
 
 ## Deploy and configure Prometheus Server
 
-The Prometheus server must be configured so that it can discover endpoints of services. If a Prometheus server is already running in the cluster and if it is configured in a way that it can find the ingress controller pods, no extra configuration is needed.
+Note that the kustomize bases used in this tutorial are stored in the [deploy](https://github.com/kubernetes/ingress-nginx/tree/master/deploy) folder of the GitHub repository [kubernetes/ingress-nginx](https://github.com/kubernetes/ingress-nginx).
 
-If there is no existing Prometheus server running, the rest of this tutorial will guide you through the steps needed to deploy a properly configured Prometheus server.
+- The Prometheus server must be configured so that it can discover endpoints of services. If a Prometheus server is already running in the cluster and if it is configured in a way that it can find the ingress controller pods, no extra configuration is needed.
 
-Running the following command deploys prometheus in Kubernetes:
+- If there is no existing Prometheus server running, the rest of this tutorial will guide you through the steps needed to deploy a properly configured Prometheus server.
 
-```console
-kubectl apply --kustomize github.com/kubernetes/ingress-nginx/deploy/prometheus/
-```
+- Running the following command deploys prometheus in Kubernetes:
+
+  ```
+  kubectl apply --kustomize github.com/kubernetes/ingress-nginx/deploy/prometheus/
+  ```
 
 ### Prometheus Dashboard
 
-Open Prometheus dashboard in a web browser:
+- Open Prometheus dashboard in a web browser:
 
-```console
-kubectl get svc -n ingress-nginx
-NAME                   TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)                                      AGE
-default-http-backend   ClusterIP   10.103.59.201   <none>        80/TCP                                       3d
-ingress-nginx          NodePort    10.97.44.72     <none>        80:30100/TCP,443:30154/TCP,10254:32049/TCP   5h
-prometheus-server      NodePort    10.98.233.86    <none>        9090:32630/TCP                               1m
-```
+  ```console
+  kubectl get svc -n ingress-nginx
+  NAME                   TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)                                      AGE
+  default-http-backend   ClusterIP   10.103.59.201   <none>        80/TCP                                       3d
+  ingress-nginx          NodePort    10.97.44.72     <none>        80:30100/TCP,443:30154/TCP,10254:32049/TCP   5h
+  prometheus-server      NodePort    10.98.233.86    <none>        9090:32630/TCP                               1m
+  ```
 
-Obtain the IP address of the nodes in the running cluster:
+  - Obtain the IP address of the nodes in the running cluster:
 
-```console
-kubectl get nodes -o wide
-```
+  ```console
+  kubectl get nodes -o wide
+  ```
 
-In some cases where the node only have internal IP addresses we need to execute:
+  - In some cases where the node only have internal IP addresses we need to execute:
 
-```console
-kubectl get nodes --selector=kubernetes.io/role!=master -o jsonpath={.items[*].status.addresses[?\(@.type==\"InternalIP\"\)].address}
-10.192.0.2 10.192.0.3 10.192.0.4
-```
+  ```
+  kubectl get nodes --selector=kubernetes.io/role!=master -o jsonpath={.items[*].status.addresses[?\(@.type==\"InternalIP\"\)].address}
+  10.192.0.2 10.192.0.3 10.192.0.4
+  ```
 
-Open your browser and visit the following URL: _http://{node IP address}:{prometheus-svc-nodeport}_ to load the Prometheus Dashboard.
+  - Open your browser and visit the following URL: _http://{node IP address}:{prometheus-svc-nodeport}_ to load the Prometheus Dashboard.
 
-According to the above example, this URL will be http://10.192.0.3:32630
+  - According to the above example, this URL will be http://10.192.0.3:32630
 
-![Dashboard](../images/prometheus-dashboard.png)
+  ![Prometheus Dashboard](../images/prometheus-dashboard.png)
 
 ### Grafana
 
-```console
-kubectl apply --kustomize github.com/kubernetes/ingress-nginx/deploy/grafana/
-```
+  - Install grafana using the below command
+  ```
+  kubectl apply --kustomize github.com/kubernetes/ingress-nginx/deploy/grafana/
+  ```
+  - Look at the services
+  ```
+  kubectl get svc -n ingress-nginx
+  NAME                   TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)                                      AGE
+  default-http-backend   ClusterIP   10.103.59.201   <none>        80/TCP                                       3d
+  ingress-nginx          NodePort    10.97.44.72     <none>        80:30100/TCP,443:30154/TCP,10254:32049/TCP   5h
+  prometheus-server      NodePort    10.98.233.86    <none>        9090:32630/TCP                               10m
+  grafana                NodePort    10.98.233.87    <none>        3000:31086/TCP                               10m
+  ```
 
-```console
-kubectl get svc -n ingress-nginx
-NAME                   TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)                                      AGE
-default-http-backend   ClusterIP   10.103.59.201   <none>        80/TCP                                       3d
-ingress-nginx          NodePort    10.97.44.72     <none>        80:30100/TCP,443:30154/TCP,10254:32049/TCP   5h
-prometheus-server      NodePort    10.98.233.86    <none>        9090:32630/TCP                               10m
-grafana                NodePort    10.98.233.87    <none>        3000:31086/TCP                               10m
-```
-
-Open your browser and visit the following URL: _http://{node IP address}:{grafana-svc-nodeport}_ to load the Grafana Dashboard.
+  - Open your browser and visit the following URL: _http://{node IP address}:{grafana-svc-nodeport}_ to load the Grafana Dashboard.
 According to the above example, this URL will be http://10.192.0.3:31086
 
-The username and password is `admin`
+  The username and password is `admin`
 
-After the login you can import the Grafana dashboard from [official dashboards](https://github.com/kubernetes/ingress-nginx/tree/master/deploy/grafana/dashboards)
+  - After the login you can import the Grafana dashboard from [official dashboards](https://github.com/kubernetes/ingress-nginx/tree/master/deploy/grafana/dashboards), by following steps given below :
 
-![Dashboard](../images/grafana.png)
+    - Navigate to lefthand panel of grafana
+    - Hover on the gearwheel icon for Configuration and click "Data Sources"
+    - Click "Add data source"
+    - Select "Prometheus"
+    - Enter the details (note: I used http://CLUSTER_IP_PROMETHEUS_SVC:9090)
+    - Left menu (hover over +) -> Dashboard
+    - Click "Import"
+    - Enter the copy pasted json from https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/grafana/dashboards/nginx.json
+    - Click Import JSON
+    - Select the Prometheus data source
+    - Click "Import"
+
+
+
+  ![Grafana Dashboard](../images/grafana.png)
 
 ## Caveats
 
 ### Wildcard ingresses
 
-By default request metrics are labeled with the hostname. When you have a wildcard domain ingress, then there will be no metrics for that ingress (to prevent the metrics from exploding in cardinality). To get metrics in this case you need to run the ingress controller with `--metrics-per-host=false` (you will lose labeling by hostname, but still have labeling by ingress).
+  - By default request metrics are labeled with the hostname. When you have a wildcard domain ingress, then there will be no metrics for that ingress (to prevent the metrics from exploding in cardinality). To get metrics in this case you need to run the ingress controller with `--metrics-per-host=false` (you will lose labeling by hostname, but still have labeling by ingress).
+
+## Grafana dashboard using ingress resource
+  - If you want to expose the dashboard for grafana using a ingress resource, then you can : 
+    - change the service type of the prometheus-server service and the grafana service to "ClusterIP" like this :
+    ```
+    kubectl -n ingress-nginx edit svc grafana
+    ```
+    - This will open the currently deployed service grafana in the default editor configured in your shell (vi/nvim/nano/other)
+    - scroll down to line 34 that looks like "type: NodePort"
+    - change it to look like "type: ClusterIP". Save and exit.
+    - create a ingress reource with backend as "grafana" and port as "3000"
+  - Similarly, you can edit the service "prometheus-server" and add a ingress resource.


### PR DESCRIPTION
## What this PR does / why we need it:
The documentation for prometheus & grafana installation is not describing how to enable metrics. The kustomization files for prometheus and grafana have hardcoded outdated versions. This PR inserts the instructions to enable metrics and also removes the tag for image from kustomization yaml file, so that latest prometheus and grafana gets installed. There is also instructions added to import the dashboard which was too short before.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
fixes #7197 
fixes #7285 

## How Has This Been Tested?

![image](https://user-images.githubusercontent.com/5085914/125199031-10c67700-e282-11eb-8103-e23b9211c703.png)


![image](https://user-images.githubusercontent.com/5085914/125165153-5b2cf280-e1b3-11eb-8279-d3731739a1f0.png)

```
__$ k -n ingress-nginx describe deployments.apps prometheus-server 
Name:                   prometheus-server
Namespace:              ingress-nginx
CreationTimestamp:      Sat, 10 Jul 2021 13:11:01 +0530
Labels:                 app.kubernetes.io/name=prometheus
                        app.kubernetes.io/part-of=ingress-nginx
Annotations:            deployment.kubernetes.io/revision: 1
Selector:               app.kubernetes.io/name=prometheus,app.kubernetes.io/part-of=ingress-nginx
Replicas:               1 desired | 1 updated | 1 total | 1 available | 0 unavailable
StrategyType:           RollingUpdate
MinReadySeconds:        0
RollingUpdateStrategy:  25% max unavailable, 25% max surge
Pod Template:
  Labels:           app.kubernetes.io/name=prometheus
                    app.kubernetes.io/part-of=ingress-nginx
  Service Account:  prometheus-server
  Containers:
   prometheus:
    Image:      prom/prometheus
    Port:       9090/TCP
    Host Port:  0/TCP
    Args:
      --config.file=/etc/prometheus/prometheus.yaml
      --storage.tsdb.path=/prometheus/
    Environment:  <none>
    Mounts:
      /etc/prometheus/ from prometheus-config-volume (rw)
      /prometheus/ from prometheus-storage-volume (rw)
  Volumes:
   prometheus-config-volume:
    Type:      ConfigMap (a volume populated by a ConfigMap)
    Name:      prometheus-configuration-8hk4m6bf76
    Optional:  false
   prometheus-storage-volume:
    Type:       EmptyDir (a temporary directory that shares a pod's lifetime)
    Medium:     
    SizeLimit:  <unset>
Conditions:
  Type           Status  Reason
  ----           ------  ------
  Progressing    True    NewReplicaSetAvailable
  Available      True    MinimumReplicasAvailable
OldReplicaSets:  <none>
NewReplicaSet:   prometheus-server-779c8d44cf (1/1 replicas created)
Events:          <none>

__$ k -n ingress-nginx describe deployments.apps ingcontroller0-ingress-nginx-controller                                                                                                                      
Name:                   ingcontroller0-ingress-nginx-controller                                                                                                                                               
Namespace:              ingress-nginx                                                                                                                                                                         
CreationTimestamp:      Thu, 08 Jul 2021 06:44:20 +0530                                                                                                                                                       
Labels:                 app.kubernetes.io/component=controller                                                                                                                                                
                        app.kubernetes.io/instance=ingcontroller0                                                                                                                                             
                        app.kubernetes.io/managed-by=Helm                                                                                                                                                     
                        app.kubernetes.io/name=ingress-nginx                                                                                                                                                  
                        app.kubernetes.io/version=0.47.0                                                                                                                                                      
                        helm.sh/chart=ingress-nginx-3.34.0                                                                                                                                                    
Annotations:            deployment.kubernetes.io/revision: 2                                                                                                                                                  
                        meta.helm.sh/release-name: ingcontroller0                                                                                                                                             
                        meta.helm.sh/release-namespace: ingress-nginx                                                                                                                                         
Selector:               app.kubernetes.io/component=controller,app.kubernetes.io/instance=ingcontroller0,app.kubernetes.io/name=ingress-nginx                                                                 
Replicas:               1 desired | 1 updated | 1 total | 1 available | 0 unavailable                                                                                                                         
StrategyType:           RollingUpdate
MinReadySeconds:        0
RollingUpdateStrategy:  25% max unavailable, 25% max surge
Pod Template:
  Labels:           app.kubernetes.io/component=controller
                    app.kubernetes.io/instance=ingcontroller0
                    app.kubernetes.io/name=ingress-nginx
  Annotations:      prometheus.io/port: 10254
                    prometheus.io/scrape: true
  Service Account:  ingcontroller0-ingress-nginx
  Containers:
   controller:
    Image:       k8s.gcr.io/ingress-nginx/controller:v0.47.0@sha256:a1e4efc107be0bb78f32eaec37bef17d7a0c81bec8066cdf2572508d21351d0b
    Ports:       80/TCP, 443/TCP, 10254/TCP, 8443/TCP
    Host Ports:  0/TCP, 0/TCP, 0/TCP, 0/TCP
    Args:
      /nginx-ingress-controller
      --publish-service=$(POD_NAMESPACE)/ingcontroller0-ingress-nginx-controller
      --election-id=ingress-controller-leader
      --ingress-class=nginx
      --configmap=$(POD_NAMESPACE)/ingcontroller0-ingress-nginx-controller
      --validating-webhook=:8443
      --validating-webhook-certificate=/usr/local/certificates/cert
      --validating-webhook-key=/usr/local/certificates/key
    Requests:
      cpu:      100m
      memory:   90Mi
    Liveness:   http-get http://:10254/healthz delay=10s timeout=1s period=10s #success=1 #failure=5
    Readiness:  http-get http://:10254/healthz delay=10s timeout=1s period=10s #success=1 #failure=3
    Environment:
      POD_NAME:        (v1:metadata.name)
      POD_NAMESPACE:   (v1:metadata.namespace)
      LD_PRELOAD:     /usr/local/lib/libmimalloc.so
    Mounts:
      /usr/local/certificates/ from webhook-cert (ro)
  Volumes:
   webhook-cert:
    Type:        Secret (a volume populated by a Secret)
    SecretName:  ingcontroller0-ingress-nginx-admission
    Optional:    false
Conditions:
  Type           Status  Reason
  ----           ------  ------
  Progressing    True    NewReplicaSetAvailable
  Available      True    MinimumReplicasAvailable
OldReplicaSets:  <none>
NewReplicaSet:   ingcontroller0-ingress-nginx-controller-787ff955fd (1/1 replicas created)
Events:          <none>
```

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
