### PR TITLE
Add the shareProcessNamespace as a configurable setting in the helm chart

### DIFF
--- a/charts/ingress-nginx/README.md
+++ b/charts/ingress-nginx/README.md
@@ -409,6 +409,7 @@ Kubernetes: `>=1.19.0-0`
 | controller.service.targetPorts.http | string | `"http"` |  |
 | controller.service.targetPorts.https | string | `"https"` |  |
 | controller.service.type | string | `"LoadBalancer"` |  |
+| controller.shareProcessNamespace | bool | `false` |  This can be used for example to signal log rotation using `kill -USR1` from a sidecar. |
 | controller.sysctls | object | `{}` | See https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster/ for notes on enabling and using sysctls |
 | controller.tcp.annotations | object | `{}` | Annotations to be added to the tcp config configmap |
 | controller.tcp.configMapNamespace | string | `""` | Allows customization of the tcp-services-configmap; defaults to $(POD_NAMESPACE) |

--- a/charts/ingress-nginx/templates/controller-daemonset.yaml
+++ b/charts/ingress-nginx/templates/controller-daemonset.yaml
@@ -68,6 +68,9 @@ spec:
           value: {{ $value | quote }}
     {{- end }}
     {{- end }}
+    {{- if .Values.controller.shareProcessNamespace }}
+      shareProcessNamespace: {{ .Values.controller.shareProcessNamespace }}
+    {{- end }}
       containers:
         - name: {{ .Values.controller.containerName }}
           {{- with .Values.controller.image }}

--- a/charts/ingress-nginx/templates/controller-deployment.yaml
+++ b/charts/ingress-nginx/templates/controller-deployment.yaml
@@ -72,6 +72,9 @@ spec:
           value: {{ $value | quote }}
     {{- end }}
     {{- end }}
+    {{- if .Values.controller.shareProcessNamespace }}
+      shareProcessNamespace: {{ .Values.controller.shareProcessNamespace }}
+    {{- end }}
       containers:
         - name: {{ .Values.controller.containerName }}
           {{- with .Values.controller.image }}

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -529,6 +529,10 @@ controller:
       ## Ref: https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typeloadbalancer
       # externalTrafficPolicy: ""
 
+  # shareProcessNamespace enables process namespace sharing within the pod.
+  # This can be used for example to signal log rotation using `kill -USR1` from a sidecar.
+  shareProcessNamespace: false
+
   # -- Additional containers to be added to the controller pod.
   # See https://github.com/lemonldap-ng-controller/lemonldap-ng-controller as example.
   extraContainers: []


### PR DESCRIPTION
## What this PR does / why we need it:
This PR allows setting the [shareProcessNamespace](https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/) to share processes across containers in the pod.
With this setting enabled its possible for sidecars to signal NGINX to re-open the logs files.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
fixes https://github.com/kubernetes/ingress-nginx/issues/8279

## How Has This Been Tested?
In a local kubernetes cluster with a container added in `extraContainers` enabled `shareProcessNamespace: true` and executed ps in a bash script in the sidecar.

Result with `shareProcessNamespace: true:`
```
$ kubectl exec -it --container rotate `kubectl get pods | grep controller | grep Running | cut -d' ' -f1` -- ps ax
PID   USER     TIME  COMMAND
    1 65535     0:00 /pause
    8 www-data  0:00 /usr/bin/dumb-init -- /nginx-ingress-controller --publish-service=default/nginx-ingress-ingress-nginx-controller --election-id=ingress-controller-leader --controller-class=k8s.io/ing
   15 www-data  0:00 /nginx-ingress-controller --publish-service=default/nginx-ingress-ingress-nginx-controller --election-id=ingress-controller-leader --controller-class=k8s.io/ingress-nginx --ingress-c
   23 100       0:00 tini -- /bin/entrypoint.sh fluentd
   29 100       0:01 {fluentd} /usr/bin/ruby /usr/bin/fluentd --config /fluentd/etc/fluent.conf --plugin /fluentd/plugins
   53 root      0:00 /usr/sbin/crond -f -l 0 -L /dev/stdout
   64 100       0:00 /usr/bin/ruby -Eascii-8bit:ascii-8bit /usr/bin/fluentd --config /fluentd/etc/fluent.conf --plugin /fluentd/plugins --under-supervisor
   65 www-data  0:00 nginx: master process /usr/local/nginx/sbin/nginx -c /etc/nginx/nginx.conf
   69 www-data  0:00 nginx: worker process
   70 www-data  0:00 nginx: worker process
   71 www-data  0:00 nginx: worker process
   72 www-data  0:00 nginx: worker process
   73 www-data  0:00 nginx: worker process
  138 www-data  0:00 nginx: worker process
  139 www-data  0:00 nginx: worker process
  140 www-data  0:00 nginx: worker process
  141 www-data  0:00 nginx: cache manager process
  142 www-data  0:00 nginx: cache loader process
  343 root      0:00 bash
  349 root      0:00 ps ax
```

Result with `shareProcessNamespace: false:`
```
$ kubectl exec -it --container rotate `kubectl get pods | grep controller | grep Running | cut -d' ' -f1` -- ps ax
PID   USER     TIME  COMMAND
    1 root      0:00 /usr/sbin/crond -f -l 0 -L /dev/stdout
    7 root      0:00 bash
   13 root      0:00 ps ax
```

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
