### PR TITLE
Fix YAML indentation issue for sample ConfigMap

### DIFF
--- a/deploy/static/provider/aws/deploy-tls-termination.yaml
+++ b/deploy/static/provider/aws/deploy-tls-termination.yaml
@@ -37,7 +37,7 @@ metadata:
   name: ingress-nginx-controller
   namespace: ingress-nginx
 data:
-  http-snippet:|
+  http-snippet: |
     server{
       listen 2443;
       return 308 https://$host$request_uri;


### PR DESCRIPTION
`http-snippet:|` does not work for kubernetes 1.21.4, it requires extra space: `http-snippet: |`

## What this PR does / why we need it:
Without the extra space, kubernetes 1.21.4 complains.

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
Kubernetes complains about valid YAML config: `error: error parsing nginx.yaml: error converting YAML to JSON: yaml: line 20: mapping values are not allowed in this context`

## How Has This Been Tested?
I have ran the YAML against kubernetes 1.21.4

```
$ cat nginx.yaml
# Source: ingress-nginx/templates/controller-configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  labels:
    helm.sh/chart: ingress-nginx-4.0.1
    app.kubernetes.io/name: ingress-nginx
    app.kubernetes.io/instance: ingress-nginx
    app.kubernetes.io/version: 1.0.0
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: controller
  name: ingress-nginx-controller
  namespace: ingress-nginx
data:
  http-snippet:|
    server{
      listen 2443;
      return 308 https://$host$request_uri;
    }
  proxy-real-ip-cidr: 10.1.0.0/16
  use-forwarded-headers: 'true'
$ kubectl apply -f nginx.yaml
error: error parsing nginx.yaml: error converting YAML to JSON: yaml: line 20: mapping values are not allowed in this context
```

After the fix:

```
$ cat nginx.yaml
# Source: ingress-nginx/templates/controller-configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  labels:
    helm.sh/chart: ingress-nginx-4.0.1
    app.kubernetes.io/name: ingress-nginx
    app.kubernetes.io/instance: ingress-nginx
    app.kubernetes.io/version: 1.0.0
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: controller
  name: ingress-nginx-controller
  namespace: ingress-nginx
data:
  http-snippet: |
    server{
      listen 2443;
      return 308 https://$host$request_uri;
    }
  proxy-real-ip-cidr: 10.1.0.0/16
  use-forwarded-headers: 'true'
$ kubectl apply -f nginx.yaml
configmap/ingress-nginx-controller configured
```



## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ X] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
