### PR TITLE
update default block list,docs, tests

### DIFF
--- a/docs/user-guide/nginx-configuration/configmap.md
+++ b/docs/user-guide/nginx-configuration/configmap.md
@@ -30,7 +30,7 @@ The following table shows a configuration option's name, type, and the default v
 |[add-headers](#add-headers)|string|""|
 |[allow-backend-server-header](#allow-backend-server-header)|bool|"false"|
 |[allow-snippet-annotations](#allow-snippet-annotations)|bool|true|
-|[annotation-value-word-blocklist](#annotation-value-word-blocklist)|string array|"load_module","lua_package","_by_lua","location","root","proxy_pass","serviceaccount","{","}","'","\"
+|[annotation-value-word-blocklist](#annotation-value-word-blocklist)|string array|""|
 |[hide-headers](#hide-headers)|string array|empty|
 |[access-log-params](#access-log-params)|string|""|
 |[access-log-path](#access-log-path)|string|"/var/log/nginx/access.log"|
@@ -226,20 +226,17 @@ may allow a user to add restricted configurations to the final nginx.conf file
 ## annotation-value-word-blocklist
 
 Contains a comma-separated value of chars/words that are well known of being used to abuse Ingress configuration 
-and must be blocked.
+and must be blocked. Related to [CVE-2021-25742](https://github.com/kubernetes/ingress-nginx/issues/7837) 
 
-When an annotation is detected with a value that matches one of the blocked badwords, the whole Ingress wont be configured.
+When an annotation is detected with a value that matches one of the blocked bad words, the whole Ingress won't be configured.
 
-_**default:**_ `"load_module,lua_package,_by_lua,location,root,proxy_pass,serviceaccount,{,},',\"`
+_**default:**_ `""`
 
+When doing this, the default blocklist is override, which means that the Ingress admin should add all the words
+that should be blocked, here is a suggested block list.
 
-Warning: The default value already contains a sane set of badwords. Some features like mod_security needs characters that are blocked, and it's up to the Ingress admin to remove this characters from the blocklist.
+_**suggested:**_ `"load_module,lua_package,_by_lua,location,root,proxy_pass,serviceaccount,{,},',\"`
 
-When doing this, the default blocklist is overrided, which means that the Ingress admin should add all the words
-that should be blocked.
-
-If you find some word should not be on the default list, or if you think that we should add more badwords, please 
-feel free to open an issue with your case!
 ## hide-headers
 
 Sets additional header that will not be passed from the upstream server to the client response.

--- a/internal/admission/controller/main.go
+++ b/internal/admission/controller/main.go
@@ -83,7 +83,7 @@ func (ia *IngressAdmission) HandleAdmission(obj runtime.Object) (runtime.Object,
 		}
 
 		review.Response = status
-		return review, nil
+		return review, err
 	}
 
 	if err := ia.Checker.CheckIngress(&ingress); err != nil {
@@ -95,7 +95,7 @@ func (ia *IngressAdmission) HandleAdmission(obj runtime.Object) (runtime.Object,
 		}
 
 		review.Response = status
-		return review, nil
+		return review, err
 	}
 
 	klog.InfoS("successfully validated configuration, accepting", "ingress", fmt.Sprintf("%v/%v", review.Request.Name, review.Request.Namespace))

--- a/internal/admission/controller/main.go
+++ b/internal/admission/controller/main.go
@@ -83,7 +83,7 @@ func (ia *IngressAdmission) HandleAdmission(obj runtime.Object) (runtime.Object,
 		}
 
 		review.Response = status
-		return review, err
+		return review, nil
 	}
 
 	if err := ia.Checker.CheckIngress(&ingress); err != nil {
@@ -95,7 +95,7 @@ func (ia *IngressAdmission) HandleAdmission(obj runtime.Object) (runtime.Object,
 		}
 
 		review.Response = status
-		return review, err
+		return review, nil
 	}
 
 	klog.InfoS("successfully validated configuration, accepting", "ingress", fmt.Sprintf("%v/%v", review.Request.Name, review.Request.Namespace))

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -18,7 +18,6 @@ package config
 
 import (
 	"strconv"
-	"strings"
 	"time"
 
 	"k8s.io/klog/v2"
@@ -767,21 +766,6 @@ func NewDefault() Configuration {
 	defNginxStatusIpv4Whitelist := make([]string, 0)
 	defNginxStatusIpv6Whitelist := make([]string, 0)
 	defResponseHeaders := make([]string, 0)
-
-	defAnnotationValueWordBlocklist := []string{
-		"load_module",
-		"lua_package",
-		"_by_lua",
-		"location",
-		"root",
-		"proxy_pass",
-		"serviceaccount",
-		"{",
-		"}",
-		"'",
-		"\\",
-	}
-
 	defIPCIDR = append(defIPCIDR, "0.0.0.0/0")
 	defNginxStatusIpv4Whitelist = append(defNginxStatusIpv4Whitelist, "127.0.0.1")
 	defNginxStatusIpv6Whitelist = append(defNginxStatusIpv6Whitelist, "::1")
@@ -792,7 +776,7 @@ func NewDefault() Configuration {
 
 		AllowSnippetAnnotations:          true,
 		AllowBackendServerHeader:         false,
-		AnnotationValueWordBlocklist:     strings.Join(defAnnotationValueWordBlocklist, ","),
+		AnnotationValueWordBlocklist:     "",
 		AccessLogPath:                    "/var/log/nginx/access.log",
 		AccessLogParams:                  "",
 		EnableAccessLogForDefaultBackend: false,

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -256,7 +256,7 @@ func (n *NGINXController) CheckIngress(ing *networking.Ingress) error {
 				return fmt.Errorf("This deployment has a custom annotation prefix defined. Use '%s' instead of '%s'", parser.AnnotationsPrefix, parser.DefaultAnnotationsPrefix)
 			}
 		}
-		
+
 		if strings.HasPrefix(key, fmt.Sprintf("%s/", parser.AnnotationsPrefix)) && len(arrayBadWords) != 0 {
 			for _, forbiddenvalue := range arrayBadWords {
 				if strings.Contains(value, strings.TrimSpace(forbiddenvalue)) {

--- a/internal/ingress/controller/store/store.go
+++ b/internal/ingress/controller/store/store.go
@@ -823,10 +823,11 @@ func (s *k8sStore) syncIngress(ing *networkingv1.Ingress) {
 	copyIng := &networkingv1.Ingress{}
 	ing.ObjectMeta.DeepCopyInto(&copyIng.ObjectMeta)
 
-	klog.Errorf("Blocklist: %v", s.backendConfig.AnnotationValueWordBlocklist)
-	if err := checkBadAnnotationValue(copyIng.Annotations, s.backendConfig.AnnotationValueWordBlocklist); err != nil {
-		klog.Errorf("skipping ingress %s: %s", key, err)
-		return
+	if s.backendConfig.AnnotationValueWordBlocklist != "" {
+		if err := checkBadAnnotationValue(copyIng.Annotations, s.backendConfig.AnnotationValueWordBlocklist); err != nil {
+			klog.Errorf("skipping ingress %s: %s", key, err)
+			return
+		}
 	}
 
 	ing.Spec.DeepCopyInto(&copyIng.Spec)

--- a/test/e2e/admission/admission.go
+++ b/test/e2e/admission/admission.go
@@ -126,6 +126,7 @@ var _ = framework.IngressNginxDescribe("[Serial] admission controller", func() {
 
 		annotations := map[string]string{
 			"nginx.ingress.kubernetes.io/connection-proxy-header": "a;}",
+			"annotation-value-word-blocklist":"}",
 		}
 		firstIngress := framework.NewSingleIngress("first-ingress", "/", host, f.Namespace, framework.EchoService, 80, annotations)
 		_, err := f.KubeClientSet.NetworkingV1().Ingresses(f.Namespace).Create(context.TODO(), firstIngress, metav1.CreateOptions{})
@@ -137,6 +138,7 @@ var _ = framework.IngressNginxDescribe("[Serial] admission controller", func() {
 
 		annotations := map[string]string{
 			"nginx.ingress.kubernetes.io/connection-proxy-header": "set_by_lua",
+		  "annotation-value-word-blocklist": "set_by_lua",
 		}
 		firstIngress := framework.NewSingleIngress("first-ingress", "/", host, f.Namespace, framework.EchoService, 80, annotations)
 		_, err := f.KubeClientSet.NetworkingV1().Ingresses(f.Namespace).Create(context.TODO(), firstIngress, metav1.CreateOptions{})

--- a/test/e2e/admission/admission.go
+++ b/test/e2e/admission/admission.go
@@ -126,8 +126,11 @@ var _ = framework.IngressNginxDescribe("[Serial] admission controller", func() {
 
 		annotations := map[string]string{
 			"nginx.ingress.kubernetes.io/connection-proxy-header": "a;}",
-			"annotation-value-word-blocklist":"}",
+
 		}
+
+		f.UpdateNginxConfigMapData("annotation-value-word-blocklist", "}")
+
 		firstIngress := framework.NewSingleIngress("first-ingress", "/", host, f.Namespace, framework.EchoService, 80, annotations)
 		_, err := f.KubeClientSet.NetworkingV1().Ingresses(f.Namespace).Create(context.TODO(), firstIngress, metav1.CreateOptions{})
 		assert.NotNil(ginkgo.GinkgoT(), err, "creating an ingress with invalid annotation value should return an error")
@@ -138,8 +141,10 @@ var _ = framework.IngressNginxDescribe("[Serial] admission controller", func() {
 
 		annotations := map[string]string{
 			"nginx.ingress.kubernetes.io/connection-proxy-header": "set_by_lua",
-		  "annotation-value-word-blocklist": "set_by_lua",
 		}
+
+		f.UpdateNginxConfigMapData( "annotation-value-word-blocklist", "set_by_lua")
+
 		firstIngress := framework.NewSingleIngress("first-ingress", "/", host, f.Namespace, framework.EchoService, 80, annotations)
 		_, err := f.KubeClientSet.NetworkingV1().Ingresses(f.Namespace).Create(context.TODO(), firstIngress, metav1.CreateOptions{})
 		assert.NotNil(ginkgo.GinkgoT(), err, "creating an ingress with invalid annotation value should return an error")

--- a/test/e2e/admission/admission.go
+++ b/test/e2e/admission/admission.go
@@ -126,7 +126,6 @@ var _ = framework.IngressNginxDescribe("[Serial] admission controller", func() {
 
 		annotations := map[string]string{
 			"nginx.ingress.kubernetes.io/connection-proxy-header": "a;}",
-
 		}
 
 		f.UpdateNginxConfigMapData("annotation-value-word-blocklist", "}")
@@ -143,7 +142,7 @@ var _ = framework.IngressNginxDescribe("[Serial] admission controller", func() {
 			"nginx.ingress.kubernetes.io/connection-proxy-header": "set_by_lua",
 		}
 
-		f.UpdateNginxConfigMapData( "annotation-value-word-blocklist", "set_by_lua")
+		f.UpdateNginxConfigMapData("annotation-value-word-blocklist", "set_by_lua")
 
 		firstIngress := framework.NewSingleIngress("first-ingress", "/", host, f.Namespace, framework.EchoService, 80, annotations)
 		_, err := f.KubeClientSet.NetworkingV1().Ingresses(f.Namespace).Create(context.TODO(), firstIngress, metav1.CreateOptions{})

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -42,7 +42,7 @@ const (
 	Poll = 2 * time.Second
 
 	// DefaultTimeout time to wait for operations to complete
-	DefaultTimeout = 30 * time.Second
+	DefaultTimeout = 90 * time.Second
 )
 
 func nowStamp() string {

--- a/test/e2e/settings/badannotationvalues.go
+++ b/test/e2e/settings/badannotationvalues.go
@@ -44,7 +44,7 @@ var _ = framework.DescribeAnnotation("Bad annotation values", func() {
 		ing := framework.NewSingleIngress(host, "/", host, f.Namespace, framework.EchoService, 80, annotations)
 		f.UpdateNginxConfigMapData("allow-snippet-annotations", "true")
 		f.UpdateNginxConfigMapData("annotation-value-word-blocklist", "something_forbidden,otherthing_forbidden,{")
-		
+
 		f.EnsureIngress(ing)
 
 		f.WaitForNginxServer(host,
@@ -138,7 +138,6 @@ var _ = framework.DescribeAnnotation("Bad annotation values", func() {
 			# something_forbidden`,
 		}
 
-
 		ing := framework.NewSingleIngress(host, "/", host, f.Namespace, framework.EchoService, 80, annotations)
 		f.UpdateNginxConfigMapData("annotation-value-word-blocklist", "something_forbidden,otherthing_forbidden")
 		// Sleep a while just to guarantee that the configmap is applied
@@ -150,12 +149,10 @@ var _ = framework.DescribeAnnotation("Bad annotation values", func() {
 				return !strings.Contains(server, fmt.Sprintf("server_name %s ;", host))
 			})
 
-
 		f.WaitForNginxServer(host,
 			func(server string) bool {
 				return !strings.Contains(server, "# something_forbidden")
 			})
-
 
 		f.HTTPTestClient().
 			GET("/").

--- a/test/e2e/settings/badannotationvalues.go
+++ b/test/e2e/settings/badannotationvalues.go
@@ -33,7 +33,7 @@ var _ = framework.DescribeAnnotation("Bad annotation values", func() {
 		f.NewEchoDeployment()
 	})
 
-	ginkgo.It("should drop an ingress if there is an invalid character in some annotation", func() {
+	ginkgo.It("[BAD_ANNOTATIONS] should drop an ingress if there is an invalid character in some annotation", func() {
 		host := "invalid-value-test"
 
 		annotations := map[string]string{
@@ -43,6 +43,8 @@ var _ = framework.DescribeAnnotation("Bad annotation values", func() {
 
 		ing := framework.NewSingleIngress(host, "/", host, f.Namespace, framework.EchoService, 80, annotations)
 		f.UpdateNginxConfigMapData("allow-snippet-annotations", "true")
+		f.UpdateNginxConfigMapData("annotation-value-word-blocklist", "something_forbidden,otherthing_forbidden,{")
+		
 		f.EnsureIngress(ing)
 
 		f.WaitForNginxServer(host,
@@ -62,7 +64,7 @@ var _ = framework.DescribeAnnotation("Bad annotation values", func() {
 			Status(http.StatusNotFound)
 	})
 
-	ginkgo.It("should drop an ingress if there is a forbidden word in some annotation", func() {
+	ginkgo.It("[BAD_ANNOTATIONS] should drop an ingress if there is a forbidden word in some annotation", func() {
 		host := "forbidden-value-test"
 
 		annotations := map[string]string{
@@ -75,6 +77,7 @@ var _ = framework.DescribeAnnotation("Bad annotation values", func() {
 
 		ing := framework.NewSingleIngress(host, "/", host, f.Namespace, framework.EchoService, 80, annotations)
 		f.UpdateNginxConfigMapData("allow-snippet-annotations", "true")
+		f.UpdateNginxConfigMapData("annotation-value-word-blocklist", "something_forbidden,otherthing_forbidden,content_by_lua_block")
 		// Sleep a while just to guarantee that the configmap is applied
 		framework.Sleep()
 		f.EnsureIngress(ing)
@@ -96,13 +99,7 @@ var _ = framework.DescribeAnnotation("Bad annotation values", func() {
 			Status(http.StatusNotFound)
 	})
 
-	ginkgo.It("should drop an ingress if there is a custom blocklist config in place and allow others to pass", func() {
-		host := "custom-forbidden-value-test"
-
-		annotations := map[string]string{
-			"nginx.ingress.kubernetes.io/configuration-snippet": `
-			# something_forbidden`,
-		}
+	ginkgo.It("[BAD_ANNOTATIONS] should allow an ingress if there is a default blocklist config in place", func() {
 
 		hostValid := "custom-allowed-value-test"
 		annotationsValid := map[string]string{
@@ -110,27 +107,15 @@ var _ = framework.DescribeAnnotation("Bad annotation values", func() {
 			# bla_by_lua`,
 		}
 
-		ing := framework.NewSingleIngress(host, "/", host, f.Namespace, framework.EchoService, 80, annotations)
 		ingValid := framework.NewSingleIngress(hostValid, "/", hostValid, f.Namespace, framework.EchoService, 80, annotationsValid)
-		f.UpdateNginxConfigMapData("annotation-value-word-blocklist", "something_forbidden,otherthing_forbidden")
+
 		// Sleep a while just to guarantee that the configmap is applied
 		framework.Sleep()
-		f.EnsureIngress(ing)
 		f.EnsureIngress(ingValid)
-
-		f.WaitForNginxServer(host,
-			func(server string) bool {
-				return !strings.Contains(server, fmt.Sprintf("server_name %s ;", host))
-			})
 
 		f.WaitForNginxServer(hostValid,
 			func(server string) bool {
 				return strings.Contains(server, fmt.Sprintf("server_name %s ;", hostValid))
-			})
-
-		f.WaitForNginxServer(host,
-			func(server string) bool {
-				return !strings.Contains(server, "# something_forbidden")
 			})
 
 		f.WaitForNginxServer(hostValid,
@@ -140,14 +125,43 @@ var _ = framework.DescribeAnnotation("Bad annotation values", func() {
 
 		f.HTTPTestClient().
 			GET("/").
+			WithHeader("Host", hostValid).
+			Expect().
+			Status(http.StatusOK)
+	})
+
+	ginkgo.It("[BAD_ANNOTATIONS] should drop an ingress if there is a custom blocklist config in place and allow others to pass", func() {
+		host := "custom-forbidden-value-test"
+
+		annotations := map[string]string{
+			"nginx.ingress.kubernetes.io/configuration-snippet": `
+			# something_forbidden`,
+		}
+
+
+		ing := framework.NewSingleIngress(host, "/", host, f.Namespace, framework.EchoService, 80, annotations)
+		f.UpdateNginxConfigMapData("annotation-value-word-blocklist", "something_forbidden,otherthing_forbidden")
+		// Sleep a while just to guarantee that the configmap is applied
+		framework.Sleep()
+		f.EnsureIngress(ing)
+
+		f.WaitForNginxServer(host,
+			func(server string) bool {
+				return !strings.Contains(server, fmt.Sprintf("server_name %s ;", host))
+			})
+
+
+		f.WaitForNginxServer(host,
+			func(server string) bool {
+				return !strings.Contains(server, "# something_forbidden")
+			})
+
+
+		f.HTTPTestClient().
+			GET("/").
 			WithHeader("Host", host).
 			Expect().
 			Status(http.StatusNotFound)
 
-		f.HTTPTestClient().
-			GET("/").
-			WithHeader("Host", hostValid).
-			Expect().
-			Status(http.StatusOK)
 	})
 })


### PR DESCRIPTION
1.0.5 created a breaking change with a default blocklist for user, this PR reverts that and makes the default blocklist an empty string. 

## What this PR does / why we need it:
fixes https://github.com/kubernetes/ingress-nginx/issues/7939

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only


## How Has This Been Tested?
make test and e2e-test locally

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] My change requires a change to the documentation.
- [X ] I have updated the documentation accordingly.
- [X ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [X ] I have added tests to cover my changes.
- [X ] All new and existing tests passed.
