### PR TITLE
Fix ingress without class in kind deployment

### DIFF
--- a/deploy/static/provider/kind/deploy.yaml
+++ b/deploy/static/provider/kind/deploy.yaml
@@ -339,6 +339,7 @@ spec:
             - --validating-webhook=:8443
             - --validating-webhook-certificate=/usr/local/certificates/cert
             - --validating-webhook-key=/usr/local/certificates/key
+            - --watch-ingress-without-class=true
             - --publish-status-address=localhost
           securityContext:
             capabilities:

--- a/hack/generate-deploy-scripts.sh
+++ b/hack/generate-deploy-scripts.sh
@@ -135,6 +135,7 @@ controller:
   terminationGracePeriodSeconds: 0
   service:
     type: NodePort
+  watchIngressWithoutClass: true
 
   nodeSelector:
     ingress-ready: "true"


### PR DESCRIPTION
Due to an error when I was releasing v1.0.2 I forgot to add watch-ingress-without-class in KinD manifest.

This may fix the current deployment scripts and also future deployments

Fixes: #7725 