### PR TITLE
Add X-Forwarded-For in custom error template

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -860,6 +860,7 @@ stream {
             proxy_set_header       X-Service-Name     $service_name;
             proxy_set_header       X-Service-Port     $service_port;
             proxy_set_header       X-Request-ID       $req_id;
+            proxy_set_header       X-Forwarded-For    $remote_addr;
             proxy_set_header       Host               $best_http_host;
 
             set $proxy_upstream_name {{ $upstreamName | quote }};


### PR DESCRIPTION
## What this PR does / why we need it:

For logging purposes, it is convenient to have the value of `$remote_addr` available to the default backend.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes

## How Has This Been Tested?

Tested with controller version 1.0.4.

To test, I used the altered `nginx.tmpl` as a custom nginx template. I also used a modified version of [custom-error-pages](https://github.com/kubernetes/ingress-nginx/tree/b8e62019bcceaaead8a29a6888d8a7f280c65deb/images/custom-error-pages) which dumps all headers to stdout.  
After the template was changed, it showed `X-Forwarded-For: <source ip>` as expected.

## Checklist:
- [x] My change requires a change to the documentation. *might be appropriate mentioning the header on the custom error page documentation*
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
