### PR TITLE
put modsecurity e2e tests into their own packages

### DIFF
--- a/test/e2e/annotations/modsecurity/modsecurity.go
+++ b/test/e2e/annotations/modsecurity/modsecurity.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package annotations
+package modsecurity
 
 import (
 	"net/http"

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -32,6 +32,7 @@ import (
 	// tests to run
 	_ "k8s.io/ingress-nginx/test/e2e/admission"
 	_ "k8s.io/ingress-nginx/test/e2e/annotations"
+	_ "k8s.io/ingress-nginx/test/e2e/annotations/modsecurity"
 	_ "k8s.io/ingress-nginx/test/e2e/dbg"
 	_ "k8s.io/ingress-nginx/test/e2e/defaultbackend"
 	_ "k8s.io/ingress-nginx/test/e2e/gracefulshutdown"
@@ -42,6 +43,7 @@ import (
 	_ "k8s.io/ingress-nginx/test/e2e/security"
 	_ "k8s.io/ingress-nginx/test/e2e/servicebackend"
 	_ "k8s.io/ingress-nginx/test/e2e/settings"
+	_ "k8s.io/ingress-nginx/test/e2e/settings/modsecurity"
 	_ "k8s.io/ingress-nginx/test/e2e/settings/ocsp"
 	_ "k8s.io/ingress-nginx/test/e2e/ssl"
 	_ "k8s.io/ingress-nginx/test/e2e/status"

--- a/test/e2e/settings/modsecurity/modsecurity_snippet.go
+++ b/test/e2e/settings/modsecurity/modsecurity_snippet.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package settings
+package modsecurity
 
 import (
 	"strings"


### PR DESCRIPTION
This will allow users not wanting modsecurity to easily remove it from base image and also disable corresponding e2e tests by editing `test/e2e/e2e.go`. Eventually we can even parametrize e2e command to not require editing `e2e.go`. If this is something reviewers approves then I'll apply the same approach to few other e2e tests (i.e all the opentracing related stuff) too where they are not crucial to core ingress-nginx and that some users might want to strip them out from the final image.