### PR TITLE
sending signal to nginx to re-read cert store

### DIFF
--- a/internal/ingress/controller/store/backend_ssl.go
+++ b/internal/ingress/controller/store/backend_ssl.go
@@ -19,6 +19,7 @@ package store
 import (
 	"fmt"
 	"strings"
+        "os/exec"
 
 	"k8s.io/klog/v2"
 
@@ -57,6 +58,26 @@ func (s *k8sStore) syncSecret(key string) {
 		}
 		klog.InfoS("Updating secret in local store", "name", key)
 		s.sslStore.Update(key, cert)
+
+		klog.InfoS("Running nginx -s reload to re-read certificates")
+
+
+		app := "nginx"
+
+		arg0 := "-s"
+		arg1 := "reload"
+
+		cmd := exec.Command(app, arg0, arg1)
+		stdout, err := cmd.Output()
+
+		if err != nil {
+		    fmt.Println(err.Error())
+		    return
+		}
+
+		fmt.Println(string(stdout))
+
+
 		// this update must trigger an update
 		// (like an update event from a change in Ingress)
 		s.sendDummyEvent()


### PR DESCRIPTION
Nginx ingress controller does not update proxy_ssl_trusted_certificate in nginx.conf when the proxy-ssl-secret is updated. As a result, nginx ingress continues to use an outdated trusted certificate.

The only way to force this update is by deleting the ingress config using kubectl delete and applying the updated config using kubectl apply.

As a FIX once the proxy-ssl-secret is updated we force reload of nginx ingress controller, which ultimately causes reloading of the proxy_ssl_trusted_certificate in nginx.conf.



## What this PR does / why we need it:
When securing communication between nginx ingress controller and the pods/services, it is desired to rotate proxy_ssl_trusted_certificate. That is currently not possible without redeploying ingress configuration, which causes nginx ingress to update the proxy_ssl_trusted_certificate.

Nginx Ingress should be capable to reload the certificate automaticaly.

FIX for :
https://github.com/kubernetes/ingress-nginx/issues/5608

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x  ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only


## How Has This Been Tested?
Proposed fix was tested manualy on 2 AKS clusters with enabled mtls between nginx ingress controller and service/pods. mTLS was enabled using Open Service Mesh, while validity of certificates was set below 10 minutes, while keepalive configuration was set to 1 minute, to quickly kill connections established with expired certificate.

With this setup we let the clusters run for several days and ingress was capable to reach the services without any issues, while the proxy_ssl_trusted_certificate was being reloaded correctly.

So we spend several hours (more than 60hrs per each test) of testing on 2 AKS clusters
after this fix nginx continuously refreshes the certificate


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x  ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
