### PR TITLE
Support cors-allow-origin with multiple origins

### DIFF
--- a/build/dev-env.sh
+++ b/build/dev-env.sh
@@ -61,7 +61,7 @@ echo "[dev-env] building image"
 make build image
 docker tag "${REGISTRY}/controller:${TAG}" "${DEV_IMAGE}"
 
-export K8S_VERSION=${K8S_VERSION:-v1.20.2@sha256:8f7ea6e7642c0da54f04a7ee10431549c0257315b3a634f6ef2fecaaedb19bab}
+export K8S_VERSION=${K8S_VERSION:-v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6}
 
 KIND_CLUSTER_NAME="ingress-nginx-dev"
 

--- a/charts/ingress-nginx/templates/NOTES.txt
+++ b/charts/ingress-nginx/templates/NOTES.txt
@@ -33,7 +33,7 @@ An example Ingress that makes use of the controller:
   kind: Ingress
   metadata:
     annotations:
-      kubernetes.io/ingress.class: {{ .Values.controller.ingressClass }}
+      kubernetes.io/ingress.class: {{ .Values.controller.ingressClassResource.name }}
     name: example
     namespace: foo
   spec:

--- a/docs/user-guide/nginx-configuration/annotations.md
+++ b/docs/user-guide/nginx-configuration/annotations.md
@@ -356,6 +356,9 @@ CORS can be controlled with the following annotations:
     - Default: `*`
     - Example: `nginx.ingress.kubernetes.io/cors-allow-origin: "https://origin-site.com:4443, http://origin-site.com, https://example.org:1199"`
 
+    It also supports single level wildcard subdomains and follows this format: `http(s)://*.foo.bar`, `http(s)://*.bar.foo:8080` or `http(s)://*.abc.bar.foo:9000`
+    - Example: `nginx.ingress.kubernetes.io/cors-allow-origin: "https://*.origin-site.com:4443, http://*.origin-site.com, https://example.org:1199"`
+
 * `nginx.ingress.kubernetes.io/cors-allow-credentials`: Controls if credentials can be passed during CORS operations.
 
     - Default: `true`

--- a/docs/user-guide/nginx-configuration/annotations.md
+++ b/docs/user-guide/nginx-configuration/annotations.md
@@ -351,10 +351,10 @@ CORS can be controlled with the following annotations:
 
 * `nginx.ingress.kubernetes.io/cors-allow-origin`: Controls what's the accepted Origin for CORS.
 
-    This is a single field value, with the following format: `http(s)://origin-site.com` or `http(s)://origin-site.com:port`
+    This is a multi-valued field, separated by ','. It must follow the this format: `http(s)://origin-site.com` or `http(s)://origin-site.com:port`
 
     - Default: `*`
-    - Example: `nginx.ingress.kubernetes.io/cors-allow-origin: "https://origin-site.com:4443"`
+    - Example: `nginx.ingress.kubernetes.io/cors-allow-origin: "https://origin-site.com:4443, http://origin-site.com, https://example.org:1199"`
 
 * `nginx.ingress.kubernetes.io/cors-allow-credentials`: Controls if credentials can be passed during CORS operations.
 

--- a/docs/user-guide/nginx-configuration/annotations.md
+++ b/docs/user-guide/nginx-configuration/annotations.md
@@ -351,7 +351,7 @@ CORS can be controlled with the following annotations:
 
 * `nginx.ingress.kubernetes.io/cors-allow-origin`: Controls what's the accepted Origin for CORS.
 
-    This is a multi-valued field, separated by ','. It must follow the this format: `http(s)://origin-site.com` or `http(s)://origin-site.com:port`
+    This is a multi-valued field, separated by ','. It must follow this format: `http(s)://origin-site.com` or `http(s)://origin-site.com:port`
 
     - Default: `*`
     - Example: `nginx.ingress.kubernetes.io/cors-allow-origin: "https://origin-site.com:4443, http://origin-site.com, https://example.org:1199"`

--- a/go.mod
+++ b/go.mod
@@ -78,6 +78,7 @@ require (
 	github.com/go-openapi/jsonreference v0.19.3 // indirect
 	github.com/go-openapi/spec v0.19.5 // indirect
 	github.com/go-openapi/swag v0.19.5 // indirect
+	github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 // indirect
 	github.com/godbus/dbus/v5 v5.0.4 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect

--- a/go.sum
+++ b/go.sum
@@ -266,6 +266,7 @@ github.com/go-openapi/validate v0.19.2/go.mod h1:1tRCw7m3jtI8eNWEEliiAqUIcBztB2K
 github.com/go-openapi/validate v0.19.8/go.mod h1:8DJv2CVJQ6kGNpFW6eV9N3JviE1C85nY1c2z52x1Gk4=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 h1:p104kn46Q8WdvHunIJ9dAyjPVtrBPhSr3KT2yUst43I=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/gobuffalo/here v0.6.0/go.mod h1:wAG085dHOYqUpf+Ap+WOdrPTp5IYcDAs/x7PLa8Y5fM=
 github.com/godbus/dbus/v5 v5.0.4 h1:9349emZab16e7zQvpmsbtjc18ykshndd8y2PG3sgJbA=

--- a/internal/ingress/annotations/annotations_test.go
+++ b/internal/ingress/annotations/annotations_test.go
@@ -215,15 +215,15 @@ func TestCors(t *testing.T) {
 		corsenabled bool
 		methods     string
 		headers     string
-		origin      string
+		origin      []string
 		credentials bool
 		expose      string
 	}{
-		{map[string]string{annotationCorsEnabled: "true"}, true, defaultCorsMethods, defaultCorsHeaders, "*", true, ""},
-		{map[string]string{annotationCorsEnabled: "true", annotationCorsAllowMethods: "POST, GET, OPTIONS", annotationCorsAllowHeaders: "$nginx_version", annotationCorsAllowCredentials: "false", annotationCorsExposeHeaders: "X-CustomResponseHeader"}, true, "POST, GET, OPTIONS", defaultCorsHeaders, "*", false, "X-CustomResponseHeader"},
-		{map[string]string{annotationCorsEnabled: "true", annotationCorsAllowCredentials: "false"}, true, defaultCorsMethods, defaultCorsHeaders, "*", false, ""},
-		{map[string]string{}, false, defaultCorsMethods, defaultCorsHeaders, "*", true, ""},
-		{nil, false, defaultCorsMethods, defaultCorsHeaders, "*", true, ""},
+		{map[string]string{annotationCorsEnabled: "true"}, true, defaultCorsMethods, defaultCorsHeaders, []string{}, true, ""},
+		{map[string]string{annotationCorsEnabled: "true", annotationCorsAllowMethods: "POST, GET, OPTIONS", annotationCorsAllowHeaders: "$nginx_version", annotationCorsAllowCredentials: "false", annotationCorsExposeHeaders: "X-CustomResponseHeader"}, true, "POST, GET, OPTIONS", defaultCorsHeaders, []string{}, false, "X-CustomResponseHeader"},
+		{map[string]string{annotationCorsEnabled: "true", annotationCorsAllowCredentials: "false"}, true, defaultCorsMethods, defaultCorsHeaders, []string{}, false, ""},
+		{map[string]string{}, false, defaultCorsMethods, defaultCorsHeaders, []string{}, true, ""},
+		{nil, false, defaultCorsMethods, defaultCorsHeaders, []string{}, true, ""},
 	}
 
 	for _, foo := range fooAnns {
@@ -243,8 +243,14 @@ func TestCors(t *testing.T) {
 			t.Errorf("Returned %v but expected %v for Cors Methods", r.CorsAllowMethods, foo.methods)
 		}
 
-		if r.CorsAllowOrigin != foo.origin {
-			t.Errorf("Returned %v but expected %v for Cors Origins", r.CorsAllowOrigin, foo.origin)
+		if len(r.CorsAllowOrigin) != len(foo.origin) {
+			t.Errorf("Lengths of Cors Origins are not equal. Expected %v - Actual %v", r.CorsAllowOrigin, foo.origin)
+		}
+
+		for i, v := range r.CorsAllowOrigin {
+			if v != foo.origin[i] {
+				t.Errorf("Values of Cors Origins are not equal. Expected %v - Actual %v", r.CorsAllowOrigin, foo.origin)
+			}
 		}
 
 		if r.CorsAllowCredentials != foo.credentials {

--- a/internal/ingress/annotations/annotations_test.go
+++ b/internal/ingress/annotations/annotations_test.go
@@ -219,11 +219,11 @@ func TestCors(t *testing.T) {
 		credentials bool
 		expose      string
 	}{
-		{map[string]string{annotationCorsEnabled: "true"}, true, defaultCorsMethods, defaultCorsHeaders, []string{}, true, ""},
-		{map[string]string{annotationCorsEnabled: "true", annotationCorsAllowMethods: "POST, GET, OPTIONS", annotationCorsAllowHeaders: "$nginx_version", annotationCorsAllowCredentials: "false", annotationCorsExposeHeaders: "X-CustomResponseHeader"}, true, "POST, GET, OPTIONS", defaultCorsHeaders, []string{}, false, "X-CustomResponseHeader"},
-		{map[string]string{annotationCorsEnabled: "true", annotationCorsAllowCredentials: "false"}, true, defaultCorsMethods, defaultCorsHeaders, []string{}, false, ""},
-		{map[string]string{}, false, defaultCorsMethods, defaultCorsHeaders, []string{}, true, ""},
-		{nil, false, defaultCorsMethods, defaultCorsHeaders, []string{}, true, ""},
+		{map[string]string{annotationCorsEnabled: "true"}, true, defaultCorsMethods, defaultCorsHeaders, []string{"*"}, true, ""},
+		{map[string]string{annotationCorsEnabled: "true", annotationCorsAllowMethods: "POST, GET, OPTIONS", annotationCorsAllowHeaders: "$nginx_version", annotationCorsAllowCredentials: "false", annotationCorsExposeHeaders: "X-CustomResponseHeader"}, true, "POST, GET, OPTIONS", defaultCorsHeaders, []string{"*"}, false, "X-CustomResponseHeader"},
+		{map[string]string{annotationCorsEnabled: "true", annotationCorsAllowCredentials: "false"}, true, defaultCorsMethods, defaultCorsHeaders, []string{"*"}, false, ""},
+		{map[string]string{}, false, defaultCorsMethods, defaultCorsHeaders, []string{"*"}, true, ""},
+		{nil, false, defaultCorsMethods, defaultCorsHeaders, []string{"*"}, true, ""},
 	}
 
 	for _, foo := range fooAnns {

--- a/internal/ingress/annotations/annotations_test.go
+++ b/internal/ingress/annotations/annotations_test.go
@@ -244,11 +244,11 @@ func TestCors(t *testing.T) {
 		}
 
 		if r.CorsAllowOrigin != foo.origin {
-			t.Errorf("Returned %v but expected %v for Cors Methods", r.CorsAllowOrigin, foo.origin)
+			t.Errorf("Returned %v but expected %v for Cors Origins", r.CorsAllowOrigin, foo.origin)
 		}
 
 		if r.CorsAllowCredentials != foo.credentials {
-			t.Errorf("Returned %v but expected %v for Cors Methods", r.CorsAllowCredentials, foo.credentials)
+			t.Errorf("Returned %v but expected %v for Cors Credentials", r.CorsAllowCredentials, foo.credentials)
 		}
 
 	}

--- a/internal/ingress/annotations/cors/main.go
+++ b/internal/ingress/annotations/cors/main.go
@@ -36,7 +36,7 @@ var (
 	// Regex are defined here to prevent information leak, if user tries to set anything not valid
 	// that could cause the Response to contain some internal value/variable (like returning $pid, $upstream_addr, etc)
 	// Origin must contain a http/s Origin (including or not the port) or the value '*'
-	corsOriginRegex = regexp.MustCompile(`^(https?://[A-Za-z0-9\-\.]*(:[0-9]+)?|\*)?$`)
+	corsOriginRegex = regexp.MustCompile(`^(https?:\/\/[A-Za-z0-9\-\.]*(:[0-9]+)?|\*)?`)
 	// Method must contain valid methods list (PUT, GET, POST, BLA)
 	// May contain or not spaces between each verb
 	corsMethodsRegex = regexp.MustCompile(`^([A-Za-z]+,?\s?)+$`)
@@ -143,5 +143,4 @@ func (c cors) Parse(ing *networking.Ingress) (interface{}, error) {
 	}
 
 	return config, nil
-
 }

--- a/internal/ingress/annotations/cors/main.go
+++ b/internal/ingress/annotations/cors/main.go
@@ -20,6 +20,7 @@ import (
 	"regexp"
 
 	networking "k8s.io/api/networking/v1"
+	"k8s.io/klog/v2"
 
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	"k8s.io/ingress-nginx/internal/ingress/resolver"
@@ -114,6 +115,7 @@ func (c cors) Parse(ing *networking.Ingress) (interface{}, error) {
 
 	config.CorsAllowOrigin, err = parser.GetStringAnnotation("cors-allow-origin", ing)
 	if err != nil || !corsOriginRegex.MatchString(config.CorsAllowOrigin) {
+		klog.Errorf("Error parsing cors-allow-origin parameters using '*', supplied string: %s", config.CorsAllowOrigin)
 		config.CorsAllowOrigin = "*"
 	}
 

--- a/internal/ingress/annotations/cors/main.go
+++ b/internal/ingress/annotations/cors/main.go
@@ -136,6 +136,8 @@ func (c cors) Parse(ing *networking.Ingress) (interface{}, error) {
 			}
 			klog.Infof("Current config.corsAllowOrigin %v", config.CorsAllowOrigin)
 		}
+	} else {
+		config.CorsAllowOrigin = []string{"*"}
 	}
 
 	config.CorsAllowHeaders, err = parser.GetStringAnnotation("cors-allow-headers", ing)

--- a/internal/ingress/annotations/cors/main.go
+++ b/internal/ingress/annotations/cors/main.go
@@ -38,7 +38,7 @@ var (
 	// Regex are defined here to prevent information leak, if user tries to set anything not valid
 	// that could cause the Response to contain some internal value/variable (like returning $pid, $upstream_addr, etc)
 	// Origin must contain a http/s Origin (including or not the port) or the value '*'
-	corsOriginRegex = regexp.MustCompile(`^(https?://[A-Za-z0-9\-\.]*(:[0-9]+)?|\*)?$`)
+	corsOriginRegex = regexp.MustCompile(`^(https?://(\*\.)?[A-Za-z0-9\-\.]*(:[0-9]+)?|\*)?$`)
 	// Method must contain valid methods list (PUT, GET, POST, BLA)
 	// May contain or not spaces between each verb
 	corsMethodsRegex = regexp.MustCompile(`^([A-Za-z]+,?\s?)+$`)

--- a/internal/ingress/annotations/cors/main_test.go
+++ b/internal/ingress/annotations/cors/main_test.go
@@ -110,7 +110,7 @@ func TestIngressCorsConfigValid(t *testing.T) {
 		t.Errorf("expected %v but returned %v", data[parser.GetAnnotationWithPrefix("cors-allow-methods")], nginxCors.CorsAllowMethods)
 	}
 
-	if nginxCors.CorsAllowOrigin != "https://origin123.test.com:4443" {
+	if nginxCors.CorsAllowOrigin[0] != "https://origin123.test.com:4443" {
 		t.Errorf("expected %v but returned %v", data[parser.GetAnnotationWithPrefix("cors-allow-origin")], nginxCors.CorsAllowOrigin)
 	}
 
@@ -162,10 +162,6 @@ func TestIngressCorsConfigInvalid(t *testing.T) {
 
 	if nginxCors.CorsAllowMethods != defaultCorsMethods {
 		t.Errorf("expected %v but returned %v", defaultCorsHeaders, nginxCors.CorsAllowMethods)
-	}
-
-	if nginxCors.CorsAllowOrigin != "*" {
-		t.Errorf("expected %v but returned %v", "*", nginxCors.CorsAllowOrigin)
 	}
 
 	if nginxCors.CorsExposeHeaders != "" {

--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -1677,7 +1677,12 @@ func convertGoSliceIntoLuaTable(goSliceInterface interface{}, emptyStringAsNil b
 // buildOriginRegex returns an origin as a regex
 func buildOriginRegex(origin string) string {
 	if !strings.HasPrefix(origin, "*") {
-		return origin
+		escapedOrigin := regexp.QuoteMeta(origin)
+		escapedOrigin = strings.Replace(escapedOrigin, "\\*", "[A-Za-z0-9]+", 1)
+		if len(strings.Split(escapedOrigin, ":")) < 3 {
+			escapedOrigin += "(:[0-9][0-9]+)?"
+		}
+		return escapedOrigin
 	}
 
 	origin = strings.Replace(origin, "*.", "", 1)
@@ -1697,10 +1702,7 @@ func buildCorsOriginRegex(origins string) string {
 	for i, origin := range originSplitList {
 		originTrimmed := strings.TrimSpace(origin)
 		if len(originTrimmed) > 0 {
-			builtOrigin := regexp.QuoteMeta(buildOriginRegex(originTrimmed))
-			if len(strings.Split(originTrimmed, ":")) < 3 {
-				builtOrigin += "(:[0-9][0-9]+)?"
-			}
+			builtOrigin := buildOriginRegex(originTrimmed)
 			originsRegex += builtOrigin
 			if i != len(originSplitList)-1 {
 				originsRegex = originsRegex + "|"

--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -1697,7 +1697,11 @@ func buildCorsOriginRegex(origins string) string {
 	for i, origin := range originSplitList {
 		originTrimmed := strings.TrimSpace(origin)
 		if len(originTrimmed) > 0 {
-			originsRegex = originsRegex + regexp.QuoteMeta(buildOriginRegex(originTrimmed))
+			builtOrigin := regexp.QuoteMeta(buildOriginRegex(originTrimmed))
+			if len(strings.Split(originTrimmed, ":")) < 3 {
+				builtOrigin += "(:[0-9][0-9]+)?"
+			}
+			originsRegex += builtOrigin
 			if i != len(originSplitList)-1 {
 				originsRegex = originsRegex + "|"
 			}

--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -1692,32 +1692,22 @@ func buildOriginRegex(origin string) string {
 }
 
 // buildCorsOriginRegex builds the regex string required by nginx
-func buildCorsOriginRegex(origins string) string {
-	var originSplitList = strings.Split(origins, ",")
-	if searchCorsOrigins(originSplitList, "*") {
+func buildCorsOriginRegex(corsOrigins []string) string {
+	if len(corsOrigins) == 1 && corsOrigins[0] == "*" {
 		return "set $http_origin *;\nset $cors 'true';"
 	}
 
 	var originsRegex string = "if ($http_origin ~* ("
-	for i, origin := range originSplitList {
+	for i, origin := range corsOrigins {
 		originTrimmed := strings.TrimSpace(origin)
 		if len(originTrimmed) > 0 {
 			builtOrigin := buildOriginRegex(originTrimmed)
 			originsRegex += builtOrigin
-			if i != len(originSplitList)-1 {
+			if i != len(corsOrigins)-1 {
 				originsRegex = originsRegex + "|"
 			}
 		}
 	}
 	originsRegex = originsRegex + ")$ ) { set $cors 'true'; }"
 	return originsRegex
-}
-
-func searchCorsOrigins(splice []string, search string) bool {
-	for _, element := range splice {
-		if strings.TrimSpace(element) == search {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -1679,9 +1679,6 @@ func buildOriginRegex(origin string) string {
 	if !strings.HasPrefix(origin, "*") {
 		escapedOrigin := regexp.QuoteMeta(origin)
 		escapedOrigin = strings.Replace(escapedOrigin, "\\*", "[A-Za-z0-9]+", 1)
-		if len(strings.Split(escapedOrigin, ":")) < 3 {
-			escapedOrigin += "(:[0-9][0-9]+)?"
-		}
 		return escapedOrigin
 	}
 

--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -1674,21 +1674,12 @@ func convertGoSliceIntoLuaTable(goSliceInterface interface{}, emptyStringAsNil b
 	}
 }
 
-// buildOriginRegex returns an origin as a regex
 func buildOriginRegex(origin string) string {
-	if !strings.HasPrefix(origin, "*") {
-		escapedOrigin := regexp.QuoteMeta(origin)
-		escapedOrigin = strings.Replace(escapedOrigin, "\\*", "[A-Za-z0-9]+", 1)
-		return escapedOrigin
-	}
-
-	origin = strings.Replace(origin, "*.", "", 1)
-	parts := strings.Split(origin, ".")
-
-	return "(" + strings.Join(parts, ".") + ")"
+	origin = regexp.QuoteMeta(origin)
+	origin = strings.Replace(origin, "\\*", "[A-Za-z0-9]+", 1)
+	return fmt.Sprintf("(%s)", origin)
 }
 
-// buildCorsOriginRegex builds the regex string required by nginx
 func buildCorsOriginRegex(corsOrigins []string) string {
 	if len(corsOrigins) == 1 && corsOrigins[0] == "*" {
 		return "set $http_origin *;\nset $cors 'true';"

--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -1696,9 +1696,11 @@ func buildCorsOriginRegex(origins string) string {
 	var originsRegex string = "if ($http_origin ~* ("
 	for i, origin := range originSplitList {
 		originTrimmed := strings.TrimSpace(origin)
-		originsRegex = originsRegex + regexp.QuoteMeta(buildOriginRegex(originTrimmed))
-		if i != len(originSplitList)-1 {
-			originsRegex = originsRegex + "|"
+		if len(originTrimmed) > 0 {
+			originsRegex = originsRegex + regexp.QuoteMeta(buildOriginRegex(originTrimmed))
+			if i != len(originSplitList)-1 {
+				originsRegex = originsRegex + "|"
+			}
 		}
 	}
 	originsRegex = originsRegex + ")$ ) { set $cors 'true'; }"
@@ -1707,7 +1709,7 @@ func buildCorsOriginRegex(origins string) string {
 
 func searchCorsOrigins(splice []string, search string) bool {
 	for _, element := range splice {
-		if element == search {
+		if strings.TrimSpace(element) == search {
 			return true
 		}
 	}

--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -1683,7 +1683,7 @@ func buildOriginRegex(origin string) string {
 	origin = strings.Replace(origin, "*.", "", 1)
 	parts := strings.Split(origin, ".")
 
-	return "(" + strings.Join(parts, "\\.") + ")"
+	return "(" + strings.Join(parts, ".") + ")"
 }
 
 // buildCorsOriginRegex builds the regex string required by nginx
@@ -1693,9 +1693,10 @@ func buildCorsOriginRegex(origins string) string {
 		return "set $http_origin *;\nset $cors 'true';"
 	}
 
-	var originsRegex string = "if ($http_origin ~* .*("
+	var originsRegex string = "if ($http_origin ~* ("
 	for i, origin := range originSplitList {
-		originsRegex = originsRegex + buildOriginRegex(strings.TrimSpace(origin))
+		originTrimmed := strings.TrimSpace(origin)
+		originsRegex = originsRegex + regexp.QuoteMeta(buildOriginRegex(originTrimmed))
 		if i != len(originSplitList)-1 {
 			originsRegex = originsRegex + "|"
 		}

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -866,8 +866,25 @@ stream {
 {{ define "CORS" }}
      {{ $cors := .CorsConfig }}
      # Cors Preflight methods needs additional options and different Return Code
+     if ($http_origin ~* {{ buildCorsOriginRegex $cors.CorsAllowOrigin }}) {
+         set $cors "true";
+     }
+
      if ($request_method = 'OPTIONS') {
-        more_set_headers 'Access-Control-Allow-Origin: {{ $cors.CorsAllowOrigin }}';
+        set $cors ${cors}options;
+     }
+
+     if ($cors = "true") {
+        more_set_headers 'Access-Control-Allow-Origin: $http_origin';
+        {{ if $cors.CorsAllowCredentials }} more_set_headers 'Access-Control-Allow-Credentials: {{ $cors.CorsAllowCredentials }}'; {{ end }}
+        more_set_headers 'Access-Control-Allow-Methods: {{ $cors.CorsAllowMethods }}';
+        more_set_headers 'Access-Control-Allow-Headers: {{ $cors.CorsAllowHeaders }}';
+        {{ if not (empty $cors.CorsExposeHeaders) }} more_set_headers 'Access-Control-Expose-Headers: {{ $cors.CorsExposeHeaders }}'; {{ end }}
+        more_set_headers 'Access-Control-Max-Age: {{ $cors.CorsMaxAge }}';
+     }
+
+     if ($cors = "trueoptions") {
+        more_set_headers 'Access-Control-Allow-Origin: $http_origin';
         {{ if $cors.CorsAllowCredentials }} more_set_headers 'Access-Control-Allow-Credentials: {{ $cors.CorsAllowCredentials }}'; {{ end }}
         more_set_headers 'Access-Control-Allow-Methods: {{ $cors.CorsAllowMethods }}';
         more_set_headers 'Access-Control-Allow-Headers: {{ $cors.CorsAllowHeaders }}';
@@ -877,10 +894,6 @@ stream {
         more_set_headers 'Content-Length: 0';
         return 204;
      }
-
-        more_set_headers 'Access-Control-Allow-Origin: {{ $cors.CorsAllowOrigin }}';
-        {{ if $cors.CorsAllowCredentials }} more_set_headers 'Access-Control-Allow-Credentials: {{ $cors.CorsAllowCredentials }}'; {{ end }}
-        {{ if not (empty $cors.CorsExposeHeaders) }} more_set_headers 'Access-Control-Expose-Headers: {{ $cors.CorsExposeHeaders }}'; {{ end }}
 
 {{ end }}
 

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -868,7 +868,7 @@ stream {
      # Cors Preflight methods needs additional options and different Return Code
      {{ if $cors.CorsAllowOrigin }}
         {{ buildCorsOriginRegex $cors.CorsAllowOrigin }}
-
+     {{ end }}
      if ($request_method = 'OPTIONS') {
         set $cors ${cors}options;
      }
@@ -893,7 +893,6 @@ stream {
         more_set_headers 'Content-Length: 0';
         return 204;
      }
-     {{ end }}
 {{ end }}
 
 {{/* definition of server-template to avoid repetitions with server-alias */}}

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -866,9 +866,12 @@ stream {
 {{ define "CORS" }}
      {{ $cors := .CorsConfig }}
      # Cors Preflight methods needs additional options and different Return Code
-     if ($http_origin ~* {{ buildCorsOriginRegex $cors.CorsAllowOrigin }}) {
-         set $cors "true";
-     }
+     {{ if not (empty $cors.CorsAllowOrigin) }}
+        {{ buildCorsOriginRegex $cors.CorsAllowOrigin }}
+     {{ else }}
+     set $http_origin *;
+     set $cors "true";
+     {{ end }}
 
      if ($request_method = 'OPTIONS') {
         set $cors ${cors}options;

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -866,12 +866,8 @@ stream {
 {{ define "CORS" }}
      {{ $cors := .CorsConfig }}
      # Cors Preflight methods needs additional options and different Return Code
-     {{ if not (empty $cors.CorsAllowOrigin) }}
+     {{ if $cors.CorsAllowOrigin }}
         {{ buildCorsOriginRegex $cors.CorsAllowOrigin }}
-     {{ else }}
-     set $http_origin *;
-     set $cors "true";
-     {{ end }}
 
      if ($request_method = 'OPTIONS') {
         set $cors ${cors}options;
@@ -897,7 +893,7 @@ stream {
         more_set_headers 'Content-Length: 0';
         return 204;
      }
-
+     {{ end }}
 {{ end }}
 
 {{/* definition of server-template to avoid repetitions with server-alias */}}

--- a/test/e2e/annotations/cors.go
+++ b/test/e2e/annotations/cors.go
@@ -292,5 +292,3 @@ var _ = framework.DescribeAnnotation("cors-*", func() {
 			Headers().NotContainsKey("Access-Control-Allow-Origin")
 	})
 })
-
-// cors-* should block single origin for multiple cors values

--- a/test/e2e/annotations/cors.go
+++ b/test/e2e/annotations/cors.go
@@ -44,10 +44,12 @@ var _ = framework.DescribeAnnotation("cors-*", func() {
 		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return strings.Contains(server, "more_set_headers 'Access-Control-Allow-Methods: GET, PUT, POST, DELETE, PATCH, OPTIONS';") &&
-					strings.Contains(server, "more_set_headers 'Access-Control-Allow-Origin: *';") &&
+					strings.Contains(server, "more_set_headers 'Access-Control-Allow-Origin: $http_origin';") &&
 					strings.Contains(server, "more_set_headers 'Access-Control-Allow-Headers: DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization';") &&
 					strings.Contains(server, "more_set_headers 'Access-Control-Max-Age: 1728000';") &&
-					strings.Contains(server, "more_set_headers 'Access-Control-Allow-Credentials: true';")
+					strings.Contains(server, "more_set_headers 'Access-Control-Allow-Credentials: true';") &&
+					strings.Contains(server, "set $http_origin *;") &&
+					strings.Contains(server, "$cors 'true';")
 			})
 
 		f.HTTPTestClient().

--- a/test/e2e/annotations/cors.go
+++ b/test/e2e/annotations/cors.go
@@ -124,6 +124,14 @@ var _ = framework.DescribeAnnotation("cors-*", func() {
 			WithHeader("Origin", origin).
 			Expect().
 			Headers().ContainsKey("Access-Control-Allow-Origin")
+
+		f.HTTPTestClient().
+			GET("/").
+			WithHeader("Host", host).
+			WithHeader("Origin", origin).
+			Expect().
+			Status(http.StatusOK).Headers().
+			ValueEqual("Access-Control-Allow-Origin", []string{origin})
 	})
 
 	ginkgo.It("should allow headers for cors", func() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
Using CORS, the purpose is to allow multiple origins but only return the `origin` having access to the location block.

This way, if a client requests access and isn't in the list of allowed origins for ingress they will not receive the Access-Control* headers and it won't leak other origins that can access the resource.

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Previously, this was attempted in PR #7134 however, when returning multiple values this is not the intended behavior and has since been reverted.
Based off documentation from Mozilla the `Access-Control-Allow-Origin`  must always return 1 origin. See here: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin

The new feature request is here: #5496 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
#5496

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This was tested locally using the `kind-e2e-test` from the `Makefile` and using the `make dev-env` + deploying an echoserver with ingress. Having this, it was possible to use `curl -v` to see whether the headers were present or not. 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
