### PR TITLE
fix inconsistent-label-cardinality for prometheus metrics: nginx_ingress_controller_requests

### DIFF
--- a/internal/ingress/metric/collectors/socket.go
+++ b/internal/ingress/metric/collectors/socket.go
@@ -259,9 +259,6 @@ func (sc *SocketCollector) handleMessage(msg []byte) {
 			"service":   stats.Service,
 			"canary":    stats.Canary,
 		}
-		if sc.metricsPerHost {
-			requestLabels["host"] = stats.Host
-		}
 
 		collectorLabels := prometheus.Labels{
 			"namespace": stats.Namespace,
@@ -269,9 +266,12 @@ func (sc *SocketCollector) handleMessage(msg []byte) {
 			"status":    stats.Status,
 			"service":   stats.Service,
 			"canary":    stats.Canary,
-			"host":      stats.Host,
 			"method":    stats.Method,
 			"path":      stats.Path,
+		}
+		if sc.metricsPerHost {
+			requestLabels["host"] = stats.Host
+			collectorLabels["host"] = stats.Host
 		}
 
 		latencyLabels := prometheus.Labels{

--- a/internal/ingress/metric/collectors/socket.go
+++ b/internal/ingress/metric/collectors/socket.go
@@ -217,6 +217,7 @@ func NewSocketCollector(pod, namespace, class string, metricsPerHost bool, bucke
 	}
 
 	sc.metricMapping = map[string]interface{}{
+		prometheus.BuildFQName(PrometheusNamespace, "", "requests"):                 sc.requests,
 		prometheus.BuildFQName(PrometheusNamespace, "", "request_duration_seconds"): sc.requestTime,
 		prometheus.BuildFQName(PrometheusNamespace, "", "request_size"):             sc.requestLength,
 
@@ -268,6 +269,9 @@ func (sc *SocketCollector) handleMessage(msg []byte) {
 			"status":    stats.Status,
 			"service":   stats.Service,
 			"canary":    stats.Canary,
+			"host":      stats.Host,
+			"method":    stats.Method,
+			"path":      stats.Path,
 		}
 
 		latencyLabels := prometheus.Labels{
@@ -412,6 +416,12 @@ func (sc *SocketCollector) RemoveMetrics(ingresses []string, registry prometheus
 			if ok {
 				removed := s.Delete(labels)
 				if !removed {
+					klog.V(2).InfoS("metric not removed", "name", metricName, "ingress", ingKey, "labels", labels)
+				}
+			}
+
+			if c, ok := metric.(*prometheus.CounterVec); ok {
+				if removed := c.Delete(labels); !removed {
 					klog.V(2).InfoS("metric not removed", "name", metricName, "ingress", ingKey, "labels", labels)
 				}
 			}

--- a/internal/ingress/metric/collectors/socket_test.go
+++ b/internal/ingress/metric/collectors/socket_test.go
@@ -153,7 +153,35 @@ func TestCollector(t *testing.T) {
 			wantAfter: `
 			`,
 		},
-
+		{
+			name: "valid metric object should update requests metrics",
+			data: []string{`[{
+				"host":"testshop.com",
+				"status":"200",
+				"bytesSent":150.0,
+				"method":"GET",
+				"path":"/admin",
+				"requestLength":300.0,
+				"requestTime":60.0,
+				"upstreamName":"test-upstream",
+				"upstreamIP":"1.1.1.1:8080",
+				"upstreamResponseTime":200,
+				"upstreamStatus":"220",
+				"namespace":"test-app-production",
+				"ingress":"web-yml",
+				"service":"test-app",
+				"canary":""
+			}]`},
+			metrics: []string{"nginx_ingress_controller_requests"},
+			wantBefore: `
+				# HELP nginx_ingress_controller_requests The total number of client requests.
+				# TYPE nginx_ingress_controller_requests counter
+				nginx_ingress_controller_requests{canary="",controller_class="ingress",controller_namespace="default",controller_pod="pod",host="testshop.com",ingress="web-yml",method="GET",namespace="test-app-production",path="/admin",service="test-app",status="200"} 1
+			`,
+			removeIngresses: []string{"test-app-production/web-yml"},
+			wantAfter: `
+			`,
+		},
 		{
 			name: "valid metric object with canary information should update prometheus metrics",
 			data: []string{`[{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
it fixes a bug:
- described in issue: https://github.com/kubernetes/ingress-nginx/issues/8224
-  introduced by PR: https://github.com/kubernetes/ingress-nginx/pull/8201

the bug prevents the collection of metrics: `nginx_ingress_controller_requests` 

<!--- If it fixes an open issue, please link to the issue here. -->

https://github.com/kubernetes/ingress-nginx/issues/8224


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->
fixes #8224 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
added unit test which failed without this fix, and passes with this fix in place.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
