### PR TITLE
Add keepalive support for auth requests

### DIFF
--- a/docs/user-guide/nginx-configuration/annotations.md
+++ b/docs/user-guide/nginx-configuration/annotations.md
@@ -31,6 +31,9 @@ You can add these Kubernetes annotations to specific Ingress objects to customiz
 |[nginx.ingress.kubernetes.io/auth-url](#external-authentication)|string|
 |[nginx.ingress.kubernetes.io/auth-cache-key](#external-authentication)|string|
 |[nginx.ingress.kubernetes.io/auth-cache-duration](#external-authentication)|string|
+|[nginx.ingress.kubernetes.io/auth-keepalive](#external-authentication)|number|
+|[nginx.ingress.kubernetes.io/auth-keepalive-requests](#external-authentication)|number|
+|[nginx.ingress.kubernetes.io/auth-keepalive-timeout](#external-authentication)|number|
 |[nginx.ingress.kubernetes.io/auth-proxy-set-headers](#external-authentication)|string|
 |[nginx.ingress.kubernetes.io/auth-snippet](#external-authentication)|string|
 |[nginx.ingress.kubernetes.io/enable-global-auth](#external-authentication)|"true" or "false"|
@@ -453,6 +456,15 @@ nginx.ingress.kubernetes.io/auth-url: "URL to the authentication service"
 
 Additionally it is possible to set:
 
+* `nginx.ingress.kubernetes.io/auth-keepalive`:
+  `<Connections>` to specify the maximum number of keepalive connections to `auth-url`. Only takes effect
+   when no variables are used in the host part of the URL. Defaults to `0` (keepalive disabled).
+* `nginx.ingress.kubernetes.io/auth-keepalive-requests`:
+  `<Requests>` to specify the maximum number of requests that can be served through one keepalive connection.
+  Defaults to `1000` and only applied if `auth-keepalive` is set to higher than `0`.
+* `nginx.ingress.kubernetes.io/auth-keepalive-timeout`:
+  `<Timeout>` to specify a duration in seconds which an idle keepalive connection to an upstream server will stay open.
+  Defaults to `60` and only applied if `auth-keepalive` is set to higher than `0`.
 * `nginx.ingress.kubernetes.io/auth-method`:
   `<Method>` to specify the HTTP method to use.
 * `nginx.ingress.kubernetes.io/auth-signin`:

--- a/docs/user-guide/nginx-configuration/annotations.md
+++ b/docs/user-guide/nginx-configuration/annotations.md
@@ -459,6 +459,10 @@ Additionally it is possible to set:
 * `nginx.ingress.kubernetes.io/auth-keepalive`:
   `<Connections>` to specify the maximum number of keepalive connections to `auth-url`. Only takes effect
    when no variables are used in the host part of the URL. Defaults to `0` (keepalive disabled).
+
+> Note: does not work with HTTP/2 listener because of a limitation in Lua [subrequests](https://github.com/openresty/lua-nginx-module#spdy-mode-not-fully-supported).
+> [UseHTTP2](./configmap.md#use-http2) configuration should be disabled!
+
 * `nginx.ingress.kubernetes.io/auth-keepalive-requests`:
   `<Requests>` to specify the maximum number of requests that can be served through one keepalive connection.
   Defaults to `1000` and only applied if `auth-keepalive` is set to higher than `0`.

--- a/internal/ingress/annotations/authreq/main.go
+++ b/internal/ingress/annotations/authreq/main.go
@@ -222,7 +222,7 @@ func (a authReq) Parse(ing *networking.Ingress) (interface{}, error) {
 	}
 	// NOTE: upstream block cannot reference a variable in the server directive
 	if keepaliveConnections != 0 && strings.IndexByte(authURL.Host, '$') != -1 {
-		klog.Warningf("auth-url annotation (%v) contains $ in the host:port part, setting auth-keepalive to 0", authURL.Host)
+		klog.Warningf("auth-url annotation (%s) contains $ in the host:port part, setting auth-keepalive to 0", authURL.Host)
 		keepaliveConnections = 0
 	}
 

--- a/internal/ingress/annotations/authreq/main.go
+++ b/internal/ingress/annotations/authreq/main.go
@@ -221,7 +221,7 @@ func (a authReq) Parse(ing *networking.Ingress) (interface{}, error) {
 		keepaliveConnections = defaultKeepaliveConnections
 	}
 	// NOTE: upstream block cannot reference a variable in the server directive
-	if keepaliveConnections != 0 && strings.IndexByte(authURL.Host, '$') != -1 {
+	if keepaliveConnections > 0 && strings.IndexByte(authURL.Host, '$') != -1 {
 		klog.Warningf("auth-url annotation (%s) contains $ in the host:port part, setting auth-keepalive to 0", authURL.Host)
 		keepaliveConnections = 0
 	}

--- a/internal/ingress/annotations/authreq/main.go
+++ b/internal/ingress/annotations/authreq/main.go
@@ -222,7 +222,7 @@ func (a authReq) Parse(ing *networking.Ingress) (interface{}, error) {
 	}
 	// NOTE: upstream block cannot reference a variable in the server directive
 	if keepaliveConnections != 0 && strings.IndexByte(authURL.Host, '$') != -1 {
-		klog.V(3).InfoS("auth-url annotation contains $ in the host:port part, setting auth-keepalive to 0")
+		klog.Warningf("auth-url annotation (%v) contains $ in the host:port part, setting auth-keepalive to 0", authURL.Host)
 		keepaliveConnections = 0
 	}
 

--- a/internal/ingress/annotations/authreq/main_test.go
+++ b/internal/ingress/annotations/authreq/main_test.go
@@ -280,7 +280,8 @@ func TestKeepaliveAnnotations(t *testing.T) {
 
 		i, err := NewParser(&resolver.Mock{}).Parse(ing)
 		if err != nil {
-			t.Errorf("expected no error")
+			t.Errorf("%v: unexpected error: %v", test.title, err)
+			continue
 		}
 
 		u, ok := i.(*Config)

--- a/internal/ingress/annotations/authreq/main_test.go
+++ b/internal/ingress/annotations/authreq/main_test.go
@@ -266,6 +266,10 @@ func TestKeepaliveAnnotations(t *testing.T) {
 		{"default for invalid timeout", "http://goog.url", "5", "500", "x", 5, 500, defaultKeepaliveTimeout},
 		{"variable in host", "http://$host:5000/a/b", "5", "", "", 0, defaultKeepaliveRequests, defaultKeepaliveTimeout},
 		{"variable in path", "http://goog.url:5000/$path", "5", "", "", 5, defaultKeepaliveRequests, defaultKeepaliveTimeout},
+		{"negative connections", "http://goog.url", "-2", "", "", 0, defaultKeepaliveRequests, defaultKeepaliveTimeout},
+		{"negative requests", "http://goog.url", "5", "-1", "", 0, -1, defaultKeepaliveTimeout},
+		{"negative timeout", "http://goog.url", "5", "", "-1", 0, defaultKeepaliveRequests, -1},
+		{"negative request and timeout", "http://goog.url", "5", "-2", "-3", 0, -2, -3},
 	}
 
 	for _, test := range tests {

--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -618,7 +618,7 @@ func buildAuthUpstreamName(input interface{}, host string) string {
 }
 
 // shouldApplyAuthUpstream returns true only in case when ExternalAuth.URL and
-// ExternalAuth.KeeapliveConnections are all set
+// ExternalAuth.KeepaliveConnections are all set
 func shouldApplyAuthUpstream(input interface{}) bool {
 	location, ok := input.(*ingress.Location)
 	if !ok {

--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -613,7 +613,6 @@ func buildAuthUpstreamName(input interface{}, host string) string {
 		return ""
 	}
 
-	host = strings.Replace(host, ".", "_", -1)
 	return fmt.Sprintf("%v-%v", host, authPath[2:])
 }
 

--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -603,8 +603,8 @@ func buildAuthUpstreamHeaders(proxySetHeader string, headers []string) []string 
 	}
 
 	for i, h := range headers {
-		res = append(res, fmt.Sprintf("set $authHeader%v '';", i))
-		res = append(res, fmt.Sprintf("%s '%v' $authHeader%v;", proxySetHeader, h, i))
+		res = append(res, fmt.Sprintf("set $authHeader%d '';", i))
+		res = append(res, fmt.Sprintf("%s '%s' $authHeader%d;", proxySetHeader, h, i))
 	}
 	return res
 }
@@ -617,7 +617,7 @@ func buildAuthUpstreamLuaHeaders(proxySetHeader string, headers []string) []stri
 	}
 
 	for i, h := range headers {
-		res = append(res, fmt.Sprintf("ngx.var.authHeader%v = res.header['%v']", i, h))
+		res = append(res, fmt.Sprintf("ngx.var.authHeader%d = res.header['%s']", i, h))
 	}
 	return res
 }
@@ -642,7 +642,7 @@ func buildAuthUpstreamName(input interface{}, host string) string {
 		return ""
 	}
 
-	return fmt.Sprintf("%v-%v", host, authPath[2:])
+	return fmt.Sprintf("%s-%s", host, authPath[2:])
 }
 
 // shouldApplyAuthUpstream returns true only in case when ExternalAuth.URL and
@@ -682,7 +682,7 @@ func extractHostPort(url string) string {
 
 	authURL, err := parser.StringToURL(url)
 	if err != nil {
-		klog.Errorf("expected a valid URL but %v was returned", url)
+		klog.Errorf("expected a valid URL but %s was returned", url)
 		return ""
 	}
 
@@ -697,7 +697,7 @@ func changeHostPort(url string, value string) string {
 
 	authURL, err := parser.StringToURL(url)
 	if err != nil {
-		klog.Errorf("expected a valid URL but %v was returned", url)
+		klog.Errorf("expected a valid URL but %s was returned", url)
 		return ""
 	}
 

--- a/internal/ingress/controller/template/template_test.go
+++ b/internal/ingress/controller/template/template_test.go
@@ -588,7 +588,7 @@ func TestShouldApplyAuthUpstream(t *testing.T) {
 		expected             bool
 	}{
 		{"authURL, no keepalive", authURL, 0, false},
-		{"authURL, keeaplive", authURL, 10, true},
+		{"authURL, keepalive", authURL, 10, true},
 		{"empty, no keepalive", "", 0, false},
 		{"empty, keepalive", "", 10, false},
 	}

--- a/internal/ingress/controller/template/template_test.go
+++ b/internal/ingress/controller/template/template_test.go
@@ -557,8 +557,8 @@ func TestBuildAuthUpstreamName(t *testing.T) {
 		host     string
 		expected string
 	}{
-		{"valid host", "auth.my.site", fmt.Sprintf("%s-%s", "auth_my_site", externalAuthPath)},
-		{"valid host", "your.auth.site", fmt.Sprintf("%s-%s", "your_auth_site", externalAuthPath)},
+		{"valid host", "auth.my.site", fmt.Sprintf("%s-%s", "auth.my.site", externalAuthPath)},
+		{"valid host", "your.auth.site", fmt.Sprintf("%s-%s", "your.auth.site", externalAuthPath)},
 		{"empty host", "", ""},
 	}
 

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -609,24 +609,24 @@ http {
     ## end server {{ $redirect.From }}
     {{ end }}
 
-    ## start auth upstream
     {{ range $server := $servers }}
     {{ range $location := $server.Locations }}
     {{ $applyGlobalAuth := shouldApplyGlobalAuth $location $all.Cfg.GlobalExternalAuth.URL }}
-    {{ $applyAuthUpstream := shouldApplyAuthUpstream $location }}
+    {{ $applyAuthUpstream := shouldApplyAuthUpstream $location $all.Cfg }}
     {{ if and (eq $applyAuthUpstream true) (eq $applyGlobalAuth false) }}
+    ## start auth upstream {{ $server.Hostname }}{{ $location.Path }}
     upstream {{ buildAuthUpstreamName $location $server.Hostname }} {
-        {{ $externalAuth := $location.ExternalAuth }}
+        {{- $externalAuth := $location.ExternalAuth }}
         server {{ extractHostPort $externalAuth.URL }};
 
         keepalive {{ $externalAuth.KeepaliveConnections }};
         keepalive_requests {{ $externalAuth.KeepaliveRequests }};
         keepalive_timeout {{ $externalAuth.KeepaliveTimeout }}s;
     }
+    ## end auth upstream {{ $server.Hostname }}{{ $location.Path }}
     {{ end }}
     {{ end }}
     {{ end }}
-    ## end auth upstream
 
     {{ range $server := $servers }}
     ## start server {{ $server.Hostname }}
@@ -1013,7 +1013,7 @@ stream {
         {{ $proxySetHeader := proxySetHeader $location }}
         {{ $authPath := buildAuthLocation $location $all.Cfg.GlobalExternalAuth.URL }}
         {{ $applyGlobalAuth := shouldApplyGlobalAuth $location $all.Cfg.GlobalExternalAuth.URL }}
-        {{ $applyAuthUpstream := shouldApplyAuthUpstream $location }}
+        {{ $applyAuthUpstream := shouldApplyAuthUpstream $location $all.Cfg }}
 
         {{ $externalAuth := $location.ExternalAuth }}
         {{ if eq $applyGlobalAuth true }}
@@ -1238,12 +1238,36 @@ stream {
             {{ if not (isLocationInLocationList $location $all.Cfg.NoAuthLocations) }}
             {{ if $authPath }}
             # this location requires authentication
+            {{ if and (eq $applyAuthUpstream true) (eq $applyGlobalAuth false) }}
+            set $auth_cookie '';
+            add_header Set-Cookie $auth_cookie;
+            {{- range $line := buildAuthUpstreamHeaders $proxySetHeader $externalAuth.ResponseHeaders }}
+            {{ $line }}
+            {{- end }}
+            # `auth_request` module does not support HTTP keepalives in upstream block:
+            # https://trac.nginx.org/nginx/ticket/1579
+            access_by_lua_block {
+                local res = ngx.location.capture('{{ $authPath }}', { method = ngx.HTTP_GET, body = '' })
+                if res.status == ngx.HTTP_OK then
+                    ngx.var.auth_cookie = res.header['Set-Cookie']
+                    {{- range $line := buildAuthUpstreamLuaHeaders $proxySetHeader $externalAuth.ResponseHeaders }}
+                    {{ $line }}
+                    {{- end }}
+                    return
+                end
+                if res.status == ngx.HTTP_FORBIDDEN then
+                    ngx.exit(res.status)
+                end
+                ngx.exit(ngx.HTTP_INTERNAL_SERVER_ERROR)
+            }
+            {{ else }}
             auth_request        {{ $authPath }};
             auth_request_set    $auth_cookie $upstream_http_set_cookie;
             add_header          Set-Cookie $auth_cookie;
             {{- range $line := buildAuthResponseHeaders $proxySetHeader $externalAuth.ResponseHeaders }}
             {{ $line }}
             {{- end }}
+            {{ end }}
             {{ end }}
 
             {{ if $externalAuth.SigninURL }}

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -1241,7 +1241,7 @@ stream {
             {{ if and (eq $applyAuthUpstream true) (eq $applyGlobalAuth false) }}
             set $auth_cookie '';
             add_header Set-Cookie $auth_cookie;
-            {{- range $line := buildAuthUpstreamHeaders $proxySetHeader $externalAuth.ResponseHeaders }}
+            {{- range $line := buildAuthResponseHeaders $externalAuth.ResponseHeaders true }}
             {{ $line }}
             {{- end }}
             # `auth_request` module does not support HTTP keepalives in upstream block:
@@ -1264,7 +1264,7 @@ stream {
             auth_request        {{ $authPath }};
             auth_request_set    $auth_cookie $upstream_http_set_cookie;
             add_header          Set-Cookie $auth_cookie;
-            {{- range $line := buildAuthResponseHeaders $proxySetHeader $externalAuth.ResponseHeaders }}
+            {{- range $line := buildAuthResponseHeaders $proxySetHeader $externalAuth.ResponseHeaders false }}
             {{ $line }}
             {{- end }}
             {{ end }}

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -609,8 +609,26 @@ http {
     ## end server {{ $redirect.From }}
     {{ end }}
 
+    ## start auth upstream
     {{ range $server := $servers }}
+    {{ range $location := $server.Locations }}
+    {{ $applyGlobalAuth := shouldApplyGlobalAuth $location $all.Cfg.GlobalExternalAuth.URL }}
+    {{ $applyAuthUpstream := shouldApplyAuthUpstream $location }}
+    {{ if and (eq $applyAuthUpstream true) (eq $applyGlobalAuth false) }}
+    upstream {{ buildAuthUpstreamName $location $server.Hostname }} {
+        {{ $externalAuth := $location.ExternalAuth }}
+        server {{ extractHostPort $externalAuth.URL }};
 
+        keepalive {{ $externalAuth.KeepaliveConnections }};
+        keepalive_requests {{ $externalAuth.KeepaliveRequests }};
+        keepalive_timeout {{ $externalAuth.KeepaliveTimeout }}s;
+    }
+    {{ end }}
+    {{ end }}
+    {{ end }}
+    ## end auth upstream
+
+    {{ range $server := $servers }}
     ## start server {{ $server.Hostname }}
     server {
         server_name {{ buildServerName $server.Hostname }} {{range $server.Aliases }}{{ . }} {{ end }};
@@ -995,6 +1013,7 @@ stream {
         {{ $proxySetHeader := proxySetHeader $location }}
         {{ $authPath := buildAuthLocation $location $all.Cfg.GlobalExternalAuth.URL }}
         {{ $applyGlobalAuth := shouldApplyGlobalAuth $location $all.Cfg.GlobalExternalAuth.URL }}
+        {{ $applyAuthUpstream := shouldApplyAuthUpstream $location }}
 
         {{ $externalAuth := $location.ExternalAuth }}
         {{ if eq $applyGlobalAuth true }}
@@ -1074,7 +1093,6 @@ stream {
             proxy_buffer_size                       {{ $location.Proxy.BufferSize }};
             proxy_buffers                           {{ $location.Proxy.BuffersNumber }} {{ $location.Proxy.BufferSize }};
             proxy_request_buffering                 {{ $location.Proxy.RequestBuffering }};
-            proxy_http_version                      {{ $location.Proxy.ProxyHTTPVersion }};
 
             proxy_ssl_server_name       on;
             proxy_pass_request_headers  on;
@@ -1103,7 +1121,15 @@ stream {
             {{ $externalAuth.AuthSnippet }}
             {{ end }}
 
+            {{ if and (eq $applyAuthUpstream true) (eq $applyGlobalAuth false) }}
+            {{ $authUpstreamName := buildAuthUpstreamName $location $server.Hostname }}
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+            set $target {{ changeHostPort $externalAuth.URL $authUpstreamName }};
+            {{ else }}
+            proxy_http_version {{ $location.Proxy.ProxyHTTPVersion }};
             set $target {{ $externalAuth.URL }};
+            {{ end }}
             proxy_pass $target;
         }
         {{ end }}

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -1241,7 +1241,7 @@ stream {
             {{ if and (eq $applyAuthUpstream true) (eq $applyGlobalAuth false) }}
             set $auth_cookie '';
             add_header Set-Cookie $auth_cookie;
-            {{- range $line := buildAuthResponseHeaders $externalAuth.ResponseHeaders true }}
+            {{- range $line := buildAuthResponseHeaders $proxySetHeader $externalAuth.ResponseHeaders true }}
             {{ $line }}
             {{- end }}
             # `auth_request` module does not support HTTP keepalives in upstream block:
@@ -1250,7 +1250,7 @@ stream {
                 local res = ngx.location.capture('{{ $authPath }}', { method = ngx.HTTP_GET, body = '' })
                 if res.status == ngx.HTTP_OK then
                     ngx.var.auth_cookie = res.header['Set-Cookie']
-                    {{- range $line := buildAuthUpstreamLuaHeaders $proxySetHeader $externalAuth.ResponseHeaders }}
+                    {{- range $line := buildAuthUpstreamLuaHeaders $externalAuth.ResponseHeaders }}
                     {{ $line }}
                     {{- end }}
                     return

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -1123,6 +1123,10 @@ stream {
 
             {{ if and (eq $applyAuthUpstream true) (eq $applyGlobalAuth false) }}
             {{ $authUpstreamName := buildAuthUpstreamName $location $server.Hostname }}
+            # The target is an upstream with HTTP keepalive, that is why the
+            # Connection header is cleared and the HTTP version is set to 1.1 as
+            # the Nginx documentation suggests:
+            # http://nginx.org/en/docs/http/ngx_http_upstream_module.html#keepalive
             proxy_http_version 1.1;
             proxy_set_header Connection "";
             set $target {{ changeHostPort $externalAuth.URL $authUpstreamName }};

--- a/test/e2e/annotations/auth.go
+++ b/test/e2e/annotations/auth.go
@@ -497,7 +497,7 @@ http {
 				func(server string) bool {
 					return strings.Contains(server, "http://$host/path") &&
 						!strings.Contains(server, `upstream auth-external-auth`) &&
-						!strings.Contains(server, `keeaplive 123;`)
+						!strings.Contains(server, `keepalive 123;`)
 				})
 		})
 

--- a/test/e2e/annotations/auth.go
+++ b/test/e2e/annotations/auth.go
@@ -478,6 +478,13 @@ http {
 		})
 
 		ginkgo.It(`should not create additional upstream block when auth-keepalive is not set`, func() {
+			f.UpdateNginxConfigMapData("use-http2", "false")
+			defer func() {
+				f.UpdateNginxConfigMapData("use-http2", "true")
+			}()
+			// Sleep a while just to guarantee that the configmap is applied
+			framework.Sleep()
+
 			annotations["nginx.ingress.kubernetes.io/auth-url"] = "http://foo.bar.baz:5000/path"
 			f.UpdateIngress(ing)
 
@@ -489,6 +496,13 @@ http {
 		})
 
 		ginkgo.It(`should not create additional upstream block when host part of auth-url contains a variable`, func() {
+			f.UpdateNginxConfigMapData("use-http2", "false")
+			defer func() {
+				f.UpdateNginxConfigMapData("use-http2", "true")
+			}()
+			// Sleep a while just to guarantee that the configmap is applied
+			framework.Sleep()
+
 			annotations["nginx.ingress.kubernetes.io/auth-url"] = "http://$host/path"
 			annotations["nginx.ingress.kubernetes.io/auth-keepalive"] = "123"
 			f.UpdateIngress(ing)
@@ -501,7 +515,28 @@ http {
 				})
 		})
 
-		ginkgo.It(`should create additional upstream block when auth-keepalive is set`, func() {
+		ginkgo.It(`should not create additional upstream block when auth-keepalive is set with HTTP/2`, func() {
+			annotations["nginx.ingress.kubernetes.io/auth-url"] = "http://foo.bar.baz:5000/path"
+			annotations["nginx.ingress.kubernetes.io/auth-keepalive"] = "123"
+			annotations["nginx.ingress.kubernetes.io/auth-keepalive-requests"] = "456"
+			annotations["nginx.ingress.kubernetes.io/auth-keepalive-timeout"] = "789"
+			f.UpdateIngress(ing)
+
+			f.WaitForNginxServer("",
+				func(server string) bool {
+					return strings.Contains(server, "http://foo.bar.baz:5000/path") &&
+						!strings.Contains(server, `upstream auth-external-auth`)
+				})
+		})
+
+		ginkgo.It(`should create additional upstream block when auth-keepalive is set with HTTP/1.x`, func() {
+			f.UpdateNginxConfigMapData("use-http2", "false")
+			defer func() {
+				f.UpdateNginxConfigMapData("use-http2", "true")
+			}()
+			// Sleep a while just to guarantee that the configmap is applied
+			framework.Sleep()
+
 			annotations["nginx.ingress.kubernetes.io/auth-keepalive"] = "123"
 			annotations["nginx.ingress.kubernetes.io/auth-keepalive-requests"] = "456"
 			annotations["nginx.ingress.kubernetes.io/auth-keepalive-timeout"] = "789"


### PR DESCRIPTION
This PR adds keepalive support for auth request backends.

## What this PR does / why we need it:
The ingress controller supports external authentication, but it does not use keepalive for those connections. For a high-traffic site, we create as many TCP connections as client requests we get. Using keepalive will reuse the existing TCP connections if possible.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
No issue found.

## How Has This Been Tested?
Tested on 1.20 version of Kubernetes and e2e tests also passed.

### How it affects other areas of the code?
If `auth-url` annotation is used along with `auth-keepalive` then we create an upsteam block with the host and port of `auth_url` and reference this upstream in `proxy_pass`.

⚠️ Unfortunately `auth_request` module ignores the `keepalive` directive (see: https://trac.nginx.org/nginx/ticket/1579), that is why we use `access_by_lua_block` to mimic the same functionality. The `ngx.location.capture` is not supported when HTTP/2 is used, so it only takes effect if `use-http2: "false"` configuration parameter is set.

Example annotations:
```yaml
    nginx.ingress.kubernetes.io/auth-keepalive: "20"
    nginx.ingress.kubernetes.io/auth-response-headers: Authorization
    nginx.ingress.kubernetes.io/auth-url: "http://my.auth.server:5000/auth"
```

Example generated code:
```conf
        upstream my.custom.domain-external-auth-Lw-Prefix {
                server my.auth.server:5000;

                keepalive 20;
                keepalive_requests 1000;
                keepalive_timeout 60s;
        }

        server {
                server_name my.custom.domain ;
                ...

                location = /_external-auth-Lw-Prefix {
                        ...

                        proxy_http_version 1.1;
                        proxy_set_header Connection "";
                        set $target http://my.custom.domain-external-auth-Lw-Prefix/auth;

                        proxy_pass $target;
                }

                location / {
                        ...
                        # this location requires authentication
                        set $auth_cookie '';
                        add_header Set-Cookie $auth_cookie;
                        set $authHeader0 '';
                        proxy_set_header 'Authorization' $authHeader0;
                        
                        # `auth_request` module does not support HTTP keepalives in upstream block:
                        # https://trac.nginx.org/nginx/ticket/1579
                        access_by_lua_block {
                                local res = ngx.location.capture('/_external-auth-L3YxYmV0YTEvZnVuZGFtZW50YWwvKC4qKQ-Prefix', { method = ngx.HTTP_GET, body = '' })
                                if res.status == ngx.HTTP_OK then
                                        ngx.var.auth_cookie = res.header['Set-Cookie']
                                        ngx.var.authHeader0 = res.header['Authorization']
                                        return
                                end
                                if res.status == ngx.HTTP_FORBIDDEN then
                                        ngx.exit(res.status)
                                end
                                ngx.exit(ngx.HTTP_INTERNAL_SERVER_ERROR)
                        }
                        ....
                }
```

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
