### PR TITLE
Change the order of annotation just to trigger a new helm release

### DIFF
--- a/charts/ingress-nginx/Chart.yaml
+++ b/charts/ingress-nginx/Chart.yaml
@@ -18,8 +18,8 @@ maintainers:
 engine: gotpl
 kubeVersion: ">=1.19.0-0"
 annotations:
+  artifacthub.io/prerelease: "true"
   # List of changes for the release in artifacthub.io
   # https://artifacthub.io/packages/helm/ingress-nginx/ingress-nginx?modal=changelog
-  artifacthub.io/prerelease: "true"
   artifacthub.io/changes: |
     - Drop support for extensions/v1beta1, networking.k8s.io/v1beta1


### PR DESCRIPTION
## What this PR does / why we need it:
Trigger helm dev-v1 releasde
