### PR TITLE
Fix default backend annotation test

### DIFF
--- a/test/e2e/annotations/customhttperrors.go
+++ b/test/e2e/annotations/customhttperrors.go
@@ -116,7 +116,7 @@ var _ = framework.DescribeAnnotation("custom-http-errors", func() {
 			}
 			return false
 		})
-		assert.Contains(ginkgo.GinkgoT(), serverConfig, errorBlockName(fmt.Sprintf("custom-default-backend-%s", customDefaultBackend), "503"))
-		assert.Contains(ginkgo.GinkgoT(), serverConfig, fmt.Sprintf("error_page %s = %s", "503", errorBlockName(fmt.Sprintf("custom-default-backend-%s", customDefaultBackend), "503")))
+		assert.Contains(ginkgo.GinkgoT(), serverConfig, errorBlockName(fmt.Sprintf("custom-default-backend-%s-%s", f.Namespace, customDefaultBackend), "503"))
+		assert.Contains(ginkgo.GinkgoT(), serverConfig, fmt.Sprintf("error_page %s = %s", "503", errorBlockName(fmt.Sprintf("custom-default-backend-%s-%s", f.Namespace, customDefaultBackend), "503")))
 	})
 })


### PR DESCRIPTION
Due to how critical #7479 was it was force merged, even with tests not passing.

This PR fixes the tests