### PR TITLE
Disable default modsecurity_rules_file if modsecurity-snippet is specified

### DIFF
--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -1530,9 +1530,6 @@ func buildModSecurityForLocation(cfg config.Configuration, location *ingress.Loc
 %v
 ';
 `, location.ModSecurity.Snippet))
-	} else {
-		buffer.WriteString(`modsecurity_rules_file /etc/nginx/modsecurity/modsecurity.conf;
-`)
 	}
 
 	if location.ModSecurity.TransactionID != "" {

--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -1537,11 +1537,6 @@ func buildModSecurityForLocation(cfg config.Configuration, location *ingress.Loc
 `, location.ModSecurity.TransactionID))
 	}
 
-	if !isMSEnabled && location.ModSecurity.Snippet == "" {
-		buffer.WriteString(`modsecurity_rules_file /etc/nginx/modsecurity/modsecurity.conf;
-`)
-	}
-
 	if !cfg.EnableOWASPCoreRules && location.ModSecurity.OWASPRules {
 		buffer.WriteString(`modsecurity_rules_file /etc/nginx/owasp-modsecurity-crs/nginx-modsecurity.conf;
 `)

--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -1530,16 +1530,14 @@ func buildModSecurityForLocation(cfg config.Configuration, location *ingress.Loc
 %v
 ';
 `, location.ModSecurity.Snippet))
+	} else {
+		buffer.WriteString(`modsecurity_rules_file /etc/nginx/modsecurity/modsecurity.conf;
+`)
 	}
 
 	if location.ModSecurity.TransactionID != "" {
 		buffer.WriteString(fmt.Sprintf(`modsecurity_transaction_id "%v";
 `, location.ModSecurity.TransactionID))
-	}
-
-	if !isMSEnabled {
-		buffer.WriteString(`modsecurity_rules_file /etc/nginx/modsecurity/modsecurity.conf;
-`)
 	}
 
 	if !cfg.EnableOWASPCoreRules && location.ModSecurity.OWASPRules {

--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -1537,6 +1537,11 @@ func buildModSecurityForLocation(cfg config.Configuration, location *ingress.Loc
 `, location.ModSecurity.TransactionID))
 	}
 
+	if !isMSEnabled && location.ModSecurity.Snippet == "" {
+		buffer.WriteString(`modsecurity_rules_file /etc/nginx/modsecurity/modsecurity.conf;
+`)
+	}
+
 	if !cfg.EnableOWASPCoreRules && location.ModSecurity.OWASPRules {
 		buffer.WriteString(`modsecurity_rules_file /etc/nginx/owasp-modsecurity-crs/nginx-modsecurity.conf;
 `)

--- a/internal/ingress/controller/template/template_test.go
+++ b/internal/ingress/controller/template/template_test.go
@@ -1781,8 +1781,8 @@ func TestModSecurityForLocation(t *testing.T) {
 		{"configmap enabled, configmap OWASP enabled, annotation enabled, OWASP disabled", true, true, true, true, false, "", "", ""},
 		{"configmap disabled, annotation enabled, OWASP disabled", false, false, true, true, false, "", "", fmt.Sprintf("%v%v", loadModule, modSecCfg)},
 		{"configmap disabled, annotation disabled, OWASP disabled", false, false, false, true, false, "", "", ""},
-		{"configmap disabled, annotation enabled, OWASP disabled", false, false, true, true, false, testRule, "", fmt.Sprintf("%v%v%v", loadModule, modsecRule, modSecCfg)},
-		{"configmap disabled, annotation enabled, OWASP enabled", false, false, true, true, false, testRule, "", fmt.Sprintf("%v%v%v", loadModule, modsecRule, modSecCfg)},
+		{"configmap disabled, annotation enabled, OWASP disabled", false, false, true, true, false, testRule, "", fmt.Sprintf("%v%v", loadModule, modsecRule)},
+		{"configmap disabled, annotation enabled, OWASP enabled", false, false, true, true, false, testRule, "", fmt.Sprintf("%v%v", loadModule, modsecRule)},
 	}
 
 	for _, testCase := range testCases {

--- a/internal/ingress/controller/template/template_test.go
+++ b/internal/ingress/controller/template/template_test.go
@@ -1781,8 +1781,8 @@ func TestModSecurityForLocation(t *testing.T) {
 		{"configmap enabled, configmap OWASP enabled, annotation enabled, OWASP disabled", true, true, true, true, false, "", "", ""},
 		{"configmap disabled, annotation enabled, OWASP disabled", false, false, true, true, false, "", "", fmt.Sprintf("%v%v", loadModule, modSecCfg)},
 		{"configmap disabled, annotation disabled, OWASP disabled", false, false, false, true, false, "", "", ""},
-		{"configmap disabled, annotation enabled, OWASP disabled", false, false, true, true, false, testRule, "", fmt.Sprintf("%v%v%v", loadModule, modsecRule, modSecCfg)},
-		{"configmap disabled, annotation enabled, OWASP enabled", false, false, true, true, false, testRule, "", fmt.Sprintf("%v%v%v", loadModule, modsecRule, modSecCfg)},
+		{"configmap disabled, annotation enabled, OWASP disabled", false, false, true, true, false, testRule, "", fmt.Sprintf("%v%v%v", loadModule, modsecRule)},
+		{"configmap disabled, annotation enabled, OWASP enabled", false, false, true, true, false, testRule, "", fmt.Sprintf("%v%v%v", loadModule, modsecRule)},
 	}
 
 	for _, testCase := range testCases {

--- a/internal/ingress/controller/template/template_test.go
+++ b/internal/ingress/controller/template/template_test.go
@@ -1781,8 +1781,8 @@ func TestModSecurityForLocation(t *testing.T) {
 		{"configmap enabled, configmap OWASP enabled, annotation enabled, OWASP disabled", true, true, true, true, false, "", "", ""},
 		{"configmap disabled, annotation enabled, OWASP disabled", false, false, true, true, false, "", "", fmt.Sprintf("%v%v", loadModule, modSecCfg)},
 		{"configmap disabled, annotation disabled, OWASP disabled", false, false, false, true, false, "", "", ""},
-		{"configmap disabled, annotation enabled, OWASP disabled", false, false, true, true, false, testRule, "", fmt.Sprintf("%v%v%v", loadModule, modsecRule)},
-		{"configmap disabled, annotation enabled, OWASP enabled", false, false, true, true, false, testRule, "", fmt.Sprintf("%v%v%v", loadModule, modsecRule)},
+		{"configmap disabled, annotation enabled, OWASP disabled", false, false, true, true, false, testRule, "", fmt.Sprintf("%v%v%v", loadModule, modsecRule, modSecCfg)},
+		{"configmap disabled, annotation enabled, OWASP enabled", false, false, true, true, false, testRule, "", fmt.Sprintf("%v%v%v", loadModule, modsecRule, modSecCfg)},
 	}
 
 	for _, testCase := range testCases {

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -155,11 +155,10 @@ http {
     ';
     {{ end }}
     
-    {{ if (not (empty $all.Cfg.ModsecuritySnippet)) }}
-    # modsecurity_rules_file /etc/nginx/modsecurity/modsecurity.conf;
-    {{ else }}
+    {{ if (empty $all.Cfg.ModsecuritySnippet) }}
     modsecurity_rules_file /etc/nginx/modsecurity/modsecurity.conf;
     {{ end }}
+    
     {{ if $all.Cfg.EnableOWASPCoreRules }}
     modsecurity_rules_file /etc/nginx/owasp-modsecurity-crs/nginx-modsecurity.conf;
     {{ end }}

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -153,9 +153,7 @@ http {
     modsecurity_rules '
       {{ $all.Cfg.ModsecuritySnippet }}
     ';
-    {{ end }}
-    
-    {{ if (empty $all.Cfg.ModsecuritySnippet) }}
+    {{ else }}
     modsecurity_rules_file /etc/nginx/modsecurity/modsecurity.conf;
     {{ end }}
     

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -154,9 +154,12 @@ http {
       {{ $all.Cfg.ModsecuritySnippet }}
     ';
     {{ end }}
-
+    
+    {{ if (not (empty $all.Cfg.ModsecuritySnippet)) }}
+    # modsecurity_rules_file /etc/nginx/modsecurity/modsecurity.conf;
+    {{ else }}
     modsecurity_rules_file /etc/nginx/modsecurity/modsecurity.conf;
-
+    {{ end }}
     {{ if $all.Cfg.EnableOWASPCoreRules }}
     modsecurity_rules_file /etc/nginx/owasp-modsecurity-crs/nginx-modsecurity.conf;
     {{ end }}

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -155,7 +155,7 @@ http {
     ';
     {{ end }}
     
-    {{ if (empty $all.Cfg.ModsecuritySnippet) }}
+    {{ if not $all.Cfg.ModsecuritySnippet }}
     modsecurity_rules_file /etc/nginx/modsecurity/modsecurity.conf;
     {{ end }}
     

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -155,7 +155,7 @@ http {
     ';
     {{ end }}
     
-    {{ if not $all.Cfg.ModsecuritySnippet }}
+    {{ if (empty $all.Cfg.ModsecuritySnippet) }}
     modsecurity_rules_file /etc/nginx/modsecurity/modsecurity.conf;
     {{ end }}
     

--- a/test/e2e/annotations/modsecurity/modsecurity.go
+++ b/test/e2e/annotations/modsecurity/modsecurity.go
@@ -342,7 +342,7 @@ var _ = framework.DescribeAnnotation("modsecurity owasp", func() {
 			Expect().
 			Status(http.StatusOK)
 	})
-	
+
 	ginkgo.It("should disable default modsecurity conf setting when modsecurity-snippet is specified", func() {
 		host := "modsecurity.foo.com"
 		nameSpace := f.Namespace

--- a/test/e2e/annotations/modsecurity/modsecurity.go
+++ b/test/e2e/annotations/modsecurity/modsecurity.go
@@ -342,4 +342,40 @@ var _ = framework.DescribeAnnotation("modsecurity owasp", func() {
 			Expect().
 			Status(http.StatusOK)
 	})
+	
+	ginkgo.It("should disable default modsecurity conf setting when modsecurity-snippet is specified", func() {
+		host := "modsecurity.foo.com"
+		nameSpace := f.Namespace
+
+		snippet := `SecRuleEngine On
+		SecRequestBodyAccess On
+		SecAuditEngine RelevantOnly
+		SecAuditLogParts ABIJDEFHZ
+		SecAuditLogType Concurrent
+		SecAuditLog /var/tmp/modsec_audit.log
+		SecAuditLogStorageDir /var/tmp/
+		SecRule REQUEST_HEADERS:User-Agent \"block-ua\" \"log,deny,id:107,status:403,msg:\'UA blocked\'\"`
+
+		annotations := map[string]string{
+			"nginx.ingress.kubernetes.io/enable-modsecurity":  "true",
+			"nginx.ingress.kubernetes.io/modsecurity-snippet": snippet,
+		}
+		f.UpdateNginxConfigMapData("annotation-value-word-blocklist", "load_module, lua_package, _by_lua, location, root, {, }")
+		// Sleep a while just to guarantee that the configmap is applied
+		framework.Sleep()
+		ing := framework.NewSingleIngress(host, "/", host, nameSpace, framework.EchoService, 80, annotations)
+		f.EnsureIngress(ing)
+
+		f.WaitForNginxServer(host,
+			func(server string) bool {
+				return !strings.Contains(server, "modsecurity_rules_file /etc/nginx/modsecurity/modsecurity.conf;")
+			})
+
+		f.HTTPTestClient().
+			GET("/").
+			WithHeader("Host", host).
+			WithHeader("User-Agent", "block-ua").
+			Expect().
+			Status(http.StatusForbidden)
+	})
 })

--- a/test/e2e/annotations/modsecurity/modsecurity.go
+++ b/test/e2e/annotations/modsecurity/modsecurity.go
@@ -368,7 +368,8 @@ var _ = framework.DescribeAnnotation("modsecurity owasp", func() {
 
 		f.WaitForNginxServer(host,
 			func(server string) bool {
-				return !strings.Contains(server, "modsecurity_rules_file /etc/nginx/modsecurity/modsecurity.conf;")
+				return !strings.Contains(server, "modsecurity_rules_file /etc/nginx/modsecurity/modsecurity.conf;") &&
+					strings.Contains(server, "SecAuditLog /var/tmp/modsec_audit.log")
 			})
 
 		f.HTTPTestClient().


### PR DESCRIPTION
The default modsecurity_rules_file (/etc/nginx/modsecurity/modsecurity.conf;) has settings that override the ModSecurity-snippet if it is specified with custom config settings like "SecAuditLog",  "SecAuditLogStorageDir" and "SecRuleEngine On". 

<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
To disable the  default modsecurity_rules_file (/etc/nginx/modsecurity/modsecurity.conf;) if custom modsecurity-snippet is specified

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes

[6307](https://github.com/kubernetes/ingress-nginx/issues/6307)
[6438](https://github.com/kubernetes/ingress-nginx/issues/6438)
[4640](https://github.com/kubernetes/ingress-nginx/issues/4640)


## How Has This Been Tested?

In the values yaml file have the config below
config:
      enable-modsecurity: "true"
      enable-owasp-modsecurity-crs: "false"
      modsecurity-snippet: |-
          SecRuleEngine On
          SecAuditEngine RelevantOnly
          SecAuditLogParts ABIJDEFHZ
          SecAuditLogRelevantStatus "^(?:05912300)"
          SecAuditLogType Concurrent
          SecAuditLog /var/tmp/modsec_audit.log
          SecAuditLogStorageDir /var/tmp/

Then deploying the latest nginx controller
helm upgrade --install --values your-values-with-config-above.yaml your-release-name ingress-nginx/ingress-nginx --version 4.0.13

After you deploy, exec into one nginx pod and browse " /etc/nginx/nginx.conf ". You will find after your modsecurity custom config the below line is included

      modsecurity_rules_file /etc/nginx/modsecurity/modsecurity.conf;

Browsing this file, you will find some settings that conflict with the settings in your "modsecurity-snippet: | " such as:
        
        SecRuleEngine DetectionOnly
        SecAuditLog /var/log/modsec_audit.log
        SecAuditLogStorageDir /var/log/audit/


Verification:
make some suspicious traffic to your nginx ingress such as

   curl http://your-url/index.html\?exec\=/bin/bash

Then when you exec into the nginx pod, you will see the logs are in "/var/log/modsec_audit.log" (from the default modsecurity file) instead of the customized configured one "/var/tmp/modsec_audit.log" in the (modsecurity-snippet)



This PR will not have this include file " modsecurity_rules_file /etc/nginx/modsecurity/modsecurity.conf" in the nginx configuration file. After deploying this PR, all the custom modsecurity-snippet will take effect and not be overridden.
Then if you do suspicious traffic to your nginx ingress like the one above,t he audit log will be /var/tmp/modsec_audit.log , and SecRuleEngine On will be on the blocking mode according to the rules in your modsecurity-snippet


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
