### PR TITLE
fix to really execute plugins in order

### DIFF
--- a/rootfs/etc/nginx/lua/test/plugins_test.lua
+++ b/rootfs/etc/nginx/lua/test/plugins_test.lua
@@ -1,0 +1,23 @@
+describe("plugins", function()
+  describe("#run", function()
+    it("runs the plugins in the given order", function()
+      ngx.get_phase = function() return "rewrite" end
+      local plugins = require("plugins")
+      local called_plugins = {}
+      local plugins_to_mock = {"plugins.pluginfirst.main", "plugins.pluginsecond.main", "plugins.pluginthird.main"}
+      for i=1, 3, 1
+      do
+        package.loaded[plugins_to_mock[i]] = {
+          rewrite = function()
+            called_plugins[#called_plugins + 1] = plugins_to_mock[i]
+          end
+        }
+      end
+      assert.has_no.errors(function()
+        plugins.init({"pluginfirst", "pluginsecond", "pluginthird"})
+      end)
+      assert.has_no.errors(plugins.run)
+      assert.are.same(plugins_to_mock, called_plugins)
+    end)
+  end)
+end)


### PR DESCRIPTION
This [readme](https://github.com/kubernetes/ingress-nginx/tree/main/rootfs/etc/nginx/lua/plugins#enabling-plugins) claims the order of plugin invocation is preserved, but that's not true given [it iterates through Lua dictionary](https://github.com/kubernetes/ingress-nginx/blob/main/rootfs/etc/nginx/lua/plugins.lua#L42), where iteration is not predictable / ordered. If we use an index and [ipairs, instead of pairs](https://stackoverflow.com/questions/55108794/what-is-the-difference-of-pairs-vs-ipairs-in-lua) and no index, we can guarantee the order.

## What this PR does / why we need it:
To execute lua plugins in order, as declared.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## How Has This Been Tested?
I have added a unit test to cover my change.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
