### PR TITLE
Add header Host into mirror annotations

### DIFF
--- a/docs/user-guide/nginx-configuration/annotations.md
+++ b/docs/user-guide/nginx-configuration/annotations.md
@@ -127,6 +127,7 @@ You can add these Kubernetes annotations to specific Ingress objects to customiz
 |[nginx.ingress.kubernetes.io/modsecurity-snippet](#modsecurity)|string|
 |[nginx.ingress.kubernetes.io/mirror-request-body](#mirror)|string|
 |[nginx.ingress.kubernetes.io/mirror-target](#mirror)|string|
+|[nginx.ingress.kubernetes.io/mirror-host](#mirror)|string|
 
 ### Canary
 
@@ -921,6 +922,13 @@ By default the request-body is sent to the mirror backend, but can be turned off
 
 ```yaml
 nginx.ingress.kubernetes.io/mirror-request-body: "off"
+```
+
+Also by default header Host for mirrored requests will be set the same as a host part of uri in the "mirror-target" annotation. You can override it by "mirror-host" annotation:
+
+```yaml
+nginx.ingress.kubernetes.io/mirror-target: https://1.2.3.4/$request_uri
+nginx.ingress.kubernetes.io/mirror-host: "test.env.com"
 ```
 
 **Note:** The mirror directive will be applied to all paths within the ingress resource.

--- a/internal/ingress/annotations/mirror/main_test.go
+++ b/internal/ingress/annotations/mirror/main_test.go
@@ -30,6 +30,7 @@ import (
 func TestParse(t *testing.T) {
 	requestBody := parser.GetAnnotationWithPrefix("mirror-request-body")
 	backendURL := parser.GetAnnotationWithPrefix("mirror-target")
+	host := parser.GetAnnotationWithPrefix("mirror-host")
 
 	ap := NewParser(&resolver.Mock{})
 	if ap == nil {
@@ -45,11 +46,43 @@ func TestParse(t *testing.T) {
 			Source:      ngxURI,
 			RequestBody: "on",
 			Target:      "https://test.env.com/$request_uri",
+			Host:        "test.env.com",
 		}},
 		{map[string]string{requestBody: "off"}, &Config{
 			Source:      "",
 			RequestBody: "off",
 			Target:      "",
+			Host:        "",
+		}},
+		{map[string]string{host: "test.env.com", backendURL: "http://some.test.env.com/$someparam"}, &Config{
+			Source:      ngxURI,
+			RequestBody: "on",
+			Target:      "http://some.test.env.com/$someparam",
+			Host:        "test.env.com",
+		}},
+		{map[string]string{backendURL: "IamNotAURL"}, &Config{
+			Source:      ngxURI,
+			RequestBody: "on",
+			Target:      "IamNotAURL",
+			Host:        "",
+		}},
+		{map[string]string{backendURL: "http://some.test.env.com:2121/$someparam=1&$someotherparam=2"}, &Config{
+			Source:      ngxURI,
+			RequestBody: "on",
+			Target:      "http://some.test.env.com:2121/$someparam=1&$someotherparam=2",
+			Host:        "some.test.env.com",
+		}},
+		{map[string]string{backendURL: "http://some.test.env.com", host: "someInvalidParm.%^&*()_=!@#'\""}, &Config{
+			Source:      ngxURI,
+			RequestBody: "on",
+			Target:      "http://some.test.env.com",
+			Host:        "someInvalidParm.%^&*()_=!@#'\"",
+		}},
+		{map[string]string{backendURL: "http://some.test.env.com", host: "_sbrubles-i\"@xpto:12345"}, &Config{
+			Source:      ngxURI,
+			RequestBody: "on",
+			Target:      "http://some.test.env.com",
+			Host:        "_sbrubles-i\"@xpto:12345",
 		}},
 	}
 

--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -1565,10 +1565,11 @@ func buildMirrorLocations(locs []*ingress.Location) string {
 		mapped.Insert(loc.Mirror.Source)
 		buffer.WriteString(fmt.Sprintf(`location = %v {
 internal;
+proxy_set_header Host %v;
 proxy_pass %v;
 }
 
-`, loc.Mirror.Source, loc.Mirror.Target))
+`, loc.Mirror.Source, loc.Mirror.Host, loc.Mirror.Target))
 	}
 
 	return buffer.String()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR allow to customize Host header for mirror requests. Also this PR fix behavior, when ingress-nginx set Host header as a backend name. Details in #4901 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #4901 
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have created dev environment and test header Host with different ingress configurations. 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
