### PR TITLE
Fix listener names for tcp and udp service posts

### DIFF
--- a/charts/ingress-nginx/templates/controller-service.yaml
+++ b/charts/ingress-nginx/templates/controller-service.yaml
@@ -58,7 +58,7 @@ spec:
     {{- end }}
   {{- end }}
   {{- range $key, $value := .Values.tcp }}
-    - name: {{ $key }}-tcp
+    - name: port-{{ $key }}-tcp
       port: {{ $key }}
       protocol: TCP
       targetPort: {{ $key }}-tcp
@@ -69,7 +69,7 @@ spec:
     {{- end }}
   {{- end }}
   {{- range $key, $value := .Values.udp }}
-    - name: {{ $key }}-udp
+    - name: port-{{ $key }}-udp
       port: {{ $key }}
       protocol: UDP
       targetPort: {{ $key }}-udp


### PR DESCRIPTION
## What this PR does / why we need it:
I encountered the same problem as in issue #6416. Without it, it is impossible to use tcp and udp services on Yandex.Cloud environment.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
fixes #6416

## How Has This Been Tested?
Made sure the load balancer is provisioned successfully after installing the patch chart. Testing environment: Yandex Managed Service for Kubernetes.

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
