### PR TITLE
Automatically add area labels to help triaging

### DIFF
--- a/docs/OWNERS
+++ b/docs/OWNERS
@@ -1,10 +1,4 @@
 # See the OWNERS docs: https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md
 
-approvers:
-- ingress-nginx-helm-maintainers
-
-reviewers:
-- ingress-nginx-helm-reviewers
-
 labels:
-- area/helm
+- area/docs

--- a/rootfs/etc/nginx/lua/OWNERS
+++ b/rootfs/etc/nginx/lua/OWNERS
@@ -1,10 +1,4 @@
 # See the OWNERS docs: https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md
 
-approvers:
-- ingress-nginx-helm-maintainers
-
-reviewers:
-- ingress-nginx-helm-reviewers
-
 labels:
-- area/helm
+- area/lua


### PR DESCRIPTION
We can use prow to automatically add labels and help reviewers to filter the PRs

/assign @cpanato @strongjz 
/cc @cpanato @strongjz 
/kind cleanup
/priority backlog
/triage accepted