### PR TITLE
force prow job by changing something in images/ot dir

### DIFF
--- a/images/opentelemetry/cloudbuild.yaml
+++ b/images/opentelemetry/cloudbuild.yaml
@@ -21,4 +21,4 @@ steps:
       && make push
 substitutions:
   _GIT_TAG: "12345"
-  _PULL_BASE_REF: "master"
+  _PULL_BASE_REF: "main"


### PR DESCRIPTION
Images dir was merged in before the test-infra prow job, so the image was never built. 

https://github.com/kubernetes/ingress-nginx/pull/8013 Jan 16

https://github.com/kubernetes/test-infra/pull/25344/files Prow job 4 days ago.
