### PR TITLE
Comment busy owners

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,9 +1,7 @@
 # See the OWNERS docs: https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md
 
 approvers:
-- ingress-nginx-admins
 - ingress-nginx-maintainers
-- sig-network-leads
 
 reviewers:
 - ingress-nginx-reviewers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -9,16 +9,15 @@ aliases:
   ingress-nginx-admins:
   - bowei
   - rikatz
+  - strongjz
 
   ingress-nginx-maintainers:
   - ElvinEfendi
-  - justinsb
   - rikatz
   - strongjz
 
   ingress-nginx-reviewers:
   - ElvinEfendi
-  - cmluciano
   - rikatz
   - strongjz
   - tao12345666333

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -30,5 +30,10 @@ aliases:
   - ChiefAlexander
   - cpanato
 
+  ingress-nginx-docs-maintainers:
+  - IamNoah1
+  - longwuyuan
+  - tao12345666333
+
   ingress-nginx-kube-webhook-certgen-reviewers:
   - invidian

--- a/docs/OWNERS
+++ b/docs/OWNERS
@@ -1,4 +1,7 @@
 # See the OWNERS docs: https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md
 
+approvers:
+- ingress-nginx-docs-maintainers
+
 labels:
 - area/docs


### PR DESCRIPTION
As a user, it's frustrating when you add a PR, then wait for someone to review and the bot assign two persons not able to do so :)

We are thankful for all the past reviewers and approvers here and welcome they all to contribute as soon as they are able!

While that, we need to make the bot stop assigning them reviews or approvals and leave users waiting.

And we welcome all the new reviewers and approvers :)

