### PR TITLE
Add new flag to watch ingressclass by name

### DIFF
--- a/charts/ingress-nginx/templates/controller-daemonset.yaml
+++ b/charts/ingress-nginx/templates/controller-daemonset.yaml
@@ -114,6 +114,9 @@ spec:
           {{- if .Values.controller.healthCheckHost }}
             - --healthz-host={{ .Values.controller.healthCheckHost }}
           {{- end }}
+          {{- if .Values.controller.ingressClassByName }}
+            - --ingress-class-by-name=true
+          {{- end }}
           {{- if .Values.controller.watchIngressWithoutClass }}
             - --watch-ingress-without-class=true
           {{- end }}

--- a/charts/ingress-nginx/templates/controller-deployment.yaml
+++ b/charts/ingress-nginx/templates/controller-deployment.yaml
@@ -115,6 +115,9 @@ spec:
           {{- if not (eq .Values.controller.healthCheckPath "/healthz") }}
             - --health-check-path={{ .Values.controller.healthCheckPath }}
           {{- end }}
+          {{- if .Values.controller.ingressClassByName }}
+            - --ingress-class-by-name=true
+          {{- end }}
           {{- if .Values.controller.watchIngressWithoutClass }}
             - --watch-ingress-without-class=true
           {{- end }}

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -66,6 +66,9 @@ controller:
   # Defaults to false
   watchIngressWithoutClass: false
 
+  # Process IngressClass per name (additionally as per spec.controller)
+  ingressClassByName: false
+
   # Required for use with CNI based kubernetes installations (such as ones set up by kubeadm),
   # since CNI and hostport don't mix yet. Can be deprecated once https://github.com/kubernetes/kubernetes/issues/23920
   # is merged

--- a/cmd/nginx/flags.go
+++ b/cmd/nginx/flags.go
@@ -68,6 +68,9 @@ referenced in an Ingress Object should be the same value specified here to make 
 		watchWithoutClass = flags.Bool("watch-ingress-without-class", false,
 			`Define if Ingress Controller should also watch for Ingresses without an IngressClass or the annotation specified`)
 
+		ingressClassByName = flags.Bool("ingress-class-by-name", false,
+			`Define if Ingress Controller should watch for Ingress Class by Name together with Controller Class`)
+
 		configMap = flags.String("configmap", "",
 			`Name of the ConfigMap containing custom global configurations for the controller.`)
 
@@ -299,9 +302,10 @@ https://blog.maxmind.com/2019/12/18/significant-changes-to-accessing-and-using-g
 			SSLProxy: *sslProxyPort,
 		},
 		IngressClassConfiguration: &ingressclass.IngressClassConfiguration{
-			Controller:        *ingressClassController,
-			AnnotationValue:   *ingressClassAnnotation,
-			WatchWithoutClass: *watchWithoutClass,
+			Controller:         *ingressClassController,
+			AnnotationValue:    *ingressClassAnnotation,
+			WatchWithoutClass:  *watchWithoutClass,
+			IngressClassByName: *ingressClassByName,
 		},
 		DisableCatchAll:           *disableCatchAll,
 		ValidationWebhook:         *validationWebhook,

--- a/internal/ingress/controller/ingressclass/ingressclass.go
+++ b/internal/ingress/controller/ingressclass/ingressclass.go
@@ -42,4 +42,8 @@ type IngressClassConfiguration struct {
 	// WatchWithoutClass defines if Controller should watch to Ingress Objects that does
 	// not contain an IngressClass configuration
 	WatchWithoutClass bool
+
+	//IngressClassByName defines if the Controller should watch for Ingress Classes by
+	// .metadata.name together with .spec.Controller
+	IngressClassByName bool
 }

--- a/internal/ingress/controller/store/store.go
+++ b/internal/ingress/controller/store/store.go
@@ -426,7 +426,12 @@ func New(
 	ingressClassEventHandler := cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			ingressclass := obj.(*networkingv1.IngressClass)
-			if ingressclass.Spec.Controller != icConfig.Controller {
+			foundClassByName := false
+			if icConfig.IngressClassByName && ingressclass.Name == icConfig.AnnotationValue {
+				klog.InfoS("adding ingressclass as ingress-class-by-name is configured", "ingressclass", klog.KObj(ingressclass))
+				foundClassByName = true
+			}
+			if !foundClassByName && ingressclass.Spec.Controller != icConfig.Controller {
 				klog.InfoS("ignoring ingressclass as the spec.controller is not the same of this ingress", "ingressclass", klog.KObj(ingressclass))
 				return
 			}


### PR DESCRIPTION
## What this PR does / why we need it:
The new IngressClass logics watches for .spec.controller being the same of the controller when it starts. Some users complain (with reason) that they expect an ingress to be watched by the ingressClassName regardless of the .spec.controller from that object.

This PR adds a new flag: `--ingress-class-by-name`.

Now, creating an ingressClass called "nginx-bla", for example, adding that in ingressClassName spec and running the controller with `--ingress-class-by-name --ingress-class=nginx-bla` will make the controller to watch for objects containing the .spec.controller but also just validate objects by name nginx-bla

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
Fixes: #7502

## How Has This Been Tested?
Wrote unit tests and e2e tests for the feature

/kind bug


