### PR TITLE
priorityClassName should be in " "

### DIFF
--- a/charts/ingress-nginx/templates/controller-deployment.yaml
+++ b/charts/ingress-nginx/templates/controller-deployment.yaml
@@ -54,7 +54,7 @@ spec:
       imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 8 }}
     {{- end }}
     {{- if .Values.controller.priorityClassName }}
-      priorityClassName: {{ .Values.controller.priorityClassName }}
+      priorityClassName: "{{ .Values.controller.priorityClassName }}"
     {{- end }}
     {{- if or .Values.controller.podSecurityContext .Values.controller.sysctls }}
       securityContext:


### PR DESCRIPTION
Example:  https://github.com/helm/charts/blob/master/stable/k8s-spot-rescheduler/templates/deployment.yaml#L28

Without my fix i have error:
```
Error: Deployment in version "v1" cannot be handled as a Deployment: v1.Deployment.Spec: v1.DeploymentSpec.Template: v1.PodTemplateSpec.Spec: v1.PodSpec.PriorityClassName: ReadString: expects " or n, but found 8, error found in #10 byte of ...|assName":800,"servic|..., bigger context ...|],"dnsPolicy":"ClusterFirst","priorityClassName":800,"serviceAccountName":"ingress-nginx-external","|...
```