### PR TITLE
generating SHA for CA only certs in backend_ssl.go + comparision of P…

### DIFF
--- a/internal/ingress/controller/store/backend_ssl.go
+++ b/internal/ingress/controller/store/backend_ssl.go
@@ -154,6 +154,8 @@ func (s *k8sStore) getPemCertificate(secretName string) (*ingress.SSLCert, error
 			return nil, fmt.Errorf("error configuring CA certificate: %v", err)
 		}
 
+		sslCert.CASHA = file.SHA1(sslCert.CAFileName)
+
 		if len(crl) > 0 {
 			err = ssl.ConfigureCRL(nsSecName, crl, sslCert)
 			if err != nil {

--- a/internal/ingress/types_equals.go
+++ b/internal/ingress/types_equals.go
@@ -317,6 +317,9 @@ func (s1 *Server) Equal(s2 *Server) bool {
 	if s1.AuthTLSError != s2.AuthTLSError {
 		return false
 	}
+	if !(&s1.ProxySSL).Equal(&s2.ProxySSL) {
+		return false
+	}
 
 	if len(s1.Locations) != len(s2.Locations) {
 		return false
@@ -399,6 +402,9 @@ func (l1 *Location) Equal(l2 *Location) bool {
 		return false
 	}
 	if !(&l1.Proxy).Equal(&l2.Proxy) {
+		return false
+	}
+	if !(&l1.ProxySSL).Equal(&l2.ProxySSL) {
 		return false
 	}
 	if l1.UsePortInRedirects != l2.UsePortInRedirects {
@@ -556,6 +562,12 @@ func (s1 *SSLCert) Equal(s2 *SSLCert) bool {
 		return false
 	}
 	if s1.PemSHA != s2.PemSHA {
+		return false
+	}
+	if s1.CAFileName != s2.CAFileName {
+		return false
+	}
+	if s1.CRLFileName != s2.CRLFileName {
 		return false
 	}
 	if !s1.ExpireTime.Equal(s2.ExpireTime) {


### PR DESCRIPTION
Nginx ingress controller does not update proxy_ssl_trusted_certificate in nginx.conf when the proxy-ssl-secret is updated. As a result, nginx ingress continues to use an outdated trusted certificate.

The only way to force this update is by deleting the ingress config using kubectl delete and applying the updated config using kubectl apply.

As a FIX once the proxy-ssl-secret is updated we forced reload of nginx ingress controller, which ultimately causes reloading of the proxy_ssl_trusted_certificate in nginx.conf.

after @rikatz 2 patches I changed PR to solve the problem by modifying 2 files 

## What this PR does / why we need it:
When securing communication between nginx ingress controller and the pods/services, it is desired to rotate proxy_ssl_trusted_certificate. That is currently not possible without redeploying ingress configuration, which causes nginx ingress to update the proxy_ssl_trusted_certificate.

Nginx Ingress should be capable to reload the certificate automaticaly.

FIX for :
https://github.com/kubernetes/ingress-nginx/issues/5608

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x  ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only


## How Has This Been Tested?
Proposed fix was tested manualy on 2 AKS clusters with enabled mtls between nginx ingress controller and service/pods. mTLS was enabled using Open Service Mesh, while validity of certificates was set below 10 minutes, while keepalive configuration was set to 1 minute, to quickly kill connections established with expired certificate.

With this setup we let the clusters run for several days and ingress was capable to reach the services without any issues, while the proxy_ssl_trusted_certificate was being reloaded correctly.

So we spend several hours (more than 60hrs per each test) of testing on 2 AKS clusters
after this fix nginx continuously refreshes the certificate


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x  ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
