### PR TITLE
Add appProtocol field to all ServicePorts

### DIFF
--- a/charts/ingress-nginx/templates/controller-service-internal.yaml
+++ b/charts/ingress-nginx/templates/controller-service-internal.yaml
@@ -32,6 +32,9 @@ spec:
       port: {{ .Values.controller.service.ports.http }}
       protocol: TCP
       targetPort: {{ .Values.controller.service.targetPorts.http }}
+    {{- if semverCompare ">=1.20" .Capabilities.KubeVersion.Version }}
+      appProtocol: http
+    {{- end }}
     {{- if (and $setNodePorts (not (empty .Values.controller.service.nodePorts.http))) }}
       nodePort: {{ .Values.controller.service.nodePorts.http }}
     {{- end }}
@@ -41,6 +44,9 @@ spec:
       port: {{ .Values.controller.service.ports.https }}
       protocol: TCP
       targetPort: {{ .Values.controller.service.targetPorts.https }}
+    {{- if semverCompare ">=1.20" .Capabilities.KubeVersion.Version }}
+      appProtocol: https
+    {{- end }}
     {{- if (and $setNodePorts (not (empty .Values.controller.service.nodePorts.https))) }}
       nodePort: {{ .Values.controller.service.nodePorts.https }}
     {{- end }}

--- a/charts/ingress-nginx/templates/controller-service-webhook.yaml
+++ b/charts/ingress-nginx/templates/controller-service-webhook.yaml
@@ -28,6 +28,9 @@ spec:
     - name: https-webhook
       port: 443
       targetPort: webhook
+    {{- if semverCompare ">=1.20" .Capabilities.KubeVersion.Version }}
+      appProtocol: https
+    {{- end }}
   selector:
     {{- include "ingress-nginx.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: controller

--- a/charts/ingress-nginx/templates/controller-service.yaml
+++ b/charts/ingress-nginx/templates/controller-service.yaml
@@ -44,6 +44,9 @@ spec:
       port: {{ .Values.controller.service.ports.http }}
       protocol: TCP
       targetPort: {{ .Values.controller.service.targetPorts.http }}
+    {{- if semverCompare ">=1.20" .Capabilities.KubeVersion.Version }}
+      appProtocol: http
+    {{- end }}
     {{- if (and $setNodePorts (not (empty .Values.controller.service.nodePorts.http))) }}
       nodePort: {{ .Values.controller.service.nodePorts.http }}
     {{- end }}
@@ -53,6 +56,9 @@ spec:
       port: {{ .Values.controller.service.ports.https }}
       protocol: TCP
       targetPort: {{ .Values.controller.service.targetPorts.https }}
+    {{- if semverCompare ">=1.20" .Capabilities.KubeVersion.Version }}
+      appProtocol: https
+    {{- end }}
     {{- if (and $setNodePorts (not (empty .Values.controller.service.nodePorts.https))) }}
       nodePort: {{ .Values.controller.service.nodePorts.https }}
     {{- end }}

--- a/charts/ingress-nginx/templates/default-backend-service.yaml
+++ b/charts/ingress-nginx/templates/default-backend-service.yaml
@@ -29,6 +29,9 @@ spec:
       port: {{ .Values.defaultBackend.service.servicePort }}
       protocol: TCP
       targetPort: http
+    {{- if semverCompare ">=1.20" .Capabilities.KubeVersion.Version }}
+      appProtocol: http
+    {{- end }}
   selector:
     {{- include "ingress-nginx.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: default-backend


### PR DESCRIPTION
Minor update to the helm chart to set the [appProtocol][1] field on all
http / https ports defined in the various services created by the helm
chart:

- http and https for controller-service
- http and https for controller-service-internal
- https for controler-service-webhook
- http for default-backend-service

These are only added in kubernetes >= 1.20, which is when this feature
became stable.

[1]: https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol

## What this PR does / why we need it:
This is a minor change to make the deployment more semantic - although there is no particular reason to require this at this current time, having ports identify themselves makes life easier for any extensions / metrics scrapers / projects in future.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
None

## How Has This Been Tested?
Helm template ran locally and the output inspected to ensure correct output.

It's not clear if there are specific tests for the helm charts - if there are, any pointers in that direction would be appreciated.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
