### PR TITLE
Add dev-v1 branch into helm releaser

### DIFF
--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - dev-v1
 
 jobs:
 


### PR DESCRIPTION
## What this PR does / why we need it:
We need to put dev-v1 into gh actions so the pre release helms can also be released :D
