### PR TITLE
Fix Indentation of example and link to cert-manager tutorial

### DIFF
--- a/docs/user-guide/tls.md
+++ b/docs/user-guide/tls.md
@@ -115,7 +115,7 @@ spec:
   tls:
     - hosts:
         - ingress-demo.example.com
-        secretName: ingress-demo-tls
+      secretName: ingress-demo-tls
     [...]
 ```
 
@@ -156,5 +156,5 @@ data:
 [SNI]: https://en.wikipedia.org/wiki/Server_Name_Indication
 [mozilla-ssl-config-old]: https://ssl-config.mozilla.org/#server=nginx&config=old
 [cert-manager]: https://github.com/jetstack/cert-manager/
-[full-cert-manager-example]:https://cert-manager.io/docs/tutorials/acme/ingress/
+[full-cert-manager-example]:https://cert-manager.io/docs/tutorials/acme/nginx-ingress/
 [cert-manager-issuer-config]:https://cert-manager.io/docs/configuration/


### PR DESCRIPTION

## What this PR does / why we need it:
This pull requests fixes some minor details on the TLS documentation namely:
- Indentation on the ingress config example
- link to the official cert-manager documentation

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation only

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
