### PR TITLE
add OpenTelemetry to nginx base image

### DIFF
--- a/images/nginx/README.md
+++ b/images/nginx/README.md
@@ -4,6 +4,8 @@ This custom image contains:
 
 - [nginx-http-auth-digest](https://github.com/atomx/nginx-http-auth-digest)
 - [ngx_http_substitutions_filter_module](https://github.com/yaoweibin/ngx_http_substitutions_filter_module)
+- [OpenTelemetry-CPP](https://github.com/open-telemetry/opentelemetry-cpp)
+- [OpenTelemetry-CPP-Nginx](https://github.com/open-telemetry/opentelemetry-cpp-contrib/tree/main/instrumentation/nginx)
 - [nginx-opentracing](https://github.com/opentracing-contrib/nginx-opentracing)
 - [opentracing-cpp](https://github.com/opentracing/opentracing-cpp)
 - [zipkin-cpp-opentracing](https://github.com/rnburn/zipkin-cpp-opentracing)

--- a/images/nginx/rootfs/build.sh
+++ b/images/nginx/rootfs/build.sh
@@ -35,6 +35,12 @@ export NGINX_DIGEST_AUTH=1.0.0
 # Check for recent changes: https://github.com/yaoweibin/ngx_http_substitutions_filter_module/compare/v0.6.4...master
 export NGINX_SUBSTITUTIONS=b8a71eacc7f986ba091282ab8b1bbbc6ae1807e0
 
+# Check for recent changes: https://github.com/open-telemetry/opentelemetry-cpp/compare/v1.0.0...main
+export OPENTELEMETRY_CPP_VERSION=1.0.0
+
+# Check for recent changes: https://github.com/open-telemetry/opentelemetry-cpp-contrib/compare/4c4933...main
+export OPENTELEMETRY_CONTRIB_COMMIT=4c4933dc207c04e3528a9b20c28b639bc99773ad
+
 # Check for recent changes: https://github.com/opentracing-contrib/nginx-opentracing/compare/v0.19.0...master
 export NGINX_OPENTRACING_VERSION=0.19.0
 
@@ -131,11 +137,13 @@ export BUILD_PATH=/tmp/build
 
 ARCH=$(uname -m)
 
+export USE_OPENTELEMETRY=true
 if [[ ${ARCH} == "s390x" ]]; then
   export LUAJIT_VERSION=9d5750d28478abfdcaefdfdc408f87752a21e431
   export LUA_RESTY_CORE=0.1.17
   export LUA_NGX_VERSION=0.10.15
   export LUA_STREAM_NGX_VERSION=0.0.7
+  export USE_OPENTELEMETRY=false
 fi
 
 get_src()
@@ -214,6 +222,9 @@ get_src f09851e6309560a8ff3e901548405066c83f1f6ff88aa7171e0763bd9514762b \
 
 get_src a98b48947359166326d58700ccdc27256d2648218072da138ab6b47de47fbd8f \
         "https://github.com/yaoweibin/ngx_http_substitutions_filter_module/archive/$NGINX_SUBSTITUTIONS.tar.gz"
+
+get_src 49519dcf5a2324f9122819141045744fdcbcf411c730f173c4f3d993f02c92b5 \
+        "https://github.com/dmathieu/opentelemetry-cpp-contrib/archive/$OPENTELEMETRY_CONTRIB_COMMIT.tar.gz"
 
 get_src 6f97776ebdf019b105a755c7736b70bdbd7e575c7f0d39db5fe127873c7abf17 \
         "https://github.com/opentracing-contrib/nginx-opentracing/archive/v$NGINX_OPENTRACING_VERSION.tar.gz"
@@ -468,6 +479,32 @@ cmake -DCMAKE_BUILD_TYPE=Release \
 make
 make install
 
+if [ $USE_OPENTELEMETRY ]; then
+  # build opentelemetry lib
+  apk add protobuf-dev \
+    grpc \
+    grpc-dev \
+    gtest-dev \
+    c-ares-dev
+
+  cd $BUILD_PATH
+  git clone --recursive https://github.com/open-telemetry/opentelemetry-cpp opentelemetry-cpp-$OPENTELEMETRY_CPP_VERSION
+  cd "opentelemetry-cpp-$OPENTELEMETRY_CPP_VERSION"
+  git checkout v$OPENTELEMETRY_CPP_VERSION
+  mkdir .build
+  cd .build
+
+  cmake -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_TESTING=OFF \
+        -DWITH_EXAMPLES=OFF \
+        -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+        -DWITH_OTLP=ON \
+        -DWITH_OTLP_HTTP=OFF \
+        ..
+  make
+  make install
+fi
+
 # Get Brotli source and deps
 cd "$BUILD_PATH"
 git clone --depth=1 https://github.com/google/ngx_brotli.git
@@ -634,6 +671,11 @@ WITH_MODULES=" \
   --add-dynamic-module=$BUILD_PATH/ModSecurity-nginx-$MODSECURITY_VERSION \
   --add-dynamic-module=$BUILD_PATH/ngx_http_geoip2_module-${GEOIP2_VERSION} \
   --add-dynamic-module=$BUILD_PATH/ngx_brotli"
+
+if [ $USE_OPENTELEMETRY ]; then
+  WITH_MODULES+=" \
+    --add-dynamic-module=$BUILD_PATH/opentelemetry-cpp-contrib-$OPENTELEMETRY_CONTRIB_COMMIT/instrumentation/nginx"
+fi
 
 ./configure \
   --prefix=/usr/local/nginx \


### PR DESCRIPTION
I'm splitting this from #7621 so the image can be built and releases independently from the rest of the code changes.

This adds OpenTelemetry CPP and the nginx module to the docker image so it can be used by the controller later.

S390x is skipped, because the GRPC package has been removed from the alpine image, so we can't install the required dependencies.