### PR TITLE
Only build nginx-errors for linux/amd64

### DIFF
--- a/docs/examples/customization/custom-errors/custom-default-backend.yaml
+++ b/docs/examples/customization/custom-errors/custom-default-backend.yaml
@@ -36,7 +36,7 @@ spec:
     spec:
       containers:
       - name: nginx-error-server
-        image: gcr.io/k8s-staging-ingress-nginx/nginx-errors:0.48.1
+        image: k8s.gcr.io/ingress-nginx/nginx-errors:0.48.1
         ports:
         - containerPort: 8080
         # Setting the environment variable DEBUG we can see the headers sent 

--- a/images/custom-error-pages/Makefile
+++ b/images/custom-error-pages/Makefile
@@ -29,7 +29,7 @@ IMAGE = $(REGISTRY)/nginx-errors
 export DOCKER_CLI_EXPERIMENTAL=enabled
 
 # build with buildx
-PLATFORMS?=linux/amd64,linux/arm,linux/arm64
+PLATFORMS?=linux/amd64
 OUTPUT=
 PROGRESS=plain
 


### PR DESCRIPTION
## What this PR does / why we need it:
This PR changes the Makefile for the nginx-errors example to only build amd64 images.  
This is done because the build is currently failing due to multiarch builds taking too many resources.

I also updated the container image link in the docs because I had accidentally used an incorrect one in my previous PR (#7460)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change) 
   -> kind of, considering non-amd64 images will no longer be built automatically

## How Has This Been Tested?
I built the images using the updated Makefile on my local Linux machine and it worked as expected.

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes. -> does not apply
- [ ] All new and existing tests passed. -> does not apply
