### PR TITLE
Fix selector for shutting down Pods

### DIFF
--- a/internal/ingress/status/status.go
+++ b/internal/ingress/status/status.go
@@ -234,7 +234,7 @@ func (s *statusSync) isRunningMultiplePods() bool {
 	// cover 95% of the cases
 	podLabel := make(map[string]string)
 	for k, v := range k8s.IngressPodDetails.Labels {
-		if k != "pod-template-hash" {
+		if k != "pod-template-hash" && k != "controller-revision-hash" && k != "pod-template-generation" {
 			podLabel[k] = v
 		}
 	}

--- a/internal/ingress/status/status.go
+++ b/internal/ingress/status/status.go
@@ -226,8 +226,21 @@ func (s *statusSync) runningAddresses() ([]apiv1.LoadBalancerIngress, error) {
 }
 
 func (s *statusSync) isRunningMultiplePods() bool {
+
+	// As a standard, app.kubernetes.io are "reserved well-known" labels.
+	// In our case, we add those labels as identifiers of the Ingress
+	// deployment in this namespace, so we can select it as a set of Ingress instances.
+	// As those labels are also generated as part of a HELM deployment, we can be "safe" they
+	// cover 95% of the cases
+	podLabel := make(map[string]string)
+	for k, v := range k8s.IngressPodDetails.Labels {
+		if k != "pod-template-hash" {
+			podLabel[k] = v
+		}
+	}
+
 	pods, err := s.Client.CoreV1().Pods(k8s.IngressPodDetails.Namespace).List(context.TODO(), metav1.ListOptions{
-		LabelSelector: labels.SelectorFromSet(k8s.IngressPodDetails.Labels).String(),
+		LabelSelector: labels.SelectorFromSet(podLabel).String(),
 	})
 	if err != nil {
 		return false


### PR DESCRIPTION
## What this PR does / why we need it:
Fixes the selector when checking if there are multiple Pods running Ingress.

Per previous code, it used the Pods labels to check if other Pods from the same application were running. This was necessary to not remove the IP from .status field before being sure no other Pod was running and serving.

The labels contained the pod-hash generated by ReplicaSet, but everytime someone does a rollout deployment a new hash was created, turning that selector always false and always removing the IP address from the .status.

This field is used by AWS and other cloud providers as the de-facto IP address/name to be used when publishing a new service on DNS.

We don't still verify yet if the list of Pods is properly running or not. While doing the implementation, it seems that selecting the phase of the Pod can lead into some wrong status reporting, so I decided to leave this field selector out of this PR so far.

**EDIT**: I have added some fallback, as not everybody is using the recommended labels `app.kubernetes.io`. The idea is just to drop the auto generated label "pod-template-hash" added by the replicaset or the statefulset

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
fixes #7047 

## How Has This Been Tested?
Folliwing the script provided in #7047 I could verify that when rolling out deployments, there wasn't a situation anymore when the IP address was removed and re-added. Now there is always an IP address there, unless there are set --replicas=0

