### PR TITLE
fix missing `\-` in regex expression for CORS wildcard domain

### DIFF
--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -1680,7 +1680,7 @@ func convertGoSliceIntoLuaTable(goSliceInterface interface{}, emptyStringAsNil b
 
 func buildOriginRegex(origin string) string {
 	origin = regexp.QuoteMeta(origin)
-	origin = strings.Replace(origin, "\\*", "[A-Za-z0-9]+", 1)
+	origin = strings.Replace(origin, "\\*", `[A-Za-z0-9\-]+`, 1)
 	return fmt.Sprintf("(%s)", origin)
 }
 

--- a/test/e2e/annotations/cors.go
+++ b/test/e2e/annotations/cors.go
@@ -425,6 +425,7 @@ var _ = framework.DescribeAnnotation("cors-*", func() {
 	ginkgo.It("should allow - matching origin with wildcard origin (2 subdomains)", func() {
 		host := "cors.foo.com"
 		origin := "http://foo.origin.cors.com"
+		origin2 := "http://bar-foo.origin.cors.com"
 		annotations := map[string]string{
 			"nginx.ingress.kubernetes.io/enable-cors":       "true",
 			"nginx.ingress.kubernetes.io/cors-allow-origin": "http://*.origin.cors.com, http://*.origin.com:8080",
@@ -447,6 +448,21 @@ var _ = framework.DescribeAnnotation("cors-*", func() {
 			Expect().
 			Status(http.StatusOK).Headers().
 			ValueEqual("Access-Control-Allow-Origin", []string{origin})
+
+		f.HTTPTestClient().
+			GET("/").
+			WithHeader("Host", host).
+			WithHeader("Origin", origin2).
+			Expect().
+			Headers().ContainsKey("Access-Control-Allow-Origin")
+
+		f.HTTPTestClient().
+			GET("/").
+			WithHeader("Host", host).
+			WithHeader("Origin", origin2).
+			Expect().
+			Status(http.StatusOK).Headers().
+			ValueEqual("Access-Control-Allow-Origin", []string{origin2})
 	})
 
 	ginkgo.It("should not allow - unmatching origin with wildcard origin (2 subdomains)", func() {


### PR DESCRIPTION
Fixes a bug where `my-domain.bar.com` would not much `*.bar.com`

## What this PR does / why we need it:
This addresses a small issue in #7614 where the built origin regex would not have the `\-` dash as an available character therefore, when requests with `my-domain.bar.com` they would not be matched to their underlying wildcard domain.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## How Has This Been Tested?
kind e2e-tests

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
