### PR TITLE
Add cpanato as Helm chart approver

### DIFF
--- a/charts/ingress-nginx/OWNERS
+++ b/charts/ingress-nginx/OWNERS
@@ -1,5 +1,7 @@
 approvers:
   - ChiefAlexander
+  - cpanato
 
 reviewers:
   - ChiefAlexander
+  - cpanato


### PR DESCRIPTION
Signed-off-by: Ricardo Katz <rkatz@vmware.com>

Add @cpanato as Helm Charts approver

/assign @cpanato 
/cc @cpanato