### PR TITLE
remove git tag env from cloud build

### DIFF
--- a/images/opentelemetry/cloudbuild.yaml
+++ b/images/opentelemetry/cloudbuild.yaml
@@ -8,7 +8,6 @@ steps:
     entrypoint: bash
     env:
       - DOCKER_CLI_EXPERIMENTAL=enabled
-      - TAG=$_GIT_TAG
       - BASE_REF=$_PULL_BASE_REF
       - REGISTRY=gcr.io/k8s-staging-ingress-nginx
       # default cloudbuild has HOME=/builder/home and docker buildx is in /root/.docker/cli-plugins/docker-buildx


### PR DESCRIPTION
the latest git tag is from helm, so force the make file use of TAG ?=v$(shell date +%m%d%Y)-$(shell git rev-parse --short HEAD)
