### PR TITLE
Adding annotations to the controller service account

### DIFF
--- a/charts/ingress-nginx/README.md
+++ b/charts/ingress-nginx/README.md
@@ -473,6 +473,7 @@ Kubernetes: `>=1.19.0-0`
 | rbac.create | bool | `true` |  |
 | rbac.scope | bool | `false` |  |
 | revisionHistoryLimit | int | `10` | Rollback limit |
+| serviceAccount.annotations | object | `{}` | Annotations for the controller service account |
 | serviceAccount.automountServiceAccountToken | bool | `true` |  |
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `""` |  |

--- a/charts/ingress-nginx/templates/controller-serviceaccount.yaml
+++ b/charts/ingress-nginx/templates/controller-serviceaccount.yaml
@@ -12,7 +12,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   {{- if .Values.serviceAccount.annotations }}
   annotations:
-  {{- toYaml .Values.serviceAccount.annotations | indent 4 }}
+  {{ toYaml .Values.serviceAccount.annotations | indent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- end }}

--- a/charts/ingress-nginx/templates/controller-serviceaccount.yaml
+++ b/charts/ingress-nginx/templates/controller-serviceaccount.yaml
@@ -10,5 +10,9 @@ metadata:
     {{- end }}
   name: {{ template "ingress-nginx.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
+  {{- if .Values.serviceAccount.annotations }}
+  annotations:
+  {{- toYaml .Values.serviceAccount.annotations | indent 4 }}
+  {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- end }}

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -888,6 +888,7 @@ serviceAccount:
   create: true
   name: ""
   automountServiceAccountToken: true
+  annotations: {}
 
 # -- Optional array of imagePullSecrets containing private registry credentials
 ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/


### PR DESCRIPTION
## What this PR does / why we need it:
Adds the ability to annotate the controller service account. This is particularly useful when using [IRSA](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) on AWS.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
Ability to annotate the controller service account, this could be viewed as new functionality but as its such a small change and was part of the [deprecated nginx helm chart](https://github.com/helm/charts/tree/master/stable/nginx-ingress) I've put it as a fix.

## How Has This Been Tested?
Tested changes with updated values file, everything deployed successfully with the service account annotations being provisioned correctly.

## Checklist:
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
