### PR TITLE
Fix command in index.md

### DIFF
--- a/docs/deploy/index.md
+++ b/docs/deploy/index.md
@@ -116,6 +116,13 @@ kubectl create ingress demo --class=nginx \
   --rule="www.demo.io/*=demo:80"
 ```
 
+Alternatively, the ```--rule``` opption and below can be rewritten as follows.
+```console
+kubectl create ingress demo --class=nginx \
+  --rule www.demo.io/=demo:80
+```
+
+
 You should then be able to see the "It works!" page when you connect to http://www.demo.io/. Congratulations, you are serving a public web site hosted on a Kubernetes cluster! 🎉
 
 ## Environment-specific instructions

--- a/docs/deploy/index.md
+++ b/docs/deploy/index.md
@@ -113,7 +113,7 @@ Set up a DNS record pointing to that IP address or FQDN; then create an ingress 
 
 ```console
 kubectl create ingress demo --class=nginx \
-  --rule=www.demo.io/*=demo:80
+  --rule="www.demo.io/*=demo:80"
 ```
 
 You should then be able to see the "It works!" page when you connect to http://www.demo.io/. Congratulations, you are serving a public web site hosted on a Kubernetes cluster! 🎉

--- a/docs/deploy/index.md
+++ b/docs/deploy/index.md
@@ -116,7 +116,7 @@ kubectl create ingress demo --class=nginx \
   --rule="www.demo.io/*=demo:80"
 ```
 
-Alternatively, the ```--rule``` opption and below can be rewritten as follows.
+Alternatively, the above command can be rewritten as follows for the ```--rule``` command and below.
 ```console
 kubectl create ingress demo --class=nginx \
   --rule www.demo.io/=demo:80


### PR DESCRIPTION
Hi, 
I fixed the documentation typo.
Please check and merge it.

<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The command line has a typo.
The command ```www.demo.io/*=demo:80``` seems to need Quotation Mark.
```console
kubectl create ingress demo --class=nginx \
  --rule=www.demo.io/*=demo:80
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->
Add Quotation Mark on the following command line.
```console
kubectl create ingress demo --class=nginx \
  --rule="www.demo.io/*=demo:80"
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The fixed command was executed in my local Mac terminal.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
