### PR TITLE
fix broken link in synchronization loop pattern

### DIFF
--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -64,7 +64,7 @@ To prevent this situation to happen, the nginx ingress controller optionally exp
 This webhook appends the incoming ingress objects to the list of ingresses, generates the configuration and calls nginx to ensure the configuration has no syntax errors.
 
 [0]: https://github.com/openresty/lua-nginx-module/pull/1259
-[1]: https://coreos.com/kubernetes/docs/latest/replication-controller.html#the-reconciliation-loop-in-detail
+[1]: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/
 [2]: https://godoc.org/k8s.io/client-go/informers#NewFilteredSharedInformerFactory
 [3]: https://godoc.org/k8s.io/client-go/tools/cache#ResourceEventHandlerFuncs
 [4]: https://github.com/kubernetes/ingress-nginx/blob/master/internal/task/queue.go#L38


### PR DESCRIPTION
Currently it is refering to an old coreos link which lands nowhere in RedHat. Wouldn't it be better to link to the source in Kubernetes. Please see the suggested link.

<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
