### PR TITLE
Set header X-Original-Forwarded-For for external authentication provider

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -1027,6 +1027,9 @@ stream {
             proxy_set_header            X-Forwarded-For        $remote_addr;
             {{ end }}
 
+            # Pass the original X-Forwarded-For
+            proxy_set_header            X-Original-Forwarded-For $http_x_forwarded_for;
+
             {{ if $externalAuth.RequestRedirect }}
             proxy_set_header            X-Auth-Request-Redirect {{ $externalAuth.RequestRedirect }};
             {{ else }}


### PR DESCRIPTION
Set header `X-Original-Forwarded-For` for the module ngx_auth_request. This is useful for the external application to know what is the real client IP and take action on it.

For example, AWS Load Balancer returns a chain of IPs.

> The X-Forwarded-For request header may contain multiple IP addresses that are comma separated. The left-most address is the client IP address where the request was first made. This is followed by any subsequent proxy identifiers, in a chain. -> https://docs.aws.amazon.com/elasticloadbalancing/latest/application/x-forwarded-headers.html#x-forwarded-for

This header `X-Original-Forwarded-For` is defined already for the upstream but not for the auth request block.

## What this PR does / why we need it:
Set the header `X-Original-Forwarded-For` to get the real client IP in the external application for authentication via subrequests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?
I tested adding to the ingress the following.
```
nginx.ingress.kubernetes.io/auth-snippet: |
  proxy_set_header X-Original-Forwarded-For $http_x_forwarded_for;
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
