### PR TITLE
Sync Hostname and IP address from service to ingress status

### DIFF
--- a/internal/ingress/status/status.go
+++ b/internal/ingress/status/status.go
@@ -355,9 +355,10 @@ func statusAddressFromService(service string, kubeClient clientset.Interface) ([
 		addrs := make([]apiv1.LoadBalancerIngress, len(svc.Status.LoadBalancer.Ingress))
 		for i, ingress := range svc.Status.LoadBalancer.Ingress {
 			addrs[i] = apiv1.LoadBalancerIngress{}
-			if ingress.IP == "" {
+			if ingress.Hostname != "" {
 				addrs[i].Hostname = ingress.Hostname
-			} else {
+			}
+			if ingress.IP != "" {
 				addrs[i].IP = ingress.IP
 			}
 		}

--- a/internal/ingress/status/status_test.go
+++ b/internal/ingress/status/status_test.go
@@ -382,7 +382,7 @@ func TestKeyfunc(t *testing.T) {
 func TestRunningAddressesWithPublishService(t *testing.T) {
 	testCases := map[string]struct {
 		fakeClient  *testclient.Clientset
-		expected    []string
+		expected    []apiv1.LoadBalancerIngress
 		errExpected bool
 	}{
 		"service type ClusterIP": {
@@ -416,7 +416,9 @@ func TestRunningAddressesWithPublishService(t *testing.T) {
 				},
 				},
 			),
-			[]string{"1.1.1.1"},
+			[]apiv1.LoadBalancerIngress{
+				{IP: "1.1.1.1"},
+			},
 			false,
 		},
 		"service type NodePort": {
@@ -435,7 +437,9 @@ func TestRunningAddressesWithPublishService(t *testing.T) {
 				},
 				},
 			),
-			[]string{"1.1.1.1"},
+			[]apiv1.LoadBalancerIngress{
+				{IP: "1.1.1.1"},
+			},
 			false,
 		},
 		"service type ExternalName": {
@@ -454,7 +458,9 @@ func TestRunningAddressesWithPublishService(t *testing.T) {
 				},
 				},
 			),
-			[]string{"foo.bar"},
+			[]apiv1.LoadBalancerIngress{
+				{Hostname: "foo.bar"},
+			},
 			false,
 		},
 		"service type LoadBalancer": {
@@ -485,7 +491,10 @@ func TestRunningAddressesWithPublishService(t *testing.T) {
 				},
 				},
 			),
-			[]string{"10.0.0.1", "foo"},
+			[]apiv1.LoadBalancerIngress{
+				{IP: "10.0.0.1"},
+				{Hostname: "foo"},
+			},
 			false,
 		},
 		"service type LoadBalancer with same externalIP and ingress IP": {
@@ -513,7 +522,9 @@ func TestRunningAddressesWithPublishService(t *testing.T) {
 				},
 				},
 			),
-			[]string{"10.0.0.1"},
+			[]apiv1.LoadBalancerIngress{
+				{IP: "10.0.0.1"},
+			},
 			false,
 		},
 		"invalid service type": {
@@ -549,7 +560,7 @@ func TestRunningAddressesWithPublishService(t *testing.T) {
 			}
 
 			if ra == nil {
-				t.Fatalf("returned nil but expected valid []string")
+				t.Fatalf("returned nil but expected valid []apiv1.LoadBalancerIngress")
 			}
 
 			if !reflect.DeepEqual(tc.expected, ra) {
@@ -565,15 +576,15 @@ func TestRunningAddressesWithPods(t *testing.T) {
 
 	r, _ := fk.runningAddresses()
 	if r == nil {
-		t.Fatalf("returned nil but expected valid []string")
+		t.Fatalf("returned nil but expected valid []apiv1.LoadBalancerIngress")
 	}
 	rl := len(r)
 	if len(r) != 1 {
 		t.Fatalf("returned %v but expected %v", rl, 1)
 	}
 	rv := r[0]
-	if rv != "11.0.0.2" {
-		t.Errorf("returned %v but expected %v", rv, "11.0.0.2")
+	if rv.IP != "11.0.0.2" {
+		t.Errorf("returned %v but expected %v", rv, apiv1.LoadBalancerIngress{IP: "11.0.0.2"})
 	}
 }
 
@@ -583,15 +594,15 @@ func TestRunningAddressesWithPublishStatusAddress(t *testing.T) {
 
 	ra, _ := fk.runningAddresses()
 	if ra == nil {
-		t.Fatalf("returned nil but expected valid []string")
+		t.Fatalf("returned nil but expected valid []apiv1.LoadBalancerIngress")
 	}
 	rl := len(ra)
 	if len(ra) != 1 {
 		t.Errorf("returned %v but expected %v", rl, 1)
 	}
 	rv := ra[0]
-	if rv != "127.0.0.1" {
-		t.Errorf("returned %v but expected %v", rv, "127.0.0.1")
+	if rv.IP != "127.0.0.1" {
+		t.Errorf("returned %v but expected %v", rv, apiv1.LoadBalancerIngress{IP: "127.0.0.1"})
 	}
 }
 
@@ -601,7 +612,7 @@ func TestRunningAddressesWithPublishStatusAddresses(t *testing.T) {
 
 	ra, _ := fk.runningAddresses()
 	if ra == nil {
-		t.Fatalf("returned nil but expected valid []string")
+		t.Fatalf("returned nil but expected valid []apiv1.LoadBalancerIngress")
 	}
 	rl := len(ra)
 	if len(ra) != 2 {
@@ -609,11 +620,11 @@ func TestRunningAddressesWithPublishStatusAddresses(t *testing.T) {
 	}
 	rv := ra[0]
 	rv2 := ra[1]
-	if rv != "127.0.0.1" {
-		t.Errorf("returned %v but expected %v", rv, "127.0.0.1")
+	if rv.IP != "127.0.0.1" {
+		t.Errorf("returned %v but expected %v", rv, apiv1.LoadBalancerIngress{IP: "127.0.0.1"})
 	}
-	if rv2 != "1.1.1.1" {
-		t.Errorf("returned %v but expected %v", rv2, "1.1.1.1")
+	if rv2.IP != "1.1.1.1" {
+		t.Errorf("returned %v but expected %v", rv2, apiv1.LoadBalancerIngress{IP: "1.1.1.1"})
 	}
 }
 
@@ -623,7 +634,7 @@ func TestRunningAddressesWithPublishStatusAddressesAndSpaces(t *testing.T) {
 
 	ra, _ := fk.runningAddresses()
 	if ra == nil {
-		t.Fatalf("returned nil but expected valid []string")
+		t.Fatalf("returned nil but expected valid []apiv1.LoadBalancerIngresst")
 	}
 	rl := len(ra)
 	if len(ra) != 2 {
@@ -631,22 +642,22 @@ func TestRunningAddressesWithPublishStatusAddressesAndSpaces(t *testing.T) {
 	}
 	rv := ra[0]
 	rv2 := ra[1]
-	if rv != "127.0.0.1" {
-		t.Errorf("returned %v but expected %v", rv, "127.0.0.1")
+	if rv.IP != "127.0.0.1" {
+		t.Errorf("returned %v but expected %v", rv, apiv1.LoadBalancerIngress{IP: "127.0.0.1"})
 	}
-	if rv2 != "1.1.1.1" {
-		t.Errorf("returned %v but expected %v", rv2, "1.1.1.1")
+	if rv2.IP != "1.1.1.1" {
+		t.Errorf("returned %v but expected %v", rv2, apiv1.LoadBalancerIngress{IP: "1.1.1.1"})
 	}
 }
 
-func TestSliceToStatus(t *testing.T) {
-	fkEndpoints := []string{
-		"10.0.0.1",
-		"2001:db8::68",
-		"opensource-k8s-ingress",
+func TestStandardizeLoadBalancerIngresses(t *testing.T) {
+	fkEndpoints := []apiv1.LoadBalancerIngress{
+		{IP: "2001:db8::68"},
+		{IP: "10.0.0.1"},
+		{Hostname: "opensource-k8s-ingress"},
 	}
 
-	r := sliceToStatus(fkEndpoints)
+	r := standardizeLoadBalancerIngresses(fkEndpoints)
 
 	if r == nil {
 		t.Fatalf("returned nil but expected a valid []apiv1.LoadBalancerIngress")

--- a/internal/ingress/status/status_test.go
+++ b/internal/ingress/status/status_test.go
@@ -484,6 +484,10 @@ func TestRunningAddressesWithPublishService(t *testing.T) {
 										IP:       "",
 										Hostname: "foo",
 									},
+									{
+										IP:       "10.0.0.2",
+										Hostname: "10-0-0-2.cloudprovider.example.net",
+									},
 								},
 							},
 						},
@@ -494,6 +498,10 @@ func TestRunningAddressesWithPublishService(t *testing.T) {
 			[]apiv1.LoadBalancerIngress{
 				{IP: "10.0.0.1"},
 				{Hostname: "foo"},
+				{
+					IP:       "10.0.0.2",
+					Hostname: "10-0-0-2.cloudprovider.example.net",
+				},
 			},
 			false,
 		},


### PR DESCRIPTION
The current behaviour when syncing LoadBalancerIngress records is to favour the IP address, which means hostnames are ignored if an IP address is available. Hostnames were only synced when the IP address is not blank. This change updates the `runningAddresses()` and associated funcs logic to sync _both_ IP address and host name when they are present.

NB: Because `runningAddresses()` originally returned a string slice, this required a refactor to return LoadBalancerIngresses instead so that hostname/ip addresses could remain together.

## What this PR does / why we need it:
There are some applications where a hostname is prefered and/or required. For example, we are currently working on a project which sets up AWS CloudFront Distributions in front of Ingress / LoadBalancer Service resources - CloudFront _only_ supports hostname origins.

The refactor, although primarily performed to facilitate the above change, has some secondary benefits:
- Previously, each entry had to be processed with net.ParseIP() to determine if it is an IP address or Hostname - there is less of a need to do this now as ClusterIP, ExternalIPs, etc can be set to LoadBalancerIngress.IP without checking.
- This gives scope for furture work, for example supporting future fields on the LoadBalancerIngress (for example, k8s 1.20's [PortStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#portstatus-v1-core).
- It is a more "correct" solution - if the information is there, so it is nice to have it.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
None Known

## How Has This Been Tested?
```
make test
make lua-test
```

The controller has also been installed into our own cluster and confirmed to be working as expected:

**Load Balancer Values set correctly**
```
> kubectl -n website-27724102-production get ingress production-auto-deploy -o json | jq '.status'
{
  "loadBalancer": {
    "ingress": [
      {
        "hostname": "nb-185-3-92-240.london.nodebalancer.linode.com",
        "ip": "185.3.92.240"
      }
    ]
  }
}
```

**printColumns are not broken by this change**
```
> kubectl -n website-27724102-production get ingress
NAME                     CLASS    HOSTS         ADDRESS        PORTS     AGE
production-auto-deploy   <none>   redcoat.dev   185.3.92.240   80, 443   42d
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
