### PR TITLE
Remove ingressclasses from controller role

### DIFF
--- a/charts/ingress-nginx/templates/controller-role.yaml
+++ b/charts/ingress-nginx/templates/controller-role.yaml
@@ -51,14 +51,6 @@ rules:
     verbs:
       - update
   - apiGroups:
-      - networking.k8s.io
-    resources:
-      - ingressclasses
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
       - ""
     resources:
       - configmaps

--- a/docs/deploy/rbac.md
+++ b/docs/deploy/rbac.md
@@ -36,6 +36,7 @@ granted to the ClusterRole named `ingress-nginx`
 * `services`, `ingresses`: get, list, watch
 * `events`: create, patch
 * `ingresses/status`: update
+* `ingressclasses`: get, list, watch
 
 ### Namespace Permissions
 


### PR DESCRIPTION
## What this PR does / why we need it:
The controller role contains a rule for the cluster-scoped IngressClasses resource. This rule has no effect when used in a role resource, and it presents issues for users of large multi-tenant clusters where access to cluster-scoped resources is often restricted. This PR removes the redundant rule.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## How Has This Been Tested?
Tested with kind E2E chart tests.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
