### PR TITLE
Add cli flag for `leader-election-resource-lock`

### DIFF
--- a/charts/ingress-nginx/templates/clusterrole.yaml
+++ b/charts/ingress-nginx/templates/clusterrole.yaml
@@ -29,6 +29,13 @@ rules:
     verbs:
       - list
       - watch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - list
+      - watch
 {{- if and .Values.controller.scope.enabled .Values.controller.scope.namespace }}
   - apiGroups:
       - ""

--- a/charts/ingress-nginx/templates/controller-role.yaml
+++ b/charts/ingress-nginx/templates/controller-role.yaml
@@ -74,6 +74,21 @@ rules:
     verbs:
       - create
   - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    resourceNames:
+      - {{ .Values.controller.electionID }}
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+  - apiGroups:
       - ""
     resources:
       - events

--- a/cmd/nginx/flags.go
+++ b/cmd/nginx/flags.go
@@ -26,6 +26,7 @@ import (
 	"github.com/spf13/pflag"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/ingress-nginx/internal/ingress/annotations/parser"
 	"k8s.io/ingress-nginx/internal/ingress/controller"
 	ngx_config "k8s.io/ingress-nginx/internal/ingress/controller/config"
@@ -126,6 +127,9 @@ Requires setting the publish-service parameter to a valid Service reference.`)
 
 		electionID = flags.String("election-id", "ingress-controller-leader",
 			`Election id to use for Ingress status updates.`)
+
+		leaderElectionResourceLock = flags.String("leader-election-resource-lock", resourcelock.ConfigMapsResourceLock,
+			`Resourcelock to use for ingress-controller leader-election. Supported values are "configmaps", "configmapsleases", "leases".`)
 
 		updateStatusOnShutdown = flags.Bool("update-status-on-shutdown", true,
 			`Update the load-balancer status of Ingress objects when the controller shuts down.
@@ -309,6 +313,7 @@ https://blog.maxmind.com/2019/12/18/significant-changes-to-accessing-and-using-g
 		KubeConfigFile:              *kubeConfigFile,
 		UpdateStatus:                *updateStatus,
 		ElectionID:                  *electionID,
+		LeaderElectionResourceLock:  *leaderElectionResourceLock,
 		EnableProfiling:             *profiling,
 		EnableMetrics:               *enableMetrics,
 		MetricsPerHost:              *metricsPerHost,

--- a/docs/deploy/rbac.md
+++ b/docs/deploy/rbac.md
@@ -47,6 +47,8 @@ permissions are granted to the Role named `ingress-nginx`
 
 Furthermore to support leader-election, the ingress-nginx-controller needs to
 have access to a `configmap` using the resourceName `ingress-controller-leader-nginx`
+and also a `lease` using the resourceName `ingress-controller-leader-nginx` 
+if `configmapsleases` or `leases` is used as default leader-election resource-lock.
 
 > Note that resourceNames can NOT be used to limit requests using the “create”
 > verb because authorizers only have access to information that can be obtained
@@ -55,6 +57,8 @@ have access to a `configmap` using the resourceName `ingress-controller-leader-n
 
 * `configmaps`: get, update (for resourceName `ingress-controller-leader-nginx`)
 * `configmaps`: create
+* `leases`: get, update (for resourceName `ingress-controller-leader-nginx`)
+* `leases`: create
 
 This resourceName is the concatenation of the `election-id` and the
 `ingress-class` as defined by the ingress-controller, which defaults to:

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -83,10 +83,11 @@ type Configuration struct {
 	PublishService       string
 	PublishStatusAddress string
 
-	UpdateStatus           bool
-	UseNodeInternalIP      bool
-	ElectionID             string
-	UpdateStatusOnShutdown bool
+	UpdateStatus               bool
+	UseNodeInternalIP          bool
+	ElectionID                 string
+	LeaderElectionResourceLock string
+	UpdateStatusOnShutdown     bool
 
 	HealthCheckHost string
 	ListenPorts     *ngx_config.ListenPorts

--- a/internal/ingress/controller/nginx.go
+++ b/internal/ingress/controller/nginx.go
@@ -265,8 +265,10 @@ func (n *NGINXController) Start() {
 	electionID := n.cfg.ElectionID
 
 	setupLeaderElection(&leaderElectionConfig{
-		Client:     n.cfg.Client,
-		ElectionID: electionID,
+		Client:                     n.cfg.Client,
+		ElectionID:                 electionID,
+		LeaderElectionResourceLock: n.cfg.LeaderElectionResourceLock,
+
 		OnStartedLeading: func(stopCh chan struct{}) {
 			if n.syncStatus != nil {
 				go n.syncStatus.Run(stopCh)


### PR DESCRIPTION
## What this PR does / why we need it:

Support for  configmaps lock for leaderelection is removed in K8s 1.24 with kubernetes/kubernetes#106852.
More details about the motivation to switch to leases - ref kubernetes/kubernetes#80289.

ingress-nginx is currently using configmaps . This PR proposes to add a cli flag for `leader-election-resource-lock` which is defaulted to `configmaps`. If the operator has updated the necessary RBAC permissions, they should first use `configmapsleases` for migration purposes and then switch to `leases` in the next release.

**Release Notes**:
```
 A CLI flag `--leader-election-resource-lock` is introduced which defaults to the `configmaps`. If you want to migrate to `configmapsleases` and then `leases` in the future, necessary RBAC should be added in your component. You should atleast be running a release with `configmapsleases` as the resourcelock before setting the flag to `leases`.
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):
-->
fixes #8091 

## How Has This Been Tested?
Tested by creating an image and updating on an existing deployment.
Resourcelocks were created as per set in the container spec of the `ingress-nginx-controller` deployment manifest.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
