### PR TITLE
Add a note to README.md with context on CVE-2021-23017 patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ For detailed changes on the `ingress-nginx` helm chart, please check the followi
 
 | Ingress-nginx version | k8s supported version  | Alpine Version | Nginx Version |
 |-----------------------|-------------           |----------------|---------------|
-| v1.0.2                | 1.22, 1.21, 1.20, 1.19 | 3.14.2         |  1.19.9       |
-| v1.0.1                | 1.22, 1.21, 1.20, 1.19 | 3.14.2         |  1.19.9       |
+| v1.0.2                | 1.22, 1.21, 1.20, 1.19 | 3.14.2         |  1.19.9†      |
+| v1.0.1                | 1.22, 1.21, 1.20, 1.19 | 3.14.2         |  1.19.9†      |
 | v1.0.0                | 1.22, 1.21, 1.20, 1.19 | 3.13.5         |  1.20.1       |
 | v0.49.2               | 1.21, 1.20, 1.19       | 3.14.2         |  1.19.9       |
 | v0.49.1               | 1.21, 1.20, 1.19       | 3.14.2         |  1.19.9       |
@@ -40,6 +40,7 @@ For detailed changes on the `ingress-nginx` helm chart, please check the followi
 | v0.47.0               | 1.21, 1.20, 1.19       | 3.13.5         |  1.20.1       |
 | v0.46.0               | 1.21, 1.20, 1.19       | 3.13.2         |  1.19.6       |
 
+† _This build is [patched against CVE-2021-23017](https://github.com/openresty/openresty/commit/4b5ec7edd78616f544abc194308e0cf4b788725b#diff-42ef841dc27fe0b5aa2d06bd31308bb63a59cdcddcbcddd917248349d22020a3)._
 
 See [this article](https://kubernetes.io/blog/2021/07/26/update-with-ingress-nginx/) if you want upgrade to the stable Ingress API. 
 


### PR DESCRIPTION
This adds a note to the README indicating that the build of nginx 1.19.9 used here is patched against CVE-2021-23017

## What this PR does / why we need it:

[CVE-2021-23017](https://nvd.nist.gov/vuln/detail/CVE-2021-23017) is a critical vulnerability impacting nginx 1.19.9. Users concerned about the vulnerability may conclude that the build shipped in ingress-nginx is affected by the vulnerability, when in fact it has specifically been patched against it. 

It took quite a bit of sleuthing to figure that out, so thought it might be nice to add a prominent note for future me. 😄 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation only

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
