### PR TITLE
Update RBAC to be namespace-safe for multiple installations

### DIFF
--- a/charts/ingress-nginx/templates/clusterrole.yaml
+++ b/charts/ingress-nginx/templates/clusterrole.yaml
@@ -10,7 +10,7 @@ kind: ClusterRole
 metadata:
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
-  name: {{ include "ingress-nginx.fullname" . }}
+  name: {{ include "ingress-nginx.fullname" . }}-{{ .Release.Namespace }}
 rules:
   - apiGroups:
       - ""

--- a/charts/ingress-nginx/templates/clusterrole.yaml
+++ b/charts/ingress-nginx/templates/clusterrole.yaml
@@ -10,7 +10,7 @@ kind: ClusterRole
 metadata:
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
-  name: {{ include "ingress-nginx.fullname" . }}-{{ .Release.Namespace }}
+  name: {{ include "ingress-nginx.fullname" . }}
 rules:
   - apiGroups:
       - ""

--- a/charts/ingress-nginx/templates/clusterrolebinding.yaml
+++ b/charts/ingress-nginx/templates/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
-  name: {{ include "ingress-nginx.fullname" . }}
+  name: {{ include "ingress-nginx.fullname" . }}-{{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION

## What this PR does / why we need it:
This Fixes a bug where multiple installations of NGINX ingresses break on install.
If you have nginx ingress installed under a namespace, and then install a second copy of nginx ingress under a different namespace, but the same package name (often done for environment separation on the same cluster) the RBAC fails to install on the second namespace due to a naming conflict

## Types of changes
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
None

## How Has This Been Tested?
As this is a very simple change, we have tested it locally installing into an isolated environment, and then installed into a multi-tenant environment and the configurations remain the same. As this is merely a change of name the scope for testing is very small

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [X ] All new and existing tests passed.
