### PR TITLE
Fixing missing space on http-snippet

### DIFF
--- a/deploy/static/provider/aws/deploy-tls-termination.yaml
+++ b/deploy/static/provider/aws/deploy-tls-termination.yaml
@@ -37,7 +37,7 @@ metadata:
   name: ingress-nginx-controller
   namespace: ingress-nginx
 data:
-  http-snippet:|
+  http-snippet: |
     server{
       listen 2443;
       return 308 https://$host$request_uri;


### PR DESCRIPTION
This was breaking the YAML and making [this file](https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.0.0/deploy/static/provider/aws/deploy-tls-termination.yaml) to be unusable, we should also force tag the controller-v1.0.0 version to this new commit

I'm not sure if y'all prefer me to tag this as `controller-v1.0.1` or overwrite the current `controller-v1.0.0` ... if we do the first option, we also need to update the [docs](https://kubernetes.github.io/ingress-nginx/deploy/#aws) with the new link

<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
The [official docs](https://kubernetes.github.io/ingress-nginx/deploy/#aws) point to this file and it's broken 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?
```
$ k --context minikube -n ingress-nginx apply --dry-run -f /tmp/nginx.yaml
namespace/ingress-nginx created (dry run)
serviceaccount/ingress-nginx created (dry run)
error: error parsing /tmp/hola.yaml: error converting YAML to JSON: yaml: line 20: mapping values are not allowed in this context
$ k --context minikube -n ingress-nginx apply --dry-run -f /tmp/nginx.yaml
namespace/ingress-nginx created (dry run)
serviceaccount/ingress-nginx created (dry run)
configmap/ingress-nginx-controller created (dry run)
clusterrole.rbac.authorization.k8s.io/ingress-nginx created (dry run)
clusterrolebinding.rbac.authorization.k8s.io/ingress-nginx created (dry run)
role.rbac.authorization.k8s.io/ingress-nginx created (dry run)
rolebinding.rbac.authorization.k8s.io/ingress-nginx created (dry run)
service/ingress-nginx-controller-admission created (dry run)
service/ingress-nginx-controller created (dry run)
deployment.apps/ingress-nginx-controller created (dry run)
ingressclass.networking.k8s.io/nginx created (dry run)
validatingwebhookconfiguration.admissionregistration.k8s.io/ingress-nginx-admission created (dry run)
serviceaccount/ingress-nginx-admission created (dry run)
clusterrole.rbac.authorization.k8s.io/ingress-nginx-admission created (dry run)
clusterrolebinding.rbac.authorization.k8s.io/ingress-nginx-admission created (dry run)
role.rbac.authorization.k8s.io/ingress-nginx-admission created (dry run)
rolebinding.rbac.authorization.k8s.io/ingress-nginx-admission created (dry run)
job.batch/ingress-nginx-admission-create created (dry run)
job.batch/ingress-nginx-admission-patch created (dry run)
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
