### PR TITLE
disable modsecurity on error page

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -850,6 +850,8 @@ stream {
         location @custom_{{ $upstreamName }}_{{ $errCode }} {
             internal;
 
+            modsecurity off;
+
             proxy_intercept_errors off;
 
             proxy_set_header       X-Code             {{ $errCode }};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If modsecurity is enabled and some "attack" like `http://localhost/?asdf=../../etc/passwd` is performed. The custom error pages for 403 are not shown as modsecurity also blocks loading them. Therefore it is required to disable modsecurity on custom error pages. This should be no risk as the custom error pages are `internal` and therefore not accessible by any user.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->
- none

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
As mentioned, try browsing this page `http://localhost/?asdf=../../etc/passwd` when you have custom error pages configured with the default backend like described here https://github.com/kubernetes/ingress-nginx/tree/main/docs/examples/customization/custom-errors. You will see that they are also blocked even if the 404 one comes on `http://YOURIP` default side. With this patch the default error pages are always displayed.
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
