### PR TITLE
added K8s v1.22 tip for kind cluster, and commands in bug-report format

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -37,7 +37,32 @@ This questions are the first thing we need to know to understand the context.
 - **OS** (e.g. from /etc/os-release):
 - **Kernel** (e.g. `uname -a`):
 - **Install tools**:
+  - `Please mention how/where was clsuter created like kubeadm/kops/minikube/kind etc. `
+- **Basic cluster related info**:
+  - `kubectl version`
+  - `kubectl get nodes -o wide`
+
+- **How was the ingress-nginx-controller installed**:
+  - If helm was used then please show output of `helm ls -A`
+  - If helm was used then please show output of `helm -n <ingresscontrollernamepspace> get values <helmreleasename>`
+  - If helm was not used, then please explain how the ingress-nginx-controller was installed or copy/paste the command used to install the controller below
+  - if you have more than one instance of the ingress-nginx-controller installed in the same cluster, please provide details for all the instances
+
+- **Current State of the controller**:
+  - `kubectl -n <ingresscontrollernamespace> get all -A -o wide`
+  - `kubectl -n <ingresscontrollernamespace> describe po <ingresscontrollerpodname>`
+  - `kubectl -n <ingresscontrollernamespace> describe svc <ingresscontrollerservicename>`
+
+- **Current state of ingress object, if applicable**:
+  - `kubectl -n <appnnamespace> get all,ing -o wide`
+  - `kubectl -n <appnamespace> describe ing <ingressname>`
+  - If applicable, then, your complete and exact curl/grpcurl command (redacted if required) and the reponse to the curl/grpcurl command with the -v flag
+
 - **Others**:
+  - Any other related information like ;
+    - copy/paste of the snippet (if applicable)
+    - `kubectl describe ...` of any custom configmap(s) created and in use
+    - Any other related information that may help
 
 **What happened**:
 

--- a/docs/developer-guide/getting-started.md
+++ b/docs/developer-guide/getting-started.md
@@ -29,6 +29,7 @@ Start a local Kubernetes cluster using [kind](https://kind.sigs.k8s.io/), build 
 ```console
 make dev-env
 ```
+- If you are working on the v1.x.x version of this controler, and you want to create a cluster with kubernetes version 1.22, then please visit the [documentation for kind](https://kind.sigs.k8s.io/docs/user/configuration/#a-note-on-cli-parameters-and-configuration-files), and look for how to set a custom image for the kind node (image: kindest/node...), in the kind config file.
 
 ### Testing
 


### PR DESCRIPTION
## What this PR does / why we need it:
(1) We are going to maintain 2 editions of the controller. One for pre K8s v1.19 and one for K8s v1.19 and above only. New contributors may need to use K8s ~ v1.22 cluster created with "kind". The current "Makefile" creates a K8s v1.20 "kind" cluster, by default. So added a note on how to create a kind cluster with K8s version v1.22 (or newer).

(2) Added some commands for asking cluster, controller and ingress related information in the bug-report-format

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
Developer Document update

## How Has This Been Tested?
Edited/Checked the text in my fork
## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
