### PR TITLE
Allow to configure delay before controller exits

### DIFF
--- a/cmd/nginx/flags.go
+++ b/cmd/nginx/flags.go
@@ -192,6 +192,8 @@ Takes the form "<host>:port". If not provided, no admission controller is starte
 		statusUpdateInterval = flags.Int("status-update-interval", status.UpdateInterval, "Time interval in seconds in which the status should check if an update is required. Default is 60 seconds")
 
 		shutdownGracePeriod = flags.Int("shutdown-grace-period", 0, "Seconds to wait after receiving the shutdown signal, before stopping the nginx process.")
+
+		postShutdownGracePeriod = flags.Int("post-shutdown-grace-period", 10, "Seconds to wait after the nginx process has stopped before controller exits.")
 	)
 
 	flags.StringVar(&nginx.MaxmindMirror, "maxmind-mirror", "", `Maxmind mirror url (example: http://geoip.local/databases`)
@@ -309,6 +311,7 @@ https://blog.maxmind.com/2019/12/18/significant-changes-to-accessing-and-using-g
 		PublishStatusAddress:       *publishStatusAddress,
 		UpdateStatusOnShutdown:     *updateStatusOnShutdown,
 		ShutdownGracePeriod:        *shutdownGracePeriod,
+		PostShutdownGracePeriod:    *postShutdownGracePeriod,
 		UseNodeInternalIP:          *useNodeInternalIP,
 		SyncRateLimit:              *syncRateLimit,
 		HealthCheckHost:            *healthzHost,

--- a/cmd/nginx/main.go
+++ b/cmd/nginx/main.go
@@ -174,10 +174,7 @@ func handleSigterm(ngx *controller.NGINXController, delay int, exit exiter) {
 		exitCode = 1
 	}
 
-	klog.Infof(
-		"Handled quit, delaying controller exit for %d seconds",
-		delay,
-	)
+	klog.Infof("Handled quit, delaying controller exit for %d seconds", delay)
 	time.Sleep(time.Duration(delay) * time.Second)
 
 	klog.InfoS("Exiting", "code", exitCode)

--- a/cmd/nginx/main.go
+++ b/cmd/nginx/main.go
@@ -155,14 +155,14 @@ func main() {
 	go startHTTPServer(conf.HealthCheckHost, conf.ListenPorts.Health, mux)
 	go ngx.Start()
 
-	handleSigterm(ngx, func(code int) {
+	handleSigterm(ngx, conf.PostShutdownGracePeriod, func(code int) {
 		os.Exit(code)
 	})
 }
 
 type exiter func(code int)
 
-func handleSigterm(ngx *controller.NGINXController, exit exiter) {
+func handleSigterm(ngx *controller.NGINXController, delay int, exit exiter) {
 	signalChan := make(chan os.Signal, 1)
 	signal.Notify(signalChan, syscall.SIGTERM)
 	<-signalChan
@@ -174,8 +174,11 @@ func handleSigterm(ngx *controller.NGINXController, exit exiter) {
 		exitCode = 1
 	}
 
-	klog.InfoS("Handled quit, awaiting Pod deletion")
-	time.Sleep(10 * time.Second)
+	klog.Infof(
+		"Handled quit, delaying controller exit for %d seconds",
+		delay,
+	)
+	time.Sleep(time.Duration(delay) * time.Second)
 
 	klog.InfoS("Exiting", "code", exitCode)
 	exit(exitCode)

--- a/cmd/nginx/main_test.go
+++ b/cmd/nginx/main_test.go
@@ -105,7 +105,7 @@ func TestHandleSigterm(t *testing.T) {
 
 	ngx := controller.NewNGINXController(conf, nil)
 
-	go handleSigterm(ngx, func(code int) {
+	go handleSigterm(ngx, 10, func(code int) {
 		if code != 1 {
 			t.Errorf("Expected exit code 1 but %d received", code)
 		}

--- a/docs/user-guide/cli-arguments.md
+++ b/docs/user-guide/cli-arguments.md
@@ -40,6 +40,7 @@ They are set in the container spec of the `ingress-nginx-controller` Deployment 
 | `--maxmind-retries-count`          | Number of attempts to download the GeoIP DB. (default 1) |
 | `--maxmind-license-key`            | Maxmind license key to download GeoLite2 Databases. https://blog.maxmind.com/2019/12/18/significant-changes-to-accessing-and-using-geolite2-databases |
 | `--metrics-per-host`               | Export metrics per-host (default true) |
+| `--post-shutdown-grace-period`     | Additional delay in seconds before controller container exits. (default 10) |
 | `--profiler-port`                  | Port to use for expose the ingress controller Go profiler when it is enabled. (default 10245) |
 | `--profiling`                      | Enable profiling via web interface host:port/debug/pprof/ (default true) |
 | `--publish-service`                | Service fronting the Ingress controller. Takes the form "namespace/name". When used together with update-status, the controller mirrors the address of this service's endpoints to the load-balancer status of all Ingress objects it satisfies. |

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -116,7 +116,8 @@ type Configuration struct {
 
 	MonitorMaxBatchSize int
 
-	ShutdownGracePeriod int
+	PostShutdownGracePeriod int
+	ShutdownGracePeriod     int
 }
 
 // GetPublishService returns the Service used to set the load-balancer status of Ingresses.


### PR DESCRIPTION
## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Today there is a hardcoded 10 second delay after nginx has quit before the controller exits when the pod is to be terminated:
https://github.com/kubernetes/ingress-nginx/blob/5f7656f4ccb24dc29ed24941ebddaeab802d7285/cmd/nginx/main.go#L178

This was raised as [an issue](https://github.com/kubernetes/ingress-nginx/issues/8095) since it adds unnecessary delay to pod termination. This PR makes it configurable while keeping the current behavior as default.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
https://github.com/kubernetes/ingress-nginx/issues/8095

## How Has This Been Tested?
Tested in local dev environment by adding `--post-shutdown-grace-period` with various values and terminating the pod to see the new log message and the delay.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
