### PR TITLE
Print warning only instead of error if no permission on ingressclass

### DIFF
--- a/cmd/nginx/main.go
+++ b/cmd/nginx/main.go
@@ -110,8 +110,11 @@ func main() {
 	_, err = kubeClient.NetworkingV1().IngressClasses().List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		if !errors.IsNotFound(err) {
-			if errors.IsUnauthorized(err) || !errors.IsForbidden(err) {
+			if errors.IsUnauthorized(err) {
 				klog.Fatalf("Error searching IngressClass: Please verify your RBAC and allow Ingress Controller to list and get Ingress Classes: %v", err)
+			} else if errors.IsForbidden(err) {
+				klog.Warningf("No permissions to list and get Ingress Classes: %v, IngressClass feature will be disabled", err)
+				conf.IngressClassConfiguration.IgnoreIngressClass = true
 			}
 		}
 	}

--- a/internal/ingress/controller/ingressclass/ingressclass.go
+++ b/internal/ingress/controller/ingressclass/ingressclass.go
@@ -42,4 +42,7 @@ type IngressClassConfiguration struct {
 	// WatchWithoutClass defines if Controller should watch to Ingress Objects that does
 	// not contain an IngressClass configuration
 	WatchWithoutClass bool
+	// IgnoreIngressClass defines if Controller should ignore the IngressClass Object if no permissions are
+	// granted on IngressClass
+	IgnoreIngressClass bool
 }

--- a/internal/ingress/controller/store/store.go
+++ b/internal/ingress/controller/store/store.go
@@ -151,20 +151,24 @@ func (e NotExistsError) Error() string {
 func (i *Informer) Run(stopCh chan struct{}) {
 	go i.Secret.Run(stopCh)
 	go i.Endpoint.Run(stopCh)
-	go i.IngressClass.Run(stopCh)
+	if i.IngressClass != nil {
+		go i.IngressClass.Run(stopCh)
+	}
 	go i.Service.Run(stopCh)
 	go i.ConfigMap.Run(stopCh)
 
 	// wait for all involved caches to be synced before processing items
 	// from the queue
 	if !cache.WaitForCacheSync(stopCh,
-		i.Endpoint.HasSynced,
-		i.IngressClass.HasSynced,
+		i.Endpoint.HasSynced,		
 		i.Service.HasSynced,
 		i.Secret.HasSynced,
 		i.ConfigMap.HasSynced,
 	) {
 		runtime.HandleError(fmt.Errorf("timed out waiting for caches to sync"))
+	}
+	if i.IngressClass != nil && !cache.WaitForCacheSync(stopCh, i.IngressClass.HasSynced) {
+		runtime.HandleError(fmt.Errorf("timed out waiting for ingress classcaches to sync"))
 	}
 
 	// in big clusters, deltas can keep arriving even after HasSynced
@@ -299,9 +303,11 @@ func New(
 
 	store.informers.Ingress = infFactory.Networking().V1().Ingresses().Informer()
 	store.listers.Ingress.Store = store.informers.Ingress.GetStore()
-
-	store.informers.IngressClass = infFactory.Networking().V1().IngressClasses().Informer()
-	store.listers.IngressClass.Store = cache.NewStore(cache.MetaNamespaceKeyFunc)
+	
+	if !icConfig.IgnoreIngressClass {
+		store.informers.IngressClass = infFactory.Networking().V1().IngressClasses().Informer()
+		store.listers.IngressClass.Store = cache.NewStore(cache.MetaNamespaceKeyFunc)
+	}
 
 	store.informers.Endpoint = infFactory.Core().V1().Endpoints().Informer()
 	store.listers.Endpoint.Store = store.informers.Endpoint.GetStore()
@@ -385,8 +391,12 @@ func New(
 			oldIng, _ := toIngress(old)
 			curIng, _ := toIngress(cur)
 
-			_, errOld := store.GetIngressClass(oldIng, icConfig)
-			classCur, errCur := store.GetIngressClass(curIng, icConfig)
+			var errOld, errCur error
+			var classCur string
+			if !icConfig.IgnoreIngressClass {
+				_, errOld = store.GetIngressClass(oldIng, icConfig)
+				classCur, errCur = store.GetIngressClass(curIng, icConfig)
+			}
 			if errOld != nil && errCur == nil {
 				if hasCatchAllIngressRule(curIng.Spec) && disableCatchAll {
 					klog.InfoS("ignoring update for catch-all ingress because of --disable-catch-all", "ingress", klog.KObj(curIng))
@@ -676,7 +686,9 @@ func New(
 	}
 
 	store.informers.Ingress.AddEventHandler(ingEventHandler)
-	store.informers.IngressClass.AddEventHandler(ingressClassEventHandler)
+	if !icConfig.IgnoreIngressClass {
+		store.informers.IngressClass.AddEventHandler(ingressClassEventHandler)
+	}
 	store.informers.Endpoint.AddEventHandler(epEventHandler)
 	store.informers.Secret.AddEventHandler(secrEventHandler)
 	store.informers.ConfigMap.AddEventHandler(cmEventHandler)
@@ -829,7 +841,7 @@ func (s *k8sStore) GetService(key string) (*corev1.Service, error) {
 
 func (s *k8sStore) GetIngressClass(ing *networkingv1.Ingress, icConfig *ingressclass.IngressClassConfiguration) (string, error) {
 	// First we try ingressClassName
-	if ing.Spec.IngressClassName != nil {
+	if !icConfig.IgnoreIngressClass && ing.Spec.IngressClassName != nil {
 		iclass, err := s.listers.IngressClass.ByKey(*ing.Spec.IngressClassName)
 		if err != nil {
 			return "", err


### PR DESCRIPTION
…ter level resource IngressClass

<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
for backaward compatibility, if serviceaccount who run the ingress-controller don't have permission on cluster level resource IngressClass, ingress-controller will fail directly.  Add this PR to provide backaward compabitiltiy

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
fixes #7510
https://github.com/kubernetes/ingress-nginx/issues/7510


## How Has This Been Tested?
Compile new ingress-controller and start with serviceaccount who don't have Permission on IngressClass

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
