### PR TITLE
sending signal to nginx to re-read cert store

### DIFF
--- a/internal/ingress/controller/store/backend_ssl.go
+++ b/internal/ingress/controller/store/backend_ssl.go
@@ -19,6 +19,7 @@ package store
 import (
 	"fmt"
 	"strings"
+        "os/exec"
 
 	"k8s.io/klog/v2"
 
@@ -57,6 +58,26 @@ func (s *k8sStore) syncSecret(key string) {
 		}
 		klog.InfoS("Updating secret in local store", "name", key)
 		s.sslStore.Update(key, cert)
+
+		klog.InfoS("Running nginx -s reload to re-read certificates")
+
+
+		app := "nginx"
+
+		arg0 := "-s"
+		arg1 := "reload"
+
+		cmd := exec.Command(app, arg0, arg1)
+		stdout, err := cmd.Output()
+
+		if err != nil {
+		    fmt.Println(err.Error())
+		    return
+		}
+
+		fmt.Println(string(stdout))
+
+
 		// this update must trigger an update
 		// (like an update event from a change in Ingress)
 		s.sendDummyEvent()


### PR DESCRIPTION
We are unable to get the nginx ingress controller to update proxy_ssl_trusted_certificate in nginx.conf when the proxy-ssl-secret is updated. As a result, nginx ingress continues to use an outdated trusted certificate.

as a FIX there are some additional lines to reload nginx and force nginx to read certificate stored in file 


## What this PR does / why we need it:
FIX for :
https://github.com/kubernetes/ingress-nginx/issues/5608

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x  ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only


## How Has This Been Tested?
several hours (more than 60hrs per each test) of testing on 2 AKS clusters 
after this fix nginx continuously refreshes the certificate 


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x  ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
