### PR TITLE
Add An option for Canary steering by Query parameters

### DIFF
--- a/docs/user-guide/nginx-configuration/annotations.md
+++ b/docs/user-guide/nginx-configuration/annotations.md
@@ -43,6 +43,9 @@ You can add these Kubernetes annotations to specific Ingress objects to customiz
 |[nginx.ingress.kubernetes.io/canary-by-header](#canary)|string|
 |[nginx.ingress.kubernetes.io/canary-by-header-value](#canary)|string|
 |[nginx.ingress.kubernetes.io/canary-by-header-pattern](#canary)|string|
+|[nginx.ingress.kubernetes.io/canary-by-query](#canary)|string|
+|[nginx.ingress.kubernetes.io/canary-by-query-value](#canary)|string|
+|[nginx.ingress.kubernetes.io/canary-by-query-pattern](#canary)|string|
 |[nginx.ingress.kubernetes.io/canary-by-cookie](#canary)|string|
 |[nginx.ingress.kubernetes.io/canary-weight](#canary)|number|
 |[nginx.ingress.kubernetes.io/canary-weight-total](#canary)|number|
@@ -145,12 +148,18 @@ In some cases, you may want to "canary" a new set of changes by sending a small 
 
 * `nginx.ingress.kubernetes.io/canary-by-cookie`: The cookie to use for notifying the Ingress to route the request to the service specified in the Canary Ingress. When the cookie value is set to `always`, it will be routed to the canary. When the cookie is set to `never`, it will never be routed to the canary. For any other value, the cookie will be ignored and the request compared against the other canary rules by precedence.
 
+* `nginx.ingress.kubernetes.io/canary-by-query`: The query parameter to use for notifying the Ingress to route the request to the service specified in the Canary Ingress. When the request query parameter is set to `always`, it will be routed to the canary. When the query parameter is set to `never`, it will never be routed to the canary. For any other value, the query parameter will be ignored and the request compared against the other canary rules by precedence.
+
+* `nginx.ingress.kubernetes.io/canary-by-query-value`: The query parameter value to match for notifying the Ingress to route the request to the service specified in the Canary Ingress. When the request query parameter is set to this value, it will be routed to the canary. For any other query parameter value, the query parameter will be ignored and the request compared against the other canary rules by precedence. This annotation has to be used together with . The annotation is an extension of the `nginx.ingress.kubernetes.io/canary-by-query` to allow customizing the query parameter value instead of using hardcoded values. It doesn't have any effect if the `nginx.ingress.kubernetes.io/canary-by-query` annotation is not defined.
+
+* `nginx.ingress.kubernetes.io/canary-by-query-pattern`: This works the same way as `canary-by-query-value` except it does PCRE Regex matching. Note that when `canary-by-query-value` is set this annotation will be ignored. When the given Regex causes error during request processing, the request will be considered as not matching.
+
 * `nginx.ingress.kubernetes.io/canary-weight`: The integer based (0 - <weight-total>) percent of random requests that should be routed to the service specified in the canary Ingress. A weight of 0 implies that no requests will be sent to the service in the Canary ingress by this canary rule. A weight of <weight-total> means implies all requests will be sent to the alternative service specified in the Ingress. `<weight-total>` defaults to 100, and can be increased via `nginx.ingress.kubernetes.io/canary-weight-total`.
 
 * `nginx.ingress.kubernetes.io/canary-weight-total`: The total weight of traffic. If unspecified, it defaults to 100.
 
 Canary rules are evaluated in order of precedence. Precedence is as follows:
-`canary-by-header -> canary-by-cookie -> canary-weight`
+`canary-by-header -> canary-by-cookie -> canary-by-query -> canary-weight`
 
 **Note** that when you mark an ingress as canary, then all the other non-canary annotations will be ignored (inherited from the corresponding main ingress) except `nginx.ingress.kubernetes.io/load-balance`, `nginx.ingress.kubernetes.io/upstream-hash-by`, and [annotations related to session affinity](#session-affinity). If you want to restore the original behavior of canaries when session affinity was ignored, set `nginx.ingress.kubernetes.io/affinity-canary-behavior` annotation with value `legacy` on the canary ingress definition.
 

--- a/internal/ingress/annotations/canary/main.go
+++ b/internal/ingress/annotations/canary/main.go
@@ -36,6 +36,9 @@ type Config struct {
 	Header        string
 	HeaderValue   string
 	HeaderPattern string
+	Query         string
+	QueryValue    string
+	QueryPattern  string
 	Cookie        string
 }
 
@@ -85,8 +88,23 @@ func (c canary) Parse(ing *networking.Ingress) (interface{}, error) {
 		config.Cookie = ""
 	}
 
+	config.Query, err = parser.GetStringAnnotation("canary-by-query", ing)
+	if err != nil {
+		config.Query = ""
+	}
+
+	config.QueryValue, err = parser.GetStringAnnotation("canary-by-query-value", ing)
+	if err != nil {
+		config.QueryValue = ""
+	}
+
+	config.QueryPattern, err = parser.GetStringAnnotation("canary-by-query-pattern", ing)
+	if err != nil {
+		config.QueryPattern = ""
+	}
+
 	if !config.Enabled && (config.Weight > 0 || len(config.Header) > 0 || len(config.HeaderValue) > 0 || len(config.Cookie) > 0 ||
-		len(config.HeaderPattern) > 0) {
+		len(config.HeaderPattern) > 0 || len(config.Query) > 0 || len(config.QueryValue) > 0 || len(config.QueryPattern) > 0) {
 		return nil, errors.NewInvalidAnnotationConfiguration("canary", "configured but not enabled")
 	}
 

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -935,6 +935,9 @@ func (n *NGINXController) createUpstreams(data []*ingress.Ingress, du *ingress.B
 					HeaderValue:   anns.Canary.HeaderValue,
 					HeaderPattern: anns.Canary.HeaderPattern,
 					Cookie:        anns.Canary.Cookie,
+					Query:         anns.Canary.Query,
+					QueryValue:    anns.Canary.QueryValue,
+					QueryPattern:  anns.Canary.QueryPattern,
 				}
 			}
 
@@ -1006,6 +1009,9 @@ func (n *NGINXController) createUpstreams(data []*ingress.Ingress, du *ingress.B
 						HeaderValue:   anns.Canary.HeaderValue,
 						HeaderPattern: anns.Canary.HeaderPattern,
 						Cookie:        anns.Canary.Cookie,
+						Query:         anns.Canary.Query,
+						QueryValue:    anns.Canary.QueryValue,
+						QueryPattern:  anns.Canary.QueryPattern,
 					}
 				}
 

--- a/pkg/apis/ingress/types.go
+++ b/pkg/apis/ingress/types.go
@@ -125,6 +125,12 @@ type TrafficShapingPolicy struct {
 	HeaderPattern string `json:"headerPattern"`
 	// Cookie on which to redirect requests to this backend
 	Cookie string `json:"cookie"`
+	// Query on which to redirect requests to this backend
+	Query string `json:"query"`
+	// QueryValue on which to redirect requests to this backend
+	QueryValue string `json:"queryValue"`
+	// QueryPattern on which to redirect requests to this backend
+	QueryPattern string `json:"queryPattern"`
 }
 
 // HashInclude defines if a field should be used or not to calculate the hash

--- a/pkg/apis/ingress/types_equals.go
+++ b/pkg/apis/ingress/types_equals.go
@@ -260,7 +260,15 @@ func (tsp1 TrafficShapingPolicy) Equal(tsp2 TrafficShapingPolicy) bool {
 	if tsp1.Cookie != tsp2.Cookie {
 		return false
 	}
-
+	if tsp1.Query != tsp2.Query {
+		return false
+	}
+	if tsp1.QueryValue != tsp2.QueryValue {
+		return false
+	}
+	if tsp1.QueryPattern != tsp2.QueryPattern {
+		return false
+	}
 	return true
 }
 

--- a/test/e2e/annotations/canary.go
+++ b/test/e2e/annotations/canary.go
@@ -653,7 +653,7 @@ var _ = framework.DescribeAnnotation("canary-*", func() {
 				})
 
 			canaryAnnotations := map[string]string{
-				"nginx.ingress.kubernetes.io/canary":           "true",
+				"nginx.ingress.kubernetes.io/canary":          "true",
 				"nginx.ingress.kubernetes.io/canary-by-query": "CanaryByQuery",
 			}
 
@@ -708,7 +708,7 @@ var _ = framework.DescribeAnnotation("canary-*", func() {
 				})
 
 			canaryAnnotations := map[string]string{
-				"nginx.ingress.kubernetes.io/canary":                 "true",
+				"nginx.ingress.kubernetes.io/canary":                "true",
 				"nginx.ingress.kubernetes.io/canary-by-query":       "CanaryByQuery",
 				"nginx.ingress.kubernetes.io/canary-by-query-value": "DoCanary",
 			}
@@ -771,7 +771,7 @@ var _ = framework.DescribeAnnotation("canary-*", func() {
 				})
 
 			canaryAnnotations := map[string]string{
-				"nginx.ingress.kubernetes.io/canary":                   "true",
+				"nginx.ingress.kubernetes.io/canary":                  "true",
 				"nginx.ingress.kubernetes.io/canary-by-query":         "CanaryByQuery",
 				"nginx.ingress.kubernetes.io/canary-by-query-pattern": "^Do[A-Z][a-z]+y$",
 			}
@@ -870,7 +870,7 @@ var _ = framework.DescribeAnnotation("canary-*", func() {
 		})
 	})
 
-	ginkgo.Context("when canaried by header with value and cookie", func() {
+	ginkgo.Context("when canaried by query with value and weight", func() {
 		ginkgo.It("should route requests to the correct upstream", func() {
 			host := "foo"
 			annotations := map[string]string{}
@@ -885,10 +885,10 @@ var _ = framework.DescribeAnnotation("canary-*", func() {
 				})
 
 			canaryAnnotations := map[string]string{
-				"nginx.ingress.kubernetes.io/canary":                 "true",
-				"nginx.ingress.kubernetes.io/canary-by-header":       "CanaryByHeader",
-				"nginx.ingress.kubernetes.io/canary-by-header-value": "DoCanary",
-				"nginx.ingress.kubernetes.io/canary-by-cookie":       "CanaryByCookie",
+				"nginx.ingress.kubernetes.io/canary":                "true",
+				"nginx.ingress.kubernetes.io/canary-by-query":       "CanaryByQuery",
+				"nginx.ingress.kubernetes.io/canary-by-query-value": "DoCanary",
+				"nginx.ingress.kubernetes.io/canary-weight":         "100",
 			}
 
 			canaryIngName := fmt.Sprintf("%v-canary", host)
@@ -897,12 +897,11 @@ var _ = framework.DescribeAnnotation("canary-*", func() {
 				f.Namespace, canaryService, 80, canaryAnnotations)
 			f.EnsureIngress(canaryIng)
 
-			ginkgo.By("routing requests to the canary upstream when header value does not match and cookie is set to 'always'")
+			ginkgo.By("routing requests to the canary upstream when query value does not match and weight is set to '100'")
 			f.HTTPTestClient().
 				GET("/").
 				WithHeader("Host", host).
-				WithHeader("CanaryByHeader", "otherheadervalue").
-				WithCookie("CanaryByCookie", "always").
+				WithQuery("CanaryByQuery", "otherqueryvalue").
 				Expect().
 				Status(http.StatusOK).
 				Body().Contains(canaryService)

--- a/test/e2e/annotations/canary.go
+++ b/test/e2e/annotations/canary.go
@@ -863,7 +863,7 @@ var _ = framework.DescribeAnnotation("canary-*", func() {
 			f.HTTPTestClient().
 				GET("/").
 				WithHeader("Host", host).
-				WithQuery("CanaryByHeader", "DoCanary").
+				WithQuery("CanaryByQuery", "DoCanary").
 				Expect().
 				Status(http.StatusOK).
 				Body().Contains(framework.EchoService).NotContains(canaryService)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In use-cases where we can only control the Query parameters that the client will call but can't control the cookie/header that the client will send to us - it will be helpful to have an option to choose a backend (canary or main) by query parameters.

This PR adds 3 annotations to support canary by Query Params:
- `nginx.ingress.kubernetes.io/canary-by-query`
- `nginx.ingress.kubernetes.io/canary-by-query-value`
- `nginx.ingress.kubernetes.io/canary-by-query-pattern`
The Canary anootations order will be now: `canary-by-header -> canary-by-cookie -> canary-by-query -> canary-weight`

## Examples
main ingress
```yml
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: test
spec:
  rules:
  - host: test.com
    http:
      paths:
      - backend:
          serviceName: stable-service
          servicePort: 80
        path: /path
```

- canary-by-query

```yml
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: test
  annotations:
    nginx.ingress.kubernetes.io/canary: "true"
    nginx.ingress.kubernetes.io/canary-by-query: "canary"
spec:
  rules:
  - host: test.com
    http:
      paths:
      - backend:
          serviceName: canary-service
          servicePort: 80
        path:  /path
```
curl test.com/path?canary=always -> will be routed to the canary-service
curl test.com/path?canary=never -> will be routed to the stable-service
curl test.com/path-> will be routed to the stable-service ( as there is no canary-weight annotation)

- canary-by-query-value

```yml
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: test
  annotations:
    nginx.ingress.kubernetes.io/canary: "true"
    nginx.ingress.kubernetes.io/canary-by-query: "canary"
    nginx.ingress.kubernetes.io/canary-by-query-value: "ILiveAtTheEdge"
spec:
  rules:
  - host: test.com
    http:
      paths:
      - backend:
          serviceName: canary-service
          servicePort: 80
        path: /path
```
curl test.com/path?canary=ILiveAtTheEdge -> will be routed to the canary-service
curl test.com/path?canary={any other value}-> will be routed to the stable-service ( as there is no canary-weight annotation)

- canary-by-query-pattern

```yml
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: test
  annotations:
    nginx.ingress.kubernetes.io/canary: "true"
    nginx.ingress.kubernetes.io/canary-by-query: "canary"
    nginx.ingress.kubernetes.io/canary-by-query-pattern: "^v"
spec:
  rules:
  - host: test.com
    http:
      paths:
      - backend:
          serviceName: canary-service
          servicePort: 80
        path: /path
```
curl test.com/path?canary=version -> will be routed to the canary-service
curl test.com/path?canary=yes-> will be routed to the stable-service ( as there is no canary-weight annotation)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes

fixes #7857
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):


-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All tests pass:
- Unit tests: make test
- Unit tests for Lua: make lua-test - (added test for all query scenarios)
- End-to-end tests: make kind-e2e-test - (added e2e for all query scenarios)

Tested on a k8s cluster (with make dev-env).
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
