### PR TITLE
Fix OpenTelemetry sidecar image build

### DIFF
--- a/images/opentelemetry/Makefile
+++ b/images/opentelemetry/Makefile
@@ -30,7 +30,7 @@ IMAGE = $(REGISTRY)/opentelemetry
 export DOCKER_CLI_EXPERIMENTAL=enabled
 
 # build with buildx
-PLATFORMS?=linux/amd64,linux/arm
+PLATFORMS?=linux/amd64,linux/arm64
 OUTPUT=
 PROGRESS=plain
 build: ensure-buildx

--- a/images/opentelemetry/rootfs/build.sh
+++ b/images/opentelemetry/rootfs/build.sh
@@ -60,7 +60,7 @@ get_src()
 }
 
 
-get_src e462e11533d5c30baa05df7652160ff5979591d291736cfa5edb9fd2edb48c49 \
+get_src 2e35dff06a9826e8aca940e9e8be46b7e4b12c19a48d55bfc2dc28fc9cc7d841 \
         "https://nginx.org/download/nginx-$NGINX_VERSION.tar.gz"
 
 get_src 45c52498788e47131b20a4786dbb08f4390b8cb419bd3d61c88b503cafff3324 \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:

When being introduces, the OpenTelemetry sidecar image had its nginx version changed. But the checksum was missed.
Also, the wrong ARM platform is being built. `arm` doesn't have the `grpc` package. It's `arm64` that we can build.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
See #5883 

## How Has This Been Tested?
I manually ran `make build` for this image

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
