### PR TITLE
Fix Helm Chart remove Capabilities.APIVersions for Kustomize to parse file

### DIFF
--- a/charts/ingress-nginx/templates/controller-servicemonitor.yaml
+++ b/charts/ingress-nginx/templates/controller-servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) .Values.controller.metrics.enabled .Values.controller.metrics.serviceMonitor.enabled -}}
+{{- if and .Values.controller.metrics.enabled .Values.controller.metrics.serviceMonitor.enabled -}}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->
This PR fixes the issue initially described [here](https://github.com/kubernetes-sigs/kustomize/issues/4247). The Helm chart provided could not customized by `Kustomize` to build the YAML section for `serviceMonitor`. Indeed [this Helm template file](https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/templates/controller-servicemonitor.yaml) has the following test as first line.
```
{{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) .Values.controller.metrics.enabled .Values.controller.metrics.serviceMonitor.enabled -}}
```
So Kustomize with Helm (`kubectl kustomize . --enable-helm=true`) build locally the YAML from this template and could not pass the first test `( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" )` for obvious reasons. Test failed and then did not output, as expected, the final YAML section for `serviceMonitor`.

This test irrelevant and is not present in other template files, for example like the one regarding Prometheus to build the `prometheusRule`.

This issue is not presents with vanilla Helm and only appears when `Kustomize` is used on top of `Helm`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. I fork this repo
2. I made the change into `controller-servicemonitor.yaml` file and pushed it into my forked repo
3. I change my code to pull files from my forked repo as a Helm repo
4. I ran the kustomize command provided previously (`kubectl kustomize . --enable-helm=true`)
5. Results: it outputs the YAML section for `serviceMonitor` as expected

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
