### PR TITLE
Helm notes outputs non nil value for ingress.class annotation

### DIFF
--- a/charts/ingress-nginx/templates/NOTES.txt
+++ b/charts/ingress-nginx/templates/NOTES.txt
@@ -33,7 +33,7 @@ An example Ingress that makes use of the controller:
   kind: Ingress
   metadata:
     annotations:
-      kubernetes.io/ingress.class: {{ .Values.controller.ingressClass }}
+      kubernetes.io/ingress.class: {{ .Values.controller.ingressClassResource.name }}
     name: example
     namespace: foo
   spec:


### PR DESCRIPTION
## What this PR does / why we need it:
This PR makes sure that the sample ingress output by the helm notes has correct `kubernetes.io/ingress.class` annotation

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
Fixes #7607 

## How Has This Been Tested?
Tested with `make kind-e2e-charts-test`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
