### PR TITLE
Update docs with a warning about cert chain order

### DIFF
--- a/docs/examples/PREREQUISITES.md
+++ b/docs/examples/PREREQUISITES.md
@@ -26,7 +26,7 @@ Note: If using CA Authentication, described below, you will need to sign the ser
 CA Authentication also known as Mutual Authentication allows both the server and client to verify each others
 identity via a common CA.
 
-We have a CA Certificate which we obtain usually from a Certificate Authority and use that to sign
+We have a CA Certificate which we usually obtain from a Certificate Authority and use that to sign
 both our server certificate and client certificate. Then every time we want to access our backend, we must
 pass the client certificate.
 
@@ -53,6 +53,8 @@ openssl x509 -req -sha256 -days 365 -in client.csr -CA ca.crt -CAkey ca.key -set
 ```
 
 Once this is complete you can continue to follow the instructions [here](./auth/client-certs/README.md#creating-certificate-secrets)
+
+
 
 ## Test HTTP Service
 

--- a/docs/user-guide/tls.md
+++ b/docs/user-guide/tls.md
@@ -4,6 +4,9 @@
 
 Anytime we reference a TLS secret, we mean a PEM-encoded X.509, RSA (2048) secret.
 
+!!! warning
+    Ensure that the certificate order is leaf->intermediate->root, otherwise the controller will not be able to import the certificate, and you'll see this error in the logs ```W1012 09:15:45.920000       6 backend_ssl.go:46] Error obtaining X.509 certificate: unexpected error creating SSL Cert: certificate and private key does not have a matching public key: tls: private key does not match public key```
+
 You can generate a self-signed certificate and private key with:
 
 ```bash


### PR DESCRIPTION
## What this PR does / why we need it:
Updates the documentation warning users that the certificate chain must be in the proper format. 

Tires to help with issues like in #7799 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation only


