### PR TITLE
helm: Add metrics hostPort

### DIFF
--- a/charts/ingress-nginx/templates/controller-daemonset.yaml
+++ b/charts/ingress-nginx/templates/controller-daemonset.yaml
@@ -121,6 +121,9 @@ spec:
             - name: metrics
               containerPort: {{ .Values.controller.metrics.port }}
               protocol: TCP
+              {{- if and .Values.controller.hostPort.enabled (hasKey .Values.controller.hostPort.ports "metrics") }}
+              hostPort: {{ .Values.controller.hostPort.ports.metrics }}
+              {{- end }}
           {{- end }}
           {{- if .Values.controller.admissionWebhooks.enabled }}
             - name: webhook

--- a/charts/ingress-nginx/templates/controller-deployment.yaml
+++ b/charts/ingress-nginx/templates/controller-deployment.yaml
@@ -118,6 +118,9 @@ spec:
             - name: metrics
               containerPort: {{ .Values.controller.metrics.port }}
               protocol: TCP
+              {{- if and .Values.controller.hostPort.enabled (hasKey .Values.controller.hostPort.ports "metrics") }}
+              hostPort: {{ .Values.controller.hostPort.ports.metrics }}
+              {{- end }}
           {{- end }}
           {{- if .Values.controller.admissionWebhooks.enabled }}
             - name: webhook

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -88,6 +88,7 @@ controller:
     ports:
       http: 80
       https: 443
+      # metrics: 10254
 
   ## Election ID to use for status update
   ##


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
Add hostPort support for metrics port.
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

-->
fixes #8082
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I cloned the chart and installed it and verified that the hostPort for metrics is in the Pod template.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
