### PR TITLE
Add linux node selector as default

### DIFF
--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -555,7 +555,8 @@ controller:
       ##
       priorityClassName: ""
       podAnnotations: {}
-      nodeSelector: {}
+      nodeSelector:
+        kubernetes.io/os: linux
       tolerations: []
       runAsUser: 2000
 
@@ -732,7 +733,8 @@ defaultBackend:
   ## Node labels for default backend pod assignment
   ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
   ##
-  nodeSelector: {}
+  nodeSelector:
+    kubernetes.io/os: linux
 
   ## Annotations to be added to default backend pods
   ##


### PR DESCRIPTION
## What this PR does / why we need it:
To stop pods from starting on Windows nodes (as they cannot run there)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
By manual override of values.yaml
