### PR TITLE
Add CI for images/kube-webhook-certgen

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -277,3 +277,39 @@ jobs:
         if: ${{ steps.filter-images.outputs.kube-webhook-certgen == 'true' }}
         run: |
           cd images/kube-webhook-certgen && make build
+
+  test-image:
+    runs-on: ubuntu-latest
+    env:
+      PLATFORMS: linux/amd64
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - uses: dorny/paths-filter@v2
+        id: filter-images
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          filters: |
+            kube-webhook-certgen:
+              - 'images/kube-webhook-certgen/**'
+
+      - name: Create Kubernetes cluster
+        id: kind
+        if: ${{ steps.filter-images.outputs.kube-webhook-certgen == 'true' }}
+        uses: engineerd/setup-kind@v0.5.0
+        with:
+          version: v0.11.1
+          image: kindest/node:v1.21.1
+
+      - name: Set up Go 1.17
+        id: go
+        if: ${{ steps.filter-images.outputs.kube-webhook-certgen == 'true' }}
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+
+      - name: kube-webhook-certgen image build
+        if: ${{ steps.filter-images.outputs.kube-webhook-certgen == 'true' }}
+        run: |
+          cd images/kube-webhook-certgen && make test test-e2e

--- a/images/kube-webhook-certgen/Makefile
+++ b/images/kube-webhook-certgen/Makefile
@@ -53,4 +53,10 @@ else
 endif
 	@echo "done"
 
-.PHONY: build push ensure-buildx
+test:
+	cd rootfs && go test ./...
+
+test-e2e:
+	./hack/e2e.sh
+
+.PHONY: build push ensure-buildx test test-e2e

--- a/images/kube-webhook-certgen/hack/e2e.sh
+++ b/images/kube-webhook-certgen/hack/e2e.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if [ -n "$DEBUG" ]; then
+  set -x
+fi
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+pushd rootfs
+go build
+popd
+
+export KUBECONFIG=${KUBECONFIG:-~/.kube/config}
+
+function error {
+  trap - EXIT
+  echo $@
+  exit 1
+}
+
+function cleanup {
+  kubectl delete --recursive -f hack/e2e.yaml --ignore-not-found
+}
+
+trap cleanup EXIT
+
+cleanup
+
+kubectl apply --recursive -f hack/e2e.yaml
+
+./rootfs/kube-webhook-certgen create --kubeconfig ${KUBECONFIG} --namespace test --secret-name test --host test --cert-name test
+./rootfs/kube-webhook-certgen patch --kubeconfig ${KUBECONFIG} --namespace test --secret-name test --webhook-name pod-policy.example.com
+./rootfs/kube-webhook-certgen patch --kubeconfig ${KUBECONFIG} --namespace test --secret-name test --apiservice-name v1alpha1.pod-policy.example.com
+./rootfs/kube-webhook-certgen patch --kubeconfig ${KUBECONFIG} --namespace test --secret-name test --webhook-name pod-policy.example.com --apiservice-name v1alpha1.pod-policy.example.com
+
+if [[ -z "$(kubectl get validatingwebhookconfiguration pod-policy.example.com -o jsonpath='{.webhooks[0].clientConfig.caBundle}')" ]]; then
+  error "ValidatingWebhookConfiguration pod-policy.example.com did not get CA injected"
+fi
+
+if [[ -z "$(kubectl get mutatingwebhookconfiguration pod-policy.example.com -o jsonpath='{.webhooks[0].clientConfig.caBundle}')" ]]; then
+  error "MutatingWebhookConfiguration pod-policy.example.com did not get CA injected"
+fi
+
+if [[ -z "$(kubectl get apiservice v1alpha1.pod-policy.example.com -o jsonpath='{.spec.caBundle}')" ]];then
+  error "APIService v1alpha1.pod-policy.example.com did not get CA injected"
+fi

--- a/images/kube-webhook-certgen/hack/e2e.yaml
+++ b/images/kube-webhook-certgen/hack/e2e.yaml
@@ -1,0 +1,57 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: "pod-policy.example.com"
+webhooks:
+- name: "pod-policy.example.com"
+  rules:
+  - apiGroups:   [""]
+    apiVersions: ["v1"]
+    operations:  ["CREATE"]
+    resources:   ["pods"]
+    scope:       "Namespaced"
+  clientConfig:
+    service:
+      namespace: "example-namespace"
+      name: "example-service"
+  admissionReviewVersions: ["v1", "v1beta1"]
+  sideEffects: None
+  timeoutSeconds: 5
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: "pod-policy.example.com"
+webhooks:
+- name: "pod-policy.example.com"
+  rules:
+  - apiGroups:   [""]
+    apiVersions: ["v1"]
+    operations:  ["CREATE"]
+    resources:   ["pods"]
+    scope:       "Namespaced"
+  clientConfig:
+    service:
+      namespace: "example-namespace"
+      name: "example-service"
+  admissionReviewVersions: ["v1", "v1beta1"]
+  sideEffects: None
+  timeoutSeconds: 5
+---
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: v1alpha1.pod-policy.example.com
+spec:
+  service:
+    name: "example-namespace"
+    namespace: "example-service"
+  group: pod-policy.example.com
+  version: v1alpha1
+  groupPriorityMinimum: 100
+  versionPriority: 100


### PR DESCRIPTION

## What this PR does / why we need it:

As a follow up to PR #7641, this commit adds some basic e2e tests for
kube-webhook-certgen image.

Signed-off-by: Mateusz Gozdek <mgozdek@microsoft.com>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
