### PR TITLE
Expand docker desktop installation documentation with an attention block

### DIFF
--- a/docs/deploy/index.md
+++ b/docs/deploy/index.md
@@ -53,6 +53,9 @@ Kubernetes is available in Docker Desktop
 - Mac, from [version 18.06.0-ce](https://docs.docker.com/docker-for-mac/release-notes/#stable-releases-of-2018)
 - Windows, from [version 18.06.0-ce](https://docs.docker.com/docker-for-windows/release-notes/#docker-community-edition-18060-ce-win70-2018-07-25)
 
+!!! attention
+    Before running the command at your terminal, make sure Kubernetes is enabled at Docker settings
+
 ```console
 kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.0.2/deploy/static/provider/cloud/deploy.yaml
 ```


### PR DESCRIPTION
## What this PR does / why we need it:

This is an improvement for the installation steps for Docker desktop. If Kubernetes is not enabled on docker desktop settings, user gets a cryptic error message. This attention box makes sure this oversight (Kubernetes not being enabled during installation) is addressed in the docs.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X ] Documentation only

## Checklist:
- [ ] My change requires a change to the documentation.
- [ X] I have updated the documentation accordingly.
- [ X] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
