### PR TITLE
Remove force sync for non-external backends

### DIFF
--- a/rootfs/etc/nginx/lua/balancer.lua
+++ b/rootfs/etc/nginx/lua/balancer.lua
@@ -23,7 +23,6 @@ local ngx = ngx
 -- it will take <the delay until controller POSTed the backend object to the
 -- Nginx endpoint> + BACKENDS_SYNC_INTERVAL
 local BACKENDS_SYNC_INTERVAL = 1
-local BACKENDS_FORCE_SYNC_INTERVAL = 30
 
 local DEFAULT_LB_ALG = "round_robin"
 local IMPLEMENTATIONS = {
@@ -146,10 +145,7 @@ end
 
 local function sync_backends()
   local raw_backends_last_synced_at = configuration.get_raw_backends_last_synced_at()
-  ngx.update_time()
-  local current_timestamp = ngx.time()
-  if current_timestamp - backends_last_synced_at < BACKENDS_FORCE_SYNC_INTERVAL
-      and raw_backends_last_synced_at <= backends_last_synced_at then
+  if raw_backends_last_synced_at <= backends_last_synced_at then
     return
   end
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
In PR [#5726](https://github.com/kubernetes/ingress-nginx/pull/5726) and [#5418](https://github.com/kubernetes/ingress-nginx/pull/5418), dynamic LB sync was applied to prevent syncing per second for non-external backends. However, a strategy of force syncing non-external backends per 30s was also added. Practically, the additional strategy is unnecessary but leads to waste of CPUs when number of ingresses/services is large.
## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR remove force sync for non-external backends.
The figures below show how much impact current LB has on CPU usage (%) with/without FORCE sync (No input traffic into nginx). **Without** FORCE sync, CPU usage per nginx worker keeps **<1%**.
CPU model name: Intel(R) Xeon(R) Silver 4208 CPU @ 2.10GHz
![image](https://user-images.githubusercontent.com/2732728/142937174-aeaf5b83-928d-4fe4-92e5-df738847588e.png)

1000 services&ingresses with FORCE sync
![屏幕快照 2021-11-23 上午3 13 49](https://user-images.githubusercontent.com/2732728/142929971-034127e7-da82-4a4a-a37d-11af51760c4a.png)
2000 services&ingresses with FORCE sync
![屏幕快照 2021-11-23 上午3 14 15](https://user-images.githubusercontent.com/2732728/142930125-2e5ffb84-d622-4ed0-b511-f81e41616668.png)
3000 services&ingresses with FORCE sync
![屏幕快照 2021-11-23 上午3 14 49](https://user-images.githubusercontent.com/2732728/142930225-a79c16cd-1c01-46dc-b6c9-8873a0082098.png)
4000 services&ingresses with FORCE sync
![屏幕快照 2021-11-23 上午3 16 03](https://user-images.githubusercontent.com/2732728/142930284-c6bbe685-8bb5-423d-b2b1-104a65aa4f13.png)
5000 services&ingresses with FORCE sync
![屏幕快照 2021-11-23 上午3 33 32](https://user-images.githubusercontent.com/2732728/142930321-7c135b91-9735-43c3-b06c-1fd0a9966224.png)
6000 services&ingresses with FORCE sync
![屏幕快照 2021-11-23 上午3 56 25](https://user-images.githubusercontent.com/2732728/142930378-1661aaf7-63da-43c3-8141-46e4bf472f1a.png)
7000 services&ingresses with FORCE sync
![屏幕快照 2021-11-23 上午4 19 01](https://user-images.githubusercontent.com/2732728/142930410-d59c7201-bfd2-4475-9389-585b3194a304.png)
8000 services&ingresses with FORCE sync
![屏幕快照 2021-11-23 上午5 23 50](https://user-images.githubusercontent.com/2732728/142937423-c52be80d-6c84-4ebb-83bb-650e01ef8726.png)
8000 services&ingresses **without** FORCE sync
![屏幕快照 2021-11-23 上午5 27 26](https://user-images.githubusercontent.com/2732728/142937629-7382e926-76e9-4e43-a4ef-4604e0649003.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Create a nginx deployment on port 80 with label `app: nginx`.
Save the following yaml as `press.yaml.tmpl`.
```
kind: Service
apiVersion: v1
metadata:
  name: service-press-HAHA
spec:
  selector:
    app: nginx
  ports:
    - protocol: TCP
      port: 80
---
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: ingress-press-HAHA
spec:
  rules:
  - http:
      paths:
      - path: /press/HAHA
        backend:
          serviceName: service-press-HAHA
          servicePort: 80
```
Run the bash script
```
for i in {1..7000}
do
    sed s#HAHA#${i}#g press.yaml.tmpl > tmp.yaml
    kubectl apply -f tmp.yaml
done
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
