### PR TITLE
use functional options to reduce number of methods creating an EchoDeployment

### DIFF
--- a/test/e2e/annotations/affinity.go
+++ b/test/e2e/annotations/affinity.go
@@ -36,7 +36,7 @@ var _ = framework.DescribeAnnotation("affinity session-cookie-name", func() {
 	f := framework.NewDefaultFramework("affinity")
 
 	ginkgo.BeforeEach(func() {
-		f.NewEchoDeploymentWithReplicas(2)
+		f.NewEchoDeployment(framework.WithDeploymentReplicas(2))
 	})
 
 	ginkgo.It("should set sticky cookie SERVERID", func() {

--- a/test/e2e/annotations/affinitymode.go
+++ b/test/e2e/annotations/affinitymode.go
@@ -34,7 +34,10 @@ var _ = framework.DescribeAnnotation("affinitymode", func() {
 	ginkgo.It("Balanced affinity mode should balance", func() {
 		deploymentName := "affinitybalanceecho"
 		replicas := 5
-		f.NewEchoDeploymentWithNameAndReplicas(deploymentName, replicas)
+		f.NewEchoDeployment(
+			framework.WithDeploymentName(deploymentName),
+			framework.WithDeploymentReplicas(replicas),
+		)
 
 		host := "affinity-mode-balance.com"
 		annotations := make(map[string]string)
@@ -64,7 +67,10 @@ var _ = framework.DescribeAnnotation("affinitymode", func() {
 	ginkgo.It("Check persistent affinity mode", func() {
 		deploymentName := "affinitypersistentecho"
 		replicas := 5
-		f.NewEchoDeploymentWithNameAndReplicas(deploymentName, replicas)
+		f.NewEchoDeployment(
+			framework.WithDeploymentName(deploymentName),
+			framework.WithDeploymentReplicas(replicas),
+		)
 
 		host := "affinity-mode-persistent.com"
 		annotations := make(map[string]string)

--- a/test/e2e/annotations/authtls.go
+++ b/test/e2e/annotations/authtls.go
@@ -30,7 +30,7 @@ var _ = framework.DescribeAnnotation("auth-tls-*", func() {
 	f := framework.NewDefaultFramework("authtls")
 
 	ginkgo.BeforeEach(func() {
-		f.NewEchoDeploymentWithReplicas(2)
+		f.NewEchoDeployment(framework.WithDeploymentReplicas(2))
 	})
 
 	ginkgo.It("should set sslClientCertificate, sslVerifyClient and sslVerifyDepth with auth-tls-secret", func() {

--- a/test/e2e/annotations/canary.go
+++ b/test/e2e/annotations/canary.go
@@ -39,10 +39,10 @@ var _ = framework.DescribeAnnotation("canary-*", func() {
 
 	ginkgo.BeforeEach(func() {
 		// Deployment for main backend
-		f.NewEchoDeploymentWithReplicas(1)
+		f.NewEchoDeployment()
 
 		// Deployment for canary backend
-		f.NewEchoDeploymentWithNameAndReplicas(canaryService, 1)
+		f.NewEchoDeployment(framework.WithDeploymentName(canaryService))
 	})
 
 	ginkgo.Context("when canary is created", func() {
@@ -132,7 +132,7 @@ var _ = framework.DescribeAnnotation("canary-*", func() {
 
 				ginkgo.By("returning a 503 status when the mainline deployment has 0 replicas and a request is sent to the canary")
 
-				f.NewEchoDeploymentWithReplicas(0)
+				f.NewEchoDeployment(framework.WithDeploymentReplicas(0))
 
 				resp, _, errs := gorequest.New().
 					Get(f.GetURL(framework.HTTP)).
@@ -145,7 +145,7 @@ var _ = framework.DescribeAnnotation("canary-*", func() {
 
 				ginkgo.By("returning a 200 status when the canary deployment has 0 replicas and a request is sent to the mainline ingress")
 
-				f.NewEchoDeploymentWithReplicas(1)
+				f.NewEchoDeployment()
 				f.NewDeployment(canaryService, "k8s.gcr.io/e2e-test-images/echoserver:2.3", 8080, 0)
 
 				resp, _, errs = gorequest.New().

--- a/test/e2e/annotations/cors.go
+++ b/test/e2e/annotations/cors.go
@@ -29,7 +29,7 @@ var _ = framework.DescribeAnnotation("cors-*", func() {
 	f := framework.NewDefaultFramework("cors")
 
 	ginkgo.BeforeEach(func() {
-		f.NewEchoDeploymentWithReplicas(2)
+		f.NewEchoDeployment(framework.WithDeploymentReplicas(2))
 	})
 
 	ginkgo.It("should enable cors", func() {

--- a/test/e2e/annotations/customhttperrors.go
+++ b/test/e2e/annotations/customhttperrors.go
@@ -101,7 +101,7 @@ var _ = framework.DescribeAnnotation("custom-http-errors", func() {
 
 		ginkgo.By("using the custom default-backend from annotation for upstream")
 		customDefaultBackend := "from-annotation"
-		f.NewEchoDeploymentWithNameAndReplicas(customDefaultBackend, 1)
+		f.NewEchoDeployment(framework.WithDeploymentName(customDefaultBackend))
 
 		err = framework.UpdateIngress(f.KubeClientSet, f.Namespace, host, func(ingress *networking.Ingress) error {
 			ingress.ObjectMeta.Annotations["nginx.ingress.kubernetes.io/default-backend"] = customDefaultBackend

--- a/test/e2e/annotations/proxyssl.go
+++ b/test/e2e/annotations/proxyssl.go
@@ -150,7 +150,7 @@ var _ = framework.DescribeAnnotation("proxy-ssl-*", func() {
 	ginkgo.It("proxy-ssl-location-only flag should change the nginx config server part", func() {
 		host := "proxyssl.com"
 
-		f.NewEchoDeploymentWithNameAndReplicas("echodeployment", 1)
+		f.NewEchoDeployment(framework.WithDeploymentName("echodeployment"))
 
 		secretName := "secretone"
 		annotations := make(map[string]string)

--- a/test/e2e/annotations/upstreamhashby.go
+++ b/test/e2e/annotations/upstreamhashby.go
@@ -77,7 +77,7 @@ var _ = framework.DescribeAnnotation("upstream-hash-by-*", func() {
 	f := framework.NewDefaultFramework("upstream-hash-by")
 
 	ginkgo.BeforeEach(func() {
-		f.NewEchoDeploymentWithReplicas(6)
+		f.NewEchoDeployment(framework.WithDeploymentReplicas(6))
 	})
 
 	ginkgo.It("should connect to the same pod", func() {

--- a/test/e2e/ingress/multiple_rules.go
+++ b/test/e2e/ingress/multiple_rules.go
@@ -31,8 +31,8 @@ var _ = framework.IngressNginxDescribe("single ingress - multiple hosts", func()
 	f := framework.NewDefaultFramework("simh")
 	pathprefix := networking.PathTypePrefix
 	ginkgo.BeforeEach(func() {
-		f.NewEchoDeploymentWithNameAndReplicas("first-service", 1)
-		f.NewEchoDeploymentWithNameAndReplicas("second-service", 1)
+		f.NewEchoDeployment(framework.WithDeploymentName("first-service"))
+		f.NewEchoDeployment(framework.WithDeploymentName("second-service"))
 	})
 
 	ginkgo.It("should set the correct $service_name NGINX variable", func() {

--- a/test/e2e/loadbalance/ewma.go
+++ b/test/e2e/loadbalance/ewma.go
@@ -32,7 +32,7 @@ var _ = framework.DescribeSetting("[Load Balancer] EWMA", func() {
 	f := framework.NewDefaultFramework("ewma")
 
 	ginkgo.BeforeEach(func() {
-		f.NewEchoDeploymentWithReplicas(3)
+		f.NewEchoDeployment(framework.WithDeploymentReplicas(3))
 		f.SetNginxConfigMapData(map[string]string{
 			"worker-processes": "2",
 			"load-balance":     "ewma"},

--- a/test/e2e/loadbalance/round_robin.go
+++ b/test/e2e/loadbalance/round_robin.go
@@ -32,7 +32,7 @@ var _ = framework.DescribeSetting("[Load Balancer] round-robin", func() {
 	f := framework.NewDefaultFramework("round-robin")
 
 	ginkgo.BeforeEach(func() {
-		f.NewEchoDeploymentWithReplicas(3)
+		f.NewEchoDeployment(framework.WithDeploymentReplicas(3))
 		f.UpdateNginxConfigMapData("worker-processes", "1")
 	})
 

--- a/test/e2e/lua/dynamic_configuration.go
+++ b/test/e2e/lua/dynamic_configuration.go
@@ -43,7 +43,7 @@ var _ = framework.IngressNginxDescribe("[Lua] dynamic configuration", func() {
 	f := framework.NewDefaultFramework("dynamic-configuration")
 
 	ginkgo.BeforeEach(func() {
-		f.NewEchoDeploymentWithReplicas(1)
+		f.NewEchoDeployment()
 		ensureIngress(f, "foo.com", framework.EchoService)
 	})
 
@@ -124,7 +124,10 @@ var _ = framework.IngressNginxDescribe("[Lua] dynamic configuration", func() {
 
 		ginkgo.It("handles endpoints only changes consistently (down scaling of replicas vs. empty service)", func() {
 			deploymentName := "scalingecho"
-			f.NewEchoDeploymentWithNameAndReplicas(deploymentName, 0)
+			f.NewEchoDeployment(
+				framework.WithDeploymentName(deploymentName),
+				framework.WithDeploymentReplicas(0),
+			)
 			createIngress(f, "scaling.foo.com", deploymentName)
 
 			resp := f.HTTPTestClient().

--- a/test/e2e/settings/default_ssl_certificate.go
+++ b/test/e2e/settings/default_ssl_certificate.go
@@ -38,7 +38,7 @@ var _ = framework.IngressNginxDescribe("[SSL] [Flag] default-ssl-certificate", f
 	port := 80
 
 	ginkgo.BeforeEach(func() {
-		f.NewEchoDeploymentWithReplicas(1)
+		f.NewEchoDeployment(framework.WithDeploymentReplicas(1))
 
 		var err error
 		tlsConfig, err = framework.CreateIngressTLSSecret(f.KubeClientSet,

--- a/test/e2e/settings/disable_catch_all.go
+++ b/test/e2e/settings/disable_catch_all.go
@@ -34,7 +34,7 @@ var _ = framework.IngressNginxDescribe("[Flag] disable-catch-all", func() {
 	f := framework.NewDefaultFramework("disabled-catch-all")
 
 	ginkgo.BeforeEach(func() {
-		f.NewEchoDeploymentWithReplicas(1)
+		f.NewEchoDeployment(framework.WithDeploymentReplicas(1))
 
 		err := f.UpdateIngressControllerDeployment(func(deployment *appsv1.Deployment) error {
 			args := deployment.Spec.Template.Spec.Containers[0].Args

--- a/test/e2e/settings/disable_service_external_name.go
+++ b/test/e2e/settings/disable_service_external_name.go
@@ -35,7 +35,7 @@ var _ = framework.IngressNginxDescribe("[Flag] disable-service-external-name", f
 	f := framework.NewDefaultFramework("disabled-service-external-name")
 
 	ginkgo.BeforeEach(func() {
-		f.NewEchoDeploymentWithReplicas(2)
+		f.NewEchoDeployment(framework.WithDeploymentReplicas(2))
 
 		err := f.UpdateIngressControllerDeployment(func(deployment *appsv1.Deployment) error {
 			args := deployment.Spec.Template.Spec.Containers[0].Args

--- a/test/e2e/settings/ingress_class.go
+++ b/test/e2e/settings/ingress_class.go
@@ -45,7 +45,7 @@ var _ = framework.IngressNginxDescribe("[Flag] ingress-class", func() {
 	otherController := "k8s.io/other-class"
 
 	ginkgo.BeforeEach(func() {
-		f.NewEchoDeploymentWithReplicas(1)
+		f.NewEchoDeployment(framework.WithDeploymentReplicas(1))
 
 		doOnce.Do(func() {
 			_, err := f.KubeClientSet.NetworkingV1().IngressClasses().

--- a/test/e2e/settings/namespace_selector.go
+++ b/test/e2e/settings/namespace_selector.go
@@ -37,7 +37,7 @@ var _ = framework.IngressNginxDescribe("[Flag] watch namespace selector", func()
 	prepareTestIngress := func(baseName string, host string, labels map[string]string) string {
 		ns, err := framework.CreateKubeNamespaceWithLabel(f.BaseName, labels, f.KubeClientSet)
 		assert.Nil(ginkgo.GinkgoT(), err, "creating test namespace")
-		f.NewEchoDeploymentWithNamespaceAndReplicas(ns, 1)
+		f.NewEchoDeployment(framework.WithDeploymentNamespace(ns))
 		ing := framework.NewSingleIngressWithIngressClass(host, "/", host, ns, framework.EchoService, f.IngressClass, 80, nil)
 		f.EnsureIngress(ing)
 		return ns

--- a/test/e2e/status/update.go
+++ b/test/e2e/status/update.go
@@ -69,7 +69,7 @@ var _ = framework.IngressNginxDescribe("[Status] status update", func() {
 		})
 		assert.Nil(ginkgo.GinkgoT(), err, "unexpected error updating ingress controller deployment flags")
 
-		f.NewEchoDeploymentWithReplicas(1)
+		f.NewEchoDeployment()
 
 		ing := f.EnsureIngress(framework.NewSingleIngress(host, "/", host, f.Namespace, framework.EchoService, 80, nil))
 

--- a/test/e2e/tcpudp/tcp.go
+++ b/test/e2e/tcpudp/tcp.go
@@ -38,7 +38,7 @@ var _ = framework.IngressNginxDescribe("[TCP] tcp-services", func() {
 	f := framework.NewDefaultFramework("tcp")
 
 	ginkgo.It("should expose a TCP service", func() {
-		f.NewEchoDeploymentWithReplicas(1)
+		f.NewEchoDeployment()
 
 		config, err := f.KubeClientSet.
 			CoreV1().


### PR DESCRIPTION
## What this PR does / why we need it:

This PR is a refactoring of the `NewEchoDeployment` test helper. We currently require several methods which are becoming quite long in their name, this so we can specify some arguments or others.
The refactor relies on functional attributes instead to allow specifying only the attributes we need while retaining only one method.

Before:

```
f.NewEchoDeploymentWithNamespaceAndReplicas("namespace", 2)
```

After:

```
f.NewEchoDeployment(
  framework.WithDeploymentNamespace("namespace"),
  framework.WithDeploymentReplicas(2),
)
```

I need this as part of my sidecar modules work. With this change in place, I will be able to add a `WithDeploymentModules` option which will allow configuring modules for a deployment.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

This is a refactoring of test helpers.

## How Has This Been Tested?

This is being fully tested through unit and e2e tests.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
