### PR TITLE
Docs: add documentation about default ingress helm value, corrections to only ingress section

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -120,7 +120,7 @@ When using Helm, you can enable this annotation by setting `.controller.ingressC
 If you have any old Ingress objects remaining without an IngressClass set, you can do one or more of the following to make the Ingress-NGINX controller aware of the old objects:
 
 - You can manually set the [`.spec.ingressClassName`](https://kubernetes.io/docs/reference/kubernetes-api/service-resources/ingress-v1/#IngressSpec) field in the manifest of your own Ingress resources.
-- You can re-create them after adding the "ingressclass.kubernetes.io/is-default-class" annotation to the IngressClass
+- You can re-create them after setting the `ingressclass.kubernetes.io/is-default-class` annotation to `true` on the IngressClass
 - Alternatively you can make the Ingress-NGINX controller watch Ingress objects without the ingressClassName field set by starting your Ingress-NGINX with the flag [--watch-ingress-without-class=true](#what-is-the-flag-watch-ingress-without-class) . When using Helm, you can configure your Helm chart installation's values file with `.controller.watchIngressWithoutClass: true`
 
 You can configure your Helm chart installation's values file with `.controller.watchIngressWithoutClass: true`. 

--- a/docs/index.md
+++ b/docs/index.md
@@ -114,9 +114,15 @@ The `.spec.ingressClassName` behavior has precedence over the deprecated `kubern
 
 ## I have only one instance of the Ingress-NGINX controller in my cluster. What should I do ?
 
-- If you have only one instance of the Ingress-NGINX controller running in your cluster, and you still want to use IngressClass, you should add the annotation `ingressclass.kubernetes.io/is-default-class` in your IngressClass, so that any new Ingress objects will have this one as default IngressClass.
+If you have only one instance of the Ingress-NGINX controller running in your cluster, and you still want to use IngressClass, you should add the annotation `ingressclass.kubernetes.io/is-default-class` in your IngressClass, so that any new Ingress objects will have this one as default IngressClass.
 
-In this case, you need to make your controller aware of the objects. If you have any Ingress objects that don't yet have either the [`.spec.ingressClassName`](https://kubernetes.io/docs/reference/kubernetes-api/service-resources/ingress-v1/#IngressSpec) field set in their manifest, or the ingress annotation (`kubernetes.io/ingress.class`), then you should start your Ingress-NGINX controller with the flag [--watch-ingress-without-class=true](#what-is-the-flag-watch-ingress-without-class).
+When using Helm, you can enable this annotation by setting `.controller.ingressClassResource.default: true` in your Helm chart installation's values file.
+
+If you have any old Ingress objects remaining without an IngressClass set, you can do one or more of the following to make the Ingress-NGINX controller aware of the old objects:
+
+- You can manually set the [`.spec.ingressClassName`](https://kubernetes.io/docs/reference/kubernetes-api/service-resources/ingress-v1/#IngressSpec) field in the manifest of your own Ingress resources.
+- You can re-create them after adding the "ingressclass.kubernetes.io/is-default-class" annotation to the IngressClass
+- Alternatively you can make the Ingress-NGINX controller watch Ingress objects without the ingressClassName field set by starting your Ingress-NGINX with the flag [--watch-ingress-without-class=true](## What is the flag '--watch-ingress-without-class' ?) . When using Helm, you can configure your Helm chart installation's values file with `.controller.watchIngressWithoutClass: true`
 
 You can configure your Helm chart installation's values file with `.controller.watchIngressWithoutClass: true`. 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -121,7 +121,7 @@ If you have any old Ingress objects remaining without an IngressClass set, you c
 
 - You can manually set the [`.spec.ingressClassName`](https://kubernetes.io/docs/reference/kubernetes-api/service-resources/ingress-v1/#IngressSpec) field in the manifest of your own Ingress resources.
 - You can re-create them after adding the "ingressclass.kubernetes.io/is-default-class" annotation to the IngressClass
-- Alternatively you can make the Ingress-NGINX controller watch Ingress objects without the ingressClassName field set by starting your Ingress-NGINX with the flag [--watch-ingress-without-class=true](## What is the flag '--watch-ingress-without-class' ?) . When using Helm, you can configure your Helm chart installation's values file with `.controller.watchIngressWithoutClass: true`
+- Alternatively you can make the Ingress-NGINX controller watch Ingress objects without the ingressClassName field set by starting your Ingress-NGINX with the flag [--watch-ingress-without-class=true](#what-is-the-flag-watch-ingress-without-class) . When using Helm, you can configure your Helm chart installation's values file with `.controller.watchIngressWithoutClass: true`
 
 You can configure your Helm chart installation's values file with `.controller.watchIngressWithoutClass: true`. 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -111,10 +111,9 @@ DESCRIPTION:
 The `.spec.ingressClassName` behavior has precedence over the deprecated `kubernetes.io/ingress.class` annotation.
 
 
+## I have only one ingress controller in my cluster. What should I do?
 
-## I have only one instance of the Ingress-NGINX controller in my cluster. What should I do ?
-
-If you have only one instance of the Ingress-NGINX controller running in your cluster, and you still want to use IngressClass, you should add the annotation `ingressclass.kubernetes.io/is-default-class` in your IngressClass, so that any new Ingress objects will have this one as default IngressClass.
+If a single instance of the Ingress-NGINX controller is the sole Ingress controller running in your cluster, you should add the annotation "ingressclass.kubernetes.io/is-default-class" in your IngressClass, so any new Ingress objects will have this one as default IngressClass.
 
 When using Helm, you can enable this annotation by setting `.controller.ingressClassResource.default: true` in your Helm chart installation's values file.
 


### PR DESCRIPTION
## What this PR does / why we need it:
Documentation about setting the default ingressclass annotation with helm was missing. Also this section could be interpreted as recommending setting a default ingressClass when running other ingresses besides ingress-nginx. While that is sometimes what the user wants, I don't think it's wise to recommend doing so to all users with multiple ingresses. The documentation has been changed to only recommend setting a default ingressClass when only running one ingress controller. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation only

## How Has This Been Tested?
I rendered the docs with mkdocs

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
