### PR TITLE
Tweak documentation formating about deprecated `apiVersion` values.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -63,7 +63,8 @@ FIELDS:
 
 There are 2 reasons primarily.
 
-(Reason #1) Until K8s version 1.21, it was possible to create a ingress resource, with the "apiVersion:" field set to a value like ;
+(Reason #1) Until K8s version 1.21, it was possible to create a ingress resource, with the "apiVersion:" field set to a value like:
+
   - extensions/v1beta1
   - networking.k8s.io/v1beta1
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,7 +67,7 @@ There are 2 reasons primarily.
   - extensions/v1beta1
   - networking.k8s.io/v1beta1
 
-    (You would get a message about deprecation but the ingress resource would get created.)
+You would get a message about deprecation but the ingress resource would get created.
 
 From K8s version 1.22 onwards, you can ONLY set the "apiVersion:" field of a ingress resource, to the value "networking.k8s.io/v1". The reason is [official blog on deprecated ingress api versions](https://kubernetes.io/blog/2021/07/26/update-with-ingress-nginx/).
 


### PR DESCRIPTION
## What this PR does / why we need it:

Current the docs look like this. The formatting appears a bit off:

![image](https://user-images.githubusercontent.com/7751/133909709-55801c8d-f077-4acc-9523-a05da7728cb3.png)

## Types of changes

Change the docs to render like this:

![image](https://user-images.githubusercontent.com/7751/133909713-8a6c004f-840f-48e9-9654-79a2e6151717.png)

## How Has This Been Tested?

Based on how the [CI is setup for docs](https://github.com/kubernetes/ingress-nginx/blob/main/.github/workflows/docs.yaml), I ran approximately the following commands to generate site:

```
docker build -t ingress-nginx-mkdocs .github\actions\mkdocs
docker run -v `pwd`/input -e GITHUB_WORKSPACE=/input ingress-nginx-mkdocs
```

I then opened the file `site/index.html` to take the above screenshot.

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [NA] I have added tests to cover my changes.
- [NA] All new and existing tests passed.
