### PR TITLE
docs(charts): using helm-docs for chart

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -123,6 +123,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '^1.17'
+
       - name: cache
         uses: actions/download-artifact@v2
         with:
@@ -131,6 +136,13 @@ jobs:
       - name: Lint
         run: |
           ./build/run-in-docker.sh ./hack/verify-chart-lint.sh
+
+      - name: Run helm-docs
+        run: |
+          GOBIN=$PWD GO111MODULE=on go install github.com/norwoodj/helm-docs/cmd/helm-docs@v1.6.0
+          ./helm-docs --chart-search-root=${GITHUB_WORKSPACE}/charts
+          git diff --exit-code
+          rm -f ./helm-docs
 
       - name: fix permissions
         run: |

--- a/charts/ingress-nginx/CHANGELOG.md
+++ b/charts/ingress-nginx/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file documents all notable changes to [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+### 4.0.14
+
+- [8061] https://github.com/kubernetes/ingress-nginx/pull/8061 Using helm-docs to populate values table in README.md
+
 ### 4.0.13
 
 - [8008] https://github.com/kubernetes/ingress-nginx/pull/8008 Add relabelings in controller-servicemonitor.yaml

--- a/charts/ingress-nginx/Chart.yaml
+++ b/charts/ingress-nginx/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ingress-nginx
 # When the version is modified, make sure the artifacthub.io/changes list is updated
 # Also update CHANGELOG.md
-version: 4.0.13
+version: 4.0.14
 appVersion: 1.1.0
 home: https://github.com/kubernetes/ingress-nginx
 description: Ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer
@@ -24,4 +24,4 @@ annotations:
   # List of changes for the release in artifacthub.io
   # https://artifacthub.io/packages/helm/ingress-nginx/ingress-nginx?modal=changelog
   artifacthub.io/changes: |
-    - use controller v1.1.0
+    - using helm-docs to populate values table in README.md

--- a/charts/ingress-nginx/README.md
+++ b/charts/ingress-nginx/README.md
@@ -2,6 +2,8 @@
 
 [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer
 
+![Version: 4.0.14](https://img.shields.io/badge/Version-4.0.14-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
+
 To use, add `ingressClassName: nginx` spec field or the `kubernetes.io/ingress.class: nginx` annotation to your Ingress resources.
 
 This chart bootstraps an ingress-nginx deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
@@ -226,3 +228,254 @@ Error: UPGRADE FAILED: Service "?????-controller" is invalid: spec.clusterIP: In
 Detail of how and why are in [this issue](https://github.com/helm/charts/pull/13646) but to resolve this you can set `xxxx.service.omitClusterIP` to `true` where `xxxx` is the service referenced in the error.
 
 As of version `1.26.0` of this chart, by simply not providing any clusterIP value, `invalid: spec.clusterIP: Invalid value: "": field is immutable` will no longer occur since `clusterIP: ""` will not be rendered.
+
+## Requirements
+
+Kubernetes: `>=1.19.0-0`
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| controller.addHeaders | object | `{}` | Will add custom headers before sending response traffic to the client according to: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#add-headers |
+| controller.admissionWebhooks.annotations | object | `{}` |  |
+| controller.admissionWebhooks.certificate | string | `"/usr/local/certificates/cert"` |  |
+| controller.admissionWebhooks.createSecretJob.resources | object | `{}` |  |
+| controller.admissionWebhooks.enabled | bool | `true` |  |
+| controller.admissionWebhooks.existingPsp | string | `""` | Use an existing PSP instead of creating one |
+| controller.admissionWebhooks.failurePolicy | string | `"Fail"` |  |
+| controller.admissionWebhooks.key | string | `"/usr/local/certificates/key"` |  |
+| controller.admissionWebhooks.labels | object | `{}` | Labels to be added to admission webhooks |
+| controller.admissionWebhooks.namespaceSelector | object | `{}` |  |
+| controller.admissionWebhooks.objectSelector | object | `{}` |  |
+| controller.admissionWebhooks.patch.enabled | bool | `true` |  |
+| controller.admissionWebhooks.patch.image.digest | string | `"sha256:64d8c73dca984af206adf9d6d7e46aa550362b1d7a01f3a0a91b20cc67868660"` |  |
+| controller.admissionWebhooks.patch.image.image | string | `"ingress-nginx/kube-webhook-certgen"` |  |
+| controller.admissionWebhooks.patch.image.pullPolicy | string | `"IfNotPresent"` |  |
+| controller.admissionWebhooks.patch.image.registry | string | `"k8s.gcr.io"` |  |
+| controller.admissionWebhooks.patch.image.tag | string | `"v1.1.1"` |  |
+| controller.admissionWebhooks.patch.labels | object | `{}` | Labels to be added to patch job resources |
+| controller.admissionWebhooks.patch.nodeSelector."kubernetes.io/os" | string | `"linux"` |  |
+| controller.admissionWebhooks.patch.podAnnotations | object | `{}` |  |
+| controller.admissionWebhooks.patch.priorityClassName | string | `""` | Provide a priority class name to the webhook patching job |
+| controller.admissionWebhooks.patch.runAsUser | int | `2000` |  |
+| controller.admissionWebhooks.patch.tolerations | list | `[]` |  |
+| controller.admissionWebhooks.patchWebhookJob.resources | object | `{}` |  |
+| controller.admissionWebhooks.port | int | `8443` |  |
+| controller.admissionWebhooks.service.annotations | object | `{}` |  |
+| controller.admissionWebhooks.service.externalIPs | list | `[]` |  |
+| controller.admissionWebhooks.service.loadBalancerSourceRanges | list | `[]` |  |
+| controller.admissionWebhooks.service.servicePort | int | `443` |  |
+| controller.admissionWebhooks.service.type | string | `"ClusterIP"` |  |
+| controller.affinity | object | `{}` | Affinity and anti-affinity rules for server scheduling to nodes |
+| controller.allowSnippetAnnotations | bool | `true` | This configuration defines if Ingress Controller should allow users to set their own *-snippet annotations, otherwise this is forbidden / dropped when users add those annotations. Global snippets in ConfigMap are still respected |
+| controller.annotations | object | `{}` | Annotations to be added to the controller Deployment or DaemonSet |
+| controller.autoscaling.behavior | object | `{}` |  |
+| controller.autoscaling.enabled | bool | `false` |  |
+| controller.autoscaling.maxReplicas | int | `11` |  |
+| controller.autoscaling.minReplicas | int | `1` |  |
+| controller.autoscaling.targetCPUUtilizationPercentage | int | `50` |  |
+| controller.autoscaling.targetMemoryUtilizationPercentage | int | `50` |  |
+| controller.autoscalingTemplate | list | `[]` |  |
+| controller.config | object | `{}` | Will add custom configuration options to Nginx https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/ |
+| controller.configAnnotations | object | `{}` | Annotations to be added to the controller config configuration configmap |
+| controller.configMapNamespace | string | `""` | Allows customization of the configmap / nginx-configmap namespace; defaults to $(POD_NAMESPACE) |
+| controller.containerName | string | `"controller"` | Configures the controller container name |
+| controller.containerPort | object | `{"http":80,"https":443}` | Configures the ports the nginx-controller listens on |
+| controller.customTemplate.configMapKey | string | `""` |  |
+| controller.customTemplate.configMapName | string | `""` |  |
+| controller.dnsConfig | object | `{}` | Optionally customize the pod dnsConfig. |
+| controller.dnsPolicy | string | `"ClusterFirst"` | Optionally change this to ClusterFirstWithHostNet in case you have 'hostNetwork: true'. By default, while using host network, name resolution uses the host's DNS. If you wish nginx-controller to keep resolving names inside the k8s network, use ClusterFirstWithHostNet. |
+| controller.electionID | string | `"ingress-controller-leader"` | Election ID to use for status update |
+| controller.enableMimalloc | bool | `true` | Enable mimalloc as a drop-in replacement for malloc. |
+| controller.existingPsp | string | `""` | Use an existing PSP instead of creating one |
+| controller.extraArgs | object | `{}` | Additional command line arguments to pass to nginx-ingress-controller E.g. to specify the default SSL certificate you can use |
+| controller.extraContainers | list | `[]` | Additional containers to be added to the controller pod. See https://github.com/lemonldap-ng-controller/lemonldap-ng-controller as example. |
+| controller.extraEnvs | list | `[]` | Additional environment variables to set |
+| controller.extraInitContainers | list | `[]` | Containers, which are run before the app containers are started. |
+| controller.extraVolumeMounts | list | `[]` | Additional volumeMounts to the controller main container. |
+| controller.extraVolumes | list | `[]` | Additional volumes to the controller pod. |
+| controller.healthCheckHost | string | `""` | Address to bind the health check endpoint. It is better to set this option to the internal node address if the ingress nginx controller is running in the `hostNetwork: true` mode. |
+| controller.healthCheckPath | string | `"/healthz"` | Path of the health check endpoint. All requests received on the port defined by the healthz-port parameter are forwarded internally to this path. |
+| controller.hostNetwork | bool | `false` | Required for use with CNI based kubernetes installations (such as ones set up by kubeadm), since CNI and hostport don't mix yet. Can be deprecated once https://github.com/kubernetes/kubernetes/issues/23920 is merged |
+| controller.hostPort.enabled | bool | `false` | Enable 'hostPort' or not |
+| controller.hostPort.ports.http | int | `80` | 'hostPort' http port |
+| controller.hostPort.ports.https | int | `443` | 'hostPort' https port |
+| controller.hostname | object | `{}` | Optionally customize the pod hostname. |
+| controller.image.allowPrivilegeEscalation | bool | `true` |  |
+| controller.image.digest | string | `"sha256:f766669fdcf3dc26347ed273a55e754b427eb4411ee075a53f30718b4499076a"` |  |
+| controller.image.image | string | `"ingress-nginx/controller"` |  |
+| controller.image.pullPolicy | string | `"IfNotPresent"` |  |
+| controller.image.registry | string | `"k8s.gcr.io"` |  |
+| controller.image.runAsUser | int | `101` |  |
+| controller.image.tag | string | `"v1.1.0"` |  |
+| controller.ingressClassByName | bool | `false` | Process IngressClass per name (additionally as per spec.controller) |
+| controller.ingressClassResource.controllerValue | string | `"k8s.io/ingress-nginx"` |  |
+| controller.ingressClassResource.default | bool | `false` |  |
+| controller.ingressClassResource.enabled | bool | `true` |  |
+| controller.ingressClassResource.name | string | `"nginx"` |  |
+| controller.ingressClassResource.parameters | object | `{}` | Parameters is a link to a custom resource containing additional configuration for the controller. This is optional if the controller does not require extra parameters. |
+| controller.keda.apiVersion | string | `"keda.sh/v1alpha1"` |  |
+| controller.keda.behavior | object | `{}` |  |
+| controller.keda.cooldownPeriod | int | `300` |  |
+| controller.keda.enabled | bool | `false` |  |
+| controller.keda.maxReplicas | int | `11` |  |
+| controller.keda.minReplicas | int | `1` |  |
+| controller.keda.pollingInterval | int | `30` |  |
+| controller.keda.restoreToOriginalReplicaCount | bool | `false` |  |
+| controller.keda.scaledObject.annotations | object | `{}` |  |
+| controller.keda.triggers | list | `[]` |  |
+| controller.kind | string | `"Deployment"` | Use a `DaemonSet` or `Deployment` |
+| controller.labels | object | `{}` | Labels to be added to the controller Deployment or DaemonSet and other resources that do not have option to specify labels |
+| controller.lifecycle | object | `{"preStop":{"exec":{"command":["/wait-shutdown"]}}}` | Improve connection draining when ingress controller pod is deleted using a lifecycle hook: With this new hook, we increased the default terminationGracePeriodSeconds from 30 seconds to 300, allowing the draining of connections up to five minutes. If the active connections end before that, the pod will terminate gracefully at that time. To effectively take advantage of this feature, the Configmap feature worker-shutdown-timeout new value is 240s instead of 10s. |
+| controller.livenessProbe.failureThreshold | int | `5` |  |
+| controller.livenessProbe.httpGet.path | string | `"/healthz"` |  |
+| controller.livenessProbe.httpGet.port | int | `10254` |  |
+| controller.livenessProbe.httpGet.scheme | string | `"HTTP"` |  |
+| controller.livenessProbe.initialDelaySeconds | int | `10` |  |
+| controller.livenessProbe.periodSeconds | int | `10` |  |
+| controller.livenessProbe.successThreshold | int | `1` |  |
+| controller.livenessProbe.timeoutSeconds | int | `1` |  |
+| controller.maxmindLicenseKey | string | `""` | Maxmind license key to download GeoLite2 Databases. |
+| controller.metrics.enabled | bool | `false` |  |
+| controller.metrics.port | int | `10254` |  |
+| controller.metrics.prometheusRule.additionalLabels | object | `{}` |  |
+| controller.metrics.prometheusRule.enabled | bool | `false` |  |
+| controller.metrics.prometheusRule.rules | list | `[]` |  |
+| controller.metrics.service.annotations | object | `{}` |  |
+| controller.metrics.service.externalIPs | list | `[]` | List of IP addresses at which the stats-exporter service is available |
+| controller.metrics.service.loadBalancerSourceRanges | list | `[]` |  |
+| controller.metrics.service.servicePort | int | `10254` |  |
+| controller.metrics.service.type | string | `"ClusterIP"` |  |
+| controller.metrics.serviceMonitor.additionalLabels | object | `{}` |  |
+| controller.metrics.serviceMonitor.enabled | bool | `false` |  |
+| controller.metrics.serviceMonitor.metricRelabelings | list | `[]` |  |
+| controller.metrics.serviceMonitor.namespace | string | `""` |  |
+| controller.metrics.serviceMonitor.namespaceSelector | object | `{}` |  |
+| controller.metrics.serviceMonitor.relabelings | list | `[]` |  |
+| controller.metrics.serviceMonitor.scrapeInterval | string | `"30s"` |  |
+| controller.metrics.serviceMonitor.targetLabels | list | `[]` |  |
+| controller.minAvailable | int | `1` |  |
+| controller.minReadySeconds | int | `0` | `minReadySeconds` to avoid killing pods before we are ready |
+| controller.name | string | `"controller"` |  |
+| controller.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for controller pod assignment |
+| controller.podAnnotations | object | `{}` | Annotations to be added to controller pods |
+| controller.podLabels | object | `{}` | Labels to add to the pod container metadata |
+| controller.podSecurityContext | object | `{}` | Security Context policies for controller pods |
+| controller.priorityClassName | string | `""` |  |
+| controller.proxySetHeaders | object | `{}` | Will add custom headers before sending traffic to backends according to https://github.com/kubernetes/ingress-nginx/tree/main/docs/examples/customization/custom-headers |
+| controller.publishService | object | `{"enabled":true,"pathOverride":""}` | Allows customization of the source of the IP address or FQDN to report in the ingress status field. By default, it reads the information provided by the service. If disable, the status field reports the IP address of the node or nodes where an ingress controller pod is running. |
+| controller.publishService.enabled | bool | `true` | Enable 'publishService' or not |
+| controller.publishService.pathOverride | string | `""` | Allows overriding of the publish service to bind to Must be <namespace>/<service_name> |
+| controller.readinessProbe.failureThreshold | int | `3` |  |
+| controller.readinessProbe.httpGet.path | string | `"/healthz"` |  |
+| controller.readinessProbe.httpGet.port | int | `10254` |  |
+| controller.readinessProbe.httpGet.scheme | string | `"HTTP"` |  |
+| controller.readinessProbe.initialDelaySeconds | int | `10` |  |
+| controller.readinessProbe.periodSeconds | int | `10` |  |
+| controller.readinessProbe.successThreshold | int | `1` |  |
+| controller.readinessProbe.timeoutSeconds | int | `1` |  |
+| controller.replicaCount | int | `1` |  |
+| controller.reportNodeInternalIp | bool | `false` | Bare-metal considerations via the host network https://kubernetes.github.io/ingress-nginx/deploy/baremetal/#via-the-host-network Ingress status was blank because there is no Service exposing the NGINX Ingress controller in a configuration using the host network, the default --publish-service flag used in standard cloud setups does not apply |
+| controller.resources.requests.cpu | string | `"100m"` |  |
+| controller.resources.requests.memory | string | `"90Mi"` |  |
+| controller.scope.enabled | bool | `false` | Enable 'scope' or not |
+| controller.scope.namespace | string | `""` | Namespace to limit the controller to; defaults to $(POD_NAMESPACE) |
+| controller.scope.namespaceSelector | string | `""` | When scope.enabled == false, instead of watching all namespaces, we watching namespaces whose labels only match with namespaceSelector. Format like foo=bar. Defaults to empty, means watching all namespaces. |
+| controller.service.annotations | object | `{}` |  |
+| controller.service.appProtocol | bool | `true` | If enabled is adding an appProtocol option for Kubernetes service. An appProtocol field replacing annotations that were using for setting a backend protocol. Here is an example for AWS: service.beta.kubernetes.io/aws-load-balancer-backend-protocol: http It allows choosing the protocol for each backend specified in the Kubernetes service. See the following GitHub issue for more details about the purpose: https://github.com/kubernetes/kubernetes/issues/40244 Will be ignored for Kubernetes versions older than 1.20 |
+| controller.service.enableHttp | bool | `true` |  |
+| controller.service.enableHttps | bool | `true` |  |
+| controller.service.enabled | bool | `true` |  |
+| controller.service.external.enabled | bool | `true` |  |
+| controller.service.externalIPs | list | `[]` | List of IP addresses at which the controller services are available |
+| controller.service.internal.annotations | object | `{}` | Annotations are mandatory for the load balancer to come up. Varies with the cloud service. |
+| controller.service.internal.enabled | bool | `false` | Enables an additional internal load balancer (besides the external one). |
+| controller.service.internal.loadBalancerSourceRanges | list | `[]` | Restrict access For LoadBalancer service. Defaults to 0.0.0.0/0. |
+| controller.service.ipFamilies | list | `["IPv4"]` | List of IP families (e.g. IPv4, IPv6) assigned to the service. This field is usually assigned automatically based on cluster configuration and the ipFamilyPolicy field. |
+| controller.service.ipFamilyPolicy | string | `"SingleStack"` | Represents the dual-stack-ness requested or required by this Service. Possible values are SingleStack, PreferDualStack or RequireDualStack. The ipFamilies and clusterIPs fields depend on the value of this field. |
+| controller.service.labels | object | `{}` |  |
+| controller.service.loadBalancerSourceRanges | list | `[]` |  |
+| controller.service.nodePorts.http | string | `""` |  |
+| controller.service.nodePorts.https | string | `""` |  |
+| controller.service.nodePorts.tcp | object | `{}` |  |
+| controller.service.nodePorts.udp | object | `{}` |  |
+| controller.service.ports.http | int | `80` |  |
+| controller.service.ports.https | int | `443` |  |
+| controller.service.targetPorts.http | string | `"http"` |  |
+| controller.service.targetPorts.https | string | `"https"` |  |
+| controller.service.type | string | `"LoadBalancer"` |  |
+| controller.sysctls | object | `{}` | See https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster/ for notes on enabling and using sysctls |
+| controller.tcp.annotations | object | `{}` | Annotations to be added to the tcp config configmap |
+| controller.tcp.configMapNamespace | string | `""` | Allows customization of the tcp-services-configmap; defaults to $(POD_NAMESPACE) |
+| controller.terminationGracePeriodSeconds | int | `300` | `terminationGracePeriodSeconds` to avoid killing pods before we are ready |
+| controller.tolerations | list | `[]` | Node tolerations for server scheduling to nodes with taints |
+| controller.topologySpreadConstraints | list | `[]` | Topology spread constraints rely on node labels to identify the topology domain(s) that each Node is in. |
+| controller.udp.annotations | object | `{}` | Annotations to be added to the udp config configmap |
+| controller.udp.configMapNamespace | string | `""` | Allows customization of the udp-services-configmap; defaults to $(POD_NAMESPACE) |
+| controller.updateStrategy | object | `{}` | The update strategy to apply to the Deployment or DaemonSet |
+| controller.watchIngressWithoutClass | bool | `false` | Process Ingress objects without ingressClass annotation/ingressClassName field Overrides value for --watch-ingress-without-class flag of the controller binary Defaults to false |
+| defaultBackend.affinity | object | `{}` |  |
+| defaultBackend.autoscaling.annotations | object | `{}` |  |
+| defaultBackend.autoscaling.enabled | bool | `false` |  |
+| defaultBackend.autoscaling.maxReplicas | int | `2` |  |
+| defaultBackend.autoscaling.minReplicas | int | `1` |  |
+| defaultBackend.autoscaling.targetCPUUtilizationPercentage | int | `50` |  |
+| defaultBackend.autoscaling.targetMemoryUtilizationPercentage | int | `50` |  |
+| defaultBackend.containerSecurityContext | object | `{}` | Security Context policies for controller main container. See https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster/ for notes on enabling and using sysctls |
+| defaultBackend.enabled | bool | `false` |  |
+| defaultBackend.existingPsp | string | `""` | Use an existing PSP instead of creating one |
+| defaultBackend.extraArgs | object | `{}` |  |
+| defaultBackend.extraEnvs | list | `[]` | Additional environment variables to set for defaultBackend pods |
+| defaultBackend.extraVolumeMounts | list | `[]` |  |
+| defaultBackend.extraVolumes | list | `[]` |  |
+| defaultBackend.image.allowPrivilegeEscalation | bool | `false` |  |
+| defaultBackend.image.image | string | `"defaultbackend-amd64"` |  |
+| defaultBackend.image.pullPolicy | string | `"IfNotPresent"` |  |
+| defaultBackend.image.readOnlyRootFilesystem | bool | `true` |  |
+| defaultBackend.image.registry | string | `"k8s.gcr.io"` |  |
+| defaultBackend.image.runAsNonRoot | bool | `true` |  |
+| defaultBackend.image.runAsUser | int | `65534` |  |
+| defaultBackend.image.tag | string | `"1.5"` |  |
+| defaultBackend.labels | object | `{}` | Labels to be added to the default backend resources |
+| defaultBackend.livenessProbe.failureThreshold | int | `3` |  |
+| defaultBackend.livenessProbe.initialDelaySeconds | int | `30` |  |
+| defaultBackend.livenessProbe.periodSeconds | int | `10` |  |
+| defaultBackend.livenessProbe.successThreshold | int | `1` |  |
+| defaultBackend.livenessProbe.timeoutSeconds | int | `5` |  |
+| defaultBackend.minAvailable | int | `1` |  |
+| defaultBackend.name | string | `"defaultbackend"` |  |
+| defaultBackend.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for default backend pod assignment |
+| defaultBackend.podAnnotations | object | `{}` | Annotations to be added to default backend pods |
+| defaultBackend.podLabels | object | `{}` | Labels to add to the pod container metadata |
+| defaultBackend.podSecurityContext | object | `{}` | Security Context policies for controller pods See https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster/ for notes on enabling and using sysctls |
+| defaultBackend.port | int | `8080` |  |
+| defaultBackend.priorityClassName | string | `""` |  |
+| defaultBackend.readinessProbe.failureThreshold | int | `6` |  |
+| defaultBackend.readinessProbe.initialDelaySeconds | int | `0` |  |
+| defaultBackend.readinessProbe.periodSeconds | int | `5` |  |
+| defaultBackend.readinessProbe.successThreshold | int | `1` |  |
+| defaultBackend.readinessProbe.timeoutSeconds | int | `5` |  |
+| defaultBackend.replicaCount | int | `1` |  |
+| defaultBackend.resources | object | `{}` |  |
+| defaultBackend.service.annotations | object | `{}` |  |
+| defaultBackend.service.externalIPs | list | `[]` | List of IP addresses at which the default backend service is available |
+| defaultBackend.service.loadBalancerSourceRanges | list | `[]` |  |
+| defaultBackend.service.servicePort | int | `80` |  |
+| defaultBackend.service.type | string | `"ClusterIP"` |  |
+| defaultBackend.serviceAccount.automountServiceAccountToken | bool | `true` |  |
+| defaultBackend.serviceAccount.create | bool | `true` |  |
+| defaultBackend.serviceAccount.name | string | `""` |  |
+| defaultBackend.tolerations | list | `[]` | Node tolerations for server scheduling to nodes with taints |
+| dhParam | string | `nil` | A base64-encoded Diffie-Hellman parameter. This can be generated with: `openssl dhparam 4096 2> /dev/null | base64` |
+| imagePullSecrets | list | `[]` | Optional array of imagePullSecrets containing private registry credentials |
+| podSecurityPolicy.enabled | bool | `false` |  |
+| rbac.create | bool | `true` |  |
+| rbac.scope | bool | `false` |  |
+| revisionHistoryLimit | int | `10` | Rollback limit |
+| serviceAccount.automountServiceAccountToken | bool | `true` |  |
+| serviceAccount.create | bool | `true` |  |
+| serviceAccount.name | string | `""` |  |
+| tcp | object | `{}` | TCP service key:value pairs |
+| udp | object | `{}` | UDP service key:value pairs |
+

--- a/charts/ingress-nginx/README.md.gotmpl
+++ b/charts/ingress-nginx/README.md.gotmpl
@@ -1,0 +1,235 @@
+{{ template "chart.header" . }}
+[ingress-nginx](https://github.com/kubernetes/ingress-nginx) Ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer
+
+{{ template "chart.versionBadge" . }}{{ template "chart.typeBadge" . }}{{ template "chart.appVersionBadge" . }}
+
+To use, add `ingressClassName: nginx` spec field or the `kubernetes.io/ingress.class: nginx` annotation to your Ingress resources.
+
+This chart bootstraps an ingress-nginx deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Prerequisites
+
+- Chart version 3.x.x: Kubernetes v1.16+
+- Chart version 4.x.x and above: Kubernetes v1.19+
+
+## Get Repo Info
+
+```console
+helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+helm repo update
+```
+
+## Install Chart
+
+**Important:** only helm3 is supported
+
+```console
+helm install [RELEASE_NAME] ingress-nginx/ingress-nginx
+```
+
+The command deploys ingress-nginx on the Kubernetes cluster in the default configuration.
+
+_See [configuration](#configuration) below._
+
+_See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._
+
+## Uninstall Chart
+
+```console
+helm uninstall [RELEASE_NAME]
+```
+
+This removes all the Kubernetes components associated with the chart and deletes the release.
+
+_See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command documentation._
+
+## Upgrading Chart
+
+```console
+helm upgrade [RELEASE_NAME] [CHART] --install
+```
+
+_See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
+
+### Upgrading With Zero Downtime in Production
+
+By default the ingress-nginx controller has service interruptions whenever it's pods are restarted or redeployed. In order to fix that, see the excellent blog post by Lindsay Landry from Codecademy: [Kubernetes: Nginx and Zero Downtime in Production](https://medium.com/codecademy-engineering/kubernetes-nginx-and-zero-downtime-in-production-2c910c6a5ed8).
+
+### Migrating from stable/nginx-ingress
+
+There are two main ways to migrate a release from `stable/nginx-ingress` to `ingress-nginx/ingress-nginx` chart:
+
+1. For Nginx Ingress controllers used for non-critical services, the easiest method is to [uninstall](#uninstall-chart) the old release and [install](#install-chart) the new one
+1. For critical services in production that require zero-downtime, you will want to:
+    1. [Install](#install-chart) a second Ingress controller
+    1. Redirect your DNS traffic from the old controller to the new controller
+    1. Log traffic from both controllers during this changeover
+    1. [Uninstall](#uninstall-chart) the old controller once traffic has fully drained from it
+    1. For details on all of these steps see [Upgrading With Zero Downtime in Production](#upgrading-with-zero-downtime-in-production)
+
+Note that there are some different and upgraded configurations between the two charts, described by Rimas Mocevicius from JFrog in the "Upgrading to ingress-nginx Helm chart" section of [Migrating from Helm chart nginx-ingress to ingress-nginx](https://rimusz.net/migrating-to-ingress-nginx). As the `ingress-nginx/ingress-nginx` chart continues to update, you will want to check current differences by running [helm configuration](#configuration) commands on both charts.
+
+## Configuration
+
+See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments, visit the chart's [values.yaml](./values.yaml), or run these configuration commands:
+
+```console
+helm show values ingress-nginx/ingress-nginx
+```
+
+### PodDisruptionBudget
+
+Note that the PodDisruptionBudget resource will only be defined if the replicaCount is greater than one,
+else it would make it impossible to evacuate a node. See [gh issue #7127](https://github.com/helm/charts/issues/7127) for more info.
+
+### Prometheus Metrics
+
+The Nginx ingress controller can export Prometheus metrics, by setting `controller.metrics.enabled` to `true`.
+
+You can add Prometheus annotations to the metrics service using `controller.metrics.service.annotations`.
+Alternatively, if you use the Prometheus Operator, you can enable ServiceMonitor creation using `controller.metrics.serviceMonitor.enabled`. And set `controller.metrics.serviceMonitor.additionalLabels.release="prometheus"`. "release=prometheus" should match the label configured in the prometheus servicemonitor ( see `kubectl get servicemonitor prometheus-kube-prom-prometheus -oyaml -n prometheus`)
+
+### ingress-nginx nginx\_status page/stats server
+
+Previous versions of this chart had a `controller.stats.*` configuration block, which is now obsolete due to the following changes in nginx ingress controller:
+
+- In [0.16.1](https://github.com/kubernetes/ingress-nginx/blob/main/Changelog.md#0161), the vts (virtual host traffic status) dashboard was removed
+- In [0.23.0](https://github.com/kubernetes/ingress-nginx/blob/main/Changelog.md#0230), the status page at port 18080 is now a unix socket webserver only available at localhost.
+  You can use `curl --unix-socket /tmp/nginx-status-server.sock http://localhost/nginx_status` inside the controller container to access it locally, or use the snippet from [nginx-ingress changelog](https://github.com/kubernetes/ingress-nginx/blob/main/Changelog.md#0230) to re-enable the http server
+
+### ExternalDNS Service Configuration
+
+Add an [ExternalDNS](https://github.com/kubernetes-incubator/external-dns) annotation to the LoadBalancer service:
+
+```yaml
+controller:
+  service:
+    annotations:
+      external-dns.alpha.kubernetes.io/hostname: kubernetes-example.com.
+```
+
+### AWS L7 ELB with SSL Termination
+
+Annotate the controller as shown in the [nginx-ingress l7 patch](https://github.com/kubernetes/ingress-nginx/blob/main/deploy/aws/l7/service-l7.yaml):
+
+```yaml
+controller:
+  service:
+    targetPorts:
+      http: http
+      https: http
+    annotations:
+      service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:XX-XXXX-X:XXXXXXXXX:certificate/XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXX
+      service.beta.kubernetes.io/aws-load-balancer-backend-protocol: "http"
+      service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "https"
+      service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: '3600'
+```
+
+### AWS route53-mapper
+
+To configure the LoadBalancer service with the [route53-mapper addon](https://github.com/kubernetes/kops/tree/master/addons/route53-mapper), add the `domainName` annotation and `dns` label:
+
+```yaml
+controller:
+  service:
+    labels:
+      dns: "route53"
+    annotations:
+      domainName: "kubernetes-example.com"
+```
+
+### Additional Internal Load Balancer
+
+This setup is useful when you need both external and internal load balancers but don't want to have multiple ingress controllers and multiple ingress objects per application.
+
+By default, the ingress object will point to the external load balancer address, but if correctly configured, you can make use of the internal one if the URL you are looking up resolves to the internal load balancer's URL.
+
+You'll need to set both the following values:
+
+`controller.service.internal.enabled`
+`controller.service.internal.annotations`
+
+If one of them is missing the internal load balancer will not be deployed. Example you may have `controller.service.internal.enabled=true` but no annotations set, in this case no action will be taken.
+
+`controller.service.internal.annotations` varies with the cloud service you're using.
+
+Example for AWS:
+
+```yaml
+controller:
+  service:
+    internal:
+      enabled: true
+      annotations:
+        # Create internal ELB
+        service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+        # Any other annotation can be declared here.
+```
+
+Example for GCE:
+
+```yaml
+controller:
+  service:
+    internal:
+      enabled: true
+      annotations:
+        # Create internal LB. More informations: https://cloud.google.com/kubernetes-engine/docs/how-to/internal-load-balancing
+        # For GKE versions 1.17 and later
+        networking.gke.io/load-balancer-type: "Internal"
+        # For earlier versions
+        # cloud.google.com/load-balancer-type: "Internal"
+
+        # Any other annotation can be declared here.
+```
+
+Example for Azure:
+
+```yaml
+controller:
+  service:
+      annotations:
+        # Create internal LB
+        service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+        # Any other annotation can be declared here.
+```
+
+Example for Oracle Cloud Infrastructure:
+
+```yaml
+controller:
+  service:
+      annotations:
+        # Create internal LB
+        service.beta.kubernetes.io/oci-load-balancer-internal: "true"
+        # Any other annotation can be declared here.
+```
+
+An use case for this scenario is having a split-view DNS setup where the public zone CNAME records point to the external balancer URL while the private zone CNAME records point to the internal balancer URL. This way, you only need one ingress kubernetes object.
+
+Optionally you can set `controller.service.loadBalancerIP` if you need a static IP for the resulting `LoadBalancer`.
+
+### Ingress Admission Webhooks
+
+With nginx-ingress-controller version 0.25+, the nginx ingress controller pod exposes an endpoint that will integrate with the `validatingwebhookconfiguration` Kubernetes feature to prevent bad ingress from being added to the cluster.
+**This feature is enabled by default since 0.31.0.**
+
+With nginx-ingress-controller in 0.25.* work only with kubernetes 1.14+, 0.26 fix [this issue](https://github.com/kubernetes/ingress-nginx/pull/4521)
+
+### Helm Error When Upgrading: spec.clusterIP: Invalid value: ""
+
+If you are upgrading this chart from a version between 0.31.0 and 1.2.2 then you may get an error like this:
+
+```console
+Error: UPGRADE FAILED: Service "?????-controller" is invalid: spec.clusterIP: Invalid value: "": field is immutable
+```
+
+Detail of how and why are in [this issue](https://github.com/helm/charts/pull/13646) but to resolve this you can set `xxxx.service.omitClusterIP` to `true` where `xxxx` is the service referenced in the error.
+
+As of version `1.26.0` of this chart, by simply not providing any clusterIP value, `invalid: spec.clusterIP: Invalid value: "": field is immutable` will no longer occur since `clusterIP: ""` will not be rendered.
+
+{{ template "chart.requirementsSection" . }}
+
+{{ template "chart.valuesSection" . }}
+
+{{ template "helm-docs.versionFooter" . }}

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -12,9 +12,9 @@ controller:
   image:
     registry: k8s.gcr.io
     image: ingress-nginx/controller
-    # for backwards compatibility consider setting the full image url via the repository value below
-    # use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail
-    # repository:
+    ## for backwards compatibility consider setting the full image url via the repository value below
+    ## use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail
+    ## repository:
     tag: "v1.1.0"
     digest: sha256:f766669fdcf3dc26347ed273a55e754b427eb4411ee075a53f30718b4499076a
     pullPolicy: IfNotPresent
@@ -22,154 +22,149 @@ controller:
     runAsUser: 101
     allowPrivilegeEscalation: true
 
-  # Use an existing PSP instead of creating one
+  # -- Use an existing PSP instead of creating one
   existingPsp: ""
 
-  # Configures the controller container name
+  # -- Configures the controller container name
   containerName: controller
 
-  # Configures the ports the nginx-controller listens on
+  # -- Configures the ports the nginx-controller listens on
   containerPort:
     http: 80
     https: 443
 
-  # Will add custom configuration options to Nginx https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/
+  # -- Will add custom configuration options to Nginx https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/
   config: {}
 
-  ## Annotations to be added to the controller config configuration configmap
-  ##
+  # -- Annotations to be added to the controller config configuration configmap
   configAnnotations: {}
 
-  # Will add custom headers before sending traffic to backends according to https://github.com/kubernetes/ingress-nginx/tree/main/docs/examples/customization/custom-headers
+  # -- Will add custom headers before sending traffic to backends according to https://github.com/kubernetes/ingress-nginx/tree/main/docs/examples/customization/custom-headers
   proxySetHeaders: {}
 
-  # Will add custom headers before sending response traffic to the client according to: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#add-headers
+  # -- Will add custom headers before sending response traffic to the client according to: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#add-headers
   addHeaders: {}
 
-  # Optionally customize the pod dnsConfig.
+  # -- Optionally customize the pod dnsConfig.
   dnsConfig: {}
 
-  # Optionally customize the pod hostname.
+  # -- Optionally customize the pod hostname.
   hostname: {}
 
-  # Optionally change this to ClusterFirstWithHostNet in case you have 'hostNetwork: true'.
+  # -- Optionally change this to ClusterFirstWithHostNet in case you have 'hostNetwork: true'.
   # By default, while using host network, name resolution uses the host's DNS. If you wish nginx-controller
   # to keep resolving names inside the k8s network, use ClusterFirstWithHostNet.
   dnsPolicy: ClusterFirst
 
-  # Bare-metal considerations via the host network https://kubernetes.github.io/ingress-nginx/deploy/baremetal/#via-the-host-network
+  # -- Bare-metal considerations via the host network https://kubernetes.github.io/ingress-nginx/deploy/baremetal/#via-the-host-network
   # Ingress status was blank because there is no Service exposing the NGINX Ingress controller in a configuration using the host network, the default --publish-service flag used in standard cloud setups does not apply
   reportNodeInternalIp: false
 
-  # Process Ingress objects without ingressClass annotation/ingressClassName field
+  # -- Process Ingress objects without ingressClass annotation/ingressClassName field
   # Overrides value for --watch-ingress-without-class flag of the controller binary
   # Defaults to false
   watchIngressWithoutClass: false
 
-  # Process IngressClass per name (additionally as per spec.controller)
+  # -- Process IngressClass per name (additionally as per spec.controller)
   ingressClassByName: false
 
-  # This configuration defines if Ingress Controller should allow users to set
+  # -- This configuration defines if Ingress Controller should allow users to set
   # their own *-snippet annotations, otherwise this is forbidden / dropped
   # when users add those annotations.
   # Global snippets in ConfigMap are still respected
   allowSnippetAnnotations: true
 
-  # Required for use with CNI based kubernetes installations (such as ones set up by kubeadm),
+  # -- Required for use with CNI based kubernetes installations (such as ones set up by kubeadm),
   # since CNI and hostport don't mix yet. Can be deprecated once https://github.com/kubernetes/kubernetes/issues/23920
   # is merged
   hostNetwork: false
 
   ## Use host ports 80 and 443
   ## Disabled by default
-  ##
   hostPort:
+    # -- Enable 'hostPort' or not
     enabled: false
     ports:
+      # -- 'hostPort' http port
       http: 80
+      # -- 'hostPort' https port
       https: 443
 
-  ## Election ID to use for status update
-  ##
+  # -- Election ID to use for status update
   electionID: ingress-controller-leader
 
-  # This section refers to the creation of the IngressClass resource
-  # IngressClass resources are supported since k8s >= 1.18 and required since k8s >= 1.19
+  ## This section refers to the creation of the IngressClass resource
+  ## IngressClass resources are supported since k8s >= 1.18 and required since k8s >= 1.19
   ingressClassResource:
     name: nginx
     enabled: true
     default: false
     controllerValue: "k8s.io/ingress-nginx"
 
-    # Parameters is a link to a custom resource containing additional
+    # -- Parameters is a link to a custom resource containing additional
     # configuration for the controller. This is optional if the controller
     # does not require extra parameters.
     parameters: {}
 
-  # labels to add to the pod container metadata
+  # -- Labels to add to the pod container metadata
   podLabels: {}
   #  key: value
 
-  ## Security Context policies for controller pods
-  ##
+  # -- Security Context policies for controller pods
   podSecurityContext: {}
 
-  ## See https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster/ for
-  ## notes on enabling and using sysctls
-  ###
+  # -- See https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster/ for notes on enabling and using sysctls
   sysctls: {}
   # sysctls:
   #   "net.core.somaxconn": "8192"
 
-  ## Allows customization of the source of the IP address or FQDN to report
-  ## in the ingress status field. By default, it reads the information provided
-  ## by the service. If disable, the status field reports the IP address of the
-  ## node or nodes where an ingress controller pod is running.
+  # -- Allows customization of the source of the IP address or FQDN to report
+  # in the ingress status field. By default, it reads the information provided
+  # by the service. If disable, the status field reports the IP address of the
+  # node or nodes where an ingress controller pod is running.
   publishService:
+    # -- Enable 'publishService' or not
     enabled: true
-    ## Allows overriding of the publish service to bind to
-    ## Must be <namespace>/<service_name>
-    ##
+    # -- Allows overriding of the publish service to bind to
+    # Must be <namespace>/<service_name>
     pathOverride: ""
 
-  ## Limit the scope of the controller
-  ##
+  # Limit the scope of the controller to a specific namespace
   scope:
+    # -- Enable 'scope' or not
     enabled: false
-    namespace: ""   # defaults to $(POD_NAMESPACE)
-    # When scope.enabled == false, instead of watching all namespaces, we watching namespaces whose labels
-    #   only match with namespaceSelector. Format like foo=bar. Defaults to empty, means watching all namespaces.
+    # -- Namespace to limit the controller to; defaults to $(POD_NAMESPACE)
+    namespace: ""
+    # -- When scope.enabled == false, instead of watching all namespaces, we watching namespaces whose labels
+    # only match with namespaceSelector. Format like foo=bar. Defaults to empty, means watching all namespaces.
     namespaceSelector: ""
 
-  ## Allows customization of the configmap / nginx-configmap namespace
-  ##
-  configMapNamespace: ""   # defaults to $(POD_NAMESPACE)
+  # -- Allows customization of the configmap / nginx-configmap namespace; defaults to $(POD_NAMESPACE)
+  configMapNamespace: ""
 
-  ## Allows customization of the tcp-services-configmap
-  ##
   tcp:
-    configMapNamespace: ""   # defaults to $(POD_NAMESPACE)
-    ## Annotations to be added to the tcp config configmap
+    # -- Allows customization of the tcp-services-configmap; defaults to $(POD_NAMESPACE)
+    configMapNamespace: ""
+    # -- Annotations to be added to the tcp config configmap
     annotations: {}
 
-  ## Allows customization of the udp-services-configmap
-  ##
   udp:
-    configMapNamespace: ""   # defaults to $(POD_NAMESPACE)
-    ## Annotations to be added to the udp config configmap
+    # -- Allows customization of the udp-services-configmap; defaults to $(POD_NAMESPACE)
+    configMapNamespace: ""
+    # -- Annotations to be added to the udp config configmap
     annotations: {}
 
-  # Maxmind license key to download GeoLite2 Databases
-  # https://blog.maxmind.com/2019/12/18/significant-changes-to-accessing-and-using-geolite2-databases
+  # -- Maxmind license key to download GeoLite2 Databases.
+  ## https://blog.maxmind.com/2019/12/18/significant-changes-to-accessing-and-using-geolite2-databases
   maxmindLicenseKey: ""
 
-  ## Additional command line arguments to pass to nginx-ingress-controller
-  ## E.g. to specify the default SSL certificate you can use
+  # -- Additional command line arguments to pass to nginx-ingress-controller
+  # E.g. to specify the default SSL certificate you can use
+  extraArgs: {}
   ## extraArgs:
   ##   default-ssl-certificate: "<namespace>/<secret_name>"
-  extraArgs: {}
 
-  ## Additional environment variables to set
+  # -- Additional environment variables to set
   extraEnvs: []
   # extraEnvs:
   #   - name: FOO
@@ -178,35 +173,34 @@ controller:
   #         key: FOO
   #         name: secret-resource
 
-  ## DaemonSet or Deployment
-  ##
+  # -- Use a `DaemonSet` or `Deployment`
   kind: Deployment
 
-  ## Annotations to be added to the controller Deployment or DaemonSet
+  # -- Annotations to be added to the controller Deployment or DaemonSet
   ##
   annotations: {}
   #  keel.sh/pollSchedule: "@every 60m"
 
-  ## Labels to be added to the controller Deployment or DaemonSet and other resources that do not have option to specify labels
+  # -- Labels to be added to the controller Deployment or DaemonSet and other resources that do not have option to specify labels
   ##
   labels: {}
   #  keel.sh/policy: patch
   #  keel.sh/trigger: poll
 
 
-  # The update strategy to apply to the Deployment or DaemonSet
+  # -- The update strategy to apply to the Deployment or DaemonSet
   ##
   updateStrategy: {}
   #  rollingUpdate:
   #    maxUnavailable: 1
   #  type: RollingUpdate
 
-  # minReadySeconds to avoid killing pods before we are ready
+  # -- `minReadySeconds` to avoid killing pods before we are ready
   ##
   minReadySeconds: 0
 
 
-  ## Node tolerations for server scheduling to nodes with taints
+  # -- Node tolerations for server scheduling to nodes with taints
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   ##
   tolerations: []
@@ -215,7 +209,7 @@ controller:
   #    value: "value"
   #    effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
 
-  ## Affinity and anti-affinity
+  # -- Affinity and anti-affinity rules for server scheduling to nodes
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   ##
   affinity: {}
@@ -259,7 +253,7 @@ controller:
     #         - controller
     #     topologyKey: "kubernetes.io/hostname"
 
-  ## Topology spread constraints rely on node labels to identify the topology domain(s) that each Node is in.
+  # -- Topology spread constraints rely on node labels to identify the topology domain(s) that each Node is in.
   ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
   ##
   topologySpreadConstraints: []
@@ -270,12 +264,12 @@ controller:
     #     matchLabels:
     #       app.kubernetes.io/instance: ingress-nginx-internal
 
-  ## terminationGracePeriodSeconds
+  # -- `terminationGracePeriodSeconds` to avoid killing pods before we are ready
   ## wait up to five minutes for the drain of connections
   ##
   terminationGracePeriodSeconds: 300
 
-  ## Node labels for controller pod assignment
+  # -- Node labels for controller pod assignment
   ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
   ##
   nodeSelector:
@@ -284,17 +278,17 @@ controller:
   ## Liveness and readiness probe values
   ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
   ##
-  # startupProbe:
-  #   httpGet:
-  #     # should match container.healthCheckPath
-  #     path: "/healthz"
-  #     port: 10254
-  #     scheme: HTTP
-  #   initialDelaySeconds: 5
-  #   periodSeconds: 5
-  #   timeoutSeconds: 2
-  #   successThreshold: 1
-  #   failureThreshold: 5
+  ## startupProbe:
+  ##   httpGet:
+  ##     # should match container.healthCheckPath
+  ##     path: "/healthz"
+  ##     port: 10254
+  ##     scheme: HTTP
+  ##   initialDelaySeconds: 5
+  ##   periodSeconds: 5
+  ##   timeoutSeconds: 2
+  ##   successThreshold: 1
+  ##   failureThreshold: 5
   livenessProbe:
     httpGet:
       # should match container.healthCheckPath
@@ -319,16 +313,16 @@ controller:
     failureThreshold: 3
 
 
-  # Path of the health check endpoint. All requests received on the port defined by
+  # -- Path of the health check endpoint. All requests received on the port defined by
   # the healthz-port parameter are forwarded internally to this path.
   healthCheckPath: "/healthz"
 
-  # Address to bind the health check endpoint.
+  # -- Address to bind the health check endpoint.
   # It is better to set this option to the internal node address
-  # if the ingress nginx controller is running in the hostNetwork: true mode.
+  # if the ingress nginx controller is running in the `hostNetwork: true` mode.
   healthCheckHost: ""
 
-  ## Annotations to be added to controller pods
+  # -- Annotations to be added to controller pods
   ##
   podAnnotations: {}
 
@@ -336,14 +330,14 @@ controller:
 
   minAvailable: 1
 
-  # Define requests resources to avoid probe issues due to CPU utilization in busy nodes
-  # ref: https://github.com/kubernetes/ingress-nginx/issues/4735#issuecomment-551204903
-  # Ideally, there should be no limits.
-  # https://engineering.indeedblog.com/blog/2019/12/cpu-throttling-regression-fix/
+  ## Define requests resources to avoid probe issues due to CPU utilization in busy nodes
+  ## ref: https://github.com/kubernetes/ingress-nginx/issues/4735#issuecomment-551204903
+  ## Ideally, there should be no limits.
+  ## https://engineering.indeedblog.com/blog/2019/12/cpu-throttling-regression-fix/
   resources:
-  #  limits:
-  #    cpu: 100m
-  #    memory: 90Mi
+  ##  limits:
+  ##    cpu: 100m
+  ##    memory: 90Mi
     requests:
       cpu: 100m
       memory: 90Mi
@@ -383,9 +377,9 @@ controller:
   # Mutually exclusive with hpa autoscaling
   keda:
     apiVersion: "keda.sh/v1alpha1"
-  # apiVersion changes with keda 1.x vs 2.x
-  # 2.x = keda.sh/v1alpha1
-  # 1.x = keda.k8s.io/v1alpha1
+    ## apiVersion changes with keda 1.x vs 2.x
+    ## 2.x = keda.sh/v1alpha1
+    ## 1.x = keda.k8s.io/v1alpha1
     enabled: false
     minReplicas: 1
     maxReplicas: 11
@@ -419,7 +413,7 @@ controller:
  #         value: 2
  #         periodSeconds: 60
 
-  ## Enable mimalloc as a drop-in replacement for malloc.
+  # -- Enable mimalloc as a drop-in replacement for malloc.
   ## ref: https://github.com/microsoft/mimalloc
   ##
   enableMimalloc: true
@@ -432,11 +426,11 @@ controller:
   service:
     enabled: true
 
-    ## If enabled is adding an appProtocol option for Kubernetes service. An appProtocol field replacing annotations that were
-    ## using for setting a backend protocol. Here is an example for AWS: service.beta.kubernetes.io/aws-load-balancer-backend-protocol: http
-    ## It allows choosing the protocol for each backend specified in the Kubernetes service.
-    ## See the following GitHub issue for more details about the purpose: https://github.com/kubernetes/kubernetes/issues/40244
-    ## Will be ignored for Kubernetes versions older than 1.20
+    # -- If enabled is adding an appProtocol option for Kubernetes service. An appProtocol field replacing annotations that were
+    # using for setting a backend protocol. Here is an example for AWS: service.beta.kubernetes.io/aws-load-balancer-backend-protocol: http
+    # It allows choosing the protocol for each backend specified in the Kubernetes service.
+    # See the following GitHub issue for more details about the purpose: https://github.com/kubernetes/kubernetes/issues/40244
+    # Will be ignored for Kubernetes versions older than 1.20
     ##
     appProtocol: true
 
@@ -444,7 +438,7 @@ controller:
     labels: {}
     # clusterIP: ""
 
-    ## List of IP addresses at which the controller services are available
+    # -- List of IP addresses at which the controller services are available
     ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
     ##
     externalIPs: []
@@ -468,14 +462,14 @@ controller:
     ## Ref: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
     # healthCheckNodePort: 0
 
-    ## Represents the dual-stack-ness requested or required by this Service. Possible values are
-    ## SingleStack, PreferDualStack or RequireDualStack.
-    ## The ipFamilies and clusterIPs fields depend on the value of this field.
+    # -- Represents the dual-stack-ness requested or required by this Service. Possible values are
+    # SingleStack, PreferDualStack or RequireDualStack.
+    # The ipFamilies and clusterIPs fields depend on the value of this field.
     ## Ref: https://kubernetes.io/docs/concepts/services-networking/dual-stack/
     ipFamilyPolicy: "SingleStack"
 
-    ## List of IP families (e.g. IPv4, IPv6) assigned to the service. This field is usually assigned automatically
-    ## based on cluster configuration and the ipFamilyPolicy field.
+    # -- List of IP families (e.g. IPv4, IPv6) assigned to the service. This field is usually assigned automatically
+    # based on cluster configuration and the ipFamilyPolicy field.
     ## Ref: https://kubernetes.io/docs/concepts/services-networking/dual-stack/
     ipFamilies:
       - IPv4
@@ -490,12 +484,12 @@ controller:
 
     type: LoadBalancer
 
-    # type: NodePort
-    # nodePorts:
-    #   http: 32080
-    #   https: 32443
-    #   tcp:
-    #     8080: 32808
+    ## type: NodePort
+    ## nodePorts:
+    ##   http: 32080
+    ##   https: 32443
+    ##   tcp:
+    ##     8080: 32808
     nodePorts:
       http: ""
       https: ""
@@ -505,15 +499,15 @@ controller:
     external:
       enabled: true
 
-    ## Enables an additional internal load balancer (besides the external one).
-    ## Annotations are mandatory for the load balancer to come up. Varies with the cloud service.
     internal:
+      # -- Enables an additional internal load balancer (besides the external one).
       enabled: false
+      # -- Annotations are mandatory for the load balancer to come up. Varies with the cloud service.
       annotations: {}
 
       # loadBalancerIP: ""
 
-      ## Restrict access For LoadBalancer service. Defaults to 0.0.0.0/0.
+      # -- Restrict access For LoadBalancer service. Defaults to 0.0.0.0/0.
       loadBalancerSourceRanges: []
 
       ## Set external traffic policy to: "Local" to preserve source IP on
@@ -521,9 +515,9 @@ controller:
       ## Ref: https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typeloadbalancer
       # externalTrafficPolicy: ""
 
+  # -- Additional containers to be added to the controller pod.
+  # See https://github.com/lemonldap-ng-controller/lemonldap-ng-controller as example.
   extraContainers: []
-  ## Additional containers to be added to the controller pod.
-  ## See https://github.com/lemonldap-ng-controller/lemonldap-ng-controller as example.
   #  - name: my-sidecar
   #    image: nginx:latest
   #  - name: lemonldap-ng-controller
@@ -545,18 +539,18 @@ controller:
   #    - name: copy-portal-skins
   #      mountPath: /srv/var/lib/lemonldap-ng/portal/skins
 
+  # -- Additional volumeMounts to the controller main container.
   extraVolumeMounts: []
-  ## Additional volumeMounts to the controller main container.
   #  - name: copy-portal-skins
   #   mountPath: /var/lib/lemonldap-ng/portal/skins
 
+  # -- Additional volumes to the controller pod.
   extraVolumes: []
-  ## Additional volumes to the controller pod.
   #  - name: copy-portal-skins
   #    emptyDir: {}
 
+  # -- Containers, which are run before the app containers are started.
   extraInitContainers: []
-  ## Containers, which are run before the app containers are started.
   # - name: init-myservice
   #   image: busybox
   #   command: ['sh', '-c', 'until nslookup myservice; do echo waiting for myservice; sleep 2; done;']
@@ -576,10 +570,10 @@ controller:
     key: "/usr/local/certificates/key"
     namespaceSelector: {}
     objectSelector: {}
-    ## Labels to be added to admission webhooks
+    # -- Labels to be added to admission webhooks
     labels: {}
 
-    # Use an existing PSP instead of creating one
+    # -- Use an existing PSP instead of creating one
     existingPsp: ""
 
     service:
@@ -608,20 +602,20 @@ controller:
       image:
         registry: k8s.gcr.io
         image: ingress-nginx/kube-webhook-certgen
-        # for backwards compatibility consider setting the full image url via the repository value below
-        # use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail
-        # repository:
+        ## for backwards compatibility consider setting the full image url via the repository value below
+        ## use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail
+        ## repository:
         tag: v1.1.1
         digest: sha256:64d8c73dca984af206adf9d6d7e46aa550362b1d7a01f3a0a91b20cc67868660
         pullPolicy: IfNotPresent
-      ## Provide a priority class name to the webhook patching job
+      # -- Provide a priority class name to the webhook patching job
       ##
       priorityClassName: ""
       podAnnotations: {}
       nodeSelector:
         kubernetes.io/os: linux
       tolerations: []
-      ## Labels to be added to patch job resources
+      # -- Labels to be added to patch job resources
       labels: {}
       runAsUser: 2000
 
@@ -637,7 +631,7 @@ controller:
 
       # clusterIP: ""
 
-      ## List of IP addresses at which the stats-exporter service is available
+      # -- List of IP addresses at which the stats-exporter service is available
       ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
       ##
       externalIPs: []
@@ -652,14 +646,14 @@ controller:
     serviceMonitor:
       enabled: false
       additionalLabels: {}
-      # The label to use to retrieve the job name from.
-      # jobLabel: "app.kubernetes.io/name"
+      ## The label to use to retrieve the job name from.
+      ## jobLabel: "app.kubernetes.io/name"
       namespace: ""
       namespaceSelector: {}
-      # Default: scrape .Release.Namespace only
-      # To scrape all, use the following:
-      # namespaceSelector:
-      #   any: true
+      ## Default: scrape .Release.Namespace only
+      ## To scrape all, use the following:
+      ## namespaceSelector:
+      ##   any: true
       scrapeInterval: 30s
       # honorLabels: true
       targetLabels: []
@@ -705,12 +699,12 @@ controller:
         #     description: Too many 4XXs
         #     summary: More than 5% of all requests returned 4XX, this requires your attention
 
-  ## Improve connection draining when ingress controller pod is deleted using a lifecycle hook:
-  ## With this new hook, we increased the default terminationGracePeriodSeconds from 30 seconds
-  ## to 300, allowing the draining of connections up to five minutes.
-  ## If the active connections end before that, the pod will terminate gracefully at that time.
-  ## To effectively take advantage of this feature, the Configmap feature
-  ## worker-shutdown-timeout new value is 240s instead of 10s.
+  # -- Improve connection draining when ingress controller pod is deleted using a lifecycle hook:
+  # With this new hook, we increased the default terminationGracePeriodSeconds from 30 seconds
+  # to 300, allowing the draining of connections up to five minutes.
+  # If the active connections end before that, the pod will terminate gracefully at that time.
+  # To effectively take advantage of this feature, the Configmap feature
+  # worker-shutdown-timeout new value is 240s instead of 10s.
   ##
   lifecycle:
     preStop:
@@ -720,7 +714,7 @@ controller:
 
   priorityClassName: ""
 
-## Rollback limit
+# -- Rollback limit
 ##
 revisionHistoryLimit: 10
 
@@ -734,9 +728,9 @@ defaultBackend:
   image:
     registry: k8s.gcr.io
     image: defaultbackend-amd64
-    # for backwards compatibility consider setting the full image url via the repository value below
-    # use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail
-    # repository:
+    ## for backwards compatibility consider setting the full image url via the repository value below
+    ## use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail
+    ## repository:
     tag: "1.5"
     pullPolicy: IfNotPresent
     # nobody user -> uid 65534
@@ -745,7 +739,7 @@ defaultBackend:
     readOnlyRootFilesystem: true
     allowPrivilegeEscalation: false
 
-  # Use an existing PSP instead of creating one
+  # -- Use an existing PSP instead of creating one
   existingPsp: ""
 
   extraArgs: {}
@@ -754,7 +748,7 @@ defaultBackend:
     create: true
     name: ""
     automountServiceAccountToken: true
-  ## Additional environment variables to set for defaultBackend pods
+  # -- Additional environment variables to set for defaultBackend pods
   extraEnvs: []
 
   port: 8080
@@ -775,7 +769,7 @@ defaultBackend:
     successThreshold: 1
     timeoutSeconds: 5
 
-  ## Node tolerations for server scheduling to nodes with taints
+  # -- Node tolerations for server scheduling to nodes with taints
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   ##
   tolerations: []
@@ -786,29 +780,29 @@ defaultBackend:
 
   affinity: {}
 
-  ## Security Context policies for controller pods
-  ## See https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster/ for
-  ## notes on enabling and using sysctls
+  # -- Security Context policies for controller pods
+  # See https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster/ for
+  # notes on enabling and using sysctls
   ##
   podSecurityContext: {}
 
-  ## Security Context policies for controller main container.
-  ## See https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster/ for
-  ## notes on enabling and using sysctls
+  # -- Security Context policies for controller main container.
+  # See https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster/ for
+  # notes on enabling and using sysctls
   ##
   containerSecurityContext: {}
 
-  # labels to add to the pod container metadata
+  # -- Labels to add to the pod container metadata
   podLabels: {}
   #  key: value
 
-  ## Node labels for default backend pod assignment
+  # -- Node labels for default backend pod assignment
   ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
   ##
   nodeSelector:
     kubernetes.io/os: linux
 
-  ## Annotations to be added to default backend pods
+  # -- Annotations to be added to default backend pods
   ##
   podAnnotations: {}
 
@@ -847,7 +841,7 @@ defaultBackend:
 
     # clusterIP: ""
 
-    ## List of IP addresses at which the default backend service is available
+    # -- List of IP addresses at which the default backend service is available
     ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
     ##
     externalIPs: []
@@ -858,7 +852,7 @@ defaultBackend:
     type: ClusterIP
 
   priorityClassName: ""
-  ## Labels to be added to the default backend resources
+  # -- Labels to be added to the default backend resources
   labels: {}
 
 ## Enable RBAC as per https://github.com/kubernetes/ingress-nginx/blob/main/docs/deploy/rbac.md and https://github.com/kubernetes/ingress-nginx/issues/266
@@ -866,8 +860,8 @@ rbac:
   create: true
   scope: false
 
-# If true, create & use Pod Security Policy resources
-# https://kubernetes.io/docs/concepts/policy/pod-security-policy/
+## If true, create & use Pod Security Policy resources
+## https://kubernetes.io/docs/concepts/policy/pod-security-policy/
 podSecurityPolicy:
   enabled: false
 
@@ -876,24 +870,24 @@ serviceAccount:
   name: ""
   automountServiceAccountToken: true
 
-## Optional array of imagePullSecrets containing private registry credentials
+# -- Optional array of imagePullSecrets containing private registry credentials
 ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 imagePullSecrets: []
 # - name: secretName
 
-# TCP service key:value pairs
-# Ref: https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/exposing-tcp-udp-services.md
+# -- TCP service key:value pairs
+## Ref: https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/exposing-tcp-udp-services.md
 ##
 tcp: {}
 #  8080: "default/example-tcp-svc:9000"
 
-# UDP service key:value pairs
-# Ref: https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/exposing-tcp-udp-services.md
+# -- UDP service key:value pairs
+## Ref: https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/exposing-tcp-udp-services.md
 ##
 udp: {}
 #  53: "kube-system/kube-dns:53"
 
-# A base64ed Diffie-Hellman parameter
-# This can be generated with: openssl dhparam 4096 2> /dev/null | base64
-# Ref: https://github.com/kubernetes/ingress-nginx/tree/main/docs/examples/customization/ssl-dh-param
+# -- (string) A base64-encoded Diffie-Hellman parameter.
+# This can be generated with: `openssl dhparam 4096 2> /dev/null | base64`
+## Ref: https://github.com/kubernetes/ingress-nginx/tree/main/docs/examples/customization/ssl-dh-param
 dhParam:


### PR DESCRIPTION
# Description

This enables the use of the [helm-docs](https://github.com/norwoodj/helm-docs) tool on the Helm chart located in `charts/ingress-nginx`. This will make it possible to automatically document new variables in the `values.yaml` file.

## What this PR does / why we need it:

This PR improves the documentation for the chart so that possible configuration values are documented automatically.

It also adds CI checks so that moving forward, someone adding / removing / updating values in the Helm chart will have to make sure that `helm-docs` has been run.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation only

## Which issue/s this PR fixes

Not applicable

## How Has This Been Tested?

Testing is not necessary since the documentation has already been generated.

## Checklist:

- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.