### PR TITLE
Fix cap for NET_BIND_SERVICE

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -65,6 +65,8 @@ RUN apk add --no-cache libcap \
   && setcap -v cap_net_bind_service=+ep /nginx-ingress-controller \
   && setcap    cap_net_bind_service=+ep /usr/local/nginx/sbin/nginx \
   && setcap -v cap_net_bind_service=+ep /usr/local/nginx/sbin/nginx \
+  && setcap    cap_net_bind_service=+ep /usr/bin/dumb-init \
+  && setcap -v cap_net_bind_service=+ep /usr/bin/dumb-init \
   && apk del libcap
 
 USER www-data


### PR DESCRIPTION
Signed-off-by: Tobias Giese <tobias.giese@daimler.com>

## What this PR does / why we need it:

This PR fixes the missing capability `NET_BIND_SERVICE` on the binary `dumb-init`.

We should update the Helm charts [values.yaml](https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml#L18-L19) and the [static provider manifests](https://github.com/kubernetes/ingress-nginx/tree/main/deploy/static/provider) (i.e., set `allowPrivilegeEscalation=false` and the image `tag` & `digest`) after the images are pushed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
fixes #7445

## How Has This Been Tested?
Tested via `kind` (see #7445)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<sub>Tobias Giese <tobias.giese@daimler.com>, Daimler TSS GmbH, [legal info/Impressum](https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md)</sub>