### PR TITLE
Add per worker cache for certificate and private key

### DIFF
--- a/docs/user-guide/nginx-configuration/configmap.md
+++ b/docs/user-guide/nginx-configuration/configmap.md
@@ -706,7 +706,7 @@ _References:_
 
 Sets the size of cache that stores parsed SSL certificate objects.
 
-The cache helps reduce memory consumption of SSL context per connection. Increase the value if you have huge amount of certificates.
+The cache avoids duplicate copies of parsed SSL certificate objects among connections. It can help reduce memory consumption of SSL context per connection. Recommend a value larger than the number of certificates in use.
 
 _**default:**_ is 1000.
 

--- a/docs/user-guide/nginx-configuration/configmap.md
+++ b/docs/user-guide/nginx-configuration/configmap.md
@@ -95,6 +95,7 @@ The following table shows a configuration option's name, type, and the default v
 |[ssl-session-ticket-key](#ssl-session-ticket-key)|string|`<Randomly Generated>`|
 |[ssl-session-timeout](#ssl-session-timeout)|string|"10m"||
 |[ssl-buffer-size](#ssl-buffer-size)|string|"4k"||
+|[ssl-certificate-cache-size](#ssl-certificate-cache-size)|int|1000|
 |[use-proxy-protocol](#use-proxy-protocol)|bool|"false"||
 |[proxy-protocol-header-timeout](#proxy-protocol-header-timeout)|string|"5s"||
 |[enable-aio-write](#enable-aio-write)|bool|"true"||
@@ -700,6 +701,14 @@ Sets the size of the [SSL buffer](https://nginx.org/en/docs/http/ngx_http_ssl_mo
 
 _References:_
 [https://www.igvita.com/2013/12/16/optimizing-nginx-tls-time-to-first-byte/](https://www.igvita.com/2013/12/16/optimizing-nginx-tls-time-to-first-byte/)
+
+## ssl-certificate-cache-size
+
+Sets the size of cache that stores parsed SSL certificate objects.
+
+The cache helps reduce memory consumption of SSL context per connection. Increase the value if you have huge amount of certificates.
+
+_**default:**_ is 1000.
 
 ## use-proxy-protocol
 

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -413,6 +413,10 @@ type Configuration struct {
 	// Default: false
 	SSLRejectHandshake bool `json:"ssl-reject-handshake"`
 
+	// Sets the size of cache that stores parsed SSL certificate objects.
+	// The cache helps reduce memory consumption of SSL context per connection.
+	SSLCertificateCacheSize int `json:"ssl-certificate-cache-size,omitempty"`
+
 	// Enables or disables the use of the PROXY protocol to receive client connection
 	// (real IP address) information passed through proxy servers and load balancers
 	// such as HAproxy and Amazon Elastic Load Balancer (ELB).
@@ -837,6 +841,7 @@ func NewDefault() Configuration {
 		SSLSessionCacheSize:              sslSessionCacheSize,
 		SSLSessionTickets:                false,
 		SSLSessionTimeout:                sslSessionTimeout,
+		SSLCertificateCacheSize:          1000,
 		EnableBrotli:                     false,
 		EnableAioWrite:                   true,
 		UseGzip:                          false,

--- a/rootfs/etc/nginx/lua/certificate.lua
+++ b/rootfs/etc/nginx/lua/certificate.lua
@@ -225,8 +225,8 @@ end
 
 function _M.set_cache_size(size)
   local cache, err = lrucache.new(size)
-  if err then
-    ngx.log(ngx.ERR, string.format("failed to create the certificate cache: %s", tostring(err)))
+  if not cache then
+    ngx.log(ngx.ERR, string.format("failed to create the certificate cache: %s", err))
   end
   certificate_cache = cache
 end

--- a/rootfs/etc/nginx/lua/test/certificate_test.lua
+++ b/rootfs/etc/nginx/lua/test/certificate_test.lua
@@ -78,7 +78,7 @@ describe("Certificate", function()
 
       ngx.exit = function(status) end
 
-
+      certificate.set_cache_size(1000)
       set_certificate(DEFAULT_CERT_HOSTNAME, DEFAULT_CERT, DEFAULT_UUID)
     end)
 

--- a/rootfs/etc/nginx/lua/test/certificate_test.lua
+++ b/rootfs/etc/nginx/lua/test/certificate_test.lua
@@ -94,6 +94,29 @@ describe("Certificate", function()
       assert_certificate_is_set(EXAMPLE_CERT)
     end)
 
+    it("parses certificate and key once when cache hits", function()
+      spy.on(ssl, "parse_pem_cert")
+
+      set_certificate("hostname", EXAMPLE_CERT, UUID)
+      assert_certificate_is_set(EXAMPLE_CERT)
+
+      assert_certificate_is_set(EXAMPLE_CERT)
+
+      assert.spy(ssl.parse_pem_cert).was.called(1)
+    end)
+
+    it("parses certificate and key again when cache hits but cert content changes", function()
+      spy.on(ssl, "parse_pem_cert")
+
+      set_certificate("hostname", EXAMPLE_CERT, UUID)
+      assert_certificate_is_set(EXAMPLE_CERT)
+
+      set_certificate("hostname", DEFAULT_CERT, UUID)
+      assert_certificate_is_set(DEFAULT_CERT)
+
+      assert.spy(ssl.parse_pem_cert).was.called(2)
+    end)
+
     it("sets certificate and key for wildcard cert", function()
       ssl.server_name = function() return "sub.hostname", nil end
       set_certificate("*.hostname", EXAMPLE_CERT, UUID)

--- a/rootfs/etc/nginx/lua/test/certificate_test.lua
+++ b/rootfs/etc/nginx/lua/test/certificate_test.lua
@@ -64,7 +64,14 @@ describe("Certificate", function()
           return nil, "bad format"
         else
           return "priv_key", nil
+        end
       end
+      ssl.cert_pem_to_der = function(cert)
+        if cert == "invalid" then
+          return nil, "bad format"
+        else
+          return "der_cert", nil
+        end
       end
       ssl.set_cert = function(cert) return true, "" end
       ssl.set_priv_key = function(priv_key) return true, "" end
@@ -121,7 +128,7 @@ describe("Certificate", function()
       spy.on(ngx, "log")
 
       refute_certificate_is_set()
-      assert.spy(ngx.log).was_called_with(ngx.ERR, "failed to parse PEM certificate chain: bad format")
+      assert.spy(ngx.log).was_called_with(ngx.ERR, "failed to convert certificate chain from PEM to DER: bad format")
     end)
 
     it("uses default certificate when there's none found for given hostname", function()
@@ -141,7 +148,7 @@ describe("Certificate", function()
       spy.on(ngx, "log")
 
       refute_certificate_is_set()
-      assert.spy(ngx.log).was_called_with(ngx.ERR, "failed to parse PEM certificate chain: bad format")
+      assert.spy(ngx.log).was_called_with(ngx.ERR, "failed to convert certificate chain from PEM to DER: bad format")
     end)
 
     describe("OCSP stapling", function()

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -112,6 +112,7 @@ http {
         else
           certificate = res
           certificate.is_ocsp_stapling_enabled = {{ $cfg.EnableOCSP }}
+          certificate.set_cache_size({{ $cfg.SSLCertificateCacheSize }})
         end
 
         ok, res = pcall(require, "plugins")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Originally certificate and private key are converted to DER format and
then passed to `set_der_cert` and `set_der_priv_key`. The major drawback
of this is the input of `set_der_cert` cannot be cached. The input is
DER bytes. Inside `set_der_cert`, a new `X509 *` is always created from
it. This means redundant work and causes a memory waste.

By switching to `set_cert` and `set_priv_key` APIs, we can pass in an
opaque `X509 *` pointer. Since `X509 *` is reference counted, we can
easily add a cache for it, thus it can be reused by multiple
connections.

In benchmark, it saves ~20KB memory per connection.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
fixes #8250 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Set up a websocket upstream
2. Connect 10000 websocket connections
3. Measure the Nginx memory increase

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
