### PR TITLE
Document the keep-alive 0 effect on http/2 requests

### DIFF
--- a/docs/user-guide/nginx-configuration/configmap.md
+++ b/docs/user-guide/nginx-configuration/configmap.md
@@ -394,6 +394,24 @@ Sets the time during which a keep-alive client connection will stay open on the 
 _References:_
 [http://nginx.org/en/docs/http/ngx_http_core_module.html#keepalive_timeout](http://nginx.org/en/docs/http/ngx_http_core_module.html#keepalive_timeout)
 
+!!! important
+    Setting `keep-alive: '0'` will most likely break concurrent http/2 requests due to changes introduced with nginx 1.19.7
+
+```
+Changes with nginx 1.19.7                                        16 Feb 2021
+
+    *) Change: connections handling in HTTP/2 has been changed to better
+       match HTTP/1.x; the "http2_recv_timeout", "http2_idle_timeout", and
+       "http2_max_requests" directives have been removed, the
+       "keepalive_timeout" and "keepalive_requests" directives should be
+       used instead.
+```
+
+_References:_
+[nginx change log](http://nginx.org/en/CHANGES)
+[nginx issue tracker](https://trac.nginx.org/nginx/ticket/2155)
+[nginx mailing list](https://mailman.nginx.org/pipermail/nginx/2021-May/060697.html)
+
 ## keep-alive-requests
 
 Sets the maximum number of requests that can be served through one keep-alive connection.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
nginx 1.19.7 introduced a breaking and not backwards compatible change with how http/2 requests are handled. Documenting the effect of the previous working `keep-alive: 0` setting with http/2.

## Types of changes
Documentation change

## Which issue/s this PR fixes
fixes #7396

## How Has This Been Tested?
The problem was discovered in a production site with about 50 000 requests pr minute handled by the ingress controller, where most requests are http/2. Changing `keep-alive:` to any positive number solves the net::ERR_HTTP2_SERVER_REFUSED_STREAM error.
