### PR TITLE
Add ssl_reject_handshake to defaul server

### DIFF
--- a/docs/user-guide/nginx-configuration/configmap.md
+++ b/docs/user-guide/nginx-configuration/configmap.md
@@ -208,6 +208,7 @@ The following table shows a configuration option's name, type, and the default v
 |[global-rate-limit-memcached-pool-size](#global-rate-limit)|int|50|
 |[global-rate-limit-status-code](#global-rate-limit)|int|429|
 |[service-upstream](#service-upstream)|bool|"false"|
+|[ssl-reject-handshake](#ssl-reject-handshake)|bool|"false"|
 
 ## add-headers
 
@@ -1263,3 +1264,11 @@ that ingress-nginx includes. Refer to the link to learn more about `lua-resty-gl
 
 Set if the service's Cluster IP and port should be used instead of a list of all endpoints. This can be overwritten by an annotation on an Ingress rule.
 _**default:**_ "false"
+
+## ssl-reject-handshake
+
+Set to reject SSL handshake to an unknown virtualhost. This paramter helps to mitigate the fingerprinting using default certificate of ingress.
+_**default:**_ "false"
+
+_References:_
+[https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_reject_handshake](https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_reject_handshake)

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -843,6 +843,7 @@ func NewDefault() Configuration {
 		SSLECDHCurve:                     "auto",
 		SSLProtocols:                     sslProtocols,
 		SSLEarlyData:                     sslEarlyData,
+		SSLRejectHandshake:               false,
 		SSLSessionCache:                  true,
 		SSLSessionCacheSize:              sslSessionCacheSize,
 		SSLSessionTickets:                false,

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -388,6 +388,11 @@ type Configuration struct {
 	// https://www.igvita.com/2013/12/16/optimizing-nginx-tls-time-to-first-byte/
 	SSLBufferSize string `json:"ssl-buffer-size,omitempty"`
 
+	// https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_reject_handshake
+	// If enabled, SSL handshakes to an invalid virtualhost will be rejected
+	// Default: false
+	SSLRejectHandshake bool `json:"ssl-reject-handshake"`
+
 	// Enables or disables the use of the PROXY protocol to receive client connection
 	// (real IP address) information passed through proxy servers and load balancers
 	// such as HAproxy and Amazon Elastic Load Balancer (ELB).

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -906,6 +906,10 @@ stream {
 
         set $proxy_upstream_name "-";
 
+        {{ if eq $server.Hostname "_" }}
+        ssl_reject_handshake {{ if $all.Cfg.SSLRejectHandshake }}on{{ else }}off{{ end }};
+        {{ end }}
+
         ssl_certificate_by_lua_block {
             certificate.call()
         }


### PR DESCRIPTION
Enable [ssl_reject_handshake] flag (http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_reject_handshake)

Note:- Enabling this flag will cause the HTTPS request to  `/nginx_status` and `/healthz` to fail.
But based on the usage of these endpoints, there shouldn't be an issue. (https://github.com/kubernetes/ingress-nginx/issues/6748#issuecomment-978912511)

## What this PR does / why we need it:
Fix https://github.com/kubernetes/ingress-nginx/issues/6748

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #6748
-->

## How Has This Been Tested?

Edited configmap `nginx-configuration` and added;
```
ssl-reject-handshake: true
```
Verified the SSL handshake reject with an invalid virtual host

```
curl -v -k --resolve www.example.com:443:172.31.35.68 https://www.example.com/
* Added www.example.com:443:172.31.35.68 to DNS cache
* Hostname www.example.com was found in DNS cache
*   Trying 172.31.35.68:443...
* TCP_NODELAY set
* Connected to www.example.com (172.31.35.68) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*   CAfile: /etc/ssl/certs/ca-certificates.crt
  CApath: /etc/ssl/certs
* TLSv1.3 (OUT), TLS handshake, Client hello (1):
* TLSv1.3 (IN), TLS alert, unrecognized name (624):
* error:14094458:SSL routines:ssl3_read_bytes:tlsv1 unrecognized name
* Closing connection 0
curl: (35) error:14094458:SSL routines:ssl3_read_bytes:tlsv1 unrecognized name
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
