### PR TITLE
Versioned static manifests

### DIFF
--- a/deploy/static/provider/aws/1.19/deploy.yaml
+++ b/deploy/static/provider/aws/1.19/deploy.yaml
@@ -1,4 +1,3 @@
-#GENERATED FOR K8S 1.20
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -334,13 +333,6 @@ subjects:
 apiVersion: v1
 data:
   allow-snippet-annotations: "true"
-  http-snippet: |
-    server {
-      listen 2443;
-      return 308 https://$host$request_uri;
-    }
-  proxy-real-ip-cidr: XXX.XXX.XXX/XX
-  use-forwarded-headers: "true"
 kind: ConfigMap
 metadata:
   labels:
@@ -358,10 +350,8 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "60"
+    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
     service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
-    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-west-2:XXXXXXXX:certificate/XXXXXX-XXXXXXX-XXXXXXX-XXXXXXXX
-    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: https
     service.beta.kubernetes.io/aws-load-balancer-type: nlb
   labels:
     app.kubernetes.io/component: controller
@@ -375,20 +365,15 @@ metadata:
   namespace: ingress-nginx
 spec:
   externalTrafficPolicy: Local
-  ipFamilies:
-  - IPv4
-  ipFamilyPolicy: SingleStack
   ports:
-  - appProtocol: http
-    name: http
+  - name: http
     port: 80
     protocol: TCP
-    targetPort: tohttps
-  - appProtocol: https
-    name: https
+    targetPort: http
+  - name: https
     port: 443
     protocol: TCP
-    targetPort: http
+    targetPort: https
   selector:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
@@ -410,8 +395,7 @@ metadata:
   namespace: ingress-nginx
 spec:
   ports:
-  - appProtocol: https
-    name: https-webhook
+  - name: https-webhook
     port: 443
     targetPort: webhook
   selector:
@@ -491,11 +475,8 @@ spec:
         - containerPort: 80
           name: http
           protocol: TCP
-        - containerPort: 80
+        - containerPort: 443
           name: https
-          protocol: TCP
-        - containerPort: 2443
-          name: tohttps
           protocol: TCP
         - containerPort: 8443
           name: webhook

--- a/deploy/static/provider/aws/1.19/kustomization.yaml
+++ b/deploy/static/provider/aws/1.19/kustomization.yaml
@@ -1,0 +1,11 @@
+# NOTE: kustomize is not supported. This file exists only to be able to reference it from bases.
+# https://kubectl.docs.kubernetes.io/references/kustomize/bases/
+#
+# ```
+# namespace: ingress-nginx
+# bases:
+#   - github.com/kubernetes/ingress-nginx/deploy/static/provider/aws?ref=master
+# ```
+
+resources:
+  - deploy.yaml

--- a/deploy/static/provider/aws/1.20/deploy.yaml
+++ b/deploy/static/provider/aws/1.20/deploy.yaml
@@ -1,4 +1,3 @@
-#GENERATED FOR K8S 1.20
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -334,13 +333,6 @@ subjects:
 apiVersion: v1
 data:
   allow-snippet-annotations: "true"
-  http-snippet: |
-    server {
-      listen 2443;
-      return 308 https://$host$request_uri;
-    }
-  proxy-real-ip-cidr: XXX.XXX.XXX/XX
-  use-forwarded-headers: "true"
 kind: ConfigMap
 metadata:
   labels:
@@ -358,10 +350,8 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "60"
+    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
     service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
-    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-west-2:XXXXXXXX:certificate/XXXXXX-XXXXXXX-XXXXXXX-XXXXXXXX
-    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: https
     service.beta.kubernetes.io/aws-load-balancer-type: nlb
   labels:
     app.kubernetes.io/component: controller
@@ -383,12 +373,12 @@ spec:
     name: http
     port: 80
     protocol: TCP
-    targetPort: tohttps
+    targetPort: http
   - appProtocol: https
     name: https
     port: 443
     protocol: TCP
-    targetPort: http
+    targetPort: https
   selector:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
@@ -491,11 +481,8 @@ spec:
         - containerPort: 80
           name: http
           protocol: TCP
-        - containerPort: 80
+        - containerPort: 443
           name: https
-          protocol: TCP
-        - containerPort: 2443
-          name: tohttps
           protocol: TCP
         - containerPort: 8443
           name: webhook

--- a/deploy/static/provider/aws/1.20/kustomization.yaml
+++ b/deploy/static/provider/aws/1.20/kustomization.yaml
@@ -1,0 +1,11 @@
+# NOTE: kustomize is not supported. This file exists only to be able to reference it from bases.
+# https://kubectl.docs.kubernetes.io/references/kustomize/bases/
+#
+# ```
+# namespace: ingress-nginx
+# bases:
+#   - github.com/kubernetes/ingress-nginx/deploy/static/provider/aws?ref=master
+# ```
+
+resources:
+  - deploy.yaml

--- a/deploy/static/provider/aws/1.21/deploy.yaml
+++ b/deploy/static/provider/aws/1.21/deploy.yaml
@@ -1,4 +1,3 @@
-#GENERATED FOR K8S 1.20
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -334,13 +333,6 @@ subjects:
 apiVersion: v1
 data:
   allow-snippet-annotations: "true"
-  http-snippet: |
-    server {
-      listen 2443;
-      return 308 https://$host$request_uri;
-    }
-  proxy-real-ip-cidr: XXX.XXX.XXX/XX
-  use-forwarded-headers: "true"
 kind: ConfigMap
 metadata:
   labels:
@@ -358,10 +350,8 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "60"
+    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
     service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
-    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-west-2:XXXXXXXX:certificate/XXXXXX-XXXXXXX-XXXXXXX-XXXXXXXX
-    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: https
     service.beta.kubernetes.io/aws-load-balancer-type: nlb
   labels:
     app.kubernetes.io/component: controller
@@ -383,12 +373,12 @@ spec:
     name: http
     port: 80
     protocol: TCP
-    targetPort: tohttps
+    targetPort: http
   - appProtocol: https
     name: https
     port: 443
     protocol: TCP
-    targetPort: http
+    targetPort: https
   selector:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
@@ -491,11 +481,8 @@ spec:
         - containerPort: 80
           name: http
           protocol: TCP
-        - containerPort: 80
+        - containerPort: 443
           name: https
-          protocol: TCP
-        - containerPort: 2443
-          name: tohttps
           protocol: TCP
         - containerPort: 8443
           name: webhook

--- a/deploy/static/provider/aws/1.21/kustomization.yaml
+++ b/deploy/static/provider/aws/1.21/kustomization.yaml
@@ -1,0 +1,11 @@
+# NOTE: kustomize is not supported. This file exists only to be able to reference it from bases.
+# https://kubectl.docs.kubernetes.io/references/kustomize/bases/
+#
+# ```
+# namespace: ingress-nginx
+# bases:
+#   - github.com/kubernetes/ingress-nginx/deploy/static/provider/aws?ref=master
+# ```
+
+resources:
+  - deploy.yaml

--- a/deploy/static/provider/aws/1.22/deploy.yaml
+++ b/deploy/static/provider/aws/1.22/deploy.yaml
@@ -1,4 +1,3 @@
-#GENERATED FOR K8S 1.20
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -334,13 +333,6 @@ subjects:
 apiVersion: v1
 data:
   allow-snippet-annotations: "true"
-  http-snippet: |
-    server {
-      listen 2443;
-      return 308 https://$host$request_uri;
-    }
-  proxy-real-ip-cidr: XXX.XXX.XXX/XX
-  use-forwarded-headers: "true"
 kind: ConfigMap
 metadata:
   labels:
@@ -358,10 +350,8 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "60"
+    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
     service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
-    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-west-2:XXXXXXXX:certificate/XXXXXX-XXXXXXX-XXXXXXX-XXXXXXXX
-    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: https
     service.beta.kubernetes.io/aws-load-balancer-type: nlb
   labels:
     app.kubernetes.io/component: controller
@@ -383,12 +373,12 @@ spec:
     name: http
     port: 80
     protocol: TCP
-    targetPort: tohttps
+    targetPort: http
   - appProtocol: https
     name: https
     port: 443
     protocol: TCP
-    targetPort: http
+    targetPort: https
   selector:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
@@ -491,11 +481,8 @@ spec:
         - containerPort: 80
           name: http
           protocol: TCP
-        - containerPort: 80
+        - containerPort: 443
           name: https
-          protocol: TCP
-        - containerPort: 2443
-          name: tohttps
           protocol: TCP
         - containerPort: 8443
           name: webhook

--- a/deploy/static/provider/aws/1.22/kustomization.yaml
+++ b/deploy/static/provider/aws/1.22/kustomization.yaml
@@ -1,0 +1,11 @@
+# NOTE: kustomize is not supported. This file exists only to be able to reference it from bases.
+# https://kubectl.docs.kubernetes.io/references/kustomize/bases/
+#
+# ```
+# namespace: ingress-nginx
+# bases:
+#   - github.com/kubernetes/ingress-nginx/deploy/static/provider/aws?ref=master
+# ```
+
+resources:
+  - deploy.yaml

--- a/deploy/static/provider/aws/deploy.yaml
+++ b/deploy/static/provider/aws/deploy.yaml
@@ -16,8 +16,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx
   namespace: ingress-nginx
 ---
@@ -32,8 +33,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-admission
   namespace: ingress-nginx
 ---
@@ -45,8 +47,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx
   namespace: ingress-nginx
 rules:
@@ -131,8 +134,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-admission
   namespace: ingress-nginx
 rules:
@@ -151,8 +155,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx
 rules:
 - apiGroups:
@@ -222,8 +227,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-admission
 rules:
 - apiGroups:
@@ -242,8 +248,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx
   namespace: ingress-nginx
 roleRef:
@@ -266,8 +273,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-admission
   namespace: ingress-nginx
 roleRef:
@@ -286,8 +294,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -309,8 +318,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-admission
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -331,8 +341,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-controller
   namespace: ingress-nginx
 ---
@@ -348,8 +359,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -382,8 +394,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-controller-admission
   namespace: ingress-nginx
 spec:
@@ -406,8 +419,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -521,8 +535,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-admission-create
   namespace: ingress-nginx
 spec:
@@ -533,8 +548,9 @@ spec:
         app.kubernetes.io/instance: ingress-nginx
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
+        app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.1
-        helm.sh/chart: ingress-nginx-4.0.15
+        helm.sh/chart: ingress-nginx-4.0.16
       name: ingress-nginx-admission-create
     spec:
       containers:
@@ -572,8 +588,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-admission-patch
   namespace: ingress-nginx
 spec:
@@ -584,8 +601,9 @@ spec:
         app.kubernetes.io/instance: ingress-nginx
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
+        app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.1
-        helm.sh/chart: ingress-nginx-4.0.15
+        helm.sh/chart: ingress-nginx-4.0.16
       name: ingress-nginx-admission-patch
     spec:
       containers:
@@ -622,8 +640,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
@@ -636,8 +655,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-admission
 webhooks:
 - admissionReviewVersions:

--- a/deploy/static/provider/aws/nlb-with-tls-termination/1.19/deploy.yaml
+++ b/deploy/static/provider/aws/nlb-with-tls-termination/1.19/deploy.yaml
@@ -1,4 +1,3 @@
-#GENERATED FOR K8S 1.20
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -375,17 +374,12 @@ metadata:
   namespace: ingress-nginx
 spec:
   externalTrafficPolicy: Local
-  ipFamilies:
-  - IPv4
-  ipFamilyPolicy: SingleStack
   ports:
-  - appProtocol: http
-    name: http
+  - name: http
     port: 80
     protocol: TCP
     targetPort: tohttps
-  - appProtocol: https
-    name: https
+  - name: https
     port: 443
     protocol: TCP
     targetPort: http
@@ -410,8 +404,7 @@ metadata:
   namespace: ingress-nginx
 spec:
   ports:
-  - appProtocol: https
-    name: https-webhook
+  - name: https-webhook
     port: 443
     targetPort: webhook
   selector:

--- a/deploy/static/provider/aws/nlb-with-tls-termination/1.19/kustomization.yaml
+++ b/deploy/static/provider/aws/nlb-with-tls-termination/1.19/kustomization.yaml
@@ -1,0 +1,11 @@
+# NOTE: kustomize is not supported. This file exists only to be able to reference it from bases.
+# https://kubectl.docs.kubernetes.io/references/kustomize/bases/
+#
+# ```
+# namespace: ingress-nginx
+# bases:
+#   - github.com/kubernetes/ingress-nginx/deploy/static/provider/aws/nlb-with-tls-termination?ref=master
+# ```
+
+resources:
+  - deploy.yaml

--- a/deploy/static/provider/aws/nlb-with-tls-termination/1.20/deploy.yaml
+++ b/deploy/static/provider/aws/nlb-with-tls-termination/1.20/deploy.yaml
@@ -1,4 +1,3 @@
-#GENERATED FOR K8S 1.20
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/deploy/static/provider/aws/nlb-with-tls-termination/1.20/kustomization.yaml
+++ b/deploy/static/provider/aws/nlb-with-tls-termination/1.20/kustomization.yaml
@@ -1,0 +1,11 @@
+# NOTE: kustomize is not supported. This file exists only to be able to reference it from bases.
+# https://kubectl.docs.kubernetes.io/references/kustomize/bases/
+#
+# ```
+# namespace: ingress-nginx
+# bases:
+#   - github.com/kubernetes/ingress-nginx/deploy/static/provider/aws/nlb-with-tls-termination?ref=master
+# ```
+
+resources:
+  - deploy.yaml

--- a/deploy/static/provider/aws/nlb-with-tls-termination/1.21/deploy.yaml
+++ b/deploy/static/provider/aws/nlb-with-tls-termination/1.21/deploy.yaml
@@ -1,4 +1,3 @@
-#GENERATED FOR K8S 1.20
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/deploy/static/provider/aws/nlb-with-tls-termination/1.21/kustomization.yaml
+++ b/deploy/static/provider/aws/nlb-with-tls-termination/1.21/kustomization.yaml
@@ -1,0 +1,11 @@
+# NOTE: kustomize is not supported. This file exists only to be able to reference it from bases.
+# https://kubectl.docs.kubernetes.io/references/kustomize/bases/
+#
+# ```
+# namespace: ingress-nginx
+# bases:
+#   - github.com/kubernetes/ingress-nginx/deploy/static/provider/aws/nlb-with-tls-termination?ref=master
+# ```
+
+resources:
+  - deploy.yaml

--- a/deploy/static/provider/aws/nlb-with-tls-termination/1.22/deploy.yaml
+++ b/deploy/static/provider/aws/nlb-with-tls-termination/1.22/deploy.yaml
@@ -1,4 +1,3 @@
-#GENERATED FOR K8S 1.20
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/deploy/static/provider/aws/nlb-with-tls-termination/1.22/kustomization.yaml
+++ b/deploy/static/provider/aws/nlb-with-tls-termination/1.22/kustomization.yaml
@@ -1,0 +1,11 @@
+# NOTE: kustomize is not supported. This file exists only to be able to reference it from bases.
+# https://kubectl.docs.kubernetes.io/references/kustomize/bases/
+#
+# ```
+# namespace: ingress-nginx
+# bases:
+#   - github.com/kubernetes/ingress-nginx/deploy/static/provider/aws/nlb-with-tls-termination?ref=master
+# ```
+
+resources:
+  - deploy.yaml

--- a/deploy/static/provider/baremetal/1.19/deploy.yaml
+++ b/deploy/static/provider/baremetal/1.19/deploy.yaml
@@ -1,4 +1,3 @@
-#GENERATED FOR K8S 1.20
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -334,13 +333,6 @@ subjects:
 apiVersion: v1
 data:
   allow-snippet-annotations: "true"
-  http-snippet: |
-    server {
-      listen 2443;
-      return 308 https://$host$request_uri;
-    }
-  proxy-real-ip-cidr: XXX.XXX.XXX/XX
-  use-forwarded-headers: "true"
 kind: ConfigMap
 metadata:
   labels:
@@ -357,12 +349,7 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "60"
-    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
-    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-west-2:XXXXXXXX:certificate/XXXXXX-XXXXXXX-XXXXXXX-XXXXXXXX
-    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: https
-    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+  annotations: null
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
@@ -374,26 +361,20 @@ metadata:
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
-  externalTrafficPolicy: Local
-  ipFamilies:
-  - IPv4
-  ipFamilyPolicy: SingleStack
   ports:
-  - appProtocol: http
-    name: http
+  - name: http
     port: 80
     protocol: TCP
-    targetPort: tohttps
-  - appProtocol: https
-    name: https
+    targetPort: http
+  - name: https
     port: 443
     protocol: TCP
-    targetPort: http
+    targetPort: https
   selector:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
-  type: LoadBalancer
+  type: NodePort
 ---
 apiVersion: v1
 kind: Service
@@ -410,8 +391,7 @@ metadata:
   namespace: ingress-nginx
 spec:
   ports:
-  - appProtocol: https
-    name: https-webhook
+  - name: https-webhook
     port: 443
     targetPort: webhook
   selector:
@@ -451,7 +431,6 @@ spec:
       containers:
       - args:
         - /nginx-ingress-controller
-        - --publish-service=$(POD_NAMESPACE)/ingress-nginx-controller
         - --election-id=ingress-controller-leader
         - --controller-class=k8s.io/ingress-nginx
         - --configmap=$(POD_NAMESPACE)/ingress-nginx-controller
@@ -491,11 +470,8 @@ spec:
         - containerPort: 80
           name: http
           protocol: TCP
-        - containerPort: 80
+        - containerPort: 443
           name: https
-          protocol: TCP
-        - containerPort: 2443
-          name: tohttps
           protocol: TCP
         - containerPort: 8443
           name: webhook

--- a/deploy/static/provider/baremetal/1.19/kustomization.yaml
+++ b/deploy/static/provider/baremetal/1.19/kustomization.yaml
@@ -1,0 +1,11 @@
+# NOTE: kustomize is not supported. This file exists only to be able to reference it from bases.
+# https://kubectl.docs.kubernetes.io/references/kustomize/bases/
+#
+# ```
+# namespace: ingress-nginx
+# bases:
+#   - github.com/kubernetes/ingress-nginx/deploy/static/provider/baremetal?ref=master
+# ```
+
+resources:
+  - deploy.yaml

--- a/deploy/static/provider/baremetal/1.20/deploy.yaml
+++ b/deploy/static/provider/baremetal/1.20/deploy.yaml
@@ -1,4 +1,3 @@
-#GENERATED FOR K8S 1.20
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -334,13 +333,6 @@ subjects:
 apiVersion: v1
 data:
   allow-snippet-annotations: "true"
-  http-snippet: |
-    server {
-      listen 2443;
-      return 308 https://$host$request_uri;
-    }
-  proxy-real-ip-cidr: XXX.XXX.XXX/XX
-  use-forwarded-headers: "true"
 kind: ConfigMap
 metadata:
   labels:
@@ -357,12 +349,7 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "60"
-    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
-    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-west-2:XXXXXXXX:certificate/XXXXXX-XXXXXXX-XXXXXXX-XXXXXXXX
-    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: https
-    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+  annotations: null
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
@@ -374,7 +361,6 @@ metadata:
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
-  externalTrafficPolicy: Local
   ipFamilies:
   - IPv4
   ipFamilyPolicy: SingleStack
@@ -383,17 +369,17 @@ spec:
     name: http
     port: 80
     protocol: TCP
-    targetPort: tohttps
+    targetPort: http
   - appProtocol: https
     name: https
     port: 443
     protocol: TCP
-    targetPort: http
+    targetPort: https
   selector:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
-  type: LoadBalancer
+  type: NodePort
 ---
 apiVersion: v1
 kind: Service
@@ -451,7 +437,6 @@ spec:
       containers:
       - args:
         - /nginx-ingress-controller
-        - --publish-service=$(POD_NAMESPACE)/ingress-nginx-controller
         - --election-id=ingress-controller-leader
         - --controller-class=k8s.io/ingress-nginx
         - --configmap=$(POD_NAMESPACE)/ingress-nginx-controller
@@ -491,11 +476,8 @@ spec:
         - containerPort: 80
           name: http
           protocol: TCP
-        - containerPort: 80
+        - containerPort: 443
           name: https
-          protocol: TCP
-        - containerPort: 2443
-          name: tohttps
           protocol: TCP
         - containerPort: 8443
           name: webhook

--- a/deploy/static/provider/baremetal/1.20/kustomization.yaml
+++ b/deploy/static/provider/baremetal/1.20/kustomization.yaml
@@ -1,0 +1,11 @@
+# NOTE: kustomize is not supported. This file exists only to be able to reference it from bases.
+# https://kubectl.docs.kubernetes.io/references/kustomize/bases/
+#
+# ```
+# namespace: ingress-nginx
+# bases:
+#   - github.com/kubernetes/ingress-nginx/deploy/static/provider/baremetal?ref=master
+# ```
+
+resources:
+  - deploy.yaml

--- a/deploy/static/provider/baremetal/1.21/deploy.yaml
+++ b/deploy/static/provider/baremetal/1.21/deploy.yaml
@@ -1,4 +1,3 @@
-#GENERATED FOR K8S 1.20
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -334,13 +333,6 @@ subjects:
 apiVersion: v1
 data:
   allow-snippet-annotations: "true"
-  http-snippet: |
-    server {
-      listen 2443;
-      return 308 https://$host$request_uri;
-    }
-  proxy-real-ip-cidr: XXX.XXX.XXX/XX
-  use-forwarded-headers: "true"
 kind: ConfigMap
 metadata:
   labels:
@@ -357,12 +349,7 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "60"
-    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
-    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-west-2:XXXXXXXX:certificate/XXXXXX-XXXXXXX-XXXXXXX-XXXXXXXX
-    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: https
-    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+  annotations: null
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
@@ -374,7 +361,6 @@ metadata:
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
-  externalTrafficPolicy: Local
   ipFamilies:
   - IPv4
   ipFamilyPolicy: SingleStack
@@ -383,17 +369,17 @@ spec:
     name: http
     port: 80
     protocol: TCP
-    targetPort: tohttps
+    targetPort: http
   - appProtocol: https
     name: https
     port: 443
     protocol: TCP
-    targetPort: http
+    targetPort: https
   selector:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
-  type: LoadBalancer
+  type: NodePort
 ---
 apiVersion: v1
 kind: Service
@@ -451,7 +437,6 @@ spec:
       containers:
       - args:
         - /nginx-ingress-controller
-        - --publish-service=$(POD_NAMESPACE)/ingress-nginx-controller
         - --election-id=ingress-controller-leader
         - --controller-class=k8s.io/ingress-nginx
         - --configmap=$(POD_NAMESPACE)/ingress-nginx-controller
@@ -491,11 +476,8 @@ spec:
         - containerPort: 80
           name: http
           protocol: TCP
-        - containerPort: 80
+        - containerPort: 443
           name: https
-          protocol: TCP
-        - containerPort: 2443
-          name: tohttps
           protocol: TCP
         - containerPort: 8443
           name: webhook

--- a/deploy/static/provider/baremetal/1.21/kustomization.yaml
+++ b/deploy/static/provider/baremetal/1.21/kustomization.yaml
@@ -1,0 +1,11 @@
+# NOTE: kustomize is not supported. This file exists only to be able to reference it from bases.
+# https://kubectl.docs.kubernetes.io/references/kustomize/bases/
+#
+# ```
+# namespace: ingress-nginx
+# bases:
+#   - github.com/kubernetes/ingress-nginx/deploy/static/provider/baremetal?ref=master
+# ```
+
+resources:
+  - deploy.yaml

--- a/deploy/static/provider/baremetal/1.22/deploy.yaml
+++ b/deploy/static/provider/baremetal/1.22/deploy.yaml
@@ -1,4 +1,3 @@
-#GENERATED FOR K8S 1.20
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -334,13 +333,6 @@ subjects:
 apiVersion: v1
 data:
   allow-snippet-annotations: "true"
-  http-snippet: |
-    server {
-      listen 2443;
-      return 308 https://$host$request_uri;
-    }
-  proxy-real-ip-cidr: XXX.XXX.XXX/XX
-  use-forwarded-headers: "true"
 kind: ConfigMap
 metadata:
   labels:
@@ -357,12 +349,7 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "60"
-    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
-    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-west-2:XXXXXXXX:certificate/XXXXXX-XXXXXXX-XXXXXXX-XXXXXXXX
-    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: https
-    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+  annotations: null
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
@@ -374,7 +361,6 @@ metadata:
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
-  externalTrafficPolicy: Local
   ipFamilies:
   - IPv4
   ipFamilyPolicy: SingleStack
@@ -383,17 +369,17 @@ spec:
     name: http
     port: 80
     protocol: TCP
-    targetPort: tohttps
+    targetPort: http
   - appProtocol: https
     name: https
     port: 443
     protocol: TCP
-    targetPort: http
+    targetPort: https
   selector:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
-  type: LoadBalancer
+  type: NodePort
 ---
 apiVersion: v1
 kind: Service
@@ -451,7 +437,6 @@ spec:
       containers:
       - args:
         - /nginx-ingress-controller
-        - --publish-service=$(POD_NAMESPACE)/ingress-nginx-controller
         - --election-id=ingress-controller-leader
         - --controller-class=k8s.io/ingress-nginx
         - --configmap=$(POD_NAMESPACE)/ingress-nginx-controller
@@ -491,11 +476,8 @@ spec:
         - containerPort: 80
           name: http
           protocol: TCP
-        - containerPort: 80
+        - containerPort: 443
           name: https
-          protocol: TCP
-        - containerPort: 2443
-          name: tohttps
           protocol: TCP
         - containerPort: 8443
           name: webhook

--- a/deploy/static/provider/baremetal/1.22/kustomization.yaml
+++ b/deploy/static/provider/baremetal/1.22/kustomization.yaml
@@ -1,0 +1,11 @@
+# NOTE: kustomize is not supported. This file exists only to be able to reference it from bases.
+# https://kubectl.docs.kubernetes.io/references/kustomize/bases/
+#
+# ```
+# namespace: ingress-nginx
+# bases:
+#   - github.com/kubernetes/ingress-nginx/deploy/static/provider/baremetal?ref=master
+# ```
+
+resources:
+  - deploy.yaml

--- a/deploy/static/provider/baremetal/deploy.yaml
+++ b/deploy/static/provider/baremetal/deploy.yaml
@@ -16,8 +16,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx
   namespace: ingress-nginx
 ---
@@ -32,8 +33,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-admission
   namespace: ingress-nginx
 ---
@@ -45,8 +47,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx
   namespace: ingress-nginx
 rules:
@@ -131,8 +134,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-admission
   namespace: ingress-nginx
 rules:
@@ -151,8 +155,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx
 rules:
 - apiGroups:
@@ -222,8 +227,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-admission
 rules:
 - apiGroups:
@@ -242,8 +248,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx
   namespace: ingress-nginx
 roleRef:
@@ -266,8 +273,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-admission
   namespace: ingress-nginx
 roleRef:
@@ -286,8 +294,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -309,8 +318,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-admission
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -331,8 +341,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-controller
   namespace: ingress-nginx
 ---
@@ -345,8 +356,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -378,8 +390,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-controller-admission
   namespace: ingress-nginx
 spec:
@@ -402,8 +415,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -516,8 +530,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-admission-create
   namespace: ingress-nginx
 spec:
@@ -528,8 +543,9 @@ spec:
         app.kubernetes.io/instance: ingress-nginx
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
+        app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.1
-        helm.sh/chart: ingress-nginx-4.0.15
+        helm.sh/chart: ingress-nginx-4.0.16
       name: ingress-nginx-admission-create
     spec:
       containers:
@@ -567,8 +583,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-admission-patch
   namespace: ingress-nginx
 spec:
@@ -579,8 +596,9 @@ spec:
         app.kubernetes.io/instance: ingress-nginx
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
+        app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.1
-        helm.sh/chart: ingress-nginx-4.0.15
+        helm.sh/chart: ingress-nginx-4.0.16
       name: ingress-nginx-admission-patch
     spec:
       containers:
@@ -617,8 +635,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
@@ -631,8 +650,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-admission
 webhooks:
 - admissionReviewVersions:

--- a/deploy/static/provider/cloud/1.19/deploy.yaml
+++ b/deploy/static/provider/cloud/1.19/deploy.yaml
@@ -1,4 +1,3 @@
-#GENERATED FOR K8S 1.20
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -334,13 +333,6 @@ subjects:
 apiVersion: v1
 data:
   allow-snippet-annotations: "true"
-  http-snippet: |
-    server {
-      listen 2443;
-      return 308 https://$host$request_uri;
-    }
-  proxy-real-ip-cidr: XXX.XXX.XXX/XX
-  use-forwarded-headers: "true"
 kind: ConfigMap
 metadata:
   labels:
@@ -357,12 +349,7 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "60"
-    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
-    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-west-2:XXXXXXXX:certificate/XXXXXX-XXXXXXX-XXXXXXX-XXXXXXXX
-    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: https
-    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+  annotations: null
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
@@ -375,20 +362,15 @@ metadata:
   namespace: ingress-nginx
 spec:
   externalTrafficPolicy: Local
-  ipFamilies:
-  - IPv4
-  ipFamilyPolicy: SingleStack
   ports:
-  - appProtocol: http
-    name: http
+  - name: http
     port: 80
     protocol: TCP
-    targetPort: tohttps
-  - appProtocol: https
-    name: https
+    targetPort: http
+  - name: https
     port: 443
     protocol: TCP
-    targetPort: http
+    targetPort: https
   selector:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
@@ -410,8 +392,7 @@ metadata:
   namespace: ingress-nginx
 spec:
   ports:
-  - appProtocol: https
-    name: https-webhook
+  - name: https-webhook
     port: 443
     targetPort: webhook
   selector:
@@ -491,11 +472,8 @@ spec:
         - containerPort: 80
           name: http
           protocol: TCP
-        - containerPort: 80
+        - containerPort: 443
           name: https
-          protocol: TCP
-        - containerPort: 2443
-          name: tohttps
           protocol: TCP
         - containerPort: 8443
           name: webhook

--- a/deploy/static/provider/cloud/1.19/kustomization.yaml
+++ b/deploy/static/provider/cloud/1.19/kustomization.yaml
@@ -1,0 +1,11 @@
+# NOTE: kustomize is not supported. This file exists only to be able to reference it from bases.
+# https://kubectl.docs.kubernetes.io/references/kustomize/bases/
+#
+# ```
+# namespace: ingress-nginx
+# bases:
+#   - github.com/kubernetes/ingress-nginx/deploy/static/provider/cloud?ref=master
+# ```
+
+resources:
+  - deploy.yaml

--- a/deploy/static/provider/cloud/1.20/deploy.yaml
+++ b/deploy/static/provider/cloud/1.20/deploy.yaml
@@ -1,4 +1,3 @@
-#GENERATED FOR K8S 1.20
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -334,13 +333,6 @@ subjects:
 apiVersion: v1
 data:
   allow-snippet-annotations: "true"
-  http-snippet: |
-    server {
-      listen 2443;
-      return 308 https://$host$request_uri;
-    }
-  proxy-real-ip-cidr: XXX.XXX.XXX/XX
-  use-forwarded-headers: "true"
 kind: ConfigMap
 metadata:
   labels:
@@ -357,12 +349,7 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "60"
-    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
-    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-west-2:XXXXXXXX:certificate/XXXXXX-XXXXXXX-XXXXXXX-XXXXXXXX
-    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: https
-    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+  annotations: null
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
@@ -383,12 +370,12 @@ spec:
     name: http
     port: 80
     protocol: TCP
-    targetPort: tohttps
+    targetPort: http
   - appProtocol: https
     name: https
     port: 443
     protocol: TCP
-    targetPort: http
+    targetPort: https
   selector:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
@@ -491,11 +478,8 @@ spec:
         - containerPort: 80
           name: http
           protocol: TCP
-        - containerPort: 80
+        - containerPort: 443
           name: https
-          protocol: TCP
-        - containerPort: 2443
-          name: tohttps
           protocol: TCP
         - containerPort: 8443
           name: webhook

--- a/deploy/static/provider/cloud/1.20/kustomization.yaml
+++ b/deploy/static/provider/cloud/1.20/kustomization.yaml
@@ -1,0 +1,11 @@
+# NOTE: kustomize is not supported. This file exists only to be able to reference it from bases.
+# https://kubectl.docs.kubernetes.io/references/kustomize/bases/
+#
+# ```
+# namespace: ingress-nginx
+# bases:
+#   - github.com/kubernetes/ingress-nginx/deploy/static/provider/cloud?ref=master
+# ```
+
+resources:
+  - deploy.yaml

--- a/deploy/static/provider/cloud/1.21/deploy.yaml
+++ b/deploy/static/provider/cloud/1.21/deploy.yaml
@@ -1,4 +1,3 @@
-#GENERATED FOR K8S 1.20
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -334,13 +333,6 @@ subjects:
 apiVersion: v1
 data:
   allow-snippet-annotations: "true"
-  http-snippet: |
-    server {
-      listen 2443;
-      return 308 https://$host$request_uri;
-    }
-  proxy-real-ip-cidr: XXX.XXX.XXX/XX
-  use-forwarded-headers: "true"
 kind: ConfigMap
 metadata:
   labels:
@@ -357,12 +349,7 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "60"
-    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
-    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-west-2:XXXXXXXX:certificate/XXXXXX-XXXXXXX-XXXXXXX-XXXXXXXX
-    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: https
-    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+  annotations: null
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
@@ -383,12 +370,12 @@ spec:
     name: http
     port: 80
     protocol: TCP
-    targetPort: tohttps
+    targetPort: http
   - appProtocol: https
     name: https
     port: 443
     protocol: TCP
-    targetPort: http
+    targetPort: https
   selector:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
@@ -491,11 +478,8 @@ spec:
         - containerPort: 80
           name: http
           protocol: TCP
-        - containerPort: 80
+        - containerPort: 443
           name: https
-          protocol: TCP
-        - containerPort: 2443
-          name: tohttps
           protocol: TCP
         - containerPort: 8443
           name: webhook

--- a/deploy/static/provider/cloud/1.21/kustomization.yaml
+++ b/deploy/static/provider/cloud/1.21/kustomization.yaml
@@ -1,0 +1,11 @@
+# NOTE: kustomize is not supported. This file exists only to be able to reference it from bases.
+# https://kubectl.docs.kubernetes.io/references/kustomize/bases/
+#
+# ```
+# namespace: ingress-nginx
+# bases:
+#   - github.com/kubernetes/ingress-nginx/deploy/static/provider/cloud?ref=master
+# ```
+
+resources:
+  - deploy.yaml

--- a/deploy/static/provider/cloud/1.22/deploy.yaml
+++ b/deploy/static/provider/cloud/1.22/deploy.yaml
@@ -1,4 +1,3 @@
-#GENERATED FOR K8S 1.20
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -334,13 +333,6 @@ subjects:
 apiVersion: v1
 data:
   allow-snippet-annotations: "true"
-  http-snippet: |
-    server {
-      listen 2443;
-      return 308 https://$host$request_uri;
-    }
-  proxy-real-ip-cidr: XXX.XXX.XXX/XX
-  use-forwarded-headers: "true"
 kind: ConfigMap
 metadata:
   labels:
@@ -357,12 +349,7 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "60"
-    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
-    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-west-2:XXXXXXXX:certificate/XXXXXX-XXXXXXX-XXXXXXX-XXXXXXXX
-    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: https
-    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+  annotations: null
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
@@ -383,12 +370,12 @@ spec:
     name: http
     port: 80
     protocol: TCP
-    targetPort: tohttps
+    targetPort: http
   - appProtocol: https
     name: https
     port: 443
     protocol: TCP
-    targetPort: http
+    targetPort: https
   selector:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
@@ -491,11 +478,8 @@ spec:
         - containerPort: 80
           name: http
           protocol: TCP
-        - containerPort: 80
+        - containerPort: 443
           name: https
-          protocol: TCP
-        - containerPort: 2443
-          name: tohttps
           protocol: TCP
         - containerPort: 8443
           name: webhook

--- a/deploy/static/provider/cloud/1.22/kustomization.yaml
+++ b/deploy/static/provider/cloud/1.22/kustomization.yaml
@@ -1,0 +1,11 @@
+# NOTE: kustomize is not supported. This file exists only to be able to reference it from bases.
+# https://kubectl.docs.kubernetes.io/references/kustomize/bases/
+#
+# ```
+# namespace: ingress-nginx
+# bases:
+#   - github.com/kubernetes/ingress-nginx/deploy/static/provider/cloud?ref=master
+# ```
+
+resources:
+  - deploy.yaml

--- a/deploy/static/provider/cloud/deploy.yaml
+++ b/deploy/static/provider/cloud/deploy.yaml
@@ -16,8 +16,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx
   namespace: ingress-nginx
 ---
@@ -32,8 +33,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-admission
   namespace: ingress-nginx
 ---
@@ -45,8 +47,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx
   namespace: ingress-nginx
 rules:
@@ -131,8 +134,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-admission
   namespace: ingress-nginx
 rules:
@@ -151,8 +155,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx
 rules:
 - apiGroups:
@@ -222,8 +227,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-admission
 rules:
 - apiGroups:
@@ -242,8 +248,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx
   namespace: ingress-nginx
 roleRef:
@@ -266,8 +273,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-admission
   namespace: ingress-nginx
 roleRef:
@@ -286,8 +294,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -309,8 +318,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-admission
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -331,8 +341,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-controller
   namespace: ingress-nginx
 ---
@@ -345,8 +356,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -379,8 +391,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-controller-admission
   namespace: ingress-nginx
 spec:
@@ -403,8 +416,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -518,8 +532,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-admission-create
   namespace: ingress-nginx
 spec:
@@ -530,8 +545,9 @@ spec:
         app.kubernetes.io/instance: ingress-nginx
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
+        app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.1
-        helm.sh/chart: ingress-nginx-4.0.15
+        helm.sh/chart: ingress-nginx-4.0.16
       name: ingress-nginx-admission-create
     spec:
       containers:
@@ -569,8 +585,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-admission-patch
   namespace: ingress-nginx
 spec:
@@ -581,8 +598,9 @@ spec:
         app.kubernetes.io/instance: ingress-nginx
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
+        app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.1
-        helm.sh/chart: ingress-nginx-4.0.15
+        helm.sh/chart: ingress-nginx-4.0.16
       name: ingress-nginx-admission-patch
     spec:
       containers:
@@ -619,8 +637,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
@@ -633,8 +652,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-admission
 webhooks:
 - admissionReviewVersions:

--- a/deploy/static/provider/do/1.19/deploy.yaml
+++ b/deploy/static/provider/do/1.19/deploy.yaml
@@ -1,4 +1,3 @@
-#GENERATED FOR K8S 1.20
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -334,13 +333,7 @@ subjects:
 apiVersion: v1
 data:
   allow-snippet-annotations: "true"
-  http-snippet: |
-    server {
-      listen 2443;
-      return 308 https://$host$request_uri;
-    }
-  proxy-real-ip-cidr: XXX.XXX.XXX/XX
-  use-forwarded-headers: "true"
+  use-proxy-protocol: "true"
 kind: ConfigMap
 metadata:
   labels:
@@ -358,11 +351,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "60"
-    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
-    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-west-2:XXXXXXXX:certificate/XXXXXX-XXXXXXX-XXXXXXX-XXXXXXXX
-    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: https
-    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+    service.beta.kubernetes.io/do-loadbalancer-enable-proxy-protocol: "true"
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
@@ -375,20 +364,15 @@ metadata:
   namespace: ingress-nginx
 spec:
   externalTrafficPolicy: Local
-  ipFamilies:
-  - IPv4
-  ipFamilyPolicy: SingleStack
   ports:
-  - appProtocol: http
-    name: http
+  - name: http
     port: 80
     protocol: TCP
-    targetPort: tohttps
-  - appProtocol: https
-    name: https
+    targetPort: http
+  - name: https
     port: 443
     protocol: TCP
-    targetPort: http
+    targetPort: https
   selector:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
@@ -410,8 +394,7 @@ metadata:
   namespace: ingress-nginx
 spec:
   ports:
-  - appProtocol: https
-    name: https-webhook
+  - name: https-webhook
     port: 443
     targetPort: webhook
   selector:
@@ -491,11 +474,8 @@ spec:
         - containerPort: 80
           name: http
           protocol: TCP
-        - containerPort: 80
+        - containerPort: 443
           name: https
-          protocol: TCP
-        - containerPort: 2443
-          name: tohttps
           protocol: TCP
         - containerPort: 8443
           name: webhook
@@ -693,3 +673,4 @@ webhooks:
     resources:
     - ingresses
   sideEffects: None
+  timeoutSeconds: 29

--- a/deploy/static/provider/do/1.19/kustomization.yaml
+++ b/deploy/static/provider/do/1.19/kustomization.yaml
@@ -1,0 +1,11 @@
+# NOTE: kustomize is not supported. This file exists only to be able to reference it from bases.
+# https://kubectl.docs.kubernetes.io/references/kustomize/bases/
+#
+# ```
+# namespace: ingress-nginx
+# bases:
+#   - github.com/kubernetes/ingress-nginx/deploy/static/provider/do?ref=master
+# ```
+
+resources:
+  - deploy.yaml

--- a/deploy/static/provider/do/1.20/deploy.yaml
+++ b/deploy/static/provider/do/1.20/deploy.yaml
@@ -1,4 +1,3 @@
-#GENERATED FOR K8S 1.20
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -334,13 +333,7 @@ subjects:
 apiVersion: v1
 data:
   allow-snippet-annotations: "true"
-  http-snippet: |
-    server {
-      listen 2443;
-      return 308 https://$host$request_uri;
-    }
-  proxy-real-ip-cidr: XXX.XXX.XXX/XX
-  use-forwarded-headers: "true"
+  use-proxy-protocol: "true"
 kind: ConfigMap
 metadata:
   labels:
@@ -358,11 +351,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "60"
-    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
-    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-west-2:XXXXXXXX:certificate/XXXXXX-XXXXXXX-XXXXXXX-XXXXXXXX
-    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: https
-    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+    service.beta.kubernetes.io/do-loadbalancer-enable-proxy-protocol: "true"
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
@@ -383,12 +372,12 @@ spec:
     name: http
     port: 80
     protocol: TCP
-    targetPort: tohttps
+    targetPort: http
   - appProtocol: https
     name: https
     port: 443
     protocol: TCP
-    targetPort: http
+    targetPort: https
   selector:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
@@ -491,11 +480,8 @@ spec:
         - containerPort: 80
           name: http
           protocol: TCP
-        - containerPort: 80
+        - containerPort: 443
           name: https
-          protocol: TCP
-        - containerPort: 2443
-          name: tohttps
           protocol: TCP
         - containerPort: 8443
           name: webhook
@@ -693,3 +679,4 @@ webhooks:
     resources:
     - ingresses
   sideEffects: None
+  timeoutSeconds: 29

--- a/deploy/static/provider/do/1.20/kustomization.yaml
+++ b/deploy/static/provider/do/1.20/kustomization.yaml
@@ -1,0 +1,11 @@
+# NOTE: kustomize is not supported. This file exists only to be able to reference it from bases.
+# https://kubectl.docs.kubernetes.io/references/kustomize/bases/
+#
+# ```
+# namespace: ingress-nginx
+# bases:
+#   - github.com/kubernetes/ingress-nginx/deploy/static/provider/do?ref=master
+# ```
+
+resources:
+  - deploy.yaml

--- a/deploy/static/provider/do/1.21/deploy.yaml
+++ b/deploy/static/provider/do/1.21/deploy.yaml
@@ -1,4 +1,3 @@
-#GENERATED FOR K8S 1.20
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -334,13 +333,7 @@ subjects:
 apiVersion: v1
 data:
   allow-snippet-annotations: "true"
-  http-snippet: |
-    server {
-      listen 2443;
-      return 308 https://$host$request_uri;
-    }
-  proxy-real-ip-cidr: XXX.XXX.XXX/XX
-  use-forwarded-headers: "true"
+  use-proxy-protocol: "true"
 kind: ConfigMap
 metadata:
   labels:
@@ -358,11 +351,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "60"
-    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
-    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-west-2:XXXXXXXX:certificate/XXXXXX-XXXXXXX-XXXXXXX-XXXXXXXX
-    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: https
-    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+    service.beta.kubernetes.io/do-loadbalancer-enable-proxy-protocol: "true"
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
@@ -383,12 +372,12 @@ spec:
     name: http
     port: 80
     protocol: TCP
-    targetPort: tohttps
+    targetPort: http
   - appProtocol: https
     name: https
     port: 443
     protocol: TCP
-    targetPort: http
+    targetPort: https
   selector:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
@@ -491,11 +480,8 @@ spec:
         - containerPort: 80
           name: http
           protocol: TCP
-        - containerPort: 80
+        - containerPort: 443
           name: https
-          protocol: TCP
-        - containerPort: 2443
-          name: tohttps
           protocol: TCP
         - containerPort: 8443
           name: webhook
@@ -693,3 +679,4 @@ webhooks:
     resources:
     - ingresses
   sideEffects: None
+  timeoutSeconds: 29

--- a/deploy/static/provider/do/1.21/kustomization.yaml
+++ b/deploy/static/provider/do/1.21/kustomization.yaml
@@ -1,0 +1,11 @@
+# NOTE: kustomize is not supported. This file exists only to be able to reference it from bases.
+# https://kubectl.docs.kubernetes.io/references/kustomize/bases/
+#
+# ```
+# namespace: ingress-nginx
+# bases:
+#   - github.com/kubernetes/ingress-nginx/deploy/static/provider/do?ref=master
+# ```
+
+resources:
+  - deploy.yaml

--- a/deploy/static/provider/do/1.22/deploy.yaml
+++ b/deploy/static/provider/do/1.22/deploy.yaml
@@ -1,4 +1,3 @@
-#GENERATED FOR K8S 1.20
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -334,13 +333,7 @@ subjects:
 apiVersion: v1
 data:
   allow-snippet-annotations: "true"
-  http-snippet: |
-    server {
-      listen 2443;
-      return 308 https://$host$request_uri;
-    }
-  proxy-real-ip-cidr: XXX.XXX.XXX/XX
-  use-forwarded-headers: "true"
+  use-proxy-protocol: "true"
 kind: ConfigMap
 metadata:
   labels:
@@ -358,11 +351,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "60"
-    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
-    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-west-2:XXXXXXXX:certificate/XXXXXX-XXXXXXX-XXXXXXX-XXXXXXXX
-    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: https
-    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+    service.beta.kubernetes.io/do-loadbalancer-enable-proxy-protocol: "true"
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
@@ -383,12 +372,12 @@ spec:
     name: http
     port: 80
     protocol: TCP
-    targetPort: tohttps
+    targetPort: http
   - appProtocol: https
     name: https
     port: 443
     protocol: TCP
-    targetPort: http
+    targetPort: https
   selector:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
@@ -491,11 +480,8 @@ spec:
         - containerPort: 80
           name: http
           protocol: TCP
-        - containerPort: 80
+        - containerPort: 443
           name: https
-          protocol: TCP
-        - containerPort: 2443
-          name: tohttps
           protocol: TCP
         - containerPort: 8443
           name: webhook
@@ -693,3 +679,4 @@ webhooks:
     resources:
     - ingresses
   sideEffects: None
+  timeoutSeconds: 29

--- a/deploy/static/provider/do/1.22/kustomization.yaml
+++ b/deploy/static/provider/do/1.22/kustomization.yaml
@@ -1,0 +1,11 @@
+# NOTE: kustomize is not supported. This file exists only to be able to reference it from bases.
+# https://kubectl.docs.kubernetes.io/references/kustomize/bases/
+#
+# ```
+# namespace: ingress-nginx
+# bases:
+#   - github.com/kubernetes/ingress-nginx/deploy/static/provider/do?ref=master
+# ```
+
+resources:
+  - deploy.yaml

--- a/deploy/static/provider/do/deploy.yaml
+++ b/deploy/static/provider/do/deploy.yaml
@@ -16,8 +16,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx
   namespace: ingress-nginx
 ---
@@ -32,8 +33,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-admission
   namespace: ingress-nginx
 ---
@@ -45,8 +47,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx
   namespace: ingress-nginx
 rules:
@@ -131,8 +134,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-admission
   namespace: ingress-nginx
 rules:
@@ -151,8 +155,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx
 rules:
 - apiGroups:
@@ -222,8 +227,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-admission
 rules:
 - apiGroups:
@@ -242,8 +248,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx
   namespace: ingress-nginx
 roleRef:
@@ -266,8 +273,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-admission
   namespace: ingress-nginx
 roleRef:
@@ -286,8 +294,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -309,8 +318,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-admission
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -332,8 +342,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-controller
   namespace: ingress-nginx
 ---
@@ -347,8 +358,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -381,8 +393,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-controller-admission
   namespace: ingress-nginx
 spec:
@@ -405,8 +418,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -520,8 +534,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-admission-create
   namespace: ingress-nginx
 spec:
@@ -532,8 +547,9 @@ spec:
         app.kubernetes.io/instance: ingress-nginx
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
+        app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.1
-        helm.sh/chart: ingress-nginx-4.0.15
+        helm.sh/chart: ingress-nginx-4.0.16
       name: ingress-nginx-admission-create
     spec:
       containers:
@@ -571,8 +587,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-admission-patch
   namespace: ingress-nginx
 spec:
@@ -583,8 +600,9 @@ spec:
         app.kubernetes.io/instance: ingress-nginx
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
+        app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.1
-        helm.sh/chart: ingress-nginx-4.0.15
+        helm.sh/chart: ingress-nginx-4.0.16
       name: ingress-nginx-admission-patch
     spec:
       containers:
@@ -621,8 +639,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
@@ -635,8 +654,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-admission
 webhooks:
 - admissionReviewVersions:

--- a/deploy/static/provider/exoscale/1.19/deploy.yaml
+++ b/deploy/static/provider/exoscale/1.19/deploy.yaml
@@ -1,4 +1,3 @@
-#GENERATED FOR K8S 1.20
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -334,13 +333,6 @@ subjects:
 apiVersion: v1
 data:
   allow-snippet-annotations: "true"
-  http-snippet: |
-    server {
-      listen 2443;
-      return 308 https://$host$request_uri;
-    }
-  proxy-real-ip-cidr: XXX.XXX.XXX/XX
-  use-forwarded-headers: "true"
 kind: ConfigMap
 metadata:
   labels:
@@ -358,11 +350,15 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "60"
-    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
-    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-west-2:XXXXXXXX:certificate/XXXXXX-XXXXXXX-XXXXXXX-XXXXXXXX
-    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: https
-    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+    service.beta.kubernetes.io/exoscale-loadbalancer-description: NGINX Ingress Controller
+      load balancer
+    service.beta.kubernetes.io/exoscale-loadbalancer-name: nginx-ingress-controller
+    service.beta.kubernetes.io/exoscale-loadbalancer-service-healthcheck-interval: 10s
+    service.beta.kubernetes.io/exoscale-loadbalancer-service-healthcheck-mode: http
+    service.beta.kubernetes.io/exoscale-loadbalancer-service-healthcheck-retries: "1"
+    service.beta.kubernetes.io/exoscale-loadbalancer-service-healthcheck-timeout: 3s
+    service.beta.kubernetes.io/exoscale-loadbalancer-service-healthcheck-uri: /
+    service.beta.kubernetes.io/exoscale-loadbalancer-service-strategy: source-hash
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
@@ -375,20 +371,15 @@ metadata:
   namespace: ingress-nginx
 spec:
   externalTrafficPolicy: Local
-  ipFamilies:
-  - IPv4
-  ipFamilyPolicy: SingleStack
   ports:
-  - appProtocol: http
-    name: http
+  - name: http
     port: 80
     protocol: TCP
-    targetPort: tohttps
-  - appProtocol: https
-    name: https
+    targetPort: http
+  - name: https
     port: 443
     protocol: TCP
-    targetPort: http
+    targetPort: https
   selector:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
@@ -410,8 +401,7 @@ metadata:
   namespace: ingress-nginx
 spec:
   ports:
-  - appProtocol: https
-    name: https-webhook
+  - name: https-webhook
     port: 443
     targetPort: webhook
   selector:
@@ -421,7 +411,7 @@ spec:
   type: ClusterIP
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: DaemonSet
 metadata:
   labels:
     app.kubernetes.io/component: controller
@@ -491,11 +481,8 @@ spec:
         - containerPort: 80
           name: http
           protocol: TCP
-        - containerPort: 80
+        - containerPort: 443
           name: https
-          protocol: TCP
-        - containerPort: 2443
-          name: tohttps
           protocol: TCP
         - containerPort: 8443
           name: webhook

--- a/deploy/static/provider/exoscale/1.19/kustomization.yaml
+++ b/deploy/static/provider/exoscale/1.19/kustomization.yaml
@@ -1,0 +1,11 @@
+# NOTE: kustomize is not supported. This file exists only to be able to reference it from bases.
+# https://kubectl.docs.kubernetes.io/references/kustomize/bases/
+#
+# ```
+# namespace: ingress-nginx
+# bases:
+#   - github.com/kubernetes/ingress-nginx/deploy/static/provider/exoscale?ref=master
+# ```
+
+resources:
+  - deploy.yaml

--- a/deploy/static/provider/exoscale/1.20/deploy.yaml
+++ b/deploy/static/provider/exoscale/1.20/deploy.yaml
@@ -1,4 +1,3 @@
-#GENERATED FOR K8S 1.20
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -334,13 +333,6 @@ subjects:
 apiVersion: v1
 data:
   allow-snippet-annotations: "true"
-  http-snippet: |
-    server {
-      listen 2443;
-      return 308 https://$host$request_uri;
-    }
-  proxy-real-ip-cidr: XXX.XXX.XXX/XX
-  use-forwarded-headers: "true"
 kind: ConfigMap
 metadata:
   labels:
@@ -358,11 +350,15 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "60"
-    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
-    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-west-2:XXXXXXXX:certificate/XXXXXX-XXXXXXX-XXXXXXX-XXXXXXXX
-    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: https
-    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+    service.beta.kubernetes.io/exoscale-loadbalancer-description: NGINX Ingress Controller
+      load balancer
+    service.beta.kubernetes.io/exoscale-loadbalancer-name: nginx-ingress-controller
+    service.beta.kubernetes.io/exoscale-loadbalancer-service-healthcheck-interval: 10s
+    service.beta.kubernetes.io/exoscale-loadbalancer-service-healthcheck-mode: http
+    service.beta.kubernetes.io/exoscale-loadbalancer-service-healthcheck-retries: "1"
+    service.beta.kubernetes.io/exoscale-loadbalancer-service-healthcheck-timeout: 3s
+    service.beta.kubernetes.io/exoscale-loadbalancer-service-healthcheck-uri: /
+    service.beta.kubernetes.io/exoscale-loadbalancer-service-strategy: source-hash
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
@@ -383,12 +379,12 @@ spec:
     name: http
     port: 80
     protocol: TCP
-    targetPort: tohttps
+    targetPort: http
   - appProtocol: https
     name: https
     port: 443
     protocol: TCP
-    targetPort: http
+    targetPort: https
   selector:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
@@ -421,7 +417,7 @@ spec:
   type: ClusterIP
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: DaemonSet
 metadata:
   labels:
     app.kubernetes.io/component: controller
@@ -491,11 +487,8 @@ spec:
         - containerPort: 80
           name: http
           protocol: TCP
-        - containerPort: 80
+        - containerPort: 443
           name: https
-          protocol: TCP
-        - containerPort: 2443
-          name: tohttps
           protocol: TCP
         - containerPort: 8443
           name: webhook

--- a/deploy/static/provider/exoscale/1.20/kustomization.yaml
+++ b/deploy/static/provider/exoscale/1.20/kustomization.yaml
@@ -1,0 +1,11 @@
+# NOTE: kustomize is not supported. This file exists only to be able to reference it from bases.
+# https://kubectl.docs.kubernetes.io/references/kustomize/bases/
+#
+# ```
+# namespace: ingress-nginx
+# bases:
+#   - github.com/kubernetes/ingress-nginx/deploy/static/provider/exoscale?ref=master
+# ```
+
+resources:
+  - deploy.yaml

--- a/deploy/static/provider/exoscale/1.21/deploy.yaml
+++ b/deploy/static/provider/exoscale/1.21/deploy.yaml
@@ -1,4 +1,3 @@
-#GENERATED FOR K8S 1.20
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -334,13 +333,6 @@ subjects:
 apiVersion: v1
 data:
   allow-snippet-annotations: "true"
-  http-snippet: |
-    server {
-      listen 2443;
-      return 308 https://$host$request_uri;
-    }
-  proxy-real-ip-cidr: XXX.XXX.XXX/XX
-  use-forwarded-headers: "true"
 kind: ConfigMap
 metadata:
   labels:
@@ -358,11 +350,15 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "60"
-    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
-    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-west-2:XXXXXXXX:certificate/XXXXXX-XXXXXXX-XXXXXXX-XXXXXXXX
-    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: https
-    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+    service.beta.kubernetes.io/exoscale-loadbalancer-description: NGINX Ingress Controller
+      load balancer
+    service.beta.kubernetes.io/exoscale-loadbalancer-name: nginx-ingress-controller
+    service.beta.kubernetes.io/exoscale-loadbalancer-service-healthcheck-interval: 10s
+    service.beta.kubernetes.io/exoscale-loadbalancer-service-healthcheck-mode: http
+    service.beta.kubernetes.io/exoscale-loadbalancer-service-healthcheck-retries: "1"
+    service.beta.kubernetes.io/exoscale-loadbalancer-service-healthcheck-timeout: 3s
+    service.beta.kubernetes.io/exoscale-loadbalancer-service-healthcheck-uri: /
+    service.beta.kubernetes.io/exoscale-loadbalancer-service-strategy: source-hash
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
@@ -383,12 +379,12 @@ spec:
     name: http
     port: 80
     protocol: TCP
-    targetPort: tohttps
+    targetPort: http
   - appProtocol: https
     name: https
     port: 443
     protocol: TCP
-    targetPort: http
+    targetPort: https
   selector:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
@@ -421,7 +417,7 @@ spec:
   type: ClusterIP
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: DaemonSet
 metadata:
   labels:
     app.kubernetes.io/component: controller
@@ -491,11 +487,8 @@ spec:
         - containerPort: 80
           name: http
           protocol: TCP
-        - containerPort: 80
+        - containerPort: 443
           name: https
-          protocol: TCP
-        - containerPort: 2443
-          name: tohttps
           protocol: TCP
         - containerPort: 8443
           name: webhook

--- a/deploy/static/provider/exoscale/1.21/kustomization.yaml
+++ b/deploy/static/provider/exoscale/1.21/kustomization.yaml
@@ -1,0 +1,11 @@
+# NOTE: kustomize is not supported. This file exists only to be able to reference it from bases.
+# https://kubectl.docs.kubernetes.io/references/kustomize/bases/
+#
+# ```
+# namespace: ingress-nginx
+# bases:
+#   - github.com/kubernetes/ingress-nginx/deploy/static/provider/exoscale?ref=master
+# ```
+
+resources:
+  - deploy.yaml

--- a/deploy/static/provider/exoscale/1.22/deploy.yaml
+++ b/deploy/static/provider/exoscale/1.22/deploy.yaml
@@ -1,4 +1,3 @@
-#GENERATED FOR K8S 1.20
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -334,13 +333,6 @@ subjects:
 apiVersion: v1
 data:
   allow-snippet-annotations: "true"
-  http-snippet: |
-    server {
-      listen 2443;
-      return 308 https://$host$request_uri;
-    }
-  proxy-real-ip-cidr: XXX.XXX.XXX/XX
-  use-forwarded-headers: "true"
 kind: ConfigMap
 metadata:
   labels:
@@ -358,11 +350,15 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "60"
-    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
-    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-west-2:XXXXXXXX:certificate/XXXXXX-XXXXXXX-XXXXXXX-XXXXXXXX
-    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: https
-    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+    service.beta.kubernetes.io/exoscale-loadbalancer-description: NGINX Ingress Controller
+      load balancer
+    service.beta.kubernetes.io/exoscale-loadbalancer-name: nginx-ingress-controller
+    service.beta.kubernetes.io/exoscale-loadbalancer-service-healthcheck-interval: 10s
+    service.beta.kubernetes.io/exoscale-loadbalancer-service-healthcheck-mode: http
+    service.beta.kubernetes.io/exoscale-loadbalancer-service-healthcheck-retries: "1"
+    service.beta.kubernetes.io/exoscale-loadbalancer-service-healthcheck-timeout: 3s
+    service.beta.kubernetes.io/exoscale-loadbalancer-service-healthcheck-uri: /
+    service.beta.kubernetes.io/exoscale-loadbalancer-service-strategy: source-hash
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
@@ -383,12 +379,12 @@ spec:
     name: http
     port: 80
     protocol: TCP
-    targetPort: tohttps
+    targetPort: http
   - appProtocol: https
     name: https
     port: 443
     protocol: TCP
-    targetPort: http
+    targetPort: https
   selector:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
@@ -421,7 +417,7 @@ spec:
   type: ClusterIP
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: DaemonSet
 metadata:
   labels:
     app.kubernetes.io/component: controller
@@ -491,11 +487,8 @@ spec:
         - containerPort: 80
           name: http
           protocol: TCP
-        - containerPort: 80
+        - containerPort: 443
           name: https
-          protocol: TCP
-        - containerPort: 2443
-          name: tohttps
           protocol: TCP
         - containerPort: 8443
           name: webhook

--- a/deploy/static/provider/exoscale/1.22/kustomization.yaml
+++ b/deploy/static/provider/exoscale/1.22/kustomization.yaml
@@ -1,0 +1,11 @@
+# NOTE: kustomize is not supported. This file exists only to be able to reference it from bases.
+# https://kubectl.docs.kubernetes.io/references/kustomize/bases/
+#
+# ```
+# namespace: ingress-nginx
+# bases:
+#   - github.com/kubernetes/ingress-nginx/deploy/static/provider/exoscale?ref=master
+# ```
+
+resources:
+  - deploy.yaml

--- a/deploy/static/provider/exoscale/deploy.yaml
+++ b/deploy/static/provider/exoscale/deploy.yaml
@@ -16,8 +16,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx
   namespace: ingress-nginx
 ---
@@ -32,8 +33,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-admission
   namespace: ingress-nginx
 ---
@@ -45,8 +47,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx
   namespace: ingress-nginx
 rules:
@@ -131,8 +134,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-admission
   namespace: ingress-nginx
 rules:
@@ -151,8 +155,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx
 rules:
 - apiGroups:
@@ -222,8 +227,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-admission
 rules:
 - apiGroups:
@@ -242,8 +248,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx
   namespace: ingress-nginx
 roleRef:
@@ -266,8 +273,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-admission
   namespace: ingress-nginx
 roleRef:
@@ -286,8 +294,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -309,8 +318,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-admission
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -331,8 +341,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-controller
   namespace: ingress-nginx
 ---
@@ -354,8 +365,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -388,8 +400,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-controller-admission
   namespace: ingress-nginx
 spec:
@@ -412,8 +425,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -527,8 +541,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-admission-create
   namespace: ingress-nginx
 spec:
@@ -539,8 +554,9 @@ spec:
         app.kubernetes.io/instance: ingress-nginx
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
+        app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.1
-        helm.sh/chart: ingress-nginx-4.0.15
+        helm.sh/chart: ingress-nginx-4.0.16
       name: ingress-nginx-admission-create
     spec:
       containers:
@@ -578,8 +594,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-admission-patch
   namespace: ingress-nginx
 spec:
@@ -590,8 +607,9 @@ spec:
         app.kubernetes.io/instance: ingress-nginx
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
+        app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.1
-        helm.sh/chart: ingress-nginx-4.0.15
+        helm.sh/chart: ingress-nginx-4.0.16
       name: ingress-nginx-admission-patch
     spec:
       containers:
@@ -628,8 +646,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
@@ -642,8 +661,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-admission
 webhooks:
 - admissionReviewVersions:

--- a/deploy/static/provider/kind/1.19/deploy.yaml
+++ b/deploy/static/provider/kind/1.19/deploy.yaml
@@ -1,4 +1,3 @@
-#GENERATED FOR K8S 1.20
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -334,13 +333,6 @@ subjects:
 apiVersion: v1
 data:
   allow-snippet-annotations: "true"
-  http-snippet: |
-    server {
-      listen 2443;
-      return 308 https://$host$request_uri;
-    }
-  proxy-real-ip-cidr: XXX.XXX.XXX/XX
-  use-forwarded-headers: "true"
 kind: ConfigMap
 metadata:
   labels:
@@ -357,12 +349,7 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "60"
-    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
-    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-west-2:XXXXXXXX:certificate/XXXXXX-XXXXXXX-XXXXXXX-XXXXXXXX
-    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: https
-    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+  annotations: null
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
@@ -374,26 +361,20 @@ metadata:
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
-  externalTrafficPolicy: Local
-  ipFamilies:
-  - IPv4
-  ipFamilyPolicy: SingleStack
   ports:
-  - appProtocol: http
-    name: http
+  - name: http
     port: 80
     protocol: TCP
-    targetPort: tohttps
-  - appProtocol: https
-    name: https
+    targetPort: http
+  - name: https
     port: 443
     protocol: TCP
-    targetPort: http
+    targetPort: https
   selector:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
-  type: LoadBalancer
+  type: NodePort
 ---
 apiVersion: v1
 kind: Service
@@ -410,8 +391,7 @@ metadata:
   namespace: ingress-nginx
 spec:
   ports:
-  - appProtocol: https
-    name: https-webhook
+  - name: https-webhook
     port: 443
     targetPort: webhook
   selector:
@@ -441,6 +421,10 @@ spec:
       app.kubernetes.io/component: controller
       app.kubernetes.io/instance: ingress-nginx
       app.kubernetes.io/name: ingress-nginx
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:
@@ -451,13 +435,14 @@ spec:
       containers:
       - args:
         - /nginx-ingress-controller
-        - --publish-service=$(POD_NAMESPACE)/ingress-nginx-controller
         - --election-id=ingress-controller-leader
         - --controller-class=k8s.io/ingress-nginx
         - --configmap=$(POD_NAMESPACE)/ingress-nginx-controller
         - --validating-webhook=:8443
         - --validating-webhook-certificate=/usr/local/certificates/cert
         - --validating-webhook-key=/usr/local/certificates/key
+        - --watch-ingress-without-class=true
+        - --publish-status-address=localhost
         env:
         - name: POD_NAME
           valueFrom:
@@ -489,13 +474,12 @@ spec:
         name: controller
         ports:
         - containerPort: 80
+          hostPort: 80
           name: http
           protocol: TCP
-        - containerPort: 80
+        - containerPort: 443
+          hostPort: 443
           name: https
-          protocol: TCP
-        - containerPort: 2443
-          name: tohttps
           protocol: TCP
         - containerPort: 8443
           name: webhook
@@ -528,9 +512,14 @@ spec:
           readOnly: true
       dnsPolicy: ClusterFirst
       nodeSelector:
+        ingress-ready: "true"
         kubernetes.io/os: linux
       serviceAccountName: ingress-nginx
-      terminationGracePeriodSeconds: 300
+      terminationGracePeriodSeconds: 0
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Equal
       volumes:
       - name: webhook-cert
         secret:

--- a/deploy/static/provider/kind/1.19/kustomization.yaml
+++ b/deploy/static/provider/kind/1.19/kustomization.yaml
@@ -1,0 +1,11 @@
+# NOTE: kustomize is not supported. This file exists only to be able to reference it from bases.
+# https://kubectl.docs.kubernetes.io/references/kustomize/bases/
+#
+# ```
+# namespace: ingress-nginx
+# bases:
+#   - github.com/kubernetes/ingress-nginx/deploy/static/provider/kind?ref=master
+# ```
+
+resources:
+  - deploy.yaml

--- a/deploy/static/provider/kind/1.20/deploy.yaml
+++ b/deploy/static/provider/kind/1.20/deploy.yaml
@@ -1,4 +1,3 @@
-#GENERATED FOR K8S 1.20
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -334,13 +333,6 @@ subjects:
 apiVersion: v1
 data:
   allow-snippet-annotations: "true"
-  http-snippet: |
-    server {
-      listen 2443;
-      return 308 https://$host$request_uri;
-    }
-  proxy-real-ip-cidr: XXX.XXX.XXX/XX
-  use-forwarded-headers: "true"
 kind: ConfigMap
 metadata:
   labels:
@@ -357,12 +349,7 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "60"
-    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
-    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-west-2:XXXXXXXX:certificate/XXXXXX-XXXXXXX-XXXXXXX-XXXXXXXX
-    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: https
-    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+  annotations: null
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
@@ -374,7 +361,6 @@ metadata:
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
-  externalTrafficPolicy: Local
   ipFamilies:
   - IPv4
   ipFamilyPolicy: SingleStack
@@ -383,17 +369,17 @@ spec:
     name: http
     port: 80
     protocol: TCP
-    targetPort: tohttps
+    targetPort: http
   - appProtocol: https
     name: https
     port: 443
     protocol: TCP
-    targetPort: http
+    targetPort: https
   selector:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
-  type: LoadBalancer
+  type: NodePort
 ---
 apiVersion: v1
 kind: Service
@@ -441,6 +427,10 @@ spec:
       app.kubernetes.io/component: controller
       app.kubernetes.io/instance: ingress-nginx
       app.kubernetes.io/name: ingress-nginx
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:
@@ -451,13 +441,14 @@ spec:
       containers:
       - args:
         - /nginx-ingress-controller
-        - --publish-service=$(POD_NAMESPACE)/ingress-nginx-controller
         - --election-id=ingress-controller-leader
         - --controller-class=k8s.io/ingress-nginx
         - --configmap=$(POD_NAMESPACE)/ingress-nginx-controller
         - --validating-webhook=:8443
         - --validating-webhook-certificate=/usr/local/certificates/cert
         - --validating-webhook-key=/usr/local/certificates/key
+        - --watch-ingress-without-class=true
+        - --publish-status-address=localhost
         env:
         - name: POD_NAME
           valueFrom:
@@ -489,13 +480,12 @@ spec:
         name: controller
         ports:
         - containerPort: 80
+          hostPort: 80
           name: http
           protocol: TCP
-        - containerPort: 80
+        - containerPort: 443
+          hostPort: 443
           name: https
-          protocol: TCP
-        - containerPort: 2443
-          name: tohttps
           protocol: TCP
         - containerPort: 8443
           name: webhook
@@ -528,9 +518,14 @@ spec:
           readOnly: true
       dnsPolicy: ClusterFirst
       nodeSelector:
+        ingress-ready: "true"
         kubernetes.io/os: linux
       serviceAccountName: ingress-nginx
-      terminationGracePeriodSeconds: 300
+      terminationGracePeriodSeconds: 0
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Equal
       volumes:
       - name: webhook-cert
         secret:

--- a/deploy/static/provider/kind/1.20/kustomization.yaml
+++ b/deploy/static/provider/kind/1.20/kustomization.yaml
@@ -1,0 +1,11 @@
+# NOTE: kustomize is not supported. This file exists only to be able to reference it from bases.
+# https://kubectl.docs.kubernetes.io/references/kustomize/bases/
+#
+# ```
+# namespace: ingress-nginx
+# bases:
+#   - github.com/kubernetes/ingress-nginx/deploy/static/provider/kind?ref=master
+# ```
+
+resources:
+  - deploy.yaml

--- a/deploy/static/provider/kind/1.21/deploy.yaml
+++ b/deploy/static/provider/kind/1.21/deploy.yaml
@@ -1,4 +1,3 @@
-#GENERATED FOR K8S 1.20
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -334,13 +333,6 @@ subjects:
 apiVersion: v1
 data:
   allow-snippet-annotations: "true"
-  http-snippet: |
-    server {
-      listen 2443;
-      return 308 https://$host$request_uri;
-    }
-  proxy-real-ip-cidr: XXX.XXX.XXX/XX
-  use-forwarded-headers: "true"
 kind: ConfigMap
 metadata:
   labels:
@@ -357,12 +349,7 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "60"
-    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
-    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-west-2:XXXXXXXX:certificate/XXXXXX-XXXXXXX-XXXXXXX-XXXXXXXX
-    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: https
-    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+  annotations: null
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
@@ -374,7 +361,6 @@ metadata:
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
-  externalTrafficPolicy: Local
   ipFamilies:
   - IPv4
   ipFamilyPolicy: SingleStack
@@ -383,17 +369,17 @@ spec:
     name: http
     port: 80
     protocol: TCP
-    targetPort: tohttps
+    targetPort: http
   - appProtocol: https
     name: https
     port: 443
     protocol: TCP
-    targetPort: http
+    targetPort: https
   selector:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
-  type: LoadBalancer
+  type: NodePort
 ---
 apiVersion: v1
 kind: Service
@@ -441,6 +427,10 @@ spec:
       app.kubernetes.io/component: controller
       app.kubernetes.io/instance: ingress-nginx
       app.kubernetes.io/name: ingress-nginx
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:
@@ -451,13 +441,14 @@ spec:
       containers:
       - args:
         - /nginx-ingress-controller
-        - --publish-service=$(POD_NAMESPACE)/ingress-nginx-controller
         - --election-id=ingress-controller-leader
         - --controller-class=k8s.io/ingress-nginx
         - --configmap=$(POD_NAMESPACE)/ingress-nginx-controller
         - --validating-webhook=:8443
         - --validating-webhook-certificate=/usr/local/certificates/cert
         - --validating-webhook-key=/usr/local/certificates/key
+        - --watch-ingress-without-class=true
+        - --publish-status-address=localhost
         env:
         - name: POD_NAME
           valueFrom:
@@ -489,13 +480,12 @@ spec:
         name: controller
         ports:
         - containerPort: 80
+          hostPort: 80
           name: http
           protocol: TCP
-        - containerPort: 80
+        - containerPort: 443
+          hostPort: 443
           name: https
-          protocol: TCP
-        - containerPort: 2443
-          name: tohttps
           protocol: TCP
         - containerPort: 8443
           name: webhook
@@ -528,9 +518,14 @@ spec:
           readOnly: true
       dnsPolicy: ClusterFirst
       nodeSelector:
+        ingress-ready: "true"
         kubernetes.io/os: linux
       serviceAccountName: ingress-nginx
-      terminationGracePeriodSeconds: 300
+      terminationGracePeriodSeconds: 0
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Equal
       volumes:
       - name: webhook-cert
         secret:

--- a/deploy/static/provider/kind/1.21/kustomization.yaml
+++ b/deploy/static/provider/kind/1.21/kustomization.yaml
@@ -1,0 +1,11 @@
+# NOTE: kustomize is not supported. This file exists only to be able to reference it from bases.
+# https://kubectl.docs.kubernetes.io/references/kustomize/bases/
+#
+# ```
+# namespace: ingress-nginx
+# bases:
+#   - github.com/kubernetes/ingress-nginx/deploy/static/provider/kind?ref=master
+# ```
+
+resources:
+  - deploy.yaml

--- a/deploy/static/provider/kind/1.22/deploy.yaml
+++ b/deploy/static/provider/kind/1.22/deploy.yaml
@@ -1,4 +1,3 @@
-#GENERATED FOR K8S 1.20
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -334,13 +333,6 @@ subjects:
 apiVersion: v1
 data:
   allow-snippet-annotations: "true"
-  http-snippet: |
-    server {
-      listen 2443;
-      return 308 https://$host$request_uri;
-    }
-  proxy-real-ip-cidr: XXX.XXX.XXX/XX
-  use-forwarded-headers: "true"
 kind: ConfigMap
 metadata:
   labels:
@@ -357,12 +349,7 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "60"
-    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
-    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-west-2:XXXXXXXX:certificate/XXXXXX-XXXXXXX-XXXXXXX-XXXXXXXX
-    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: https
-    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+  annotations: null
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
@@ -374,7 +361,6 @@ metadata:
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
-  externalTrafficPolicy: Local
   ipFamilies:
   - IPv4
   ipFamilyPolicy: SingleStack
@@ -383,17 +369,17 @@ spec:
     name: http
     port: 80
     protocol: TCP
-    targetPort: tohttps
+    targetPort: http
   - appProtocol: https
     name: https
     port: 443
     protocol: TCP
-    targetPort: http
+    targetPort: https
   selector:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
-  type: LoadBalancer
+  type: NodePort
 ---
 apiVersion: v1
 kind: Service
@@ -441,6 +427,10 @@ spec:
       app.kubernetes.io/component: controller
       app.kubernetes.io/instance: ingress-nginx
       app.kubernetes.io/name: ingress-nginx
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:
@@ -451,13 +441,14 @@ spec:
       containers:
       - args:
         - /nginx-ingress-controller
-        - --publish-service=$(POD_NAMESPACE)/ingress-nginx-controller
         - --election-id=ingress-controller-leader
         - --controller-class=k8s.io/ingress-nginx
         - --configmap=$(POD_NAMESPACE)/ingress-nginx-controller
         - --validating-webhook=:8443
         - --validating-webhook-certificate=/usr/local/certificates/cert
         - --validating-webhook-key=/usr/local/certificates/key
+        - --watch-ingress-without-class=true
+        - --publish-status-address=localhost
         env:
         - name: POD_NAME
           valueFrom:
@@ -489,13 +480,12 @@ spec:
         name: controller
         ports:
         - containerPort: 80
+          hostPort: 80
           name: http
           protocol: TCP
-        - containerPort: 80
+        - containerPort: 443
+          hostPort: 443
           name: https
-          protocol: TCP
-        - containerPort: 2443
-          name: tohttps
           protocol: TCP
         - containerPort: 8443
           name: webhook
@@ -528,9 +518,14 @@ spec:
           readOnly: true
       dnsPolicy: ClusterFirst
       nodeSelector:
+        ingress-ready: "true"
         kubernetes.io/os: linux
       serviceAccountName: ingress-nginx
-      terminationGracePeriodSeconds: 300
+      terminationGracePeriodSeconds: 0
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Equal
       volumes:
       - name: webhook-cert
         secret:

--- a/deploy/static/provider/kind/1.22/kustomization.yaml
+++ b/deploy/static/provider/kind/1.22/kustomization.yaml
@@ -1,0 +1,11 @@
+# NOTE: kustomize is not supported. This file exists only to be able to reference it from bases.
+# https://kubectl.docs.kubernetes.io/references/kustomize/bases/
+#
+# ```
+# namespace: ingress-nginx
+# bases:
+#   - github.com/kubernetes/ingress-nginx/deploy/static/provider/kind?ref=master
+# ```
+
+resources:
+  - deploy.yaml

--- a/deploy/static/provider/kind/deploy.yaml
+++ b/deploy/static/provider/kind/deploy.yaml
@@ -16,8 +16,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx
   namespace: ingress-nginx
 ---
@@ -32,8 +33,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-admission
   namespace: ingress-nginx
 ---
@@ -45,8 +47,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx
   namespace: ingress-nginx
 rules:
@@ -131,8 +134,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-admission
   namespace: ingress-nginx
 rules:
@@ -151,8 +155,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx
 rules:
 - apiGroups:
@@ -222,8 +227,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-admission
 rules:
 - apiGroups:
@@ -242,8 +248,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx
   namespace: ingress-nginx
 roleRef:
@@ -266,8 +273,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-admission
   namespace: ingress-nginx
 roleRef:
@@ -286,8 +294,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -309,8 +318,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-admission
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -331,8 +341,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-controller
   namespace: ingress-nginx
 ---
@@ -345,8 +356,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -378,8 +390,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-controller-admission
   namespace: ingress-nginx
 spec:
@@ -402,8 +415,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -529,8 +543,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-admission-create
   namespace: ingress-nginx
 spec:
@@ -541,8 +556,9 @@ spec:
         app.kubernetes.io/instance: ingress-nginx
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
+        app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.1
-        helm.sh/chart: ingress-nginx-4.0.15
+        helm.sh/chart: ingress-nginx-4.0.16
       name: ingress-nginx-admission-create
     spec:
       containers:
@@ -580,8 +596,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-admission-patch
   namespace: ingress-nginx
 spec:
@@ -592,8 +609,9 @@ spec:
         app.kubernetes.io/instance: ingress-nginx
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
+        app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.1
-        helm.sh/chart: ingress-nginx-4.0.15
+        helm.sh/chart: ingress-nginx-4.0.16
       name: ingress-nginx-admission-patch
     spec:
       containers:
@@ -630,8 +648,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
@@ -644,8 +663,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-admission
 webhooks:
 - admissionReviewVersions:

--- a/deploy/static/provider/scw/1.19/deploy.yaml
+++ b/deploy/static/provider/scw/1.19/deploy.yaml
@@ -1,4 +1,3 @@
-#GENERATED FOR K8S 1.20
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -334,13 +333,7 @@ subjects:
 apiVersion: v1
 data:
   allow-snippet-annotations: "true"
-  http-snippet: |
-    server {
-      listen 2443;
-      return 308 https://$host$request_uri;
-    }
-  proxy-real-ip-cidr: XXX.XXX.XXX/XX
-  use-forwarded-headers: "true"
+  use-proxy-protocol: "true"
 kind: ConfigMap
 metadata:
   labels:
@@ -358,11 +351,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "60"
-    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
-    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-west-2:XXXXXXXX:certificate/XXXXXX-XXXXXXX-XXXXXXX-XXXXXXXX
-    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: https
-    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+    service.beta.kubernetes.io/scw-loadbalancer-proxy-protocol-v2: "true"
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
@@ -375,20 +364,15 @@ metadata:
   namespace: ingress-nginx
 spec:
   externalTrafficPolicy: Local
-  ipFamilies:
-  - IPv4
-  ipFamilyPolicy: SingleStack
   ports:
-  - appProtocol: http
-    name: http
+  - name: http
     port: 80
     protocol: TCP
-    targetPort: tohttps
-  - appProtocol: https
-    name: https
+    targetPort: http
+  - name: https
     port: 443
     protocol: TCP
-    targetPort: http
+    targetPort: https
   selector:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
@@ -410,8 +394,7 @@ metadata:
   namespace: ingress-nginx
 spec:
   ports:
-  - appProtocol: https
-    name: https-webhook
+  - name: https-webhook
     port: 443
     targetPort: webhook
   selector:
@@ -491,11 +474,8 @@ spec:
         - containerPort: 80
           name: http
           protocol: TCP
-        - containerPort: 80
+        - containerPort: 443
           name: https
-          protocol: TCP
-        - containerPort: 2443
-          name: tohttps
           protocol: TCP
         - containerPort: 8443
           name: webhook

--- a/deploy/static/provider/scw/1.19/kustomization.yaml
+++ b/deploy/static/provider/scw/1.19/kustomization.yaml
@@ -1,0 +1,11 @@
+# NOTE: kustomize is not supported. This file exists only to be able to reference it from bases.
+# https://kubectl.docs.kubernetes.io/references/kustomize/bases/
+#
+# ```
+# namespace: ingress-nginx
+# bases:
+#   - github.com/kubernetes/ingress-nginx/deploy/static/provider/scw?ref=master
+# ```
+
+resources:
+  - deploy.yaml

--- a/deploy/static/provider/scw/1.20/deploy.yaml
+++ b/deploy/static/provider/scw/1.20/deploy.yaml
@@ -1,4 +1,3 @@
-#GENERATED FOR K8S 1.20
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -334,13 +333,7 @@ subjects:
 apiVersion: v1
 data:
   allow-snippet-annotations: "true"
-  http-snippet: |
-    server {
-      listen 2443;
-      return 308 https://$host$request_uri;
-    }
-  proxy-real-ip-cidr: XXX.XXX.XXX/XX
-  use-forwarded-headers: "true"
+  use-proxy-protocol: "true"
 kind: ConfigMap
 metadata:
   labels:
@@ -358,11 +351,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "60"
-    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
-    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-west-2:XXXXXXXX:certificate/XXXXXX-XXXXXXX-XXXXXXX-XXXXXXXX
-    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: https
-    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+    service.beta.kubernetes.io/scw-loadbalancer-proxy-protocol-v2: "true"
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
@@ -383,12 +372,12 @@ spec:
     name: http
     port: 80
     protocol: TCP
-    targetPort: tohttps
+    targetPort: http
   - appProtocol: https
     name: https
     port: 443
     protocol: TCP
-    targetPort: http
+    targetPort: https
   selector:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
@@ -491,11 +480,8 @@ spec:
         - containerPort: 80
           name: http
           protocol: TCP
-        - containerPort: 80
+        - containerPort: 443
           name: https
-          protocol: TCP
-        - containerPort: 2443
-          name: tohttps
           protocol: TCP
         - containerPort: 8443
           name: webhook

--- a/deploy/static/provider/scw/1.20/kustomization.yaml
+++ b/deploy/static/provider/scw/1.20/kustomization.yaml
@@ -1,0 +1,11 @@
+# NOTE: kustomize is not supported. This file exists only to be able to reference it from bases.
+# https://kubectl.docs.kubernetes.io/references/kustomize/bases/
+#
+# ```
+# namespace: ingress-nginx
+# bases:
+#   - github.com/kubernetes/ingress-nginx/deploy/static/provider/scw?ref=master
+# ```
+
+resources:
+  - deploy.yaml

--- a/deploy/static/provider/scw/1.21/deploy.yaml
+++ b/deploy/static/provider/scw/1.21/deploy.yaml
@@ -1,4 +1,3 @@
-#GENERATED FOR K8S 1.20
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -334,13 +333,7 @@ subjects:
 apiVersion: v1
 data:
   allow-snippet-annotations: "true"
-  http-snippet: |
-    server {
-      listen 2443;
-      return 308 https://$host$request_uri;
-    }
-  proxy-real-ip-cidr: XXX.XXX.XXX/XX
-  use-forwarded-headers: "true"
+  use-proxy-protocol: "true"
 kind: ConfigMap
 metadata:
   labels:
@@ -358,11 +351,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "60"
-    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
-    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-west-2:XXXXXXXX:certificate/XXXXXX-XXXXXXX-XXXXXXX-XXXXXXXX
-    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: https
-    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+    service.beta.kubernetes.io/scw-loadbalancer-proxy-protocol-v2: "true"
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
@@ -383,12 +372,12 @@ spec:
     name: http
     port: 80
     protocol: TCP
-    targetPort: tohttps
+    targetPort: http
   - appProtocol: https
     name: https
     port: 443
     protocol: TCP
-    targetPort: http
+    targetPort: https
   selector:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
@@ -491,11 +480,8 @@ spec:
         - containerPort: 80
           name: http
           protocol: TCP
-        - containerPort: 80
+        - containerPort: 443
           name: https
-          protocol: TCP
-        - containerPort: 2443
-          name: tohttps
           protocol: TCP
         - containerPort: 8443
           name: webhook

--- a/deploy/static/provider/scw/1.21/kustomization.yaml
+++ b/deploy/static/provider/scw/1.21/kustomization.yaml
@@ -1,0 +1,11 @@
+# NOTE: kustomize is not supported. This file exists only to be able to reference it from bases.
+# https://kubectl.docs.kubernetes.io/references/kustomize/bases/
+#
+# ```
+# namespace: ingress-nginx
+# bases:
+#   - github.com/kubernetes/ingress-nginx/deploy/static/provider/scw?ref=master
+# ```
+
+resources:
+  - deploy.yaml

--- a/deploy/static/provider/scw/1.22/deploy.yaml
+++ b/deploy/static/provider/scw/1.22/deploy.yaml
@@ -1,4 +1,3 @@
-#GENERATED FOR K8S 1.20
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -334,13 +333,7 @@ subjects:
 apiVersion: v1
 data:
   allow-snippet-annotations: "true"
-  http-snippet: |
-    server {
-      listen 2443;
-      return 308 https://$host$request_uri;
-    }
-  proxy-real-ip-cidr: XXX.XXX.XXX/XX
-  use-forwarded-headers: "true"
+  use-proxy-protocol: "true"
 kind: ConfigMap
 metadata:
   labels:
@@ -358,11 +351,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "60"
-    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
-    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-west-2:XXXXXXXX:certificate/XXXXXX-XXXXXXX-XXXXXXX-XXXXXXXX
-    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: https
-    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+    service.beta.kubernetes.io/scw-loadbalancer-proxy-protocol-v2: "true"
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
@@ -383,12 +372,12 @@ spec:
     name: http
     port: 80
     protocol: TCP
-    targetPort: tohttps
+    targetPort: http
   - appProtocol: https
     name: https
     port: 443
     protocol: TCP
-    targetPort: http
+    targetPort: https
   selector:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
@@ -491,11 +480,8 @@ spec:
         - containerPort: 80
           name: http
           protocol: TCP
-        - containerPort: 80
+        - containerPort: 443
           name: https
-          protocol: TCP
-        - containerPort: 2443
-          name: tohttps
           protocol: TCP
         - containerPort: 8443
           name: webhook

--- a/deploy/static/provider/scw/1.22/kustomization.yaml
+++ b/deploy/static/provider/scw/1.22/kustomization.yaml
@@ -1,0 +1,11 @@
+# NOTE: kustomize is not supported. This file exists only to be able to reference it from bases.
+# https://kubectl.docs.kubernetes.io/references/kustomize/bases/
+#
+# ```
+# namespace: ingress-nginx
+# bases:
+#   - github.com/kubernetes/ingress-nginx/deploy/static/provider/scw?ref=master
+# ```
+
+resources:
+  - deploy.yaml

--- a/deploy/static/provider/scw/deploy.yaml
+++ b/deploy/static/provider/scw/deploy.yaml
@@ -16,8 +16,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx
   namespace: ingress-nginx
 ---
@@ -32,8 +33,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-admission
   namespace: ingress-nginx
 ---
@@ -45,8 +47,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx
   namespace: ingress-nginx
 rules:
@@ -131,8 +134,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-admission
   namespace: ingress-nginx
 rules:
@@ -151,8 +155,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx
 rules:
 - apiGroups:
@@ -222,8 +227,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-admission
 rules:
 - apiGroups:
@@ -242,8 +248,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx
   namespace: ingress-nginx
 roleRef:
@@ -266,8 +273,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-admission
   namespace: ingress-nginx
 roleRef:
@@ -286,8 +294,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -309,8 +318,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-admission
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -332,8 +342,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-controller
   namespace: ingress-nginx
 ---
@@ -347,8 +358,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -381,8 +393,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-controller-admission
   namespace: ingress-nginx
 spec:
@@ -405,8 +418,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -520,8 +534,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-admission-create
   namespace: ingress-nginx
 spec:
@@ -532,8 +547,9 @@ spec:
         app.kubernetes.io/instance: ingress-nginx
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
+        app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.1
-        helm.sh/chart: ingress-nginx-4.0.15
+        helm.sh/chart: ingress-nginx-4.0.16
       name: ingress-nginx-admission-create
     spec:
       containers:
@@ -571,8 +587,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-admission-patch
   namespace: ingress-nginx
 spec:
@@ -583,8 +600,9 @@ spec:
         app.kubernetes.io/instance: ingress-nginx
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
+        app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.1
-        helm.sh/chart: ingress-nginx-4.0.15
+        helm.sh/chart: ingress-nginx-4.0.16
       name: ingress-nginx-admission-patch
     spec:
       containers:
@@ -621,8 +639,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
@@ -635,8 +654,9 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.1
-    helm.sh/chart: ingress-nginx-4.0.15
+    helm.sh/chart: ingress-nginx-4.0.16
   name: ingress-nginx-admission
 webhooks:
 - admissionReviewVersions:

--- a/hack/generate-deploy-scripts.sh
+++ b/hack/generate-deploy-scripts.sh
@@ -26,8 +26,7 @@ set -o pipefail
 # with enough docs updates, this could be removed
 # see     # DEFAULT VERSION HANDLING
 K8S_DEFAULT_VERSION=1.20
-# K8S_TARGET_VERSIONS=("1.19" "1.20" "1.21" "1.22") TODO @afirth revert for #8000
-K8S_TARGET_VERSIONS=("1.20")
+K8S_TARGET_VERSIONS=("1.19" "1.20" "1.21" "1.22")
 
 DIR=$(cd $(dirname "${BASH_SOURCE}")/.. && pwd -P)
 
@@ -66,7 +65,6 @@ do
     then
       cp ${OUTPUT_DIR}/*.yaml ${OUTPUT_DIR}/../
       sed -i "1s/^/#GENERATED FOR K8S ${K8S_VERSION}\n/" ${OUTPUT_DIR}/../deploy.yaml
-      rm -rf ${OUTPUT_DIR} # TODO @afirth remove for #8000 - this avoids the duplicate files for easier review of the build script changes
     fi
   done
 done


### PR DESCRIPTION
Generate static manifests compatible with supported K8s versions, rather than just 1.20

## What this PR does / why we need it:

Currently the helm templates have handling for different kubernetes versions, but the script to generate static manifests uses the helm default version (currently 1.20).
With this change the existing `deploy/static` manifests remain at 1.20 so we don't break docs, but additional folders are underneath with an explicit version.

For more background see #8000 and #7810. #8099 is related.

### Changes
The only real changes here are in [hack/generate-deploy-scripts.sh](https://github.com/kubernetes/ingress-nginx/pull/8162/files#diff-7b3dd6e2019d41d56cf859d2cbae90c0c3957e4e6816fc5ac0df96ef84f75ebfL29-L69)
1. generate for other supported K8s versions
2. don't delete the 1.20 folder (a hack I put in to make #8099 small enough to review)

everything else is the result of running the script.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

## Which issue/s this PR fixes
/fixes #7810

## How Has This Been Tested?
1. Ran `./generate-deploy-scripts.sh`
2. Verified existing manifests updated
3. spot-checked diffs to confirm expected changes present e.g.
```bash
$ diff deploy/static/provider/aws/1.19/deploy.yaml deploy/static/provider/aws/deploy.yaml
```
```diff
0a1
> #GENERATED FOR K8S 1.20
367a369,371
>   ipFamilies:
>   - IPv4
>   ipFamilyPolicy: SingleStack
369c373,374
<   - name: http
---
>   - appProtocol: http
>     name: http
373c378,379
<   - name: https
---
>   - appProtocol: https
>     name: https
398c404,405
<   - name: https-webhook
---
>   - appProtocol: https
>     name: https-webhook
```
1.19 does not have `appProtocol` or `ipFamilies` :+1: 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- ~~My change requires a change to the documentation.~~
- ~~I have updated the documentation accordingly.~~
(docs updates were completed in #8099)
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [n/a] I have added tests to cover my changes.
- [x] All new and existing tests passed.
