### PR TITLE
additional info for the custom-headers documentation page

### DIFF
--- a/docs/examples/customization/custom-headers/README.md
+++ b/docs/examples/customization/custom-headers/README.md
@@ -18,6 +18,14 @@ kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main
 
 The nginx ingress controller will read the `ingress-nginx/ingress-nginx-controller` ConfigMap, find the `proxy-set-headers` key, read HTTP headers from the `ingress-nginx/custom-headers` ConfigMap, and include those HTTP headers in all requests flowing from nginx to the backends.
 
+
+The above example was for passing a custom list of headers to the upstream server.
+To pass the custom headers before sending response traffic to the client, use the add-headers key:
+
+```console
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/docs/examples/customization/custom-headers/configmap-client-response.yaml
+```
+
 ## Test
 
 Check the contents of the ConfigMaps are present in the nginx.conf file using:

--- a/docs/examples/customization/custom-headers/configmap-client-response.yaml
+++ b/docs/examples/customization/custom-headers/configmap-client-response.yaml
@@ -8,4 +8,3 @@ metadata:
   labels:
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    

--- a/docs/examples/customization/custom-headers/configmap-client-response.yaml
+++ b/docs/examples/customization/custom-headers/configmap-client-response.yaml
@@ -8,3 +8,4 @@ metadata:
   labels:
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
+    

--- a/docs/examples/customization/custom-headers/configmap-client-response.yaml
+++ b/docs/examples/customization/custom-headers/configmap-client-response.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+data:
+  add-headers: "ingress-nginx/custom-headers"
+kind: ConfigMap
+metadata:
+  name: ingress-nginx-controller
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx

--- a/docs/examples/customization/custom-headers/configmap-client-response.yaml
+++ b/docs/examples/customization/custom-headers/configmap-client-response.yaml
@@ -7,4 +7,4 @@ metadata:
   namespace: ingress-nginx
   labels:
     app.kubernetes.io/name: ingress-nginx
-    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx 


### PR DESCRIPTION

## What this PR does / why we need it:
According to the documentation here: https://kubernetes.github.io/ingress-nginx/examples/customization/custom-headers/ , proxy-set-headers should cite the custom-headers configmap, therefore include all the custom headers in the requests.

In my case I needed the custom-headers to be passed before sending the response to the client. As the documentation's title is general (regarding custom-headers), I. think it would be a bit more clear to have both cases as an example


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #7566
-->

## How Has This Been Tested?
I have used the Markdown Preview
I tested ifI can read :
I checked if the https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/docs/examples/customization/custom-headers/configmap-client-response.yaml file has the right value (add-headers)



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
