### PR TITLE
Making Kube service appProtocol field optional

### DIFF
--- a/charts/ingress-nginx/CHANGELOG.md
+++ b/charts/ingress-nginx/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file documents all notable changes to [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+### 4.0.11
+
+- [7873] https://github.com/kubernetes/ingress-nginx/pull/7873 Makes the [appProtocol](https://kubernetes.io/docs/concepts/services-networking/_print/#application-protocol) field optional.
+
 ### 4.0.10
 
 - [7964] https://github.com/kubernetes/ingress-nginx/pull/7964 Update controller version to v1.1.0

--- a/charts/ingress-nginx/Chart.yaml
+++ b/charts/ingress-nginx/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ingress-nginx
 # When the version is modified, make sure the artifacthub.io/changes list is updated
 # Also update CHANGELOG.md
-version: 4.0.10
+version: 4.0.11
 appVersion: 1.1.0
 home: https://github.com/kubernetes/ingress-nginx
 description: Ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer

--- a/charts/ingress-nginx/templates/controller-service.yaml
+++ b/charts/ingress-nginx/templates/controller-service.yaml
@@ -54,7 +54,7 @@ spec:
       port: {{ .Values.controller.service.ports.http }}
       protocol: TCP
       targetPort: {{ .Values.controller.service.targetPorts.http }}
-    {{- if semverCompare ">=1.20" .Capabilities.KubeVersion.Version }}
+    {{- if and (semverCompare ">=1.20" .Capabilities.KubeVersion.Version) (.Values.controller.service.appProtocol) }}
       appProtocol: http
     {{- end }}
     {{- if (and $setNodePorts (not (empty .Values.controller.service.nodePorts.http))) }}
@@ -66,7 +66,7 @@ spec:
       port: {{ .Values.controller.service.ports.https }}
       protocol: TCP
       targetPort: {{ .Values.controller.service.targetPorts.https }}
-    {{- if semverCompare ">=1.20" .Capabilities.KubeVersion.Version }}
+    {{- if and (semverCompare ">=1.20" .Capabilities.KubeVersion.Version) (.Values.controller.service.appProtocol) }}
       appProtocol: https
     {{- end }}
     {{- if (and $setNodePorts (not (empty .Values.controller.service.nodePorts.https))) }}

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -432,6 +432,14 @@ controller:
   service:
     enabled: true
 
+    ## If enabled is adding an appProtocol option for Kubernetes service. An appProtocol field replacing annotations that were
+    ## using for setting a backend protocol. Here is an example for AWS: service.beta.kubernetes.io/aws-load-balancer-backend-protocol: http
+    ## It allows choosing the protocol for each backend specified in the Kubernetes service.
+    ## See the following GitHub issue for more details about the purpose: https://github.com/kubernetes/kubernetes/issues/40244
+    ## Will be ignored for Kubernetes versions older than 1.20
+    ##
+    appProtocol: true
+
     annotations: {}
     labels: {}
     # clusterIP: ""


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is making the [appProtocol](https://github.com/kubernetes/ingress-nginx/blob/c8ab4dc3072ff36491a2b896e4b2a1e3726b7caf/charts/ingress-nginx/templates/controller-service.yaml#L58) field of the Nginx ingress controller definition optional. 

That is needed as not all Cloud providers could correctly work with it.
For example here is what happens when we expose our Nginx ingress-controller Kubernetes service through IBM Cloud NLB instance:

```
Events:
  Type     Reason                           Age                From                Message
  ----     ------                           ----               ----                -------
  Normal   EnsuringLoadBalancer             13s (x3 over 28s)  service-controller  Ensuring load balancer
  Warning  CreatingCloudLoadBalancerFailed  13s (x3 over 28s)  ibm-cloud-provider  Error on cloud load balancer afd6a32934ebe4cc89b782a88c9dea3a for service kube-system/nginx-ingress-dal10-3157072-controller-exp with UID fd6a3293-4ebe-4cc8-9b78-2a88c9dea3a8: Service configuration is not supported: application protocol
  Warning  SyncLoadBalancerFailed           13s (x3 over 28s)  service-controller  Error syncing load balancer: failed to ensure load balancer: Error on cloud load balancer afd6a32934ebe4cc89b782a88c9dea3a for service kube-system/nginx-ingress-dal10-3157072-controller-exp with UID fd6a3293-4ebe-4cc8-9b78-2a88c9dea3a8: Service configuration is not supported: application protocol
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Here is an example of the Nginx ingress Kubernetes service that is failing:

```yaml
apiVersion: v1
kind: Service
metadata:
  annotations:
    meta.helm.sh/release-name: nginx-ingress
    meta.helm.sh/release-namespace: kube-system
    service.kubernetes.io/ibm-load-balancer-cloud-provider-enable-features: ipvs
    service.kubernetes.io/ibm-load-balancer-cloud-provider-ip-type: public
    service.kubernetes.io/ibm-load-balancer-cloud-provider-scheduler: rr
    service.kubernetes.io/ibm-load-balancer-cloud-provider-vlan: <vlan>
    service.kubernetes.io/ibm-load-balancer-cloud-provider-zone: <zone>
  labels:
    app.kubernetes.io/component: controller
    app.kubernetes.io/instance: nginx-ingress
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: ingress-nginx
    app.kubernetes.io/version: 1.0.4
    helm.sh/chart: ingress-nginx-4.0.6
    loadBalancerType: main
    nlbVersion: "2"
  name: nginx-ingress-dal10-3157072-controller-exp
  namespace: kube-system
spec:
  externalTrafficPolicy: Local
  ports:
  - name: http
    port: 80
    protocol: TCP
    targetPort: http
    appProtocol: http
  - name: https
    port: 443
    protocol: TCP
    targetPort: https
    appProtocol: https
  selector:
    app.kubernetes.io/component: controller
    app.kubernetes.io/instance: nginx-ingress-dal10-3157072
    app.kubernetes.io/name: ingress-nginx
  sessionAffinity: None
  type: LoadBalancer
``` 

If we remove the `appProtocol` field, an IBM Cloud NLB instance will be created successfully for the Nginx ingress-controller service.
We also tried to roll back into the 4.0.0 version of the Nginx ingress-controller chart (before the appProtocol field was released). And it is working for us.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
