### PR TITLE
Add link to example error page manifest in docs

### DIFF
--- a/docs/examples/customization/custom-errors/README.md
+++ b/docs/examples/customization/custom-errors/README.md
@@ -4,7 +4,9 @@ This example demonstrates how to use a custom backend to render custom error pag
 
 ## Customized default backend
 
-First, create the custom `default-backend`. It will be used by the Ingress controller later on.
+First, create the custom `default-backend`. It will be used by the Ingress controller later on.  
+To do that, you can take a look at the [example manifest](https://github.com/kubernetes/ingress-nginx/blob/main/docs/examples/customization/custom-errors/custom-default-backend.yaml)
+in this project's GitHub repository.
 
 ```
 $ kubectl create -f custom-default-backend.yaml


### PR DESCRIPTION
## What this PR does / why we need it:
The documentation read a bit like one has to build their own custom error backend from scratch and come up with the manifest on their own.  
While this is certainly an option, there already is the nginx-errors backend that even has an example manifest.

I think linking to this manifest from the readme is a good idea since people browsing the docs on the GitHub Pages page will not necessarily know that it is there.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation only

## Which issue/s this PR fixes
I don't fully understand #8010, since from my understanding the existing build of nginx-errors is official but I think this is mainly 
an issue of the documentation not being clear enough about the fact that this exists.

## How Has This Been Tested?
I read the docs in a markdown preview, followed the added link to make sure it is correct and ran my changes through my IDEs 
spellchecker

## Checklist:
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
