### PR TITLE
Update some functions' comment to begin with Parse

### DIFF
--- a/internal/ingress/annotations/authreq/main.go
+++ b/internal/ingress/annotations/authreq/main.go
@@ -153,7 +153,7 @@ func NewParser(r resolver.Resolver) parser.IngressAnnotation {
 	return authReq{r}
 }
 
-// ParseAnnotations parses the annotations contained in the ingress
+// Parse parses the annotations contained in the ingress
 // rule used to use an Config URL as source for authentication
 func (a authReq) Parse(ing *networking.Ingress) (interface{}, error) {
 	// Required Parameters

--- a/internal/ingress/annotations/authreqglobal/main.go
+++ b/internal/ingress/annotations/authreqglobal/main.go
@@ -32,7 +32,7 @@ func NewParser(r resolver.Resolver) parser.IngressAnnotation {
 	return authReqGlobal{r}
 }
 
-// ParseAnnotations parses the annotations contained in the ingress
+// Parse parses the annotations contained in the ingress
 // rule used to enable or disable global external authentication
 func (a authReqGlobal) Parse(ing *networking.Ingress) (interface{}, error) {
 

--- a/internal/ingress/annotations/backendprotocol/main.go
+++ b/internal/ingress/annotations/backendprotocol/main.go
@@ -43,7 +43,7 @@ func NewParser(r resolver.Resolver) parser.IngressAnnotation {
 	return backendProtocol{r}
 }
 
-// ParseAnnotations parses the annotations contained in the ingress
+// Parse parses the annotations contained in the ingress
 // rule used to indicate the backend protocol.
 func (a backendProtocol) Parse(ing *networking.Ingress) (interface{}, error) {
 	if ing.GetAnnotations() == nil {

--- a/internal/ingress/annotations/fastcgi/main.go
+++ b/internal/ingress/annotations/fastcgi/main.go
@@ -60,7 +60,7 @@ func NewParser(r resolver.Resolver) parser.IngressAnnotation {
 	return fastcgi{r}
 }
 
-// ParseAnnotations parses the annotations contained in the ingress
+// Parse parses the annotations contained in the ingress
 // rule used to indicate the fastcgiConfig.
 func (a fastcgi) Parse(ing *networking.Ingress) (interface{}, error) {
 

--- a/internal/ingress/annotations/ipwhitelist/main.go
+++ b/internal/ingress/annotations/ipwhitelist/main.go
@@ -56,7 +56,7 @@ func NewParser(r resolver.Resolver) parser.IngressAnnotation {
 	return ipwhitelist{r}
 }
 
-// ParseAnnotations parses the annotations contained in the ingress
+// Parse parses the annotations contained in the ingress
 // rule used to limit access to certain client addresses or networks.
 // Multiple ranges can specified using commas as separator
 // e.g. `18.0.0.0/8,56.0.0.0/8`

--- a/internal/ingress/annotations/mirror/main.go
+++ b/internal/ingress/annotations/mirror/main.go
@@ -66,7 +66,7 @@ func NewParser(r resolver.Resolver) parser.IngressAnnotation {
 	return mirror{r}
 }
 
-// ParseAnnotations parses the annotations contained in the ingress
+// Parse parses the annotations contained in the ingress
 // rule used to configure mirror
 func (a mirror) Parse(ing *networking.Ingress) (interface{}, error) {
 	config := &Config{

--- a/internal/ingress/annotations/proxy/main.go
+++ b/internal/ingress/annotations/proxy/main.go
@@ -117,7 +117,7 @@ func NewParser(r resolver.Resolver) parser.IngressAnnotation {
 	return proxy{r}
 }
 
-// ParseAnnotations parses the annotations contained in the ingress
+// Parse parses the annotations contained in the ingress
 // rule used to configure upstream check parameters
 func (a proxy) Parse(ing *networking.Ingress) (interface{}, error) {
 	defBackend := a.r.GetDefaultBackend()

--- a/internal/ingress/annotations/ratelimit/main.go
+++ b/internal/ingress/annotations/ratelimit/main.go
@@ -140,7 +140,7 @@ func NewParser(r resolver.Resolver) parser.IngressAnnotation {
 	return ratelimit{r}
 }
 
-// ParseAnnotations parses the annotations contained in the ingress
+// Parse parses the annotations contained in the ingress
 // rule used to rewrite the defined paths
 func (a ratelimit) Parse(ing *networking.Ingress) (interface{}, error) {
 	defBackend := a.r.GetDefaultBackend()

--- a/internal/ingress/annotations/rewrite/main.go
+++ b/internal/ingress/annotations/rewrite/main.go
@@ -79,7 +79,7 @@ func NewParser(r resolver.Resolver) parser.IngressAnnotation {
 	return rewrite{r}
 }
 
-// ParseAnnotations parses the annotations contained in the ingress
+// Parse parses the annotations contained in the ingress
 // rule used to rewrite the defined paths
 func (a rewrite) Parse(ing *networking.Ingress) (interface{}, error) {
 	var err error

--- a/internal/ingress/annotations/sessionaffinity/main.go
+++ b/internal/ingress/annotations/sessionaffinity/main.go
@@ -159,7 +159,7 @@ type affinity struct {
 	r resolver.Resolver
 }
 
-// ParseAnnotations parses the annotations contained in the ingress
+// Parse parses the annotations contained in the ingress
 // rule used to configure the affinity directives
 func (a affinity) Parse(ing *networking.Ingress) (interface{}, error) {
 	cookie := &Cookie{}

--- a/internal/ingress/annotations/sslpassthrough/main.go
+++ b/internal/ingress/annotations/sslpassthrough/main.go
@@ -33,7 +33,7 @@ func NewParser(r resolver.Resolver) parser.IngressAnnotation {
 	return sslpt{r}
 }
 
-// ParseAnnotations parses the annotations contained in the ingress
+// Parse parses the annotations contained in the ingress
 // rule used to indicate if is required to configure
 func (a sslpt) Parse(ing *networking.Ingress) (interface{}, error) {
 	if ing.GetAnnotations() == nil {


### PR DESCRIPTION
Signed-off-by: changzhen <changzhen5@huawei.com>

<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Just see some `Parse(ing *networking.Ingress)` functions that implement the interface `Parse(ing *networking.Ingress) (interface{}, error)`, the comment of them still begins with `ParseAnnotations`, it's inconsistency with the export name. So I update them.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
