### PR TITLE
[Docs] Correct Ingress ServiceName and Service Ports in basic auth example 

### DIFF
--- a/docs/examples/auth/basic/README.md
+++ b/docs/examples/auth/basic/README.md
@@ -46,10 +46,13 @@ spec:
   - host: foo.bar.com
     http:
       paths:
+      pathType: ImplementationSpecific
       - path: /
         backend:
-          serviceName: http-svc
-          servicePort: 80
+          service
+            name: http-svc
+            port: 
+              number: 80
 " | kubectl create -f -
 ```
 


### PR DESCRIPTION
Maps the service name and service port to the Ingress spec `networking.k8s.io/v1`

## What this PR does / why we need it:
fixes basic auth example with the right service name and service port 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
