### PR TITLE
removed space in example helm install command from docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -189,7 +189,7 @@ Bear in mind that, if your `Ingress-Nginx-Controller-nginx2` is started with the
   helm install ingress-nginx-2 ingress-nginx/ingress-nginx  \
   --namespace ingress-nginx-2 \
   --set controller.ingressClassResource.name=nginx-2 \
-  --set controller.ingressClassResource.controllerValue= "k8s.io/ingress-nginx-2" \
+  --set controller.ingressClassResource.controllerValue="k8s.io/ingress-nginx-2" \
   --set controller.ingressClassResource.enabled=true \
   --set controller.ingressClassByName=true
   ```


### PR DESCRIPTION
## What this PR does / why we need it:
Removes a bad space character from a example command in docs as detailed in the issue linked

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation only

## Which issue/s this PR fixes

fixes https://github.com/kubernetes/ingress-nginx/issues/7774

## How Has This Been Tested?
Looked in fork
## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.