### PR TITLE
make documentation clearer

### DIFF
--- a/docs/user-guide/exposing-tcp-udp-services.md
+++ b/docs/user-guide/exposing-tcp-udp-services.md
@@ -8,7 +8,7 @@ Adding `PROXY` in either or both of the two last fields we can use [Proxy Protoc
 The first `PROXY` controls the decode of the proxy protocol and the second `PROXY` controls the encoding using proxy protocol. 
 This allows an incoming connection to be decoded or an outgoing connection to be encoded. It is also possible to arbitrate between two different proxies by turning on the decode and encode on a TCP service. 
 
-The next example shows how to expose the service `example-go` running in the namespace `default` in the port `8080` using the port `9000`
+The next example shows how to expose the service `example-go` running in the namespace `default` on port `8080`. It will be exposed on the port `9000`.
 
 ```yaml
 apiVersion: v1


### PR DESCRIPTION
Improve documentation on how to expose TCP/UDP ports.

## What this PR does / why we need it:

The text is grammatically awkward and does not clearly explain the essential point: what port gets bound where?

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation only

## Which issue/s this PR fixes

## How Has This Been Tested?

This is a documentation fix. It only fixes a description. However I did follow my own description when configuring random TCP port forwarding ;-)

## Checklist:

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
