### PR TITLE
Rewrite multiple-ingress.md to work with v1

### DIFF
--- a/docs/user-guide/multiple-ingress.md
+++ b/docs/user-guide/multiple-ingress.md
@@ -2,11 +2,13 @@
 
 By default, deploying multiple Ingress controllers (e.g., `ingress-nginx` & `gce`) will result in all controllers simultaneously racing to update Ingress status fields in confusing ways.
 
-To fix this problem, you can set either the `ingressClassName` (preferred) or the `kubernetes.io/ingress.class` annotation (in deprecation) on your Ingress resources.
+To fix this problem, you can either use [IngressClasses](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class) (preferred) or use the `kubernetes.io/ingress.class` annotation (in deprecation).
 
-## Setting ingressClassName
+## Using IngressClasses
 
-If all ingress controllers respect IngressClasses (e.g. multiple instances of ingress-nginx v1.0), ensure that the `--controller-class` flag, the IngressClass name, and the `ingressClassName` field are in sync:
+If all ingress controllers respect IngressClasses (e.g. multiple instances of ingress-nginx v1.0), you can deploy two Ingress controllers by granting them control over two different IngressClasses, then selecting one of the two IngressClasses with `ingressClassName`.
+
+First, ensure the `--controller-class=` is set to something different on each ingress controller:
 
 ```yaml
 # ingress-nginx Deployment/Statfulset
@@ -17,17 +19,26 @@ spec:
          - name: nginx-ingress-internal-controller
            args:
              - /nginx-ingress-controller
-             - '--controller-class=internal-nginx'
+             - '--controller-class=k8s.io/internal-ingress-nginx'
             ...
+```
 
+Then use the same value in the IngressClass:
+
+```yaml
 # ingress-nginx IngressClass
 apiVersion: networking.k8s.io/v1
 kind: IngressClass
 metadata:
   name: internal-nginx
+spec:
+  controller: k8s.io/internal-ingress-nginx
   ...
+```
 
-# Your Ingresses
+And refer to that IngressClass in your Ingress:
+
+```yaml
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -51,13 +62,13 @@ controller:
 !!! important
 
     When running multiple ingress-nginx controllers, it will only process an unset class annotation if one of the controllers uses the default
-    `--controller-class` value (see `IsValid` method in `internal/ingress/annotations/class/main.go`), otherwise the class annotation become required.
+    `--controller-class` value (see `IsValid` method in `internal/ingress/annotations/class/main.go`), otherwise the class annotation becomes required.
 
     If `--controller-class` is set to the default value of `k8s.io/ingress-nginx`, the controller will monitor Ingresses with no class annotation *and* Ingresses with annotation class set to `nginx`. Use a non-default value for `--controller-class`, to ensure that the controller only satisfied the specific class of Ingresses.
 
-## Setting the kubernetes.io/ingress.class annotation (in deprecation)
+## Using the kubernetes.io/ingress.class annotation (in deprecation)
 
-If you're running multiple ingress controllers where one or more do not support IngressClasses, you must specify the annotation `kubernetes.io/ingress.class: "nginx"` in all ingresses that you would like the ingress-nginx controller to claim.
+If you're running multiple ingress controllers where one or more do not support IngressClasses, you must specify the annotation `kubernetes.io/ingress.class: "nginx"` in all ingresses that you would like ingress-nginx to claim.
 
 
 For instance,


### PR DESCRIPTION
## What this PR does / why we need it:
The current docs only show how to use the `kubernetes.io/ingress.class` annotation, but don't show how to use ingressClassName. Since the `--ingress-class` flag is [marked for deprecation](https://github.com/kubernetes/ingress-nginx/blob/4c4013904a2a4f5c42245db3fbf0515ec1be33d7/cmd/nginx/flags.go#L59), I figured we needed to update the docs to refer to ingress classes instead.

My specific use-case is that I needed to know the helm values for installing two ingress-nginx instances (one public, one private).

I ended up restructuring the document to be "new vs old" rather than "public cloud vs. not". I retained the docs about how to use the annotation (with the caveat that ingressClassName is preferred) because [GKE still tells you to use the annotation](https://cloud.google.com/kubernetes-engine/docs/concepts/ingress) which might mean their ingress controller doesn't support ingress classes. And there may be others out there that only support the annotation. But if not, then we could just remove that extra section.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Which issue/s this PR fixes
n/a

## How Has This Been Tested?
Docs change, n/a. I did test the helm values though.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [x] All new and existing tests passed.
