### PR TITLE
images/kube-webhook-certgen/rootfs: add missing tests and fix regression

### DIFF
--- a/images/kube-webhook-certgen/rootfs/pkg/k8s/k8s.go
+++ b/images/kube-webhook-certgen/rootfs/pkg/k8s/k8s.go
@@ -50,7 +50,8 @@ func (k8s *k8s) PatchObjects(ctx context.Context, options PatchOptions) error {
 		return fmt.Errorf("failurePolicy specified, but no webhook will be patched")
 	}
 
-	if options.MutatingWebhookConfigurationName != options.ValidatingWebhookConfigurationName {
+	if patchMutating && patchValidating &&
+		options.MutatingWebhookConfigurationName != options.ValidatingWebhookConfigurationName {
 		return fmt.Errorf("webhook names must be the same")
 	}
 
@@ -64,8 +65,13 @@ func (k8s *k8s) PatchObjects(ctx context.Context, options PatchOptions) error {
 		}
 	}
 
+	webhookName := options.ValidatingWebhookConfigurationName
+	if webhookName == "" {
+		webhookName = options.MutatingWebhookConfigurationName
+	}
+
 	if patchMutating || patchValidating {
-		return k8s.patchWebhookConfigurations(ctx, options.ValidatingWebhookConfigurationName, options.CABundle, options.FailurePolicyType, patchMutating, patchValidating)
+		return k8s.patchWebhookConfigurations(ctx, webhookName, options.CABundle, options.FailurePolicyType, patchMutating, patchValidating)
 	}
 
 	return nil

--- a/images/kube-webhook-certgen/rootfs/pkg/k8s/k8s_test.go
+++ b/images/kube-webhook-certgen/rootfs/pkg/k8s/k8s_test.go
@@ -271,6 +271,34 @@ func Test_Patching_objects(t *testing.T) {
 			}
 		})
 	})
+
+	t.Run("allows_patching_only_validating_webhook", func(t *testing.T) {
+		t.Parallel()
+
+		k := testK8sWithUnpatchedObjects()
+
+		o := PatchOptions{
+			ValidatingWebhookConfigurationName: testWebhookName,
+		}
+
+		if err := k.PatchObjects(ctx, o); err != nil {
+			t.Fatalf("Unexpected error patching objects: %v", err)
+		}
+	})
+
+	t.Run("allows_patching_only_mutating_webhook", func(t *testing.T) {
+		t.Parallel()
+
+		k := testK8sWithUnpatchedObjects()
+
+		o := PatchOptions{
+			MutatingWebhookConfigurationName: testWebhookName,
+		}
+
+		if err := k.PatchObjects(ctx, o); err != nil {
+			t.Fatalf("Unexpected error patching objects: %v", err)
+		}
+	})
 }
 
 const (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:

This PR adds missing tests implementation, which has not been added in #7641.

It also fixes an regression in not being able to patch only mutating webhook or only validating webhook.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Via unit tests + I plan to verify it as part of #7793.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
