### PR TITLE
Default KinD manifest to watch ingresses without class

### DIFF
--- a/deploy/static/provider/kind/deploy.yaml
+++ b/deploy/static/provider/kind/deploy.yaml
@@ -339,6 +339,7 @@ spec:
             - --validating-webhook-certificate=/usr/local/certificates/cert
             - --validating-webhook-key=/usr/local/certificates/key
             - --publish-status-address=localhost
+            - --watch-ingress-without-class
           securityContext:
             capabilities:
               drop:


### PR DESCRIPTION
## What this PR does / why we need it:
KinD Ingress Quickstart docs does not uses ingressClass, as it's generic for any ingress (and we are ok with that!)

As KinD is not intended to be used in production anyway, we can change the manifest deployment to watch Ingresses without class and make users happy :)

Fixes: https://github.com/kubernetes-sigs/kind/issues/2433