### PR TITLE
Use an indexed table to preserve order when loading plugins from names

### DIFF
--- a/rootfs/etc/nginx/lua/plugins.lua
+++ b/rootfs/etc/nginx/lua/plugins.lua
@@ -1,6 +1,5 @@
 local require = require
 local ngx = ngx
-local pairs = pairs
 local ipairs = ipairs
 local string_format = string.format
 local ngx_log = ngx.log

--- a/rootfs/etc/nginx/lua/plugins.lua
+++ b/rootfs/etc/nginx/lua/plugins.lua
@@ -12,7 +12,7 @@ local _M = {}
 local MAX_NUMBER_OF_PLUGINS = 20
 local plugins = {}
 
-local function load_plugin(name)
+local function load_plugin(i, name)
   local path = string_format("plugins.%s.main", name)
 
   local ok, plugin = pcall(require, path)
@@ -20,18 +20,17 @@ local function load_plugin(name)
     ngx_log(ERR, string_format("error loading plugin \"%s\": %s", path, plugin))
     return
   end
-
-  plugins[name] = plugin
+  plugins[i] = { name = name, plugin = plugin }
 end
 
 function _M.init(names)
   local count = 0
-  for _, name in ipairs(names) do
+  for i, name in ipairs(names) do
     if count >= MAX_NUMBER_OF_PLUGINS then
       ngx_log(ERR, "the total number of plugins exceed the maximum number: ", MAX_NUMBER_OF_PLUGINS)
       break
     end
-    load_plugin(name)
+    load_plugin(i, name)
     count = count + 1 -- ignore loading failure, just count the total
   end
 end
@@ -39,10 +38,11 @@ end
 function _M.run()
   local phase = ngx.get_phase()
 
-  for name, plugin in pairs(plugins) do
+  for _, plugin_module in ipairs(plugins) do
+    local name = plugin_module.name
+    local plugin = plugin_module.plugin
     if plugin[phase] then
       ngx_log(INFO, string_format("running plugin \"%s\" in phase \"%s\"", name, phase))
-
       -- TODO: consider sandboxing this, should we?
       -- probably yes, at least prohibit plugin from accessing env vars etc
       -- but since the plugins are going to be installed by ingress-nginx


### PR DESCRIPTION
…s/paths


## What this PR does / why we need it:
https://github.com/kubernetes/ingress-nginx/issues/7952

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes

fixes #7952 


## How Has This Been Tested?
This fix has been tested locally (minkube) and on an EKS cluster (see issue for details) by logging at plugin entry and exit points.
I'd like to write a formal test for this, I'll read up on the guidelines but I am a total beginner with Lua and OpenResty and I'll probably need help and/or guidance. The fix is simple and limited in scope.

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
