### PR TITLE
Working to fix bug #7760

### DIFF
--- a/internal/ingress/controller/store/store.go
+++ b/internal/ingress/controller/store/store.go
@@ -451,12 +451,9 @@ func New(
 				return
 			}
 
-			var errOld, errCur error
-			var classCur string
-			if !icConfig.IgnoreIngressClass {
-				_, errOld = store.GetIngressClass(oldIng, icConfig)
-				classCur, errCur = store.GetIngressClass(curIng, icConfig)
-			}
+			_, errOld := store.GetIngressClass(oldIng, icConfig)
+			classCur, errCur := store.GetIngressClass(curIng, icConfig)
+
 			if errOld != nil && errCur == nil {
 				if hasCatchAllIngressRule(curIng.Spec) && disableCatchAll {
 					klog.InfoS("ignoring update for catch-all ingress because of --disable-catch-all", "ingress", klog.KObj(curIng))


### PR DESCRIPTION
I found the same bug of issue #7760 

Our scenario:
* We deploy one ingress-nginx per namespace, to do that: we installed the nginx-ingress in the scope mode, turning theses flags via helm to true: rbac.scope and controller.scope.enabled
* We have other important ingress controllers running on the cluster, i.e GCE-ingress. 
* We aren't using ClusterRole, just Role, cause helm avoids a take-over of existing resources.
* The flag IgnoreIngressClass have turned on automatically cause a unexpected forbidden: https://github.com/kubernetes/ingress-nginx/blob/main/cmd/nginx/main.go#L115
* The ingress-controller has replaced status for all ingress objects that not belongs to it
* This bug caused a huge trouble in our development environment.


Reflections:

* Why we are receiving a 403 error?, we have the role assigned, but the ingressclass is not a namespace-wide object.

TODO: 
- [ ] Write a test case

fixes #7760 