### PR TITLE
reintroduce helm-docs step in ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -137,6 +137,17 @@ jobs:
         run: |
           ./build/run-in-docker.sh ./hack/verify-chart-lint.sh
 
+      - name: Run helm-docs
+        run: |
+          GOBIN=$PWD GO111MODULE=on go install github.com/norwoodj/helm-docs/cmd/helm-docs@v1.6.0
+          ./helm-docs --chart-search-root=${GITHUB_WORKSPACE}/charts
+          DIFF=$(git diff ${GITHUB_WORKSPACE}/charts/ingress-nginx/README.md)
+          if [ ! -z "$DIFF" ]; then
+            echo "Please use helm-docs in your clone, of your fork, of the project, and commit a updated README.md for the chart. https://github.com/kubernetes/ingress-nginx/blob/main/RELEASE.md#d-edit-the-valuesyaml-and-run-helm-docs"
+          fi
+          git diff --exit-code
+          rm -f ./helm-docs
+
       - name: fix permissions
         run: |
           sudo mkdir -p $HOME/.kube


### PR DESCRIPTION
helm-docs step was removed from ci.yaml so re-introducing it.

While trying to automate helm-docs in CI. But GITHUB_TOKEN failed as the committer needs to have cla-signed and GITHUB_TOKEN does not have cla-signed, and helm-docs automation requires to commit a changed /charts/ingress-nginx/README.md back into the project. Using GITHUB_TOKEN, this is the error ;
```
remote: error: GH006: Protected branch update failed for refs/heads/main.        
remote: error: Required status check "cla/linuxfoundation" is expected.        
To https://github.com/kubernetes/ingress-nginx.git
 ! [remote rejected]     main -> main (protected branch hook declined)
error: failed to push some refs to 'https://github.com/kubernetes/ingress-nginx.git'
Error: Process completed with exit code 1.
```

So now re-adding helm-docs step, only for verify, while we work on a better solution for helm-docs automation in CI.