### PR TITLE
add more guidance for the right labeling when creating doc related issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -25,6 +25,9 @@ blocks.  If they're super-long, please use the details tag like
 
 <!-- Does it require a particular kubernetes version? -->
 
-<!-- If this is actually about documentation, add `/kind documentation` below -->
+<!-- If this is actually about documentation, uncomment the following block -->
 
-/kind feature
+<!-- 
+/kind documentation
+/remove-kind feature
+-->


### PR DESCRIPTION
## What this PR does / why we need it:
New Issues of type feature request get the kind/feature label regardless of the `/kind feature` comment (see #7841). The comment in the issue template said to add `/kind documentation` if the request is documentation-related. What would happen is that the issue actually gets both `kind/feature` and `kind/documentation`. This PR adds a section to the issue template that when uncommented adds `kind/documentation` and removes `kind/feature`. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
