### PR TITLE
Names cannot contain _ (underscore)! So I changed it to -.

### DIFF
--- a/docs/examples/customization/custom-errors/custom-default-backend-error_pages.configMap.yaml
+++ b/docs/examples/customization/custom-errors/custom-default-backend-error_pages.configMap.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: custom_error_pages
+  name: custom-error-pages
 data:
   404: |
     <!DOCTYPE html>


### PR DESCRIPTION

## What this PR does / why we need it:
Names cannot contain _ (underscore)! So I changed it to -.

Error when using name "custom_error_pages": 
```bash
$ kubectl create -f custom-default-backend.yaml
The ConfigMap "custom_error_pages" is invalid: metadata.name: Invalid value: "custom_error_pages": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
```

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only


## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [X] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
