### PR TITLE
Update monitoring.md to correct placement of annotations

### DIFF
--- a/docs/user-guide/monitoring.md
+++ b/docs/user-guide/monitoring.md
@@ -20,7 +20,9 @@ This tutorial will show you how to install [Prometheus](https://prometheus.io/) 
   --namespace ingress-nginx \
   --set controller.metrics.enabled=true \
   --set-string controller.podAnnotations."prometheus\.io/scrape"="true" \
-  --set-string controller.podAnnotations."prometheus\.io/port"="10254"
+  --set-string controller.podAnnotations."prometheus\.io/port"="10254" \
+  --set-string controller.service.annotations."prometheus\.io/scrape"="true" \
+  --set-string controller.service.annotations."prometheus\.io/port"="10254"
   ```
   - You can validate that the controller is configured for metrics by looking at the values of the installed release, like this ;
   ```
@@ -32,6 +34,9 @@ This tutorial will show you how to install [Prometheus](https://prometheus.io/) 
   controller:
     metrics:
       enabled: true
+      podAnnotations:
+        prometheus.io/port: "10254"
+        prometheus.io/scrape: "true"
       service:
         annotations:
           prometheus.io/port: "10254"
@@ -39,6 +44,19 @@ This tutorial will show you how to install [Prometheus](https://prometheus.io/) 
   ..
   ```
    - If you are **not using helm**, you will have to edit your manifests like this:
+     
+     - Deployment manifest:
+       ```
+       apiVersion: apps/v1
+       kind: Deployment
+       metadata:
+        ..
+        annotations:
+          prometheus.io/scrape: "true"
+          prometheus.io/port: "10254"
+        ..
+       ```
+     
      - Service manifest:
        ```
        apiVersion: v1


### PR DESCRIPTION
The provided annotation suggestion is confusing, does not work with the given `prometheus` config in [deploy/prometheus/prometheus.yaml](https://github.com/kubernetes/ingress-nginx/blob/main/deploy/prometheus/prometheus.yaml).

## What this PR does / why we need it:
To make the above `prometheus` config work, `podAnnotations` have to be used. The `service.annotations` are useless for this config. To make the config work with metrics exposed by `metrics` endpoint of the service, following config has to be added to mentioned `prometheus.yaml` as well(opening another PR for that)-

```yaml
- job_name: service-scrape
    honor_timestamps: true
    scrape_interval: 1m
    scrape_timeout: 1m
    metrics_path: /metrics
    scheme: http
    static_configs:
    - targets:
      - <service-name>.<namespace>:10254
```

## Types of changes
- [x] Documentation only

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
