### PR TITLE
added ingressClassName field in example ingress

### DIFF
--- a/charts/ingress-nginx/templates/NOTES.txt
+++ b/charts/ingress-nginx/templates/NOTES.txt
@@ -37,19 +37,22 @@ An example Ingress that makes use of the controller:
     name: example
     namespace: foo
   spec:
+    ingressClassName: example-class
     rules:
       - host: www.example.com
         http:
           paths:
-            - backend:
-                serviceName: exampleService
-                servicePort: 80
-              path: /
+            - path: /
+              pathType: Prefix
+              backend:
+                service:
+                  name: exampleService
+                  port: 80
     # This section is only required if TLS is to be enabled for the Ingress
     tls:
-        - hosts:
-            - www.example.com
-          secretName: example-tls
+      - hosts:
+        - www.example.com
+        secretName: example-tls
 
 If TLS is enabled for the Ingress, a Secret containing the certificate and key must also be provided:
 


### PR DESCRIPTION
## What this PR does / why we need it:
Example ingress is missing the ingressClassName field. Example ingress is also not configured to show ingress.spec.rules.http.paths.backend as per api v1 specs . 
This PR adds ingressClassName field in example ingress and also fixes the specs for backend.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation only

## Which issue/s this PR fixes
fixes #7796 

## How Has This Been Tested?
Checked in fork

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.