### PR TITLE
Disable OpenTelemetry on arm

### DIFF
--- a/images/nginx/rootfs/build.sh
+++ b/images/nginx/rootfs/build.sh
@@ -137,12 +137,15 @@ export BUILD_PATH=/tmp/build
 
 ARCH=$(uname -m)
 
-export USE_OPENTELEMETRY=true
 if [[ ${ARCH} == "s390x" ]]; then
   export LUAJIT_VERSION=9d5750d28478abfdcaefdfdc408f87752a21e431
   export LUA_RESTY_CORE=0.1.17
   export LUA_NGX_VERSION=0.10.15
   export LUA_STREAM_NGX_VERSION=0.0.7
+fi
+
+export USE_OPENTELEMETRY=true
+if [[ ${ARCH} == "s390x" ]] || [[ ${ARCH} == "armv7l" ]]; then
   export USE_OPENTELEMETRY=false
 fi
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:

ARM doesn't have the gRPC package available. So we can't install OpenTelemetry on that platform either 😞 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes

There's no open issue, but this fixes the base image's build.


## How Has This Been Tested?

This was run manually locally.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
