### PR TITLE
docs_multiple_instances_one_cluster_ticket_7543

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -125,7 +125,7 @@ spec:
 And add the value "spec.ingressClassName=nginx" in your Ingress objects
 
 ## I have multiple ingress objects in my cluster. What should I do ?
-- If you don't care about ingressClass, or you have a lot of ingress objects without ingressClass configuration, you can run the ingress-controller with the flag `--watch-ingress-without-class=true`.
+- If you have lot of ingress objects without ingressClass configuration, you can run the ingress-controller with the flag `--watch-ingress-without-class=true`.
 
 ## What is the flag '--watch-ingress-without-class' ?
 - Its a flag that is passed,as an argument, to the ingress-controller executable, in the pod spec. It looks like this ;

--- a/docs/user-guide/multiple-ingress.md
+++ b/docs/user-guide/multiple-ingress.md
@@ -2,13 +2,14 @@
 
 By default, deploying multiple Ingress controllers (e.g., `ingress-nginx` & `gce`) will result in all controllers simultaneously racing to update Ingress status fields in confusing ways.
 
-To fix this problem, you can either use [IngressClasses](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class) (preferred) or use the `kubernetes.io/ingress.class` annotation (in deprecation).
+To fix this problem, use [IngressClasses](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class), the `kubernetes.io/ingress.class` annotation  is deprecated from kubernetes v1.22+.
 
 ## Using IngressClasses
 
 If all ingress controllers respect IngressClasses (e.g. multiple instances of ingress-nginx v1.0), you can deploy two Ingress controllers by granting them control over two different IngressClasses, then selecting one of the two IngressClasses with `ingressClassName`.
+When two or more 
 
-First, ensure the `--controller-class=` is set to something different on each ingress controller:
+First, ensure the `--controller-class=` and `--ingress-class` are set to something different on each ingress controller:
 
 ```yaml
 # ingress-nginx Deployment/Statfulset
@@ -19,7 +20,8 @@ spec:
          - name: ingress-nginx-internal-controller
            args:
              - /nginx-ingress-controller
-             - '--controller-class=k8s.io/internal-ingress-nginx'
+             - '--controller-class=k8s.io/internal-nginx'
+             - '--ingress-class=k8s.io/internal-nginx'
             ...
 ```
 


### PR DESCRIPTION
This pull request is for the documentation for ticket 7543 - docs on using multiple instances of Ingress-NGINX in one cluster are outdated - created by Long Wu Yuan. Since the `kubernetes.io/ingress.class` annotation is deprecated and users are being encouraged to use ingressClass for multiple ingress controllers, the document is updated. 
Please review the doc and give your suggestions.