### PR TITLE
Disable builtin ssl_session_cache

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -429,7 +429,7 @@ http {
 
     # turn on session caching to drastically improve performance
     {{ if $cfg.SSLSessionCache }}
-    ssl_session_cache builtin:1000 shared:SSL:{{ $cfg.SSLSessionCacheSize }};
+    ssl_session_cache shared:SSL:{{ $cfg.SSLSessionCacheSize }};
     ssl_session_timeout {{ $cfg.SSLSessionTimeout }};
     {{ end }}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
Fix for: https://github.com/kubernetes/ingress-nginx/issues/7080
From [docs](https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_cache):
> builtin
a cache built in OpenSSL; Use of the built-in cache can cause memory fragmentation.

> using only shared cache without the built-in cache should be more efficient.

One could still set `builtin` if needed via `ssl-session-cache-size`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
fixes #7080

## How Has This Been Tested?
Tested via [overriding whole nginx.tmpl](https://stackoverflow.com/a/61344553/1591938)
![image](https://user-images.githubusercontent.com/1803804/136517072-7880ac6d-1a52-434d-a994-9d1a96fa5981.png)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
