### PR TITLE
[WIP] Add alternative debian based base image

### DIFF
--- a/images/modsecurity/Makefile
+++ b/images/modsecurity/Makefile
@@ -1,0 +1,57 @@
+# Copyright 2017 The Kubernetes Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+.DEFAULT_GOAL:=build
+
+# set default shell
+SHELL=/bin/bash -o pipefail -o errexit
+
+DIR:=$(strip $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST)))))
+INIT_BUILDX=$(DIR)/../../hack/init-buildx.sh
+
+# 0.0.0 shouldn't clobber any released builds
+TAG ?= 0.0
+REGISTRY ?= gcr.io/k8s-staging-ingress-nginx
+
+IMAGE = $(REGISTRY)/modsecurity
+
+# required to enable buildx
+export DOCKER_CLI_EXPERIMENTAL=enabled
+
+# build with buildx
+PLATFORMS?=linux/amd64,linux/arm,linux/arm64,linux/s390x
+OUTPUT=
+PROGRESS=plain
+build: ensure-buildx
+	docker buildx build \
+		--platform=${PLATFORMS} $(OUTPUT) \
+		--progress=$(PROGRESS) \
+		--pull \
+		--tag $(IMAGE):$(TAG) rootfs
+
+# push the cross built image
+push: OUTPUT=--push
+push: build
+
+# enable buildx
+ensure-buildx:
+# this is required for cloudbuild
+ifeq ("$(wildcard $(INIT_BUILDX))","")
+	@curl -sSL https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/hack/init-buildx.sh | bash
+else
+	@exec $(INIT_BUILDX)
+endif
+	@echo "done"
+
+.PHONY: build push ensure-buildx

--- a/images/modsecurity/Makefile
+++ b/images/modsecurity/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2017 The Kubernetes Authors. All rights reserved.
+# Copyright 2021 The Kubernetes Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/images/modsecurity/README.md
+++ b/images/modsecurity/README.md
@@ -1,0 +1,5 @@
+ModSecurity library builder
+
+**How to use this image:**
+This image only contains the necessary files in /usr/local/modsecurity and /etc/nginx/modsecurity to 
+be copied to Ingress Controller deployment when ModSecurity is enabled

--- a/images/modsecurity/cloudbuild.yaml
+++ b/images/modsecurity/cloudbuild.yaml
@@ -1,0 +1,24 @@
+timeout: 10800s
+options:
+  substitution_option: ALLOW_LOOSE
+  # job builds a multi-arch docker image for amd64,arm,arm64 and s390x.
+  machineType: N1_HIGHCPU_32
+steps:
+  - name: gcr.io/k8s-testimages/gcb-docker-gcloud:v20210722-085d930
+    entrypoint: bash
+    env:
+      - DOCKER_CLI_EXPERIMENTAL=enabled
+      - TAG=$_GIT_TAG
+      - BASE_REF=$_PULL_BASE_REF
+      - REGISTRY=gcr.io/k8s-staging-ingress-nginx
+      # default cloudbuild has HOME=/builder/home and docker buildx is in /root/.docker/cli-plugins/docker-buildx
+      # set the home to /root explicitly to if using docker buildx
+      - HOME=/root
+    args:
+    - -c
+    - |
+      gcloud auth configure-docker \
+      && make push
+substitutions:
+  _GIT_TAG: "12345"
+  _PULL_BASE_REF: "master"

--- a/images/modsecurity/rootfs/Dockerfile
+++ b/images/modsecurity/rootfs/Dockerfile
@@ -1,0 +1,27 @@
+# Copyright 2015 The Kubernetes Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+FROM debian:bullseye-slim as builder
+
+COPY . /
+
+RUN apt-get update \
+  && apt-get -y dist-upgrade \
+  && /build.sh
+
+FROM busybox:latest 
+
+COPY --from=builder /etc/nginx/ /etc/nginx/
+COPY --from=builder /usr/local/modsecurity /usr/local/modsecurity

--- a/images/modsecurity/rootfs/Dockerfile
+++ b/images/modsecurity/rootfs/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2015 The Kubernetes Authors. All rights reserved.
+# Copyright 2021 The Kubernetes Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/images/modsecurity/rootfs/build.sh
+++ b/images/modsecurity/rootfs/build.sh
@@ -1,0 +1,186 @@
+#!/bin/bash
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+export NGINX_VERSION=1.20.1
+
+# Check for recent changes: https://github.com/SpiderLabs/ModSecurity-nginx/compare/v1.0.2...master
+export MODSECURITY_VERSION=1.0.2
+
+# Check for recent changes: https://github.com/SpiderLabs/ModSecurity/compare/v3.0.5...v3/master
+export MODSECURITY_LIB_VERSION=v3.0.5
+
+# Check for recent changes: https://github.com/coreruleset/coreruleset/compare/v3.3.2...v3.3/master
+export OWASP_MODSECURITY_CRS_VERSION=v3.3.2
+
+export BUILD_PATH=/tmp/build
+
+#  TODO: Verify and add the same libraries (but not dev) in main container
+apt-get install -y \
+     build-essential \
+     autoconf automake \
+     cmake curl ca-certificates libtool \
+     git libcurl4-openssl-dev libssl-dev \
+     libgeoip-dev libmaxminddb-dev liblmdb-dev libyajl-dev libyajl2 yajl-tools libxml2-dev \
+     libpcre3-dev zlib1g-dev
+
+apt-get clean -y
+rm -rf \
+   /var/cache/debconf/* \
+   /var/lib/apt/lists/* \
+   /var/log/* \
+   /tmp/* \
+   /var/tmp/*
+
+
+mkdir -p /etc/nginx
+mkdir --verbose -p "$BUILD_PATH"
+cd "$BUILD_PATH"
+
+
+get_src()
+{
+  hash="$1"
+  url="$2"
+  f=$(basename "$url")
+
+  echo "Downloading $url"
+
+  curl -sSL "$url" -o "$f"
+  echo "$hash  $f" | sha256sum -c - || exit 10
+  tar xzf "$f"
+  rm -rf "$f"
+}
+
+get_src e462e11533d5c30baa05df7652160ff5979591d291736cfa5edb9fd2edb48c49 \
+        "https://nginx.org/download/nginx-$NGINX_VERSION.tar.gz"
+
+get_src f8d3ff15520df736c5e20e91d5852ec27e0874566c2afce7dcb979e2298d6980 \
+        "https://github.com/SpiderLabs/ModSecurity-nginx/archive/v$MODSECURITY_VERSION.tar.gz"
+
+# improve compilation times
+CORES=$(($(grep -c ^processor /proc/cpuinfo) - 1))
+
+export MAKEFLAGS=-j${CORES}
+
+
+cd "$BUILD_PATH"
+git clone --depth=1 https://github.com/ssdeep-project/ssdeep
+cd ssdeep/
+
+./bootstrap
+./configure
+
+make
+make install
+
+# build modsecurity library
+cd "$BUILD_PATH"
+git clone --depth=1 -b $MODSECURITY_LIB_VERSION https://github.com/SpiderLabs/ModSecurity
+cd ModSecurity/
+git submodule init
+git submodule update
+
+sh build.sh
+
+# https://github.com/SpiderLabs/ModSecurity/issues/1909#issuecomment-465926762
+#sed -i '115i LUA_CFLAGS="${LUA_CFLAGS} -DWITH_LUA_JIT_2_1"' build/lua.m4
+#sed -i '117i AC_SUBST(LUA_CFLAGS)' build/lua.m4
+
+./configure \
+  --disable-doxygen-doc \
+  --disable-doxygen-html \
+  --disable-examples \
+  --with-lmdb \
+  --with-yajl="/usr/"
+
+make
+make install
+
+mkdir -p /etc/nginx/modsecurity
+cp modsecurity.conf-recommended /etc/nginx/modsecurity/modsecurity.conf
+cp unicode.mapping /etc/nginx/modsecurity/unicode.mapping
+
+# Replace serial logging with concurrent
+sed -i 's|SecAuditLogType Serial|SecAuditLogType Concurrent|g' /etc/nginx/modsecurity/modsecurity.conf
+
+# Concurrent logging implies the log is stored in several files
+echo "SecAuditLogStorageDir /var/log/audit/" >> /etc/nginx/modsecurity/modsecurity.conf
+
+# build nginx
+cd "$BUILD_PATH/nginx-$NGINX_VERSION"
+./configure \
+  --prefix=/usr/local/nginx \
+  --with-compat \
+  --add-dynamic-module=$BUILD_PATH/ModSecurity-nginx-$MODSECURITY_VERSION
+
+make modules
+cp objs/ngx_http_modsecurity_module.so /etc/nginx/modsecurity/
+
+# Download owasp modsecurity crs
+cd /etc/nginx/
+
+git clone -b $OWASP_MODSECURITY_CRS_VERSION https://github.com/coreruleset/coreruleset
+mv coreruleset owasp-modsecurity-crs
+cd owasp-modsecurity-crs
+
+mv crs-setup.conf.example crs-setup.conf
+mv rules/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf.example rules/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf
+mv rules/RESPONSE-999-EXCLUSION-RULES-AFTER-CRS.conf.example rules/RESPONSE-999-EXCLUSION-RULES-AFTER-CRS.conf
+cd ..
+
+# OWASP CRS v3 rules
+echo "
+Include /etc/nginx/owasp-modsecurity-crs/crs-setup.conf
+Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf
+Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-901-INITIALIZATION.conf
+Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-903.9001-DRUPAL-EXCLUSION-RULES.conf
+Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
+Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-905-COMMON-EXCEPTIONS.conf
+Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-910-IP-REPUTATION.conf
+Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-911-METHOD-ENFORCEMENT.conf
+Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-912-DOS-PROTECTION.conf
+Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-913-SCANNER-DETECTION.conf
+Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
+Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-931-APPLICATION-ATTACK-RFI.conf
+Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-934-APPLICATION-ATTACK-NODEJS.conf
+Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION.conf
+Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-944-APPLICATION-ATTACK-JAVA.conf
+Include /etc/nginx/owasp-modsecurity-crs/rules/REQUEST-949-BLOCKING-EVALUATION.conf
+Include /etc/nginx/owasp-modsecurity-crs/rules/RESPONSE-950-DATA-LEAKAGES.conf
+Include /etc/nginx/owasp-modsecurity-crs/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
+Include /etc/nginx/owasp-modsecurity-crs/rules/RESPONSE-952-DATA-LEAKAGES-JAVA.conf
+Include /etc/nginx/owasp-modsecurity-crs/rules/RESPONSE-953-DATA-LEAKAGES-PHP.conf
+Include /etc/nginx/owasp-modsecurity-crs/rules/RESPONSE-954-DATA-LEAKAGES-IIS.conf
+Include /etc/nginx/owasp-modsecurity-crs/rules/RESPONSE-959-BLOCKING-EVALUATION.conf
+Include /etc/nginx/owasp-modsecurity-crs/rules/RESPONSE-980-CORRELATION.conf
+Include /etc/nginx/owasp-modsecurity-crs/rules/RESPONSE-999-EXCLUSION-RULES-AFTER-CRS.conf
+" > /etc/nginx/owasp-modsecurity-crs/nginx-modsecurity.conf
+
+rm -rf /etc/nginx/owasp-modsecurity-crs/.git
+rm -rf /etc/nginx/owasp-modsecurity-crs/util/regression-tests
+
+# remove .a files
+find /usr/local -name "*.a" -print | xargs /bin/rm

--- a/images/nginx-debian/Makefile
+++ b/images/nginx-debian/Makefile
@@ -1,0 +1,57 @@
+# Copyright 2017 The Kubernetes Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+.DEFAULT_GOAL:=build
+
+# set default shell
+SHELL=/bin/bash -o pipefail -o errexit
+
+DIR:=$(strip $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST)))))
+INIT_BUILDX=$(DIR)/../../hack/init-buildx.sh
+
+# 0.0.0 shouldn't clobber any released builds
+TAG ?= 0.0
+REGISTRY ?= gcr.io/k8s-staging-ingress-nginx
+
+IMAGE = $(REGISTRY)/nginx-debian
+
+# required to enable buildx
+export DOCKER_CLI_EXPERIMENTAL=enabled
+
+# build with buildx
+PLATFORMS?=linux/amd64,linux/arm,linux/arm64,linux/s390x
+OUTPUT=
+PROGRESS=plain
+build: ensure-buildx
+	docker buildx build \
+		--platform=${PLATFORMS} $(OUTPUT) \
+		--progress=$(PROGRESS) \
+		--pull \
+		--tag $(IMAGE):$(TAG) rootfs
+
+# push the cross built image
+push: OUTPUT=--push
+push: build
+
+# enable buildx
+ensure-buildx:
+# this is required for cloudbuild
+ifeq ("$(wildcard $(INIT_BUILDX))","")
+	@curl -sSL https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/hack/init-buildx.sh | bash
+else
+	@exec $(INIT_BUILDX)
+endif
+	@echo "done"
+
+.PHONY: build push ensure-buildx

--- a/images/nginx-debian/Makefile
+++ b/images/nginx-debian/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2017 The Kubernetes Authors. All rights reserved.
+# Copyright 2021 The Kubernetes Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/images/nginx-debian/README.md
+++ b/images/nginx-debian/README.md
@@ -1,0 +1,22 @@
+NGINX base image using [Debian](https://www.debian.org/)
+
+This custom image contains:
+
+- [nginx-http-auth-digest](https://github.com/atomx/nginx-http-auth-digest)
+- [ngx_http_substitutions_filter_module](https://github.com/yaoweibin/ngx_http_substitutions_filter_module)
+- [nginx-opentracing](https://github.com/opentracing-contrib/nginx-opentracing)
+- [opentracing-cpp](https://github.com/opentracing/opentracing-cpp)
+- [zipkin-cpp-opentracing](https://github.com/rnburn/zipkin-cpp-opentracing)
+- [dd-opentracing-cpp](https://github.com/DataDog/dd-opentracing-cpp)
+- [ModSecurity-nginx](https://github.com/SpiderLabs/ModSecurity-nginx) (only supported in x86_64)
+- [brotli](https://github.com/google/brotli)
+- [geoip2](https://github.com/leev/ngx_http_geoip2_module)
+
+**How to use this image:**
+This image provides a default configuration file with no backend servers.
+
+_Using docker_
+
+```console
+docker run -v /some/nginx.con:/etc/nginx/nginx.conf:ro k8s.gcr.io/ingress-nginx/nginx:v20210809-g98288bc3c@sha256:f9363669cf26514c9548c1fe4f8f4e2f58dfb76616bcd638a0ff7f0ec3457c17
+```

--- a/images/nginx-debian/cloudbuild.yaml
+++ b/images/nginx-debian/cloudbuild.yaml
@@ -1,0 +1,24 @@
+timeout: 10800s
+options:
+  substitution_option: ALLOW_LOOSE
+  # job builds a multi-arch docker image for amd64,arm,arm64 and s390x.
+  machineType: N1_HIGHCPU_32
+steps:
+  - name: gcr.io/k8s-testimages/gcb-docker-gcloud:v20210722-085d930
+    entrypoint: bash
+    env:
+      - DOCKER_CLI_EXPERIMENTAL=enabled
+      - TAG=$_GIT_TAG
+      - BASE_REF=$_PULL_BASE_REF
+      - REGISTRY=gcr.io/k8s-staging-ingress-nginx
+      # default cloudbuild has HOME=/builder/home and docker buildx is in /root/.docker/cli-plugins/docker-buildx
+      # set the home to /root explicitly to if using docker buildx
+      - HOME=/root
+    args:
+    - -c
+    - |
+      gcloud auth configure-docker \
+      && make push
+substitutions:
+  _GIT_TAG: "12345"
+  _PULL_BASE_REF: "master"

--- a/images/nginx-debian/rootfs/Dockerfile
+++ b/images/nginx-debian/rootfs/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2015 The Kubernetes Authors. All rights reserved.
+# Copyright 2021 The Kubernetes Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/images/nginx-debian/rootfs/Dockerfile
+++ b/images/nginx-debian/rootfs/Dockerfile
@@ -1,0 +1,68 @@
+# Copyright 2015 The Kubernetes Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+FROM debian:bullseye-slim as builder
+
+COPY . /
+
+RUN apt-get update \
+  && apt-get -y dist-upgrade \
+  && /build.sh
+
+# Use a multi-stage build
+FROM debian:bullseye-slim
+
+ENV PATH=$PATH:/usr/local/luajit/bin:/usr/local/nginx/sbin:/usr/local/nginx/bin
+
+ENV LUA_PATH="/usr/local/share/luajit-2.1.0-beta3/?.lua;/usr/local/share/lua/5.1/?.lua;/usr/local/lib/lua/?.lua;;"
+ENV LUA_CPATH="/usr/local/lib/lua/?/?.so;/usr/local/lib/lua/?.so;;"
+
+ENV LD_LIBRARY_PATH="/usr/local/lib:/usr/local/modsecurity"
+
+COPY --from=builder /usr/local /usr/local
+COPY --from=builder /etc/nginx /etc/nginx
+
+RUN apt-get update \
+    && apt-get -y dist-upgrade \
+    && apt-get -y --no-install-recommends install libgeoip1 \
+    curl ca-certificates openssl dumb-init \
+    tzdata \
+    # Below libraries are part of modsecurity and need to be on the base image
+    libxml2 libfuzzy2 libyajl2 liblmdb0 libmaxminddb0 \
+    && ln -s /usr/local/nginx/sbin/nginx /sbin/nginx \
+    && groupmod -g 101 www-data \
+    && usermod -d /usr/local/nginx -u 101 www-data \
+    && apt-get clean -y \
+    && rm -rf \
+       /var/cache/debconf/* \
+       /var/lib/apt/lists/* \
+       /var/log/* \
+       /tmp/* \
+       /var/tmp/* \
+    && bash -eu -c ' \
+      writeDirs=( \
+        /var/log/nginx \
+        /var/lib/nginx/body \
+        /var/lib/nginx/fastcgi \
+        /var/lib/nginx/proxy \
+        /var/lib/nginx/scgi \
+        /var/lib/nginx/uwsgi \
+        /var/log/audit \
+      ); \
+      for dir in "${writeDirs[@]}"; do \
+        mkdir -p ${dir}; \
+        chown -R www-data.www-data ${dir}; \
+      done'
+ 

--- a/images/nginx-debian/rootfs/build.sh
+++ b/images/nginx-debian/rootfs/build.sh
@@ -1,0 +1,606 @@
+#!/bin/bash
+
+# Copyright 2015 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+export NGINX_VERSION=1.20.1
+
+# Check for recent changes: https://github.com/vision5/ngx_devel_kit/compare/v0.3.1...master
+export NDK_VERSION=0.3.1
+
+# Check for recent changes: https://github.com/openresty/set-misc-nginx-module/compare/v0.32...master
+export SETMISC_VERSION=0.32
+
+# Check for recent changes: https://github.com/openresty/headers-more-nginx-module/compare/v0.33...master
+export MORE_HEADERS_VERSION=0.33
+
+# Check for recent changes: https://github.com/atomx/nginx-http-auth-digest/compare/v1.0.0...atomx:master
+export NGINX_DIGEST_AUTH=1.0.0
+
+# Check for recent changes: https://github.com/yaoweibin/ngx_http_substitutions_filter_module/compare/v0.6.4...master
+export NGINX_SUBSTITUTIONS=b8a71eacc7f986ba091282ab8b1bbbc6ae1807e0
+
+# Check for recent changes: https://github.com/opentracing-contrib/nginx-opentracing/compare/v0.19.0...master
+export NGINX_OPENTRACING_VERSION=0.19.0
+
+#Check for recent changes: https://github.com/opentracing/opentracing-cpp/compare/v1.6.0...master
+export OPENTRACING_CPP_VERSION=f86b33f3d9e7322b1298ba62d5ffa7a9519c4c41
+
+# Check for recent changes: https://github.com/rnburn/zipkin-cpp-opentracing/compare/v0.5.2...master
+export ZIPKIN_CPP_VERSION=f69593138ff84ca2f6bc115992e18ca3d35f344a
+
+# Check for recent changes: https://github.com/jbeder/yaml-cpp/compare/yaml-cpp-0.7.0...master
+export YAML_CPP_VERSION=yaml-cpp-0.7.0
+
+# Check for recent changes: https://github.com/jaegertracing/jaeger-client-cpp/compare/v0.7.0...master
+export JAEGER_VERSION=0.7.0
+
+# Check for recent changes: https://github.com/msgpack/msgpack-c/compare/cpp-3.3.0...master
+export MSGPACK_VERSION=3.3.0
+
+# Check for recent changes: https://github.com/DataDog/dd-opentracing-cpp/compare/v1.3.0...master
+export DATADOG_CPP_VERSION=af53c523787cca108ae9f458ea5c962e48187a36
+
+# Check for recent changes: https://github.com/openresty/lua-nginx-module/compare/v0.10.20...master
+export LUA_NGX_VERSION=b721656a9127255003b696b42ccc871c7ec18d59
+
+# Check for recent changes: https://github.com/openresty/stream-lua-nginx-module/compare/v0.0.10...master
+export LUA_STREAM_NGX_VERSION=74f8c8bca5b95cecbf42d4e1a465bc08cd075a9b
+
+# Check for recent changes: https://github.com/openresty/lua-upstream-nginx-module/compare/v0.07...master
+export LUA_UPSTREAM_VERSION=8aa93ead98ba2060d4efd594ae33a35d153589bf
+
+# Check for recent changes: https://github.com/openresty/lua-cjson/compare/2.1.0.8...openresty:master
+export LUA_CJSON_VERSION=4b350c531de3d71008c77ae94e59275b8371b4dc
+
+export NGINX_INFLUXDB_VERSION=5b09391cb7b9a889687c0aa67964c06a2d933e8b
+
+# Check for recent changes: https://github.com/leev/ngx_http_geoip2_module/compare/3.3...master
+export GEOIP2_VERSION=a26c6beed77e81553686852dceb6c7fdacc5970d
+
+# Check for recent changes: https://github.com/yaoweibin/nginx_ajp_module/compare/v0.3.0...master
+export NGINX_AJP_VERSION=a964a0bcc6a9f2bfb82a13752d7794a36319ffac
+
+# Check for recent changes: https://github.com/openresty/luajit2/compare/v2.1-20210510...v2.1-agentzh
+export LUAJIT_VERSION=2.1-20210510
+
+# Check for recent changes: https://github.com/openresty/lua-resty-balancer/compare/v0.03...master
+export LUA_RESTY_BALANCER=56fd8ad03d5718f507a5129edc43a25948364b9f
+
+# Check for recent changes: https://github.com/openresty/lua-resty-lrucache/compare/v0.11...master
+export LUA_RESTY_CACHE=0.11
+
+# Check for recent changes: https://github.com/openresty/lua-resty-core/compare/v0.1.22...master
+export LUA_RESTY_CORE=0.1.22
+
+# Check for recent changes: https://github.com/cloudflare/lua-resty-cookie/compare/v0.1.0...master
+export LUA_RESTY_COOKIE_VERSION=303e32e512defced053a6484bc0745cf9dc0d39e
+
+# Check for recent changes: https://github.com/openresty/lua-resty-dns/compare/v0.22...master
+export LUA_RESTY_DNS=0.22
+
+# Check for recent changes: https://github.com/ledgetech/lua-resty-http/compare/v0.16.1...master
+export LUA_RESTY_HTTP=0ce55d6d15da140ecc5966fa848204c6fd9074e8
+
+# Check for recent changes: https://github.com/openresty/lua-resty-lock/compare/v0.08...master
+export LUA_RESTY_LOCK=0.08
+
+# Check for recent changes: https://github.com/openresty/lua-resty-upload/compare/v0.10...master
+export LUA_RESTY_UPLOAD_VERSION=0.10
+
+# Check for recent changes: https://github.com/openresty/lua-resty-string/compare/v0.14...master
+export LUA_RESTY_STRING_VERSION=9ace36f2dde09451c377c839117ade45eb02d460
+
+# Check for recent changes: https://github.com/openresty/lua-resty-memcached/compare/v0.16...master
+export LUA_RESTY_MEMCACHED_VERSION=0.16
+
+# Check for recent changes: https://github.com/openresty/lua-resty-redis/compare/v0.29...master
+export LUA_RESTY_REDIS_VERSION=0.29
+
+# Check for recent changes: https://github.com/api7/lua-resty-ipmatcher/compare/v0.6...master
+export LUA_RESTY_IPMATCHER_VERSION=211e0d2eb8bbb558b79368f89948a0bafdc23654
+
+# Check for recent changes: https://github.com/ElvinEfendi/lua-resty-global-throttle/compare/v0.2.0...main
+export LUA_RESTY_GLOBAL_THROTTLE_VERSION=0.2.0
+
+export BUILD_PATH=/tmp/build
+
+ARCH=$(uname -m)
+
+if [[ ${ARCH} == "s390x" ]]; then
+  export LUAJIT_VERSION=9d5750d28478abfdcaefdfdc408f87752a21e431
+  export LUA_RESTY_CORE=0.1.17
+  export LUA_NGX_VERSION=0.10.15
+  export LUA_STREAM_NGX_VERSION=0.0.7
+fi
+
+get_src()
+{
+  hash="$1"
+  url="$2"
+  f=$(basename "$url")
+
+  echo "Downloading $url"
+
+  curl -sSL "$url" -o "$f"
+  echo "$hash  $f" | sha256sum -c - || exit 10
+  tar xzf "$f"
+  rm -rf "$f"
+}
+
+apt-get install -y --no-install-recommends \
+     build-essential \
+     autoconf automake \
+     cmake curl ca-certificates \
+     git libcurl4-openssl-dev libgeoip-dev libmaxminddb-dev libssl-dev libpcre3-dev zlib1g-dev
+
+apt-get clean -y
+rm -rf \
+   /var/cache/debconf/* \
+   /var/lib/apt/lists/* \
+   /var/log/* \
+   /tmp/* \
+   /var/tmp/*
+
+mkdir -p /etc/nginx
+
+mkdir --verbose -p "$BUILD_PATH"
+cd "$BUILD_PATH"
+
+# download, verify and extract the source files
+get_src e462e11533d5c30baa05df7652160ff5979591d291736cfa5edb9fd2edb48c49 \
+        "https://nginx.org/download/nginx-$NGINX_VERSION.tar.gz"
+
+get_src 0e971105e210d272a497567fa2e2c256f4e39b845a5ba80d373e26ba1abfbd85 \
+        "https://github.com/simpl/ngx_devel_kit/archive/v$NDK_VERSION.tar.gz"
+
+get_src f1ad2459c4ee6a61771aa84f77871f4bfe42943a4aa4c30c62ba3f981f52c201 \
+        "https://github.com/openresty/set-misc-nginx-module/archive/v$SETMISC_VERSION.tar.gz"
+
+get_src a3dcbab117a9c103bc1ea5200fc00a7b7d2af97ff7fd525f16f8ac2632e30fbf \
+        "https://github.com/openresty/headers-more-nginx-module/archive/v$MORE_HEADERS_VERSION.tar.gz"
+
+get_src f09851e6309560a8ff3e901548405066c83f1f6ff88aa7171e0763bd9514762b \
+        "https://github.com/atomx/nginx-http-auth-digest/archive/v$NGINX_DIGEST_AUTH.tar.gz"
+
+get_src a98b48947359166326d58700ccdc27256d2648218072da138ab6b47de47fbd8f \
+        "https://github.com/yaoweibin/ngx_http_substitutions_filter_module/archive/$NGINX_SUBSTITUTIONS.tar.gz"
+
+get_src 6f97776ebdf019b105a755c7736b70bdbd7e575c7f0d39db5fe127873c7abf17 \
+        "https://github.com/opentracing-contrib/nginx-opentracing/archive/v$NGINX_OPENTRACING_VERSION.tar.gz"
+
+get_src cbe625cba85291712253db5bc3870d60c709acfad9a8af5a302673d3d201e3ea \
+        "https://github.com/opentracing/opentracing-cpp/archive/$OPENTRACING_CPP_VERSION.tar.gz"
+
+get_src 71de3d0658935db7ccea20e006b35e58ddc7e4c18878b9523f2addc2371e9270 \
+        "https://github.com/rnburn/zipkin-cpp-opentracing/archive/$ZIPKIN_CPP_VERSION.tar.gz"
+
+get_src 43e6a9fcb146ad871515f0d0873947e5d497a1c9c60c58cb102a97b47208b7c3 \
+        "https://github.com/jbeder/yaml-cpp/archive/$YAML_CPP_VERSION.tar.gz"
+
+get_src 3a3a03060bf5e3fef52c9a2de02e6035cb557f389453d8f3b0c1d3d570636994 \
+        "https://github.com/jaegertracing/jaeger-client-cpp/archive/v$JAEGER_VERSION.tar.gz"
+
+get_src 754c3ace499a63e45b77ef4bcab4ee602c2c414f58403bce826b76ffc2f77d0b \
+        "https://github.com/msgpack/msgpack-c/archive/cpp-$MSGPACK_VERSION.tar.gz"
+
+if [[ ${ARCH} == "s390x" ]]; then
+get_src 7d5f3439c8df56046d0564b5857fd8a30296ab1bd6df0f048aed7afb56a0a4c2 \
+        "https://github.com/openresty/lua-nginx-module/archive/v$LUA_NGX_VERSION.tar.gz"
+get_src 99c47c75c159795c9faf76bbb9fa58e5a50b75286c86565ffcec8514b1c74bf9 \
+        "https://github.com/openresty/stream-lua-nginx-module/archive/v$LUA_STREAM_NGX_VERSION.tar.gz"
+else
+get_src 085a9fb2bf9c4466977595a5fe5156d76f3a2d9a2a81be3cacaff2021773393e \
+        "https://github.com/openresty/lua-nginx-module/archive/$LUA_NGX_VERSION.tar.gz"
+
+get_src ba38c9f8e4265836ba7f2ac559ddf140693ff2f5ae33ab1e384f51f3992151ab \
+        "https://github.com/openresty/stream-lua-nginx-module/archive/$LUA_STREAM_NGX_VERSION.tar.gz"
+
+fi
+
+get_src a92c9ee6682567605ece55d4eed5d1d54446ba6fba748cff0a2482aea5713d5f \
+        "https://github.com/openresty/lua-upstream-nginx-module/archive/$LUA_UPSTREAM_VERSION.tar.gz"
+
+if [[ ${ARCH} == "s390x" ]]; then
+get_src 266ed1abb70a9806d97cb958537a44b67db6afb33d3b32292a2d68a2acedea75 \
+        "https://github.com/openresty/luajit2/archive/$LUAJIT_VERSION.tar.gz"
+else
+get_src 1ee6dad809a5bb22efb45e6dac767f7ce544ad652d353a93d7f26b605f69fe3f \
+        "https://github.com/openresty/luajit2/archive/v$LUAJIT_VERSION.tar.gz"
+fi
+
+get_src f29393f2cd9288105a0029a6a324fe1f7558a9e7e852d59a6355f7581bb90e30 \
+        "https://github.com/DataDog/dd-opentracing-cpp/archive/$DATADOG_CPP_VERSION.tar.gz"
+
+get_src 1af5a5632dc8b00ae103d51b7bf225de3a7f0df82f5c6a401996c080106e600e \
+        "https://github.com/influxdata/nginx-influxdb-module/archive/$NGINX_INFLUXDB_VERSION.tar.gz"
+
+get_src 4c1933434572226942c65b2f2b26c8a536ab76aa771a3c7f6c2629faa764976b \
+        "https://github.com/leev/ngx_http_geoip2_module/archive/$GEOIP2_VERSION.tar.gz"
+
+get_src 94d1512bf0e5e6ffa4eca0489db1279d51f45386fffcb8a1d2d9f7fe93518465 \
+        "https://github.com/yaoweibin/nginx_ajp_module/archive/$NGINX_AJP_VERSION.tar.gz"
+
+get_src 5d16e623d17d4f42cc64ea9cfb69ca960d313e12f5d828f785dd227cc483fcbd \
+        "https://github.com/openresty/lua-resty-upload/archive/v$LUA_RESTY_UPLOAD_VERSION.tar.gz"
+
+get_src 462c6b38792bab4ca8212bdfd3f2e38f6883bb45c8fb8a03474ea813e0fab853 \
+        "https://github.com/openresty/lua-resty-string/archive/$LUA_RESTY_STRING_VERSION.tar.gz"
+
+get_src b3d28adac2acee1e5904e9f65d6e80e0553b01647fa0701b812bc7e464de74ad \
+        "https://github.com/openresty/lua-resty-balancer/archive/$LUA_RESTY_BALANCER.tar.gz"
+
+if [[ ${ARCH} == "s390x" ]]; then
+get_src 8f5f76d2689a3f6b0782f0a009c56a65e4c7a4382be86422c9b3549fe95b0dc4 \
+        "https://github.com/openresty/lua-resty-core/archive/v$LUA_RESTY_CORE.tar.gz"
+else
+get_src 4d971f711fad48c097070457c128ca36053835d8a3ba25a937e9991547d55d4d \
+        "https://github.com/openresty/lua-resty-core/archive/v$LUA_RESTY_CORE.tar.gz"
+fi
+
+get_src 8d602af2669fb386931760916a39f6c9034f2363c4965f215042c086b8215238 \
+        "https://github.com/openresty/lua-cjson/archive/$LUA_CJSON_VERSION.tar.gz"
+
+get_src 5ed48c36231e2622b001308622d46a0077525ac2f751e8cc0c9905914254baa4 \
+        "https://github.com/cloudflare/lua-resty-cookie/archive/$LUA_RESTY_COOKIE_VERSION.tar.gz"
+
+get_src e810ed124fe788b8e4aac2c8960dda1b9a6f8d0ca94ce162f28d3f4d877df8af \
+        "https://github.com/openresty/lua-resty-lrucache/archive/v$LUA_RESTY_CACHE.tar.gz"
+
+get_src 2b4683f9abe73e18ca00345c65010c9056777970907a311d6e1699f753141de2 \
+        "https://github.com/openresty/lua-resty-lock/archive/v$LUA_RESTY_LOCK.tar.gz"
+
+get_src 70e9a01eb32ccade0d5116a25bcffde0445b94ad35035ce06b94ccd260ad1bf0 \
+        "https://github.com/openresty/lua-resty-dns/archive/v$LUA_RESTY_DNS.tar.gz"
+
+get_src 9fcb6db95bc37b6fce77d3b3dc740d593f9d90dce0369b405eb04844d56ac43f \
+        "https://github.com/ledgetech/lua-resty-http/archive/$LUA_RESTY_HTTP.tar.gz"
+
+get_src 42893da0e3de4ec180c9bf02f82608d78787290a70c5644b538f29d243147396 \
+        "https://github.com/openresty/lua-resty-memcached/archive/v$LUA_RESTY_MEMCACHED_VERSION.tar.gz"
+
+get_src 3f602af507aacd1f7aaeddfe7b77627fcde095fe9f115cb9d6ad8de2a52520e1 \
+        "https://github.com/openresty/lua-resty-redis/archive/v$LUA_RESTY_REDIS_VERSION.tar.gz"
+
+get_src b8dbd502751140993a852381bcd8e98a402454596bd91838c1e51268d42db261 \
+        "https://github.com/api7/lua-resty-ipmatcher/archive/$LUA_RESTY_IPMATCHER_VERSION.tar.gz"
+
+get_src 0fb790e394510e73fdba1492e576aaec0b8ee9ef08e3e821ce253a07719cf7ea \
+        "https://github.com/ElvinEfendi/lua-resty-global-throttle/archive/v$LUA_RESTY_GLOBAL_THROTTLE_VERSION.tar.gz"
+
+# improve compilation times
+CORES=$(($(grep -c ^processor /proc/cpuinfo) - 1))
+
+export MAKEFLAGS=-j${CORES}
+export CTEST_BUILD_FLAGS=${MAKEFLAGS}
+export HUNTER_JOBS_NUMBER=${CORES}
+export HUNTER_USE_CACHE_SERVERS=true
+
+# Install luajit from openresty fork
+export LUAJIT_LIB=/usr/local/lib
+export LUA_LIB_DIR="$LUAJIT_LIB/lua"
+export LUAJIT_INC=/usr/local/include/luajit-2.1
+
+cd "$BUILD_PATH/luajit2-$LUAJIT_VERSION"
+make CCDEBUG=-g
+make install
+
+ln -s /usr/local/bin/luajit /usr/local/bin/lua
+ln -s "$LUAJIT_INC" /usr/local/include/lua
+
+cd "$BUILD_PATH"
+
+# Git tuning
+git config --global --add core.compression -1
+
+# build opentracing lib
+cd "$BUILD_PATH/opentracing-cpp-$OPENTRACING_CPP_VERSION"
+mkdir .build
+cd .build
+
+cmake -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_TESTING=OFF \
+      -DBUILD_SHARED_LIBS=OFF \
+      -DBUILD_MOCKTRACER=OFF \
+      -DBUILD_STATIC_LIBS=ON \
+      -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=true \
+      ..
+
+make
+make install
+
+# build yaml-cpp
+# TODO @timmysilv: remove this and jaeger sed calls once it is fixed in jaeger-client-cpp
+cd "$BUILD_PATH/yaml-cpp-$YAML_CPP_VERSION"
+mkdir .build
+cd .build
+
+cmake -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=true \
+      -DYAML_BUILD_SHARED_LIBS=ON \
+      -DYAML_CPP_BUILD_TESTS=OFF \
+      -DYAML_CPP_BUILD_TOOLS=OFF \
+      ..
+
+make
+make install
+
+# build jaeger lib
+cd "$BUILD_PATH/jaeger-client-cpp-$JAEGER_VERSION"
+sed -i 's/-Werror/-Wno-psabi/' CMakeLists.txt
+# use the above built yaml-cpp instead until a new version of jaeger-client-cpp fixes the yaml-cpp issue
+# tl;dr new hunter is needed for new yaml-cpp, but new hunter has a conflict with old Thrift and new Boost
+sed -i 's/hunter_add_package(yaml-cpp)/#hunter_add_package(yaml-cpp)/' CMakeLists.txt
+sed -i 's/yaml-cpp::yaml-cpp/yaml-cpp/' CMakeLists.txt
+
+cat <<EOF > export.map
+{
+    global:
+        OpenTracingMakeTracerFactory;
+    local: *;
+};
+EOF
+
+mkdir .build
+cd .build
+
+cmake -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_TESTING=OFF \
+      -DJAEGERTRACING_BUILD_EXAMPLES=OFF \
+      -DJAEGERTRACING_BUILD_CROSSDOCK=OFF \
+      -DJAEGERTRACING_COVERAGE=OFF \
+      -DJAEGERTRACING_PLUGIN=ON \
+      -DHUNTER_CONFIGURATION_TYPES=Release \
+      -DBUILD_SHARED_LIBS=OFF \
+      -DJAEGERTRACING_WITH_YAML_CPP=ON \
+      -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=true \
+      ..
+
+make
+make install
+
+export HUNTER_INSTALL_DIR=$(cat _3rdParty/Hunter/install-root-dir) \
+
+mv libjaegertracing_plugin.so /usr/local/lib/libjaegertracing_plugin.so
+
+
+# build zipkin lib
+cd "$BUILD_PATH/zipkin-cpp-opentracing-$ZIPKIN_CPP_VERSION"
+
+cat <<EOF > export.map
+{
+    global:
+        OpenTracingMakeTracerFactory;
+    local: *;
+};
+EOF
+
+mkdir .build
+cd .build
+
+cmake -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_SHARED_LIBS=OFF \
+      -DBUILD_PLUGIN=ON \
+      -DBUILD_TESTING=OFF \
+      -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=true \
+      ..
+
+make
+make install
+
+# build msgpack lib
+cd "$BUILD_PATH/msgpack-c-cpp-$MSGPACK_VERSION"
+
+mkdir .build
+cd .build
+cmake -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_SHARED_LIBS=OFF \
+      -DMSGPACK_BUILD_EXAMPLES=OFF \
+      -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=true \
+      ..
+
+make
+make install
+
+# build datadog lib
+cd "$BUILD_PATH/dd-opentracing-cpp-$DATADOG_CPP_VERSION"
+
+mkdir .build
+cd .build
+
+cmake -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_TESTING=OFF \
+      -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=true \
+      ..
+
+make
+make install
+
+# Get Brotli source and deps
+cd "$BUILD_PATH"
+git clone --depth=1 https://github.com/google/ngx_brotli.git
+cd ngx_brotli
+git submodule init
+git submodule update
+
+# build nginx
+cd "$BUILD_PATH/nginx-$NGINX_VERSION"
+
+# apply nginx patches
+for PATCH in `ls /patches`;do
+  echo "Patch: $PATCH"
+  patch -p1 < /patches/$PATCH
+done
+
+WITH_FLAGS="--with-debug \
+  --with-compat \
+  --with-pcre-jit \
+  --with-http_ssl_module \
+  --with-http_stub_status_module \
+  --with-http_realip_module \
+  --with-http_auth_request_module \
+  --with-http_addition_module \
+  --with-http_geoip_module \
+  --with-http_gzip_static_module \
+  --with-http_sub_module \
+  --with-http_v2_module \
+  --with-stream \
+  --with-stream_ssl_module \
+  --with-stream_realip_module \
+  --with-stream_ssl_preread_module \
+  --with-threads \
+  --with-http_secure_link_module \
+  --with-http_gunzip_module"
+
+# "Combining -flto with -g is currently experimental and expected to produce unexpected results."
+# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html
+CC_OPT="-g -Og -fPIE -fstack-protector-strong \
+  -Wformat \
+  -Werror=format-security \
+  -Wno-deprecated-declarations \
+  -fno-strict-aliasing \
+  -D_FORTIFY_SOURCE=2 \
+  --param=ssp-buffer-size=4 \
+  -DTCP_FASTOPEN=23 \
+  -fPIC \
+  -I$HUNTER_INSTALL_DIR/include \
+  -Wno-cast-function-type"
+
+LD_OPT="-fPIE -fPIC -pie -Wl,-z,relro -Wl,-z,now -L$HUNTER_INSTALL_DIR/lib"
+
+if [[ ${ARCH} != "aarch64" ]]; then
+  WITH_FLAGS+=" --with-file-aio"
+fi
+
+if [[ ${ARCH} == "x86_64" ]]; then
+  CC_OPT+=' -m64 -mtune=native'
+fi
+
+WITH_MODULES=" \
+  --add-module=$BUILD_PATH/ngx_devel_kit-$NDK_VERSION \
+  --add-module=$BUILD_PATH/set-misc-nginx-module-$SETMISC_VERSION \
+  --add-module=$BUILD_PATH/headers-more-nginx-module-$MORE_HEADERS_VERSION \
+  --add-module=$BUILD_PATH/ngx_http_substitutions_filter_module-$NGINX_SUBSTITUTIONS \
+  --add-module=$BUILD_PATH/lua-nginx-module-$LUA_NGX_VERSION \
+  --add-module=$BUILD_PATH/stream-lua-nginx-module-$LUA_STREAM_NGX_VERSION \
+  --add-module=$BUILD_PATH/lua-upstream-nginx-module-$LUA_UPSTREAM_VERSION \
+  --add-module=$BUILD_PATH/nginx_ajp_module-${NGINX_AJP_VERSION} \
+  --add-dynamic-module=$BUILD_PATH/nginx-http-auth-digest-$NGINX_DIGEST_AUTH \
+  --add-dynamic-module=$BUILD_PATH/nginx-influxdb-module-$NGINX_INFLUXDB_VERSION \
+  --add-dynamic-module=$BUILD_PATH/nginx-opentracing-$NGINX_OPENTRACING_VERSION/opentracing \
+  --add-dynamic-module=$BUILD_PATH/ngx_http_geoip2_module-${GEOIP2_VERSION} \
+  --add-dynamic-module=$BUILD_PATH/ngx_brotli"
+
+./configure \
+  --prefix=/usr/local/nginx \
+  --conf-path=/etc/nginx/nginx.conf \
+  --modules-path=/etc/nginx/modules \
+  --http-log-path=/var/log/nginx/access.log \
+  --error-log-path=/var/log/nginx/error.log \
+  --lock-path=/var/lock/nginx.lock \
+  --pid-path=/run/nginx.pid \
+  --http-client-body-temp-path=/var/lib/nginx/body \
+  --http-fastcgi-temp-path=/var/lib/nginx/fastcgi \
+  --http-proxy-temp-path=/var/lib/nginx/proxy \
+  --http-scgi-temp-path=/var/lib/nginx/scgi \
+  --http-uwsgi-temp-path=/var/lib/nginx/uwsgi \
+  ${WITH_FLAGS} \
+  --without-mail_pop3_module \
+  --without-mail_smtp_module \
+  --without-mail_imap_module \
+  --without-http_uwsgi_module \
+  --without-http_scgi_module \
+  --with-cc-opt="${CC_OPT}" \
+  --with-ld-opt="${LD_OPT}" \
+  --user=www-data \
+  --group=www-data \
+  ${WITH_MODULES}
+
+make
+make modules
+make install
+
+cd "$BUILD_PATH/lua-resty-core-$LUA_RESTY_CORE"
+make install
+
+cd "$BUILD_PATH/lua-resty-balancer-$LUA_RESTY_BALANCER"
+make all
+make install
+
+export LUA_INCLUDE_DIR=/usr/local/include/luajit-2.1
+ln -s $LUA_INCLUDE_DIR /usr/include/lua5.1
+
+cd "$BUILD_PATH/lua-cjson-$LUA_CJSON_VERSION"
+make all
+make install
+
+cd "$BUILD_PATH/lua-resty-cookie-$LUA_RESTY_COOKIE_VERSION"
+make all
+make install
+
+cd "$BUILD_PATH/lua-resty-lrucache-$LUA_RESTY_CACHE"
+make install
+
+cd "$BUILD_PATH/lua-resty-dns-$LUA_RESTY_DNS"
+make install
+
+cd "$BUILD_PATH/lua-resty-lock-$LUA_RESTY_LOCK"
+make install
+
+# required for OCSP verification
+cd "$BUILD_PATH/lua-resty-http-$LUA_RESTY_HTTP"
+make install
+
+cd "$BUILD_PATH/lua-resty-upload-$LUA_RESTY_UPLOAD_VERSION"
+make install
+
+cd "$BUILD_PATH/lua-resty-string-$LUA_RESTY_STRING_VERSION"
+make install
+
+cd "$BUILD_PATH/lua-resty-memcached-$LUA_RESTY_MEMCACHED_VERSION"
+make install
+
+cd "$BUILD_PATH/lua-resty-redis-$LUA_RESTY_REDIS_VERSION"
+make install
+
+cd "$BUILD_PATH/lua-resty-ipmatcher-$LUA_RESTY_IPMATCHER_VERSION"
+INST_LUADIR=/usr/local/lib/lua make install
+
+cd "$BUILD_PATH/lua-resty-global-throttle-$LUA_RESTY_GLOBAL_THROTTLE_VERSION"
+make install
+
+
+# update image permissions
+writeDirs=( \
+  /etc/nginx \
+  /usr/local/nginx \
+  /var/log/audit \
+  /var/log/nginx \
+);
+
+# Compability with Alpine build 
+groupmod -g 101 www-data
+usermod -d /usr/local/nginx -u 101 www-data
+
+for dir in "${writeDirs[@]}"; do
+  mkdir -p ${dir};
+  chown -R www-data.www-data ${dir};
+done
+
+# remove .a files
+find /usr/local -name "*.a" -print | xargs /bin/rm

--- a/images/nginx-debian/rootfs/build.sh
+++ b/images/nginx-debian/rootfs/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2015 The Kubernetes Authors.
+# Copyright 2021 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/images/nginx-debian/rootfs/patches/nginx-1.19.3-balancer_status_code.patch
+++ b/images/nginx-debian/rootfs/patches/nginx-1.19.3-balancer_status_code.patch
@@ -1,0 +1,72 @@
+diff --git a/src/http/ngx_http_upstream.c b/src/http/ngx_http_upstream.c
+index f8d5707d..6efe0047 100644
+--- a/src/http/ngx_http_upstream.c
++++ b/src/http/ngx_http_upstream.c
+@@ -1515,6 +1515,11 @@ ngx_http_upstream_connect(ngx_http_request_t *r, ngx_http_upstream_t *u)
+         return;
+     }
+ 
++    if (rc >= NGX_HTTP_SPECIAL_RESPONSE) {
++        ngx_http_upstream_finalize_request(r, u, rc);
++        return;
++    }
++
+     u->state->peer = u->peer.name;
+ 
+     if (rc == NGX_BUSY) {
+diff --git a/src/http/ngx_http_upstream.h b/src/http/ngx_http_upstream.h
+index 3e714e5b..dfbb25e0 100644
+--- a/src/http/ngx_http_upstream.h
++++ b/src/http/ngx_http_upstream.h
+@@ -427,4 +427,9 @@ extern ngx_conf_bitmask_t  ngx_http_upstream_cache_method_mask[];
+ extern ngx_conf_bitmask_t  ngx_http_upstream_ignore_headers_masks[];
+ 
+ 
++#ifndef HAVE_BALANCER_STATUS_CODE_PATCH
++#define HAVE_BALANCER_STATUS_CODE_PATCH
++#endif
++
++
+ #endif /* _NGX_HTTP_UPSTREAM_H_INCLUDED_ */
+diff --git a/src/stream/ngx_stream.h b/src/stream/ngx_stream.h
+index 09d24593..d8b4b584 100644
+--- a/src/stream/ngx_stream.h
++++ b/src/stream/ngx_stream.h
+@@ -27,6 +27,7 @@ typedef struct ngx_stream_session_s  ngx_stream_session_t;
+ 
+ 
+ #define NGX_STREAM_OK                        200
++#define NGX_STREAM_SPECIAL_RESPONSE          300
+ #define NGX_STREAM_BAD_REQUEST               400
+ #define NGX_STREAM_FORBIDDEN                 403
+ #define NGX_STREAM_INTERNAL_SERVER_ERROR     500
+diff --git a/src/stream/ngx_stream_proxy_module.c b/src/stream/ngx_stream_proxy_module.c
+index 818d7329..329dcdc6 100644
+--- a/src/stream/ngx_stream_proxy_module.c
++++ b/src/stream/ngx_stream_proxy_module.c
+@@ -691,6 +691,11 @@ ngx_stream_proxy_connect(ngx_stream_session_t *s)
+         return;
+     }
+ 
++    if (rc >= NGX_STREAM_SPECIAL_RESPONSE) {
++        ngx_stream_proxy_finalize(s, rc);
++        return;
++    }
++
+     u->state->peer = u->peer.name;
+ 
+     if (rc == NGX_BUSY) {
+diff --git a/src/stream/ngx_stream_upstream.h b/src/stream/ngx_stream_upstream.h
+index 73947f46..21bc0ad7 100644
+--- a/src/stream/ngx_stream_upstream.h
++++ b/src/stream/ngx_stream_upstream.h
+@@ -151,4 +151,9 @@ ngx_stream_upstream_srv_conf_t *ngx_stream_upstream_add(ngx_conf_t *cf,
+ extern ngx_module_t  ngx_stream_upstream_module;
+ 
+ 
++#ifndef HAVE_BALANCER_STATUS_CODE_PATCH
++#define HAVE_BALANCER_STATUS_CODE_PATCH
++#endif
++
++
+ #endif /* _NGX_STREAM_UPSTREAM_H_INCLUDED_ */

--- a/images/nginx-debian/rootfs/patches/nginx-1.19.3-cache_manager_exit.patch
+++ b/images/nginx-debian/rootfs/patches/nginx-1.19.3-cache_manager_exit.patch
@@ -1,0 +1,19 @@
+# HG changeset patch
+# User Yichun Zhang <agentzh@gmail.com>
+# Date 1383598130 28800
+# Node ID f64218e1ac963337d84092536f588b8e0d99bbaa
+# Parent  dea321e5c0216efccbb23e84bbce7cf3e28f130c
+Cache: gracefully exit the cache manager process.
+
+diff -r dea321e5c021 -r f64218e1ac96 src/os/unix/ngx_process_cycle.c
+--- a/src/os/unix/ngx_process_cycle.c	Thu Oct 31 18:23:49 2013 +0400
++++ b/src/os/unix/ngx_process_cycle.c	Mon Nov 04 12:48:50 2013 -0800
+@@ -1335,7 +1335,7 @@
+ 
+         if (ngx_terminate || ngx_quit) {
+             ngx_log_error(NGX_LOG_NOTICE, cycle->log, 0, "exiting");
+-            exit(0);
++            ngx_worker_process_exit(cycle);
+         }
+ 
+         if (ngx_reopen) {

--- a/images/nginx-debian/rootfs/patches/nginx-1.19.3-delayed_posted_events.patch
+++ b/images/nginx-debian/rootfs/patches/nginx-1.19.3-delayed_posted_events.patch
@@ -1,0 +1,98 @@
+diff --git a/src/event/ngx_event.c b/src/event/ngx_event.c
+index 57af8132..4853945f 100644
+--- a/src/event/ngx_event.c
++++ b/src/event/ngx_event.c
+@@ -196,6 +196,9 @@ ngx_process_events_and_timers(ngx_cycle_t *cycle)
+     ngx_uint_t  flags;
+     ngx_msec_t  timer, delta;
+ 
++    ngx_queue_t     *q;
++    ngx_event_t     *ev;
++
+     if (ngx_timer_resolution) {
+         timer = NGX_TIMER_INFINITE;
+         flags = 0;
+@@ -215,6 +218,13 @@ ngx_process_events_and_timers(ngx_cycle_t *cycle)
+ #endif
+     }
+ 
++    if (!ngx_queue_empty(&ngx_posted_delayed_events)) {
++        ngx_log_debug0(NGX_LOG_DEBUG_EVENT, cycle->log, 0,
++                       "posted delayed event queue not empty"
++                       " making poll timeout 0");
++        timer = 0;
++    }
++
+     if (ngx_use_accept_mutex) {
+         if (ngx_accept_disabled > 0) {
+             ngx_accept_disabled--;
+@@ -257,6 +267,35 @@ ngx_process_events_and_timers(ngx_cycle_t *cycle)
+     }
+ 
+     ngx_event_process_posted(cycle, &ngx_posted_events);
++
++    while (!ngx_queue_empty(&ngx_posted_delayed_events)) {
++        q = ngx_queue_head(&ngx_posted_delayed_events);
++
++        ev = ngx_queue_data(q, ngx_event_t, queue);
++        if (ev->delayed) {
++            /* start of newly inserted nodes */
++            for (/* void */;
++                 q != ngx_queue_sentinel(&ngx_posted_delayed_events);
++                 q = ngx_queue_next(q))
++            {
++                ev = ngx_queue_data(q, ngx_event_t, queue);
++                ev->delayed = 0;
++
++                ngx_log_debug1(NGX_LOG_DEBUG_EVENT, cycle->log, 0,
++                               "skipping delayed posted event %p,"
++                               " till next iteration", ev);
++            }
++
++            break;
++        }
++
++        ngx_log_debug1(NGX_LOG_DEBUG_EVENT, cycle->log, 0,
++                       "delayed posted event %p", ev);
++
++        ngx_delete_posted_event(ev);
++
++        ev->handler(ev);
++    }
+ }
+ 
+ 
+@@ -600,6 +639,7 @@ ngx_event_process_init(ngx_cycle_t *cycle)
+ 
+     ngx_queue_init(&ngx_posted_accept_events);
+     ngx_queue_init(&ngx_posted_events);
++    ngx_queue_init(&ngx_posted_delayed_events);
+ 
+     if (ngx_event_timer_init(cycle->log) == NGX_ERROR) {
+         return NGX_ERROR;
+diff --git a/src/event/ngx_event_posted.c b/src/event/ngx_event_posted.c
+index d851f3d1..b6cea009 100644
+--- a/src/event/ngx_event_posted.c
++++ b/src/event/ngx_event_posted.c
+@@ -12,6 +12,7 @@
+ 
+ ngx_queue_t  ngx_posted_accept_events;
+ ngx_queue_t  ngx_posted_events;
++ngx_queue_t  ngx_posted_delayed_events;
+ 
+ 
+ void
+diff --git a/src/event/ngx_event_posted.h b/src/event/ngx_event_posted.h
+index 145d30fe..6c388553 100644
+--- a/src/event/ngx_event_posted.h
++++ b/src/event/ngx_event_posted.h
+@@ -43,6 +43,9 @@ void ngx_event_process_posted(ngx_cycle_t *cycle, ngx_queue_t *posted);
+ 
+ extern ngx_queue_t  ngx_posted_accept_events;
+ extern ngx_queue_t  ngx_posted_events;
++extern ngx_queue_t  ngx_posted_delayed_events;
++
++#define HAVE_POSTED_DELAYED_EVENTS_PATCH
+ 
+ 
+ #endif /* _NGX_EVENT_POSTED_H_INCLUDED_ */

--- a/images/nginx-debian/rootfs/patches/nginx-1.19.3-hash_overflow.patch
+++ b/images/nginx-debian/rootfs/patches/nginx-1.19.3-hash_overflow.patch
@@ -1,0 +1,20 @@
+# HG changeset patch
+# User Yichun Zhang <agentzh@gmail.com>
+# Date 1412276417 25200
+#      Thu Oct 02 12:00:17 2014 -0700
+# Node ID 4032b992f23b054c1a2cfb0be879330d2c6708e5
+# Parent  1ff0f68d9376e3d184d65814a6372856bf65cfcd
+Hash: buffer overflow might happen when exceeding the pre-configured limits.
+
+diff -r 1ff0f68d9376 -r 4032b992f23b src/core/ngx_hash.c
+--- a/src/core/ngx_hash.c	Tue Sep 30 15:50:28 2014 -0700
++++ b/src/core/ngx_hash.c	Thu Oct 02 12:00:17 2014 -0700
+@@ -312,6 +312,8 @@ ngx_hash_init(ngx_hash_init_t *hinit, ng
+         continue;
+     }
+ 
++    size--;
++
+     ngx_log_error(NGX_LOG_WARN, hinit->pool->log, 0,
+                   "could not build optimal %s, you should increase "
+                   "either %s_max_size: %i or %s_bucket_size: %i; "

--- a/images/nginx-debian/rootfs/patches/nginx-1.19.3-init_cycle_pool_release.patch
+++ b/images/nginx-debian/rootfs/patches/nginx-1.19.3-init_cycle_pool_release.patch
@@ -1,0 +1,59 @@
+diff -rup nginx-1.19.3/src/core/nginx.c nginx-1.19.3-patched/src/core/nginx.c
+--- nginx-1.19.3/src/core/nginx.c	2017-12-17 00:00:38.136470108 -0800
++++ nginx-1.19.3-patched/src/core/nginx.c	2017-12-16 23:59:51.680958322 -0800
+@@ -186,6 +186,7 @@ static u_char      *ngx_prefix;
+ static u_char      *ngx_conf_file;
+ static u_char      *ngx_conf_params;
+ static char        *ngx_signal;
++ngx_pool_t         *saved_init_cycle_pool = NULL;
+ 
+ 
+ static char **ngx_os_environ;
+@@ -253,6 +254,8 @@ main(int argc, char *const *argv)
+         return 1;
+     }
+ 
++    saved_init_cycle_pool = init_cycle.pool;
++
+     if (ngx_save_argv(&init_cycle, argc, argv) != NGX_OK) {
+         return 1;
+     }
+diff -rup nginx-1.19.3/src/core/ngx_core.h nginx-1.19.3-patched/src/core/ngx_core.h
+--- nginx-1.19.3/src/core/ngx_core.h	2017-10-10 08:22:51.000000000 -0700
++++ nginx-1.19.3-patched/src/core/ngx_core.h	2017-12-16 23:59:51.679958370 -0800
+@@ -108,4 +108,6 @@ void ngx_cpuinfo(void);
+ #define NGX_DISABLE_SYMLINKS_NOTOWNER   2
+ #endif
+ 
++extern ngx_pool_t        *saved_init_cycle_pool;
++
+ #endif /* _NGX_CORE_H_INCLUDED_ */
+diff -rup nginx-1.19.3/src/core/ngx_cycle.c nginx-1.19.3-patched/src/core/ngx_cycle.c
+--- nginx-1.19.3/src/core/ngx_cycle.c	2017-10-10 08:22:51.000000000 -0700
++++ nginx-1.19.3-patched/src/core/ngx_cycle.c	2017-12-16 23:59:51.678958419 -0800
+@@ -748,6 +748,10 @@ old_shm_zone_done:
+ 
+     if (ngx_process == NGX_PROCESS_MASTER || ngx_is_init_cycle(old_cycle)) {
+ 
++        if (ngx_is_init_cycle(old_cycle)) {
++            saved_init_cycle_pool = NULL;
++        }
++
+         ngx_destroy_pool(old_cycle->pool);
+         cycle->old_cycle = NULL;
+ 
+diff -rup nginx-1.19.3/src/os/unix/ngx_process_cycle.c nginx-1.19.3-patched/src/os/unix/ngx_process_cycle.c
+--- nginx-1.19.3/src/os/unix/ngx_process_cycle.c	2017-12-17 00:00:38.142469762 -0800
++++ nginx-1.19.3-patched/src/os/unix/ngx_process_cycle.c	2017-12-16 23:59:51.691957791 -0800
+@@ -783,6 +783,11 @@ ngx_master_process_exit(ngx_cycle_t *cyc
+     ngx_exit_cycle.files_n = ngx_cycle->files_n;
+     ngx_cycle = &ngx_exit_cycle;
+ 
++    if (saved_init_cycle_pool != NULL && saved_init_cycle_pool != cycle->pool) {
++        ngx_destroy_pool(saved_init_cycle_pool);
++        saved_init_cycle_pool = NULL;
++    }
++
+     ngx_destroy_pool(cycle->pool);
+ 
+     exit(0);

--- a/images/nginx-debian/rootfs/patches/nginx-1.19.3-larger_max_error_str.patch
+++ b/images/nginx-debian/rootfs/patches/nginx-1.19.3-larger_max_error_str.patch
@@ -1,0 +1,13 @@
+--- nginx-1.19.3/src/core/ngx_log.h	2013-10-08 05:07:14.000000000 -0700
++++ nginx-1.19.3-patched/src/core/ngx_log.h	2013-12-05 20:35:35.996236720 -0800
+@@ -64,7 +64,9 @@ struct ngx_log_s {
+ };
+ 
+ 
+-#define NGX_MAX_ERROR_STR   2048
++#ifndef NGX_MAX_ERROR_STR
++#define NGX_MAX_ERROR_STR   4096
++#endif
+ 
+ 
+ /*********************************/

--- a/images/nginx-debian/rootfs/patches/nginx-1.19.3-no_Werror.patch
+++ b/images/nginx-debian/rootfs/patches/nginx-1.19.3-no_Werror.patch
@@ -1,0 +1,36 @@
+diff -urp nginx-1.19.3/auto/cc/clang nginx-1.19.3-patched/auto/cc/clang
+--- nginx-1.19.3/auto/cc/clang	2014-03-04 03:39:24.000000000 -0800
++++ nginx-1.19.3-patched/auto/cc/clang	2014-03-13 20:54:26.241413360 -0700
+@@ -89,7 +89,7 @@ CFLAGS="$CFLAGS -Wconditional-uninitiali
+ CFLAGS="$CFLAGS -Wno-unused-parameter"
+ 
+ # stop on warning
+-CFLAGS="$CFLAGS -Werror"
++#CFLAGS="$CFLAGS -Werror"
+ 
+ # debug
+ CFLAGS="$CFLAGS -g"
+diff -urp nginx-1.19.3/auto/cc/gcc nginx-1.19.3-patched/auto/cc/gcc
+--- nginx-1.19.3/auto/cc/gcc	2014-03-04 03:39:24.000000000 -0800
++++ nginx-1.19.3-patched/auto/cc/gcc	2014-03-13 20:54:13.301355329 -0700
+@@ -168,7 +168,7 @@ esac
+ 
+ 
+ # stop on warning
+-CFLAGS="$CFLAGS -Werror"
++#CFLAGS="$CFLAGS -Werror"
+ 
+ # debug
+ CFLAGS="$CFLAGS -g"
+diff -urp nginx-1.19.3/auto/cc/icc nginx-1.19.3-patched/auto/cc/icc
+--- nginx-1.19.3/auto/cc/icc	2014-03-04 03:39:24.000000000 -0800
++++ nginx-1.19.3-patched/auto/cc/icc	2014-03-13 20:54:13.301355329 -0700
+@@ -115,7 +115,7 @@ case "$NGX_ICC_VER" in
+ esac
+ 
+ # stop on warning
+-CFLAGS="$CFLAGS -Werror"
++#CFLAGS="$CFLAGS -Werror"
+ 
+ # debug
+ CFLAGS="$CFLAGS -g"

--- a/images/nginx-debian/rootfs/patches/nginx-1.19.3-proxy_host_port_vars.patch
+++ b/images/nginx-debian/rootfs/patches/nginx-1.19.3-proxy_host_port_vars.patch
@@ -1,0 +1,19 @@
+--- nginx-1.19.3/src/http/modules/ngx_http_proxy_module.c	2017-07-16 14:02:51.000000000 +0800
++++ nginx-1.19.3-patched/src/http/modules/ngx_http_proxy_module.c	2017-07-16 14:02:51.000000000 +0800
+@@ -793,13 +793,13 @@ static ngx_keyval_t  ngx_http_proxy_cach
+ static ngx_http_variable_t  ngx_http_proxy_vars[] = {
+ 
+     { ngx_string("proxy_host"), NULL, ngx_http_proxy_host_variable, 0,
+-      NGX_HTTP_VAR_CHANGEABLE|NGX_HTTP_VAR_NOCACHEABLE|NGX_HTTP_VAR_NOHASH, 0 },
++      NGX_HTTP_VAR_CHANGEABLE|NGX_HTTP_VAR_NOCACHEABLE, 0 },
+ 
+     { ngx_string("proxy_port"), NULL, ngx_http_proxy_port_variable, 0,
+-      NGX_HTTP_VAR_CHANGEABLE|NGX_HTTP_VAR_NOCACHEABLE|NGX_HTTP_VAR_NOHASH, 0 },
++      NGX_HTTP_VAR_CHANGEABLE|NGX_HTTP_VAR_NOCACHEABLE, 0 },
+ 
+     { ngx_string("proxy_add_x_forwarded_for"), NULL,
+-      ngx_http_proxy_add_x_forwarded_for_variable, 0, NGX_HTTP_VAR_NOHASH, 0 },
++      ngx_http_proxy_add_x_forwarded_for_variable, 0, 0, 0 },
+ 
+ #if 0
+     { ngx_string("proxy_add_via"), NULL, NULL, 0, NGX_HTTP_VAR_NOHASH, 0 },

--- a/images/nginx-debian/rootfs/patches/nginx-1.19.3-resolver_conf_parsing.patch
+++ b/images/nginx-debian/rootfs/patches/nginx-1.19.3-resolver_conf_parsing.patch
@@ -1,0 +1,263 @@
+diff --git a/src/core/ngx_resolver.c b/src/core/ngx_resolver.c
+index cd55520c..dade1846 100644
+--- a/src/core/ngx_resolver.c
++++ b/src/core/ngx_resolver.c
+@@ -9,12 +9,26 @@
+ #include <ngx_core.h>
+ #include <ngx_event.h>
+ 
++#if !(NGX_WIN32)
++#include <resolv.h>
++#endif
++
+ 
+ #define NGX_RESOLVER_UDP_SIZE   4096
+ 
+ #define NGX_RESOLVER_TCP_RSIZE  (2 + 65535)
+ #define NGX_RESOLVER_TCP_WSIZE  8192
+ 
++#if !(NGX_WIN32)
++/*
++ * note that 2KB should be more than enough for majority of the
++ * resolv.conf files out there. it also acts as a safety guard to prevent
++ * abuse.
++ */
++#define NGX_RESOLVER_FILE_BUF_SIZE  2048
++#define NGX_RESOLVER_FILE_NAME      "/etc/resolv.conf"
++#endif
++
+ 
+ typedef struct {
+     u_char  ident_hi;
+@@ -131,6 +145,191 @@ static ngx_resolver_node_t *ngx_resolver_lookup_addr6(ngx_resolver_t *r,
+ #endif
+ 
+ 
++#if !(NGX_WIN32)
++static ngx_int_t
++ngx_resolver_read_resolv_conf(ngx_conf_t *cf, ngx_resolver_t *r, u_char *path,
++    size_t path_len)
++{
++    ngx_url_t                        u;
++    ngx_resolver_connection_t       *rec;
++    ngx_fd_t                         fd;
++    ngx_file_t                       file;
++    u_char                           buf[NGX_RESOLVER_FILE_BUF_SIZE];
++    u_char                           ipv6_buf[NGX_INET6_ADDRSTRLEN];
++    ngx_uint_t                       address = 0, j, total = 0;
++    ssize_t                          n, i;
++    enum {
++        sw_nameserver,
++        sw_spaces,
++        sw_address,
++        sw_skip
++    } state;
++
++    file.name.data = path;
++    file.name.len = path_len;
++
++    if (ngx_conf_full_name(cf->cycle, &file.name, 1) != NGX_OK) {
++        return NGX_ERROR;
++    }
++
++    fd = ngx_open_file(file.name.data, NGX_FILE_RDONLY,
++                       NGX_FILE_OPEN, 0);
++
++    if (fd == NGX_INVALID_FILE) {
++        ngx_conf_log_error(NGX_LOG_EMERG, cf, ngx_errno,
++                           ngx_open_file_n " \"%s\" failed", file.name.data);
++
++        return NGX_ERROR;
++    }
++
++    ngx_memzero(&file, sizeof(ngx_file_t));
++
++    file.fd = fd;
++    file.log = cf->log;
++
++    state = sw_nameserver;
++
++    n = ngx_read_file(&file, buf, NGX_RESOLVER_FILE_BUF_SIZE, 0);
++
++    if (n == NGX_ERROR) {
++        ngx_conf_log_error(NGX_LOG_ALERT, cf, ngx_errno,
++                           ngx_read_file_n " \"%s\" failed", file.name.data);
++    }
++
++    if (ngx_close_file(file.fd) == NGX_FILE_ERROR) {
++        ngx_conf_log_error(NGX_LOG_ALERT, cf, ngx_errno,
++                           ngx_close_file_n " \"%s\" failed", file.name.data);
++    }
++
++    if (n == NGX_ERROR) {
++        return NGX_ERROR;
++    }
++
++    if (n == 0) {
++        return NGX_OK;
++    }
++
++    for (i = 0; i < n && total < MAXNS; /* void */) {
++        if (buf[i] == '#' || buf[i] == ';') {
++            state = sw_skip;
++        }
++
++        switch (state) {
++
++        case sw_nameserver:
++
++            if ((size_t) n - i >= sizeof("nameserver") - 1
++                && ngx_memcmp(buf + i, "nameserver",
++                              sizeof("nameserver") - 1) == 0)
++            {
++                state = sw_spaces;
++                i += sizeof("nameserver") - 1;
++
++                continue;
++            }
++
++            break;
++
++        case sw_spaces:
++            if (buf[i] != '\t' && buf[i] != ' ') {
++                address = i;
++                state = sw_address;
++            }
++
++            break;
++
++        case sw_address:
++
++            if (buf[i] == CR || buf[i] == LF || i == n - 1) {
++                ngx_memzero(&u, sizeof(ngx_url_t));
++
++                u.url.data = buf + address;
++
++                if (i == n - 1 && buf[i] != CR && buf[i] != LF) {
++                    u.url.len = n - address;
++
++                } else {
++                    u.url.len = i - address;
++                }
++
++                u.default_port = 53;
++
++                /* IPv6? */
++                if (ngx_strlchr(u.url.data, u.url.data + u.url.len,
++                                ':') != NULL)
++                {
++                    if (u.url.len + 2 > sizeof(ipv6_buf)) {
++                        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
++                                           "IPv6 resolver address is too long:"
++                                           " \"%V\"", &u.url);
++
++                        return NGX_ERROR;
++                    }
++
++                    ipv6_buf[0] = '[';
++                    ngx_memcpy(ipv6_buf + 1, u.url.data, u.url.len);
++                    ipv6_buf[u.url.len + 1] = ']';
++
++                    u.url.data = ipv6_buf;
++                    u.url.len = u.url.len + 2;
++                }
++
++                if (ngx_parse_url(cf->pool, &u) != NGX_OK) {
++                    if (u.err) {
++                        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
++                                           "%s in resolver \"%V\"",
++                                           u.err, &u.url);
++                    }
++
++                    return NGX_ERROR;
++                }
++
++                rec = ngx_array_push_n(&r->connections, u.naddrs);
++                if (rec == NULL) {
++                    return NGX_ERROR;
++                }
++
++                ngx_memzero(rec, u.naddrs * sizeof(ngx_resolver_connection_t));
++
++                for (j = 0; j < u.naddrs; j++) {
++                    rec[j].sockaddr = u.addrs[j].sockaddr;
++                    rec[j].socklen = u.addrs[j].socklen;
++                    rec[j].server = u.addrs[j].name;
++                    rec[j].resolver = r;
++                }
++
++                total++;
++
++#if (NGX_DEBUG)
++                /*
++                 * logs with level below NGX_LOG_NOTICE will not be printed
++                 * in this early phase
++                 */
++                ngx_conf_log_error(NGX_LOG_NOTICE, cf, 0,
++                                   "parsed a resolver: \"%V\"", &u.url);
++#endif
++
++                state = sw_nameserver;
++            }
++
++            break;
++
++        case sw_skip:
++            if (buf[i] == CR || buf[i] == LF) {
++                state = sw_nameserver;
++            }
++
++            break;
++        }
++
++        i++;
++    }
++
++    return NGX_OK;
++}
++#endif
++
++
+ ngx_resolver_t *
+ ngx_resolver_create(ngx_conf_t *cf, ngx_str_t *names, ngx_uint_t n)
+ {
+@@ -246,6 +445,39 @@ ngx_resolver_create(ngx_conf_t *cf, ngx_str_t *names, ngx_uint_t n)
+         }
+ #endif
+ 
++#if !(NGX_WIN32)
++        if (ngx_strncmp(names[i].data, "local=", 6) == 0) {
++
++            if (ngx_strcmp(&names[i].data[6], "on") == 0) {
++                if (ngx_resolver_read_resolv_conf(cf, r,
++                                                  (u_char *)
++                                                  NGX_RESOLVER_FILE_NAME,
++                                                  sizeof(NGX_RESOLVER_FILE_NAME)
++                                                  - 1)
++                    != NGX_OK)
++                {
++                    ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
++                                       "unable to parse local resolver");
++                    return NULL;
++                }
++
++            } else if (ngx_strcmp(&names[i].data[6], "off") != 0) {
++                if (ngx_resolver_read_resolv_conf(cf, r,
++                                                  &names[i].data[6],
++                                                  names[i].len - 6)
++                    != NGX_OK)
++                {
++                    ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
++                                       "unable to parse local resolver");
++                    return NULL;
++                }
++
++            }
++
++            continue;
++        }
++#endif
++
+         ngx_memzero(&u, sizeof(ngx_url_t));
+ 
+         u.url = names[i];

--- a/images/nginx-debian/rootfs/patches/nginx-1.19.3-reuseport_close_unused_fds.patch
+++ b/images/nginx-debian/rootfs/patches/nginx-1.19.3-reuseport_close_unused_fds.patch
@@ -1,0 +1,38 @@
+diff --git a/src/core/ngx_connection.c b/src/core/ngx_connection.c
+--- a/src/core/ngx_connection.c
++++ b/src/core/ngx_connection.c
+@@ -1118,6 +1118,12 @@ ngx_close_listening_sockets(ngx_cycle_t *cycle)
+     ls = cycle->listening.elts;
+     for (i = 0; i < cycle->listening.nelts; i++) {
+ 
++#if (NGX_HAVE_REUSEPORT)
++        if (ls[i].fd == (ngx_socket_t) -1) {
++            continue;
++        }
++#endif
++
+         c = ls[i].connection;
+ 
+         if (c) {
+diff --git a/src/event/ngx_event.c b/src/event/ngx_event.c
+--- a/src/event/ngx_event.c
++++ b/src/event/ngx_event.c
+@@ -775,6 +775,18 @@ ngx_event_process_init(ngx_cycle_t *cycle)
+ 
+ #if (NGX_HAVE_REUSEPORT)
+         if (ls[i].reuseport && ls[i].worker != ngx_worker) {
++            ngx_log_debug2(NGX_LOG_DEBUG_CORE, cycle->log, 0,
++                           "closing unused fd:%d listening on %V",
++                           ls[i].fd, &ls[i].addr_text);
++
++            if (ngx_close_socket(ls[i].fd) == -1) {
++                ngx_log_error(NGX_LOG_EMERG, cycle->log, ngx_socket_errno,
++                              ngx_close_socket_n " %V failed",
++                              &ls[i].addr_text);
++            }
++
++            ls[i].fd = (ngx_socket_t) -1;
++
+             continue;
+         }
+ #endif

--- a/images/nginx-debian/rootfs/patches/nginx-1.19.3-single_process_graceful_exit.patch
+++ b/images/nginx-debian/rootfs/patches/nginx-1.19.3-single_process_graceful_exit.patch
@@ -1,0 +1,75 @@
+diff --git a/src/os/unix/ngx_process.c b/src/os/unix/ngx_process.c
+index 15680237..12a8c687 100644
+--- a/src/os/unix/ngx_process.c
++++ b/src/os/unix/ngx_process.c
+@@ -362,8 +362,15 @@ ngx_signal_handler(int signo, siginfo_t *siginfo, void *ucontext)
+             break;
+ 
+         case ngx_signal_value(NGX_RECONFIGURE_SIGNAL):
+-            ngx_reconfigure = 1;
+-            action = ", reconfiguring";
++            if (ngx_process == NGX_PROCESS_SINGLE) {
++                ngx_terminate = 1;
++                action = ", exiting";
++
++            } else {
++                ngx_reconfigure = 1;
++                action = ", reconfiguring";
++            }
++
+             break;
+ 
+         case ngx_signal_value(NGX_REOPEN_SIGNAL):
+diff --git a/src/os/unix/ngx_process_cycle.c b/src/os/unix/ngx_process_cycle.c
+index 5817a2c2..f3d58e97 100644
+--- a/src/os/unix/ngx_process_cycle.c
++++ b/src/os/unix/ngx_process_cycle.c
+@@ -305,11 +305,26 @@ ngx_single_process_cycle(ngx_cycle_t *cycle)
+     }
+ 
+     for ( ;; ) {
++        if (ngx_exiting) {
++            if (ngx_event_no_timers_left() == NGX_OK) {
++                ngx_log_error(NGX_LOG_NOTICE, cycle->log, 0, "exiting");
++
++                for (i = 0; cycle->modules[i]; i++) {
++                    if (cycle->modules[i]->exit_process) {
++                        cycle->modules[i]->exit_process(cycle);
++                    }
++                }
++
++                ngx_master_process_exit(cycle);
++            }
++        }
++
+         ngx_log_debug0(NGX_LOG_DEBUG_EVENT, cycle->log, 0, "worker cycle");
+ 
+         ngx_process_events_and_timers(cycle);
+ 
+-        if (ngx_terminate || ngx_quit) {
++        if (ngx_terminate) {
++            ngx_log_error(NGX_LOG_NOTICE, cycle->log, 0, "exiting");
+ 
+             for (i = 0; cycle->modules[i]; i++) {
+                 if (cycle->modules[i]->exit_process) {
+@@ -320,6 +335,20 @@ ngx_single_process_cycle(ngx_cycle_t *cycle)
+             ngx_master_process_exit(cycle);
+         }
+ 
++        if (ngx_quit) {
++            ngx_quit = 0;
++            ngx_log_error(NGX_LOG_NOTICE, cycle->log, 0,
++                          "gracefully shutting down");
++            ngx_setproctitle("process is shutting down");
++
++            if (!ngx_exiting) {
++                ngx_exiting = 1;
++                ngx_set_shutdown_timer(cycle);
++                ngx_close_listening_sockets(cycle);
++                ngx_close_idle_connections(cycle);
++            }
++        }
++
+         if (ngx_reconfigure) {
+             ngx_reconfigure = 0;
+             ngx_log_error(NGX_LOG_NOTICE, cycle->log, 0, "reconfiguring");

--- a/images/nginx-debian/rootfs/patches/nginx-1.19.3-socket_cloexec.patch
+++ b/images/nginx-debian/rootfs/patches/nginx-1.19.3-socket_cloexec.patch
@@ -1,0 +1,185 @@
+diff --git a/auto/unix b/auto/unix
+index 10835f6c..b5b33bb3 100644
+--- a/auto/unix
++++ b/auto/unix
+@@ -990,3 +990,27 @@ ngx_feature_test='struct addrinfo *res;
+                   if (getaddrinfo("localhost", NULL, NULL, &res) != 0) return 1;
+                   freeaddrinfo(res)'
+ . auto/feature
++
++ngx_feature="SOCK_CLOEXEC support"
++ngx_feature_name="NGX_HAVE_SOCKET_CLOEXEC"
++ngx_feature_run=no
++ngx_feature_incs="#include <sys/types.h>
++                  #include <sys/socket.h>"
++ngx_feature_path=
++ngx_feature_libs=
++ngx_feature_test="int fd;
++                  fd = socket(AF_INET, SOCK_STREAM | SOCK_CLOEXEC, 0);"
++. auto/feature
++
++ngx_feature="FD_CLOEXEC support"
++ngx_feature_name="NGX_HAVE_FD_CLOEXEC"
++ngx_feature_run=no
++ngx_feature_incs="#include <sys/types.h>
++                  #include <sys/socket.h>
++                  #include <fcntl.h>"
++ngx_feature_path=
++ngx_feature_libs=
++ngx_feature_test="int fd;
++                  fd = socket(AF_INET, SOCK_STREAM, 0);
++                  fcntl(fd, F_SETFD, FD_CLOEXEC);"
++. auto/feature
+diff --git a/src/core/ngx_resolver.c b/src/core/ngx_resolver.c
+index cd55520c..438e0806 100644
+--- a/src/core/ngx_resolver.c
++++ b/src/core/ngx_resolver.c
+@@ -4466,8 +4466,14 @@ ngx_tcp_connect(ngx_resolver_connection_t *rec)
+     ngx_event_t       *rev, *wev;
+     ngx_connection_t  *c;
+ 
++#if (NGX_HAVE_SOCKET_CLOEXEC)
++    s = ngx_socket(rec->sockaddr->sa_family, SOCK_STREAM | SOCK_CLOEXEC, 0);
++
++#else
+     s = ngx_socket(rec->sockaddr->sa_family, SOCK_STREAM, 0);
+ 
++#endif
++
+     ngx_log_debug1(NGX_LOG_DEBUG_EVENT, &rec->log, 0, "TCP socket %d", s);
+ 
+     if (s == (ngx_socket_t) -1) {
+@@ -4494,6 +4500,15 @@ ngx_tcp_connect(ngx_resolver_connection_t *rec)
+         goto failed;
+     }
+ 
++#if (NGX_HAVE_FD_CLOEXEC)
++    if (ngx_cloexec(s) == -1) {
++        ngx_log_error(NGX_LOG_ALERT, &rec->log, ngx_socket_errno,
++                      ngx_cloexec_n " failed");
++
++        goto failed;
++    }
++#endif
++
+     rev = c->read;
+     wev = c->write;
+ 
+diff --git a/src/event/ngx_event.h b/src/event/ngx_event.h
+index 19fec68..8c2f01a 100644
+--- a/src/event/ngx_event.h
++++ b/src/event/ngx_event.h
+@@ -73,6 +73,9 @@ struct ngx_event_s {
+     /* to test on worker exit */
+     unsigned         channel:1;
+     unsigned         resolver:1;
++#if (HAVE_SOCKET_CLOEXEC_PATCH)
++    unsigned         skip_socket_leak_check:1;
++#endif
+ 
+     unsigned         cancelable:1;
+ 
+diff --git a/src/event/ngx_event_accept.c b/src/event/ngx_event_accept.c
+index 77563709..5827b9d0 100644
+--- a/src/event/ngx_event_accept.c
++++ b/src/event/ngx_event_accept.c
+@@ -62,7 +62,9 @@ ngx_event_accept(ngx_event_t *ev)
+ 
+ #if (NGX_HAVE_ACCEPT4)
+         if (use_accept4) {
+-            s = accept4(lc->fd, &sa.sockaddr, &socklen, SOCK_NONBLOCK);
++            s = accept4(lc->fd, &sa.sockaddr, &socklen,
++                        SOCK_NONBLOCK | SOCK_CLOEXEC);
++
+         } else {
+             s = accept(lc->fd, &sa.sockaddr, &socklen);
+         }
+@@ -202,6 +204,16 @@ ngx_event_accept(ngx_event_t *ev)
+                     ngx_close_accepted_connection(c);
+                     return;
+                 }
++
++#if (NGX_HAVE_FD_CLOEXEC)
++                if (ngx_cloexec(s) == -1) {
++                    ngx_log_error(NGX_LOG_ALERT, ev->log, ngx_socket_errno,
++                                  ngx_cloexec_n " failed");
++                    ngx_close_accepted_connection(c);
++                    return;
++                }
++#endif
++
+             }
+         }
+ 
+diff --git a/src/event/ngx_event_connect.c b/src/event/ngx_event_connect.c
+index c5bb8068..cf33b1d2 100644
+--- a/src/event/ngx_event_connect.c
++++ b/src/event/ngx_event_connect.c
+@@ -38,8 +38,15 @@ ngx_event_connect_peer(ngx_peer_connection_t *pc)
+ 
+     type = (pc->type ? pc->type : SOCK_STREAM);
+ 
++#if (NGX_HAVE_SOCKET_CLOEXEC)
++    s = ngx_socket(pc->sockaddr->sa_family, type | SOCK_CLOEXEC, 0);
++
++#else
+     s = ngx_socket(pc->sockaddr->sa_family, type, 0);
+ 
++#endif
++
++
+     ngx_log_debug2(NGX_LOG_DEBUG_EVENT, pc->log, 0, "%s socket %d",
+                    (type == SOCK_STREAM) ? "stream" : "dgram", s);
+ 
+@@ -80,6 +87,15 @@ ngx_event_connect_peer(ngx_peer_connection_t *pc)
+         goto failed;
+     }
+ 
++#if (NGX_HAVE_FD_CLOEXEC)
++    if (ngx_cloexec(s) == -1) {
++        ngx_log_error(NGX_LOG_ALERT, pc->log, ngx_socket_errno,
++                      ngx_cloexec_n " failed");
++
++        goto failed;
++    }
++#endif
++
+     if (pc->local) {
+ 
+ #if (NGX_HAVE_TRANSPARENT_PROXY)
+diff --git a/src/os/unix/ngx_process_cycle.c b/src/os/unix/ngx_process_cycle.c
+index c4376a5..48e8fa8 100644
+--- a/src/os/unix/ngx_process_cycle.c
++++ b/src/os/unix/ngx_process_cycle.c
+@@ -1032,6 +1032,9 @@ ngx_worker_process_exit(ngx_cycle_t *cycle)
+         for (i = 0; i < cycle->connection_n; i++) {
+             if (c[i].fd != -1
+                 && c[i].read
++#if (HAVE_SOCKET_CLOEXEC_PATCH)
++                && !c[i].read->skip_socket_leak_check
++#endif
+                 && !c[i].read->accept
+                 && !c[i].read->channel
+                 && !c[i].read->resolver)
+diff --git a/src/os/unix/ngx_socket.h b/src/os/unix/ngx_socket.h
+index fcc51533..d1eebf47 100644
+--- a/src/os/unix/ngx_socket.h
++++ b/src/os/unix/ngx_socket.h
+@@ -38,6 +38,17 @@ int ngx_blocking(ngx_socket_t s);
+ 
+ #endif
+ 
++#if (NGX_HAVE_FD_CLOEXEC)
++
++#define ngx_cloexec(s)      fcntl(s, F_SETFD, FD_CLOEXEC)
++#define ngx_cloexec_n       "fcntl(FD_CLOEXEC)"
++
++/* at least FD_CLOEXEC is required to ensure connection fd is closed
++ * after execve */
++#define HAVE_SOCKET_CLOEXEC_PATCH  1
++
++#endif
++
+ int ngx_tcp_nopush(ngx_socket_t s);
+ int ngx_tcp_push(ngx_socket_t s);
+ 

--- a/images/nginx-debian/rootfs/patches/nginx-1.19.3-ssl_cert_cb_yield.patch
+++ b/images/nginx-debian/rootfs/patches/nginx-1.19.3-ssl_cert_cb_yield.patch
@@ -1,0 +1,64 @@
+# HG changeset patch
+# User Yichun Zhang <agentzh@openresty.org>
+# Date 1451762084 28800
+#      Sat Jan 02 11:14:44 2016 -0800
+# Node ID 449f0461859c16e95bdb18e8be6b94401545d3dd
+# Parent  78b4e10b4367b31367aad3c83c9c3acdd42397c4
+SSL: handled SSL_CTX_set_cert_cb() callback yielding.
+
+OpenSSL 1.0.2+ introduces SSL_CTX_set_cert_cb() to allow custom
+callbacks to serve the SSL certificiates and private keys dynamically
+and lazily. The callbacks may yield for nonblocking I/O or sleeping.
+Here we added support for such usage in NGINX 3rd-party modules
+(like ngx_lua) in NGINX's event handlers for downstream SSL
+connections.
+
+diff -r 78b4e10b4367 -r 449f0461859c src/event/ngx_event_openssl.c
+--- a/src/event/ngx_event_openssl.c Thu Dec 17 16:39:15 2015 +0300
++++ b/src/event/ngx_event_openssl.c Sat Jan 02 11:14:44 2016 -0800
+@@ -1445,6 +1445,23 @@ ngx_ssl_handshake(ngx_connection_t *c)
+         return NGX_AGAIN;
+     }
+ 
++#if OPENSSL_VERSION_NUMBER >= 0x10002000L
++    if (sslerr == SSL_ERROR_WANT_X509_LOOKUP) {
++        c->read->handler = ngx_ssl_handshake_handler;
++        c->write->handler = ngx_ssl_handshake_handler;
++
++        if (ngx_handle_read_event(c->read, 0) != NGX_OK) {
++            return NGX_ERROR;
++        }
++
++        if (ngx_handle_write_event(c->write, 0) != NGX_OK) {
++            return NGX_ERROR;
++        }
++
++        return NGX_AGAIN;
++    }
++#endif
++
+     err = (sslerr == SSL_ERROR_SYSCALL) ? ngx_errno : 0;
+ 
+     c->ssl->no_wait_shutdown = 1;
+@@ -1558,6 +1575,21 @@ ngx_ssl_try_early_data(ngx_connection_t *c)
+         return NGX_AGAIN;
+     }
+ 
++    if (sslerr == SSL_ERROR_WANT_X509_LOOKUP) {
++        c->read->handler = ngx_ssl_handshake_handler;
++        c->write->handler = ngx_ssl_handshake_handler;
++
++        if (ngx_handle_read_event(c->read, 0) != NGX_OK) {
++            return NGX_ERROR;
++        }
++
++        if (ngx_handle_write_event(c->write, 0) != NGX_OK) {
++            return NGX_ERROR;
++        }
++
++        return NGX_AGAIN;
++    }
++
+     err = (sslerr == SSL_ERROR_SYSCALL) ? ngx_errno : 0;
+ 
+     c->ssl->no_wait_shutdown = 1;

--- a/images/nginx-debian/rootfs/patches/nginx-1.19.3-ssl_sess_cb_yield.patch
+++ b/images/nginx-debian/rootfs/patches/nginx-1.19.3-ssl_sess_cb_yield.patch
@@ -1,0 +1,41 @@
+diff --git a/src/event/ngx_event_openssl.c b/src/event/ngx_event_openssl.c
+--- a/src/event/ngx_event_openssl.c
++++ b/src/event/ngx_event_openssl.c
+@@ -1446,7 +1446,12 @@ ngx_ssl_handshake(ngx_connection_t *c)
+     }
+ 
+ #if OPENSSL_VERSION_NUMBER >= 0x10002000L
+-    if (sslerr == SSL_ERROR_WANT_X509_LOOKUP) {
++    if (sslerr == SSL_ERROR_WANT_X509_LOOKUP
++#   ifdef SSL_ERROR_PENDING_SESSION
++        || sslerr == SSL_ERROR_PENDING_SESSION
++#   endif
++       )
++    {
+         c->read->handler = ngx_ssl_handshake_handler;
+         c->write->handler = ngx_ssl_handshake_handler;
+ 
+@@ -1575,6 +1580,23 @@ ngx_ssl_try_early_data(ngx_connection_t *c)
+         return NGX_AGAIN;
+     }
+ 
++#ifdef SSL_ERROR_PENDING_SESSION
++    if (sslerr == SSL_ERROR_PENDING_SESSION) {
++        c->read->handler = ngx_ssl_handshake_handler;
++        c->write->handler = ngx_ssl_handshake_handler;
++
++        if (ngx_handle_read_event(c->read, 0) != NGX_OK) {
++            return NGX_ERROR;
++        }
++
++        if (ngx_handle_write_event(c->write, 0) != NGX_OK) {
++            return NGX_ERROR;
++        }
++
++        return NGX_AGAIN;
++    }
++#endif
++
+     err = (sslerr == SSL_ERROR_SYSCALL) ? ngx_errno : 0;
+ 
+     c->ssl->no_wait_shutdown = 1;

--- a/images/nginx-debian/rootfs/patches/nginx-1.19.3-stream_proxy_get_next_upstream_tries.patch
+++ b/images/nginx-debian/rootfs/patches/nginx-1.19.3-stream_proxy_get_next_upstream_tries.patch
@@ -1,0 +1,31 @@
+diff --git a/src/stream/ngx_stream.h b/src/stream/ngx_stream.h
+index 09d2459..de92724 100644
+--- a/src/stream/ngx_stream.h
++++ b/src/stream/ngx_stream.h
+@@ -303,4 +303,7 @@ typedef ngx_int_t (*ngx_stream_filter_pt)(ngx_stream_session_t *s,
+ extern ngx_stream_filter_pt  ngx_stream_top_filter;
+ 
+ 
++#define HAS_NGX_STREAM_PROXY_GET_NEXT_UPSTREAM_TRIES_PATCH 1
++
++
+ #endif /* _NGX_STREAM_H_INCLUDED_ */
+diff --git a/src/stream/ngx_stream_proxy_module.c b/src/stream/ngx_stream_proxy_module.c
+index 0afde1c..3254ce1 100644
+--- a/src/stream/ngx_stream_proxy_module.c
++++ b/src/stream/ngx_stream_proxy_module.c
+@@ -2156,3 +2156,14 @@ ngx_stream_proxy_bind(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+ 
+     return NGX_CONF_OK;
+ }
++
++
++ngx_uint_t
++ngx_stream_proxy_get_next_upstream_tries(ngx_stream_session_t *s)
++{
++    ngx_stream_proxy_srv_conf_t      *pscf;
++
++    pscf = ngx_stream_get_module_srv_conf(s, ngx_stream_proxy_module);
++
++    return pscf->next_upstream_tries;
++}

--- a/images/nginx-debian/rootfs/patches/nginx-1.19.3-stream_ssl_preread_no_skip.patch
+++ b/images/nginx-debian/rootfs/patches/nginx-1.19.3-stream_ssl_preread_no_skip.patch
@@ -1,0 +1,13 @@
+diff --git a/src/stream/ngx_stream_ssl_preread_module.c b/src/stream/ngx_stream_ssl_preread_module.c
+index e3d11fd9..3717b5fe 100644
+--- a/src/stream/ngx_stream_ssl_preread_module.c
++++ b/src/stream/ngx_stream_ssl_preread_module.c
+@@ -159,7 +159,7 @@ ngx_stream_ssl_preread_handler(ngx_stream_session_t *s)
+ 
+         rc = ngx_stream_ssl_preread_parse_record(ctx, p, p + len);
+         if (rc != NGX_AGAIN) {
+-            return rc;
++            return rc == NGX_OK ? NGX_DECLINED : rc;
+         }
+ 
+         p += len;

--- a/images/nginx-debian/rootfs/patches/nginx-1.19.3-upstream_pipelining.patch
+++ b/images/nginx-debian/rootfs/patches/nginx-1.19.3-upstream_pipelining.patch
@@ -1,0 +1,23 @@
+commit f9907b72a76a21ac5413187b83177a919475c75f
+Author: Yichun Zhang (agentzh) <agentzh@gmail.com>
+Date:   Wed Feb 10 16:05:08 2016 -0800
+
+    bugfix: upstream: keep sending request data after the first write attempt.
+    
+    See
+    http://mailman.nginx.org/pipermail/nginx-devel/2012-March/002040.html
+    for more details on the issue.
+
+diff --git a/src/http/ngx_http_upstream.c b/src/http/ngx_http_upstream.c
+index 69019417..92b7c97f 100644
+--- a/src/http/ngx_http_upstream.c
++++ b/src/http/ngx_http_upstream.c
+@@ -2239,7 +2239,7 @@ ngx_http_upstream_send_request_handler(ngx_http_request_t *r,
+
+ #endif
+
+-    if (u->header_sent && !u->conf->preserve_output) {
++    if (u->request_body_sent && !u->conf->preserve_output) {
+         u->write_event_handler = ngx_http_upstream_dummy_handler;
+
+         (void) ngx_handle_write_event(c->write, 0);

--- a/images/nginx-debian/rootfs/patches/nginx-1.19.3-upstream_timeout_fields.patch
+++ b/images/nginx-debian/rootfs/patches/nginx-1.19.3-upstream_timeout_fields.patch
@@ -1,0 +1,112 @@
+diff --git a/src/http/ngx_http_upstream.c b/src/http/ngx_http_upstream.c
+index 69019417..2265d8f7 100644
+--- a/src/http/ngx_http_upstream.c
++++ b/src/http/ngx_http_upstream.c
+@@ -509,12 +509,19 @@ void
+ ngx_http_upstream_init(ngx_http_request_t *r)
+ {
+     ngx_connection_t     *c;
++    ngx_http_upstream_t  *u;
+ 
+     c = r->connection;
+ 
+     ngx_log_debug1(NGX_LOG_DEBUG_HTTP, c->log, 0,
+                    "http init upstream, client timer: %d", c->read->timer_set);
+ 
++    u = r->upstream;
++
++    u->connect_timeout = u->conf->connect_timeout;
++    u->send_timeout = u->conf->send_timeout;
++    u->read_timeout = u->conf->read_timeout;
++
+ #if (NGX_HTTP_V2)
+     if (r->stream) {
+         ngx_http_upstream_init_request(r);
+@@ -1626,7 +1633,7 @@ ngx_http_upstream_connect(ngx_http_request_t *r, ngx_http_upstream_t *u)
+     u->request_body_blocked = 0;
+ 
+     if (rc == NGX_AGAIN) {
+-        ngx_add_timer(c->write, u->conf->connect_timeout);
++        ngx_add_timer(c->write, u->connect_timeout);
+         return;
+     }
+ 
+@@ -1704,7 +1711,7 @@ ngx_http_upstream_ssl_init_connection(ngx_http_request_t *r,
+     if (rc == NGX_AGAIN) {
+ 
+         if (!c->write->timer_set) {
+-            ngx_add_timer(c->write, u->conf->connect_timeout);
++            ngx_add_timer(c->write, u->connect_timeout);
+         }
+ 
+         c->ssl->handler = ngx_http_upstream_ssl_handshake_handler;
+@@ -2022,7 +2029,7 @@ ngx_http_upstream_send_request(ngx_http_request_t *r, ngx_http_upstream_t *u,
+ 
+     if (rc == NGX_AGAIN) {
+         if (!c->write->ready || u->request_body_blocked) {
+-            ngx_add_timer(c->write, u->conf->send_timeout);
++            ngx_add_timer(c->write, u->send_timeout);
+ 
+         } else if (c->write->timer_set) {
+             ngx_del_timer(c->write);
+@@ -2084,7 +2091,7 @@ ngx_http_upstream_send_request(ngx_http_request_t *r, ngx_http_upstream_t *u,
+             return;
+         }
+ 
+-        ngx_add_timer(c->read, u->conf->read_timeout);
++        ngx_add_timer(c->read, u->read_timeout);
+ 
+         if (c->read->ready) {
+             ngx_http_upstream_process_header(r, u);
+@@ -3213,7 +3220,7 @@ ngx_http_upstream_send_response(ngx_http_request_t *r, ngx_http_upstream_t *u)
+         p->cyclic_temp_file = 0;
+     }
+ 
+-    p->read_timeout = u->conf->read_timeout;
++    p->read_timeout = u->read_timeout;
+     p->send_timeout = clcf->send_timeout;
+     p->send_lowat = clcf->send_lowat;
+ 
+@@ -3458,7 +3465,7 @@ ngx_http_upstream_process_upgraded(ngx_http_request_t *r,
+     }
+ 
+     if (upstream->write->active && !upstream->write->ready) {
+-        ngx_add_timer(upstream->write, u->conf->send_timeout);
++        ngx_add_timer(upstream->write, u->send_timeout);
+ 
+     } else if (upstream->write->timer_set) {
+         ngx_del_timer(upstream->write);
+@@ -3470,7 +3477,7 @@ ngx_http_upstream_process_upgraded(ngx_http_request_t *r,
+     }
+ 
+     if (upstream->read->active && !upstream->read->ready) {
+-        ngx_add_timer(upstream->read, u->conf->read_timeout);
++        ngx_add_timer(upstream->read, u->read_timeout);
+ 
+     } else if (upstream->read->timer_set) {
+         ngx_del_timer(upstream->read);
+@@ -3664,7 +3671,7 @@ ngx_http_upstream_process_non_buffered_request(ngx_http_request_t *r,
+     }
+ 
+     if (upstream->read->active && !upstream->read->ready) {
+-        ngx_add_timer(upstream->read, u->conf->read_timeout);
++        ngx_add_timer(upstream->read, u->read_timeout);
+ 
+     } else if (upstream->read->timer_set) {
+         ngx_del_timer(upstream->read);
+diff --git a/src/http/ngx_http_upstream.h b/src/http/ngx_http_upstream.h
+index c2f4dc0b..b9eef118 100644
+--- a/src/http/ngx_http_upstream.h
++++ b/src/http/ngx_http_upstream.h
+@@ -333,6 +333,11 @@ struct ngx_http_upstream_s {
+     ngx_array_t                     *caches;
+ #endif
+ 
++#define HAVE_NGX_UPSTREAM_TIMEOUT_FIELDS  1
++    ngx_msec_t                       connect_timeout;
++    ngx_msec_t                       send_timeout;
++    ngx_msec_t                       read_timeout;
++
+     ngx_http_upstream_headers_in_t   headers_in;
+ 
+     ngx_http_upstream_resolved_t    *resolved;


### PR DESCRIPTION
Fixes partially: #7518 
This is also an attempt to optimize / solve coredumps problems in #6896

On an attempt to solve random coredump problems, and have some standard image building this PR:

* Changes the base image from Alpine to Debian
* Splits the base image in two: nginx and mod_security

The old all in one alpine image got 184Mb, while the new images got 164mb (base NGINX) and 77.9Mb (modsecurity).

Although the sum of the images grows (mostly due to glibc and not optimizing Debian Image the same way it's done in https://github.com/kubernetes/release/tree/master/images/build/debian-base/bullseye, still the reduction for the majority of  users will be 20Mb (as modsecurity is going to be optional now)

**Before** merging this PR, we should wait for https://github.com/kubernetes/test-infra/pull/23478 to get merged





