### PR TITLE
update kubectl plugin build for darwin arm64

### DIFF
--- a/build/build-plugin.sh
+++ b/build/build-plugin.sh
@@ -79,5 +79,6 @@ sed -i "s/%%%tag%%%/${TAG}/g" ${release}/ingress-nginx.yaml
 echo "Generated targets in ${release} directory."
 
 build_for_arch darwin amd64 ''
+build_for_arch darwin arm64 ''
 build_for_arch linux amd64 ''
 build_for_arch windows amd64 '.exe'

--- a/cmd/plugin/ingress-nginx.yaml.tmpl
+++ b/cmd/plugin/ingress-nginx.yaml.tmpl
@@ -9,6 +9,16 @@ spec:
   version: v%%%tag%%%
   homepage: https://kubernetes.github.io/ingress-nginx/kubectl-plugin/
   platforms:
+  - uri: https://github.com/kubernetes/ingress-nginx/releases/download/nginx-%%%tag%%%/kubectl-ingress_nginx-darwin-arm64.tar.gz
+    sha256: %%%shasum_darwin_arm64%%%
+    files:
+    - from: "*"
+      to: "."
+    bin: "./kubectl-ingress_nginx"
+    selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
   - uri: https://github.com/kubernetes/ingress-nginx/releases/download/nginx-%%%tag%%%/kubectl-ingress_nginx-darwin-amd64.tar.gz
     sha256: %%%shasum_darwin_amd64%%%
     files:


### PR DESCRIPTION
Adding support for m1 for kubectl ingress plugin

## What this PR does / why we need it:
closes https://github.com/kubernetes/ingress-nginx/issues/7154

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only


## How Has This Been Tested?
make build-plugin executes and create artifacts, need to look into running this in either arm64 docker container or an m1. 


