### PR TITLE
OpenTelemetry support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -103,7 +103,7 @@ jobs:
           REGISTRY: ingress-controller
         run: |
           echo "building images..."
-          make clean-image build image image-chroot
+          make clean-image build image image-chroot image-modules
           make -C test/e2e-image image
 
           echo "creating images cache..."
@@ -111,6 +111,7 @@ jobs:
             nginx-ingress-controller:e2e \
             ingress-controller/controller:1.0.0-dev \
             ingress-controller/controller-chroot:1.0.0-dev \
+            ingress-controller/opentelemetry:1.0.0-dev \
             | pigz > docker.tar.gz
 
       - name: cache

--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,15 @@ build-plugin:  ## Build ingress-nginx krew plugin.
 		build/build-plugin.sh
 
 
+.PHONY: image-modules
+image-modules: image-module-opentelemetry ## Builds images for all the modules
+
+image-module-%: ## Builds the image for the required module
+	echo "Building $* docker image ($(ARCH))..."
+	@docker build \
+		--no-cache \
+		-t $(REGISTRY)/$*:$(TAG) images/$*/rootfs
+
 .PHONY: clean
 clean: ## Remove .gocache directory.
 	rm -rf bin/ .gocache/ .cache/

--- a/internal/ingress/annotations/annotations.go
+++ b/internal/ingress/annotations/annotations.go
@@ -48,6 +48,7 @@ import (
 	"k8s.io/ingress-nginx/internal/ingress/annotations/loadbalancing"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/log"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/mirror"
+	"k8s.io/ingress-nginx/internal/ingress/annotations/opentelemetry"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/opentracing"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/portinredirect"
@@ -92,6 +93,7 @@ type Ingress struct {
 	ExternalAuth       authreq.Config
 	EnableGlobalAuth   bool
 	HTTP2PushPreload   bool
+	OpenTelemetry      opentelemetry.Config
 	Opentracing        opentracing.Config
 	Proxy              proxy.Config
 	ProxySSL           proxyssl.Config
@@ -142,6 +144,7 @@ func NewAnnotationExtractor(cfg resolver.Resolver) Extractor {
 			"ExternalAuth":         authreq.NewParser(cfg),
 			"EnableGlobalAuth":     authreqglobal.NewParser(cfg),
 			"HTTP2PushPreload":     http2pushpreload.NewParser(cfg),
+			"OpenTelemetry":        opentelemetry.NewParser(cfg),
 			"Opentracing":          opentracing.NewParser(cfg),
 			"Proxy":                proxy.NewParser(cfg),
 			"ProxySSL":             proxyssl.NewParser(cfg),

--- a/internal/ingress/annotations/opentelemetry/main.go
+++ b/internal/ingress/annotations/opentelemetry/main.go
@@ -29,8 +29,10 @@ type opentelemetry struct {
 
 // Config contains the configuration to be used in the Ingress
 type Config struct {
-	Enabled bool `json:"enabled"`
-	Set     bool `json:"set"`
+	Enabled      bool `json:"enabled"`
+	Set          bool `json:"set"`
+	TrustEnabled bool `json:"trust-enabled"`
+	TrustSet     bool `json:"trust-set"`
 }
 
 // Equal tests for equality between two Config types
@@ -40,6 +42,10 @@ func (bd1 *Config) Equal(bd2 *Config) bool {
 	}
 
 	if bd1.Enabled != bd2.Enabled {
+		return false
+	}
+
+	if bd1.TrustEnabled != bd2.TrustEnabled {
 		return false
 	}
 
@@ -57,5 +63,10 @@ func (s opentelemetry) Parse(ing *networking.Ingress) (interface{}, error) {
 		return &Config{Set: false, Enabled: false}, nil
 	}
 
-	return &Config{Set: true, Enabled: enabled}, nil
+	trustSpan, err := parser.GetBoolAnnotation("opentelemetry-trust-incoming-span", ing)
+	if err != nil {
+		return &Config{Set: true, Enabled: enabled}, nil
+	}
+
+	return &Config{Set: true, Enabled: enabled, TrustSet: true, TrustEnabled: trustSpan}, nil
 }

--- a/internal/ingress/annotations/opentelemetry/main.go
+++ b/internal/ingress/annotations/opentelemetry/main.go
@@ -52,7 +52,7 @@ func (bd1 *Config) Equal(bd2 *Config) bool {
 	return true
 }
 
-// NewParser creates a new serviceUpstream annotation parser
+// NewParser creates a new OpenTelemetry annotation parser
 func NewParser(r resolver.Resolver) parser.IngressAnnotation {
 	return opentelemetry{r}
 }

--- a/internal/ingress/annotations/opentelemetry/main.go
+++ b/internal/ingress/annotations/opentelemetry/main.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package opentelemetry
+
+import (
+	networking "k8s.io/api/networking/v1"
+
+	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
+	"k8s.io/ingress-nginx/internal/ingress/resolver"
+)
+
+type opentelemetry struct {
+	r resolver.Resolver
+}
+
+// Config contains the configuration to be used in the Ingress
+type Config struct {
+	Enabled bool `json:"enabled"`
+	Set     bool `json:"set"`
+}
+
+// Equal tests for equality between two Config types
+func (bd1 *Config) Equal(bd2 *Config) bool {
+	if bd1.Set != bd2.Set {
+		return false
+	}
+
+	if bd1.Enabled != bd2.Enabled {
+		return false
+	}
+
+	return true
+}
+
+// NewParser creates a new serviceUpstream annotation parser
+func NewParser(r resolver.Resolver) parser.IngressAnnotation {
+	return opentelemetry{r}
+}
+
+func (s opentelemetry) Parse(ing *networking.Ingress) (interface{}, error) {
+	enabled, err := parser.GetBoolAnnotation("enable-opentelemetry", ing)
+	if err != nil {
+		return &Config{Set: false, Enabled: false}, nil
+	}
+
+	return &Config{Set: true, Enabled: enabled}, nil
+}

--- a/internal/ingress/annotations/opentelemetry/main_test.go
+++ b/internal/ingress/annotations/opentelemetry/main_test.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package opentelemetry
+
+import (
+	"testing"
+
+	api "k8s.io/api/core/v1"
+	networking "k8s.io/api/networking/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
+	"k8s.io/ingress-nginx/internal/ingress/resolver"
+)
+
+func buildIngress() *networking.Ingress {
+	defaultBackend := networking.IngressBackend{
+		Service: &networking.IngressServiceBackend{
+			Name: "default-backend",
+			Port: networking.ServiceBackendPort{
+				Number: 80,
+			},
+		},
+	}
+
+	return &networking.Ingress{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      "foo",
+			Namespace: api.NamespaceDefault,
+		},
+		Spec: networking.IngressSpec{
+			DefaultBackend: &networking.IngressBackend{
+				Service: &networking.IngressServiceBackend{
+					Name: "default-backend",
+					Port: networking.ServiceBackendPort{
+						Number: 80,
+					},
+				},
+			},
+			Rules: []networking.IngressRule{
+				{
+					Host: "foo.bar.com",
+					IngressRuleValue: networking.IngressRuleValue{
+						HTTP: &networking.HTTPIngressRuleValue{
+							Paths: []networking.HTTPIngressPath{
+								{
+									Path:    "/foo",
+									Backend: defaultBackend,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestIngressAnnotationOpenTelemetrySetTrue(t *testing.T) {
+	ing := buildIngress()
+
+	data := map[string]string{}
+	data[parser.GetAnnotationWithPrefix("enable-opentelemetry")] = "true"
+	ing.SetAnnotations(data)
+
+	val, _ := NewParser(&resolver.Mock{}).Parse(ing)
+	openTelemetry, ok := val.(*Config)
+	if !ok {
+		t.Errorf("expected a Config type")
+	}
+
+	if !openTelemetry.Enabled {
+		t.Errorf("expected annotation value to be true, got false")
+	}
+}
+
+func TestIngressAnnotationOpenTelemetrySetFalse(t *testing.T) {
+	ing := buildIngress()
+
+	// Test with explicitly set to false
+	data := map[string]string{}
+	data[parser.GetAnnotationWithPrefix("enable-opentelemetry")] = "false"
+	ing.SetAnnotations(data)
+
+	val, _ := NewParser(&resolver.Mock{}).Parse(ing)
+	openTelemetry, ok := val.(*Config)
+	if !ok {
+		t.Errorf("expected a Config type")
+	}
+
+	if openTelemetry.Enabled {
+		t.Errorf("expected annotation value to be false, got true")
+	}
+}
+
+func TestIngressAnnotationOpenTelemetryUnset(t *testing.T) {
+	ing := buildIngress()
+
+	// Test with no annotation specified
+	data := map[string]string{}
+	ing.SetAnnotations(data)
+
+	val, _ := NewParser(&resolver.Mock{}).Parse(ing)
+	_, ok := val.(*Config)
+	if !ok {
+		t.Errorf("expected a Config type")
+	}
+}

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -567,6 +567,11 @@ type Configuration struct {
 	// OpenTelemetryOperationName specifies a custom name for the server span
 	OpenTelemetryOperationName string `json:"opentelemetry-operation-name"`
 
+	// OpenTelemetryTrustIncomingSpan sets whether or not to trust incoming trace spans
+	// If false, incoming span headers will be rejected
+	// Default: true
+	OpenTelemetryTrustIncomingSpan bool `json:"opentelemetry-trust-incoming-span"`
+
 	// OtlpExporterHost defines the host of the OpenTelemetry collector instance
 	// where the data will be transmitted
 	OtlpCollectorHost string `json:"otlp-collector-host"`
@@ -925,6 +930,7 @@ func NewDefault() Configuration {
 		BindAddressIpv4:                        defBindAddress,
 		BindAddressIpv6:                        defBindAddress,
 		OpentracingTrustIncomingSpan:           true,
+		OpenTelemetryTrustIncomingSpan:         true,
 		ZipkinCollectorPort:                    9411,
 		ZipkinServiceName:                      "nginx",
 		ZipkinSampleRate:                       1.0,

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -559,6 +559,22 @@ type Configuration struct {
 	// Default: true
 	OpentracingTrustIncomingSpan bool `json:"opentracing-trust-incoming-span"`
 
+	// EnableOpenTelemetry enables the nginx OpenTelemetry extension
+	// https://github.com/open-telemetry/opentelemetry-cpp-contrib
+	// By default this is disabled
+	EnableOpenTelemetry bool `json:"enable-opentelemetry"`
+
+	// OpenTelemetryOperationName specifies a custom name for the server span
+	OpenTelemetryOperationName string `json:"opentelemetry-operation-name"`
+
+	// OtlpExporterHost defines the host of the OpenTelemetry collector instance
+	// where the data will be transmitted
+	OtlpCollectorHost string `json:"otlp-collector-host"`
+
+	// OtlpExporterPost defines the port of the OpenTelemetry collector instance
+	// where the data will be transmitted
+	OtlpCollectorPort string `json:"otlp-collector-port"`
+
 	// ZipkinCollectorHost specifies the host to use when uploading traces
 	ZipkinCollectorHost string `json:"zipkin-collector-host"`
 

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -573,7 +573,8 @@ type Configuration struct {
 
 	// OtlpExporterPost defines the port of the OpenTelemetry collector instance
 	// where the data will be transmitted
-	OtlpCollectorPort string `json:"otlp-collector-port"`
+	// Default: 4318
+	OtlpCollectorPort int `json:"otlp-collector-port"`
 
 	// ZipkinCollectorHost specifies the host to use when uploading traces
 	ZipkinCollectorHost string `json:"zipkin-collector-host"`

--- a/internal/ingress/controller/nginx_test.go
+++ b/internal/ingress/controller/nginx_test.go
@@ -415,7 +415,7 @@ name = "ingress-nginx"
 `,
 		},
 		{
-			name: "with no a collector host but not port",
+			name: "with a collector host but not port",
 			config: ngx_config.Configuration{
 				EnableOpenTelemetry: true,
 				OtlpCollectorHost:   "example.com",

--- a/internal/ingress/controller/nginx_test.go
+++ b/internal/ingress/controller/nginx_test.go
@@ -432,7 +432,7 @@ name = "ingress-nginx"
 `,
 		},
 		{
-			name: "with no a collector host and port",
+			name: "with a collector host and port",
 			config: ngx_config.Configuration{
 				EnableOpenTelemetry: true,
 				OtlpCollectorHost:   "example.com",

--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -1220,7 +1220,7 @@ func buildOpenTelemetry(c interface{}, s interface{}) string {
 	}
 
 	buf := bytes.NewBufferString("")
-	buf.WriteString("opentelemetry_config /etc/nginx/opentelemetry.toml;\r\n")
+	buf.WriteString("opentelemetry_config /etc/nginx/opentelemetry.toml;\n")
 
 	if cfg.OpenTelemetryOperationName != "" {
 		buf.WriteString(fmt.Sprintf("opentelemetry_operation_name \"%s\";\n", cfg.OpenTelemetryOperationName))

--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -1653,6 +1653,14 @@ func shouldLoadOpenTelemetryModule(c interface{}, s interface{}) bool {
 		return false
 	}
 
+	if _, err := os.Stat("/etc/nginx/modules/otel_ngx_module.so"); err != nil {
+		klog.Errorf("couldn't retrieve otel_ngx_module.so. Got %#v", err)
+
+		// Switch the config to false so the templates don't try loading the plugin
+		cfg.EnableOpenTelemetry = false
+		return false
+	}
+
 	if cfg.EnableOpenTelemetry {
 		return true
 	}

--- a/pkg/apis/ingress/types.go
+++ b/pkg/apis/ingress/types.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/ingress-nginx/internal/ingress/annotations/log"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/mirror"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/modsecurity"
+	"k8s.io/ingress-nginx/internal/ingress/annotations/opentelemetry"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/opentracing"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/proxy"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/proxyssl"
@@ -353,6 +354,9 @@ type Location struct {
 	// Opentracing allows the global opentracing setting to be overridden for a location
 	// +optional
 	Opentracing opentracing.Config `json:"opentracing"`
+	// OpenTelemetry allows the global OpenTelemetry setting to be overridden for a location
+	// +optional
+	OpenTelemetry opentelemetry.Config `json:"opentelemetry"`
 }
 
 // SSLPassthroughBackend describes a SSL upstream server configured

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -82,6 +82,6 @@ USER www-data
 RUN  ln -sf /dev/stdout /var/log/nginx/access.log \
   && ln -sf /dev/stderr /var/log/nginx/error.log
 
-ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+ENTRYPOINT ["/usr/local/entrypoint.sh", "--dumb-init"]
 
 CMD ["/nginx-ingress-controller"]

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -1207,7 +1207,7 @@ stream {
 
             {{ buildOpentracingForLocation $all.Cfg.EnableOpentracing $all.Cfg.OpentracingTrustIncomingSpan $location }}
 
-            {{ buildOpenTelemetryForLocation $all.Cfg.EnableOpenTelemetry $location }}
+            {{ buildOpenTelemetryForLocation $all.Cfg.EnableOpenTelemetry $all.Cfg.OpenTelemetryTrustIncomingSpan $location }}
 
             {{ if $location.Mirror.Source }}
             mirror {{ $location.Mirror.Source }};

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -33,6 +33,10 @@ load_module /etc/nginx/modules/ngx_http_auth_digest_module.so;
 load_module /etc/nginx/modules/ngx_http_modsecurity_module.so;
 {{ end }}
 
+{{ if (shouldLoadOpenTelemetryModule $cfg $servers) }}
+load_module /etc/nginx/modules/otel_ngx_module.so;
+{{ end }}
+
 {{ if (shouldLoadOpentracingModule $cfg $servers) }}
 load_module /etc/nginx/modules/ngx_http_opentracing_module.so;
 {{ end }}
@@ -321,6 +325,7 @@ http {
     limit_req_status                {{ $cfg.LimitReqStatusCode }};
     limit_conn_status               {{ $cfg.LimitConnStatusCode }};
 
+    {{ buildOpenTelemetry $cfg $servers }}
     {{ buildOpentracing $cfg $servers }}
 
     include /etc/nginx/mime.types;
@@ -688,6 +693,10 @@ http {
 
         access_log off;
 
+        {{ if $cfg.EnableOpenTelemetry }}
+          opentelemtry off;
+        {{ end }}
+
         {{ if $cfg.EnableOpentracing }}
         opentracing off;
         {{ end }}
@@ -1052,6 +1061,11 @@ stream {
         location = {{ $authPath }} {
             internal;
 
+            {{ if (or $all.Cfg.EnableOpenTelemetry $location.OpenTelemetry.Enabled) }}
+            opentelemetry on;
+            opentelemetry_propagate;
+            {{ end }}
+
             {{ if (or $all.Cfg.EnableOpentracing $location.Opentracing.Enabled) }}
             opentracing on;
             opentracing_propagate_context;
@@ -1192,6 +1206,8 @@ stream {
             set $global_rate_limit_exceeding n;
 
             {{ buildOpentracingForLocation $all.Cfg.EnableOpentracing $all.Cfg.OpentracingTrustIncomingSpan $location }}
+
+            {{ buildOpenTelemetryForLocation $all.Cfg.EnableOpenTelemetry $location }}
 
             {{ if $location.Mirror.Source }}
             mirror {{ $location.Mirror.Source }};
@@ -1500,6 +1516,10 @@ stream {
         {{ if eq $server.Hostname "_" }}
         # health checks in cloud providers require the use of port {{ $all.ListenPorts.HTTP }}
         location {{ $all.HealthzURI }} {
+            {{ if $all.Cfg.EnableOpenTelemetry }}
+              opentelemetry off;
+            {{ end }}
+
             {{ if $all.Cfg.EnableOpentracing }}
             opentracing off;
             {{ end }}
@@ -1511,6 +1531,10 @@ stream {
         # this is required to avoid error if nginx is being monitored
         # with an external software (like sysdig)
         location /nginx_status {
+            {{ if $all.Cfg.EnableOpenTelemetry }}
+            opentelemetry off;
+            {{ end }}
+
             {{ if $all.Cfg.EnableOpentracing }}
             opentracing off;
             {{ end }}

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -34,7 +34,7 @@ load_module /etc/nginx/modules/ngx_http_modsecurity_module.so;
 {{ end }}
 
 {{ if (shouldLoadOpenTelemetryModule $cfg $servers) }}
-load_module /etc/nginx/modules/otel_ngx_module.so;
+load_module /etc/nginx/modules/opentelemetry_nginx.so;
 {{ end }}
 
 {{ if (shouldLoadOpentracingModule $cfg $servers) }}

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -34,7 +34,7 @@ load_module /etc/nginx/modules/ngx_http_modsecurity_module.so;
 {{ end }}
 
 {{ if (shouldLoadOpenTelemetryModule $cfg $servers) }}
-load_module /etc/nginx/modules/opentelemetry_nginx.so;
+load_module /etc/nginx/modules/otel_ngx_module.so;
 {{ end }}
 
 {{ if (shouldLoadOpentracingModule $cfg $servers) }}

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -694,7 +694,7 @@ http {
         access_log off;
 
         {{ if $cfg.EnableOpenTelemetry }}
-          opentelemtry off;
+          opentelemetry off;
         {{ end }}
 
         {{ if $cfg.EnableOpentracing }}

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -83,7 +83,7 @@ if [ "${SKIP_IMAGE_CREATION:-false}" = "false" ]; then
   fi
 
   echo "[dev-env] building image"
-  make -C ${DIR}/../../ clean-image build image image-chroot
+  make -C ${DIR}/../../ clean-image build image image-chroot image-modules
   echo "[dev-env] .. done building controller images"
   echo "[dev-env] now building e2e-image.."
   make -C ${DIR}/../e2e-image image
@@ -102,6 +102,8 @@ if [ "${IS_CHROOT:-false}" = "true" ]; then
 fi
 
 kind load docker-image --name="${KIND_CLUSTER_NAME}" --nodes=${KIND_WORKERS} ${REGISTRY}/controller:${TAG}
+
+kind load docker-image --name="${KIND_CLUSTER_NAME}" --nodes=${KIND_WORKERS} ${REGISTRY}/opentelemetry:${TAG}
 
 echo "[dev-env] running e2e tests..."
 make -C ${DIR}/../../ e2e-test

--- a/test/e2e/settings/opentelemetry.go
+++ b/test/e2e/settings/opentelemetry.go
@@ -34,7 +34,9 @@ var _ = framework.IngressNginxDescribe("Configure OpenTelemetry", func() {
 	f := framework.NewDefaultFramework("enable-opentelemetry")
 
 	ginkgo.BeforeEach(func() {
-		f.NewEchoDeployment()
+		f.NewEchoDeployment(
+			framework.WithDeploymentModule("opentelemetry", "ingress-nginx/opentelemetry"),
+		)
 	})
 
 	ginkgo.AfterEach(func() {

--- a/test/e2e/settings/opentelemetry.go
+++ b/test/e2e/settings/opentelemetry.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package settings
+
+import (
+	"strings"
+
+	"github.com/onsi/ginkgo"
+
+	"k8s.io/ingress-nginx/test/e2e/framework"
+)
+
+const (
+	enableOpenTelemetry = "enable-opentelemetry"
+
+	openTelemetryOperationName = "opentelemetry-operation-name"
+)
+
+var _ = framework.IngressNginxDescribe("Configure OpenTelemetry", func() {
+	f := framework.NewDefaultFramework("enable-opentelemetry")
+
+	ginkgo.BeforeEach(func() {
+		f.NewEchoDeployment()
+	})
+
+	ginkgo.AfterEach(func() {
+	})
+
+	ginkgo.It("should not exists opentelemetry directive", func() {
+		config := map[string]string{}
+		config[enableOpenTelemetry] = "false"
+		f.SetNginxConfigMapData(config)
+
+		f.EnsureIngress(framework.NewSingleIngress(enableOpenTelemetry, "/", enableOpenTelemetry, f.Namespace, "http-svc", 80, nil))
+
+		f.WaitForNginxConfiguration(
+			func(cfg string) bool {
+				return !strings.Contains(cfg, "opentelemetry on")
+			})
+	})
+
+	ginkgo.It("should exists opentelemetry directive when is enabled", func() {
+		config := map[string]string{}
+		config[enableOpenTelemetry] = "true"
+		f.SetNginxConfigMapData(config)
+
+		f.EnsureIngress(framework.NewSingleIngress(enableOpenTelemetry, "/", enableOpenTelemetry, f.Namespace, "http-svc", 80, nil))
+
+		f.WaitForNginxConfiguration(
+			func(cfg string) bool {
+				return strings.Contains(cfg, "opentelemetry on")
+			})
+	})
+
+	ginkgo.It("should not exists opentelemetry_operation_name directive when is empty", func() {
+		config := map[string]string{}
+		config[enableOpenTelemetry] = "true"
+		config[openTelemetryOperationName] = ""
+		f.SetNginxConfigMapData(config)
+
+		f.EnsureIngress(framework.NewSingleIngress(enableOpenTelemetry, "/", enableOpenTelemetry, f.Namespace, "http-svc", 80, nil))
+
+		f.WaitForNginxConfiguration(
+			func(cfg string) bool {
+				return !strings.Contains(cfg, "opentelemetry_operation_name")
+			})
+	})
+
+	ginkgo.It("should exists opentelemetry_operation_name directive when is configured", func() {
+		config := map[string]string{}
+		config[enableOpenTelemetry] = "true"
+		config[openTelemetryOperationName] = "HTTP $request_method $uri"
+		f.SetNginxConfigMapData(config)
+
+		f.EnsureIngress(framework.NewSingleIngress(enableOpenTelemetry, "/", enableOpenTelemetry, f.Namespace, "http-svc", 80, nil))
+
+		f.WaitForNginxConfiguration(
+			func(cfg string) bool {
+				return strings.Contains(cfg, `opentelemetry_operation_name "HTTP $request_method $uri"`)
+			})
+	})
+})


### PR DESCRIPTION
## What this PR does / why we need it:

This PR adds support for OpenTelemetry (using [the official plugin](https://github.com/open-telemetry/opentelemetry-cpp-contrib/tree/main/instrumentation/nginx)), to send request traces to any otel collector.

This is still a draft, but I'm opening a PR anyway to start getting potential feedback.
The missing things are testing, as well as https://github.com/open-telemetry/opentelemetry-cpp-contrib/pull/52 to avoid using my own fork.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
This has been proposed in #5883

## How Has This Been Tested?
This is being tested through the E2E tests. Before moving this out of draft, I will be running it in a test cluster as well.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
