### PR TITLE
Updating from/to www redirect to use X-Forwarded-Proto

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -583,11 +583,17 @@ http {
                 request_uri = string.sub(request_uri, 1, -2)
             end
 
+            {{ if $cfg.UseForwardedHeaders }}
+            local redirectScheme = ngx.var.http_x_forwarded_proto
+            {{ else }}
+            local redirectScheme = ngx.var.scheme
+            {{ end }}
+
             {{ if ne $all.ListenPorts.HTTPS 443 }}
             {{ $redirect_port := (printf ":%v" $all.ListenPorts.HTTPS) }}
-            return string.format("%s://%s%s%s", ngx.var.scheme, "{{ $redirect.To }}", "{{ $redirect_port }}", request_uri)
+            return string.format("%s://%s%s%s", redirectScheme, "{{ $redirect.To }}", "{{ $redirect_port }}", request_uri)
             {{ else }}
-            return string.format("%s://%s%s", ngx.var.scheme, "{{ $redirect.To }}", request_uri)
+            return string.format("%s://%s%s", redirectScheme, "{{ $redirect.To }}", request_uri)
             {{ end }}
         }
 


### PR DESCRIPTION
## What this PR does / why we need it:
When running nginx ingress behind a load balancer (AWS ALB) that terminates SSL and using the following annotations:
```
    nginx.ingress.kubernetes.io/from-to-www-redirect: "true"
    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
```

the ingress controller will incorrectly redirect the request from HTTPS -> HTTP for the from/to www redirect.

For example, a request to **https**://mysite.com will respond with a 308 to **http**://www.mysite.com.

I believe this is because the code uses `ngx.var.scheme` in the `redirect_to` value. Because the ingress controller is behind an external load balancer, the `scheme` is always HTTP. I am updating the logic to use the `X-Forwarded-Proto` value if the configmap option `use-forwarded-headers` is set to true.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
I have tested this in AWS with the above mentioned set up and can confirm that my changes will redirect to the appropriate scheme.

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

When running `make test` there is one test that fails to pass for me, but it doesn't seem to have anything to do with my changes. The test fails even when running on `main` so it's probably something to do with my environment set up. Let me know if I need to add/change any tests.
