### PR TITLE
feat: add a _before hook for plugins

### DIFF
--- a/rootfs/etc/nginx/lua/plugins.lua
+++ b/rootfs/etc/nginx/lua/plugins.lua
@@ -58,4 +58,24 @@ function _M.run()
   end
 end
 
+function _M.run_before()
+  local phase = ngx.get_phase() .. "_before"
+
+  for name, plugin in pairs(plugins) do
+    if plugin[phase] then
+      ngx_log(INFO, string_format("running plugin \"%s\" in phase \"%s\"", name, phase))
+
+      -- TODO: consider sandboxing this, should we?
+      -- probably yes, at least prohibit plugin from accessing env vars etc
+      -- but since the plugins are going to be installed by ingress-nginx
+      -- operator they can be assumed to be safe also
+      local ok, err = pcall(plugin[phase])
+      if not ok then
+        ngx_log(ERR, string_format("error while running plugin \"%s\" in phase \"%s\": %s",
+            name, phase, err))
+      end
+    end
+  end
+end
+
 return _M

--- a/rootfs/etc/nginx/lua/plugins.lua
+++ b/rootfs/etc/nginx/lua/plugins.lua
@@ -61,9 +61,9 @@ end
 function _M.run_before()
   local phase = ngx.get_phase() .. "_before"
 
-  for name, plugin in pairs(plugins) do
+  for _, plugin in ipairs(plugins) do
     if plugin[phase] then
-      ngx_log(INFO, string_format("running plugin \"%s\" in phase \"%s\"", name, phase))
+      ngx_log(INFO, string_format("running plugin \"%s\" in phase \"%s\"", plugin.name, phase))
 
       -- TODO: consider sandboxing this, should we?
       -- probably yes, at least prohibit plugin from accessing env vars etc
@@ -72,7 +72,7 @@ function _M.run_before()
       local ok, err = pcall(plugin[phase])
       if not ok then
         ngx_log(ERR, string_format("error while running plugin \"%s\" in phase \"%s\": %s",
-            name, phase, err))
+            plugin.name, phase, err))
       end
     end
   end

--- a/rootfs/etc/nginx/lua/plugins/README.md
+++ b/rootfs/etc/nginx/lua/plugins/README.md
@@ -18,6 +18,8 @@ By defining functions with the following names, you can run your custom Lua code
  - `body_filter`: this is called when response body is received, it is useful for logging response body 
  - `log`: this is called when request processing is completed and a response is delivered to the client
 
+If you need to execute your plugin before ingress logic, it's possible to suffix with `_before`.
+
 Check this [`hello_world`](https://github.com/kubernetes/ingress-nginx/tree/main/rootfs/etc/nginx/lua/plugins/hello_world) plugin as a simple example or refer to [OpenID Connect integration](https://github.com/ElvinEfendi/ingress-nginx-openidc/tree/master/rootfs/etc/nginx/lua/plugins/openidc) for more advanced usage.
 
 Do not forget to write tests for your plugin.

--- a/rootfs/etc/nginx/lua/test/plugins_test.lua
+++ b/rootfs/etc/nginx/lua/test/plugins_test.lua
@@ -20,4 +20,26 @@ describe("plugins", function()
       assert.are.same(plugins_to_mock, called_plugins)
     end)
   end)
+
+  describe("#run_before", function()
+    it("runs the plugins in the given order", function()
+      ngx.get_phase = function() return "rewrite" end
+      local plugins = require("plugins")
+      local called_plugins = {}
+      local plugins_to_mock = {"plugins.pluginfirst.main", "plugins.pluginsecond.main", "plugins.pluginthird.main"}
+      for i=1, 3, 1
+      do
+        package.loaded[plugins_to_mock[i]] = {
+          rewrite_before = function()
+            called_plugins[#called_plugins + 1] = plugins_to_mock[i]
+          end
+        }
+      end
+      assert.has_no.errors(function()
+        plugins.init({"pluginfirst", "pluginsecond", "pluginthird"})
+      end)
+      assert.has_no.errors(plugins.run_before)
+      assert.are.same(plugins_to_mock, called_plugins)
+    end)
+  end)
 end)

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -125,6 +125,7 @@ http {
     }
 
     init_worker_by_lua_block {
+        plugins.run_before()
         lua_ingress.init_worker()
         balancer.init_worker()
         {{ if $all.EnableMetrics }}
@@ -1199,6 +1200,7 @@ stream {
             {{ end }}
 
             rewrite_by_lua_block {
+                plugins.run_before()
                 lua_ingress.rewrite({{ locationConfigForLua $location $all }})
                 balancer.rewrite()
                 plugins.run()
@@ -1211,15 +1213,18 @@ stream {
             #}
 
             header_filter_by_lua_block {
+                plugins.run_before()
                 lua_ingress.header()
                 plugins.run()
             }
 
             body_filter_by_lua_block {
+                plugins.run_before()
                 plugins.run()
             }
 
             log_by_lua_block {
+                plugins.run_before()
                 balancer.log()
                 {{ if $all.EnableMetrics }}
                 monitor.call()


### PR DESCRIPTION
Current plugin implementation prevents executing before ingress logic.
For example, can be used to correctly set `X-Forwarded-Proto` before redirect logic.
