### PR TITLE
Fixing upstreams that are shared with canaries

### DIFF
--- a/internal/ingress/controller/controller_test.go
+++ b/internal/ingress/controller/controller_test.go
@@ -389,14 +389,19 @@ func TestMergeAlternativeBackends(t *testing.T) {
 						},
 					},
 				},
+				ParsedAnnotations: &annotations.Ingress{
+					Canary: canary.Config{
+						Enabled: true, // merge is only called with canary ingresses
+					},
+				},
 			},
 			map[string]*ingress.Backend{
-				"example-http-svc-80": {
-					Name:     "example-http-svc-80",
+				"example-http-svc-80-noncanary": {
+					Name:     "example-http-svc-80-noncanary",
 					NoServer: false,
 				},
-				"example-http-svc-canary-80": {
-					Name:     "example-http-svc-canary-80",
+				"example-http-svc-canary-80-canary": {
+					Name:     "example-http-svc-canary-80-canary",
 					NoServer: true,
 					TrafficShapingPolicy: ingress.TrafficShapingPolicy{
 						Weight: 20,
@@ -410,19 +415,19 @@ func TestMergeAlternativeBackends(t *testing.T) {
 						{
 							Path:     "/",
 							PathType: &pathTypePrefix,
-							Backend:  "example-http-svc-80",
+							Backend:  "example-http-svc-80-noncanary",
 						},
 					},
 				},
 			},
 			map[string]*ingress.Backend{
-				"example-http-svc-80": {
-					Name:                "example-http-svc-80",
+				"example-http-svc-80-noncanary": {
+					Name:                "example-http-svc-80-noncanary",
 					NoServer:            false,
-					AlternativeBackends: []string{"example-http-svc-canary-80"},
+					AlternativeBackends: []string{"example-http-svc-canary-80-canary"},
 				},
-				"example-http-svc-canary-80": {
-					Name:     "example-http-svc-canary-80",
+				"example-http-svc-canary-80-canary": {
+					Name:     "example-http-svc-canary-80-canary",
 					NoServer: true,
 					TrafficShapingPolicy: ingress.TrafficShapingPolicy{
 						Weight: 20,
@@ -436,7 +441,7 @@ func TestMergeAlternativeBackends(t *testing.T) {
 						{
 							Path:     "/",
 							PathType: &pathTypePrefix,
-							Backend:  "example-http-svc-80",
+							Backend:  "example-http-svc-80-noncanary",
 						},
 					},
 				},
@@ -495,26 +500,31 @@ func TestMergeAlternativeBackends(t *testing.T) {
 						},
 					},
 				},
+				ParsedAnnotations: &annotations.Ingress{
+					Canary: canary.Config{
+						Enabled: true, // merge is only called with canary ingresses
+					},
+				},
 			},
 			map[string]*ingress.Backend{
-				"example-foo-http-svc-80": {
-					Name:     "example-foo-http-svc-80",
+				"example-foo-http-svc-80-noncanary": {
+					Name:     "example-foo-http-svc-80-noncanary",
 					NoServer: false,
 				},
-				"example-foo-http-svc-canary-80": {
-					Name:     "example-foo-http-svc-canary-80",
+				"example-foo-http-svc-canary-80-canary": {
+					Name:     "example-foo-http-svc-canary-80-canary",
 					NoServer: true,
 					TrafficShapingPolicy: ingress.TrafficShapingPolicy{
 						Weight: 20,
 					},
 				},
-				"example-http-svc-80": {
-					Name:                "example-http-svc-80",
+				"example-http-svc-80-noncanary": {
+					Name:                "example-http-svc-80-noncanary",
 					NoServer:            false,
-					AlternativeBackends: []string{"example-http-svc-canary-80"},
+					AlternativeBackends: []string{"example-http-svc-canary-80-canary"},
 				},
-				"example-http-svc-canary-80": {
-					Name:     "example-http-svc-canary-80",
+				"example-http-svc-canary-80-canary": {
+					Name:     "example-http-svc-canary-80-canary",
 					NoServer: true,
 					TrafficShapingPolicy: ingress.TrafficShapingPolicy{
 						Weight: 20,
@@ -528,7 +538,7 @@ func TestMergeAlternativeBackends(t *testing.T) {
 						{
 							Path:     "/",
 							PathType: &pathTypePrefix,
-							Backend:  "example-foo-http-svc-80",
+							Backend:  "example-foo-http-svc-80-noncanary",
 						},
 					},
 				},
@@ -538,31 +548,31 @@ func TestMergeAlternativeBackends(t *testing.T) {
 						{
 							Path:     "/",
 							PathType: &pathTypePrefix,
-							Backend:  "example-http-svc-80",
+							Backend:  "example-http-svc-80-noncanary",
 						},
 					},
 				},
 			},
 			map[string]*ingress.Backend{
-				"example-foo-http-svc-80": {
-					Name:                "example-foo-http-svc-80",
+				"example-foo-http-svc-80-noncanary": {
+					Name:                "example-foo-http-svc-80-noncanary",
 					NoServer:            false,
-					AlternativeBackends: []string{"example-foo-http-svc-canary-80"},
+					AlternativeBackends: []string{"example-foo-http-svc-canary-80-canary"},
 				},
-				"example-foo-http-svc-canary-80": {
-					Name:     "example-foo-http-svc-canary-80",
+				"example-foo-http-svc-canary-80-canary": {
+					Name:     "example-foo-http-svc-canary-80-canary",
 					NoServer: true,
 					TrafficShapingPolicy: ingress.TrafficShapingPolicy{
 						Weight: 20,
 					},
 				},
-				"example-http-svc-80": {
-					Name:                "example-http-svc-80",
+				"example-http-svc-80-noncanary": {
+					Name:                "example-http-svc-80-noncanary",
 					NoServer:            false,
-					AlternativeBackends: []string{"example-http-svc-canary-80"},
+					AlternativeBackends: []string{"example-http-svc-canary-80-canary"},
 				},
-				"example-http-svc-canary-80": {
-					Name:     "example-http-svc-canary-80",
+				"example-http-svc-canary-80-canary": {
+					Name:     "example-http-svc-canary-80-canary",
 					NoServer: true,
 					TrafficShapingPolicy: ingress.TrafficShapingPolicy{
 						Weight: 20,
@@ -576,7 +586,17 @@ func TestMergeAlternativeBackends(t *testing.T) {
 						{
 							Path:     "/",
 							PathType: &pathTypePrefix,
-							Backend:  "example-http-svc-80",
+							Backend:  "example-http-svc-80-noncanary",
+						},
+					},
+				},
+				"foo.bar": {
+					Hostname: "foo.bar",
+					Locations: []*ingress.Location{
+						{
+							Path:     "/",
+							PathType: &pathTypePrefix,
+							Backend:  "example-foo-http-svc-80-noncanary",
 						},
 					},
 				},
@@ -614,10 +634,13 @@ func TestMergeAlternativeBackends(t *testing.T) {
 						},
 					},
 				},
+				ParsedAnnotations: &annotations.Ingress{
+					Canary: canary.Config{Enabled: true},
+				},
 			},
 			map[string]*ingress.Backend{
-				"example-http-svc-canary-80": {
-					Name:     "example-http-svc-canary-80",
+				"example-http-svc-canary-80-canary": {
+					Name:     "example-http-svc-canary-80-canary",
 					NoServer: true,
 					TrafficShapingPolicy: ingress.TrafficShapingPolicy{
 						Weight: 20,
@@ -625,7 +648,17 @@ func TestMergeAlternativeBackends(t *testing.T) {
 				},
 			},
 			map[string]*ingress.Server{},
-			map[string]*ingress.Backend{},
+			map[string]*ingress.Backend{
+				// Since the host look in servers fails, the code continues and does not
+				// delete this canary upstream
+				"example-http-svc-canary-80-canary": {
+					Name:     "example-http-svc-canary-80-canary",
+					NoServer: true,
+					TrafficShapingPolicy: ingress.TrafficShapingPolicy{
+						Weight: 20,
+					},
+				},
+			},
 			map[string]*ingress.Server{},
 		},
 		"catch-all alternative backend has no server and embeds into matching real backend": {
@@ -645,14 +678,19 @@ func TestMergeAlternativeBackends(t *testing.T) {
 						},
 					},
 				},
+				ParsedAnnotations: &annotations.Ingress{
+					Canary: canary.Config{
+						Enabled: true, // merge is only called with canary ingresses
+					},
+				},
 			},
 			map[string]*ingress.Backend{
-				"example-http-svc-80": {
-					Name:     "example-http-svc-80",
+				"example-http-svc-80-noncanary": {
+					Name:     "example-http-svc-80-noncanary",
 					NoServer: false,
 				},
-				"example-http-svc-canary-80": {
-					Name:     "example-http-svc-canary-80",
+				"example-http-svc-canary-80-canary": {
+					Name:     "example-http-svc-canary-80-canary",
 					NoServer: true,
 					TrafficShapingPolicy: ingress.TrafficShapingPolicy{
 						Weight: 20,
@@ -666,19 +704,19 @@ func TestMergeAlternativeBackends(t *testing.T) {
 						{
 							Path:     "/",
 							PathType: &pathTypePrefix,
-							Backend:  "example-http-svc-80",
+							Backend:  "example-http-svc-80-noncanary",
 						},
 					},
 				},
 			},
 			map[string]*ingress.Backend{
-				"example-http-svc-80": {
-					Name:                "example-http-svc-80",
+				"example-http-svc-80-noncanary": {
+					Name:                "example-http-svc-80-noncanary",
 					NoServer:            false,
-					AlternativeBackends: []string{"example-http-svc-canary-80"},
+					AlternativeBackends: []string{"example-http-svc-canary-80-canary"},
 				},
-				"example-http-svc-canary-80": {
-					Name:     "example-http-svc-canary-80",
+				"example-http-svc-canary-80-canary": {
+					Name:     "example-http-svc-canary-80-canary",
 					NoServer: true,
 					TrafficShapingPolicy: ingress.TrafficShapingPolicy{
 						Weight: 20,
@@ -692,7 +730,7 @@ func TestMergeAlternativeBackends(t *testing.T) {
 						{
 							Path:     "/",
 							PathType: &pathTypePrefix,
-							Backend:  "example-http-svc-80",
+							Backend:  "example-http-svc-80-noncanary",
 						},
 					},
 				},
@@ -715,14 +753,19 @@ func TestMergeAlternativeBackends(t *testing.T) {
 						},
 					},
 				},
+				ParsedAnnotations: &annotations.Ingress{
+					Canary: canary.Config{
+						Enabled: true, // merge is only called with canary ingresses
+					},
+				},
 			},
 			map[string]*ingress.Backend{
-				"upstream-default-backend": {
-					Name:     "upstream-default-backend",
+				"upstream-default-backend-noncanary": {
+					Name:     "upstream-default-backend-noncanary",
 					NoServer: false,
 				},
-				"example-http-svc-canary-80": {
-					Name:     "example-http-svc-canary-80",
+				"example-http-svc-canary-80-canary": {
+					Name:     "example-http-svc-canary-80-canary",
 					NoServer: true,
 					TrafficShapingPolicy: ingress.TrafficShapingPolicy{
 						Weight: 20,
@@ -736,12 +779,25 @@ func TestMergeAlternativeBackends(t *testing.T) {
 						{
 							Path:     "/",
 							PathType: &pathTypePrefix,
-							Backend:  "upstream-default-backend",
+							Backend:  "upstream-default-backend-noncanary",
 						},
 					},
 				},
 			},
-			map[string]*ingress.Backend{},
+			map[string]*ingress.Backend{
+				"upstream-default-backend-noncanary": {
+					Name:                "upstream-default-backend-noncanary",
+					NoServer:            false,
+					AlternativeBackends: []string{"example-http-svc-canary-80-canary"},
+				},
+				"example-http-svc-canary-80-canary": {
+					Name:     "example-http-svc-canary-80-canary",
+					NoServer: true,
+					TrafficShapingPolicy: ingress.TrafficShapingPolicy{
+						Weight: 20,
+					},
+				},
+			},
 			map[string]*ingress.Server{
 				"_": {
 					Hostname: "_",
@@ -749,7 +805,7 @@ func TestMergeAlternativeBackends(t *testing.T) {
 						{
 							Path:     "/",
 							PathType: &pathTypePrefix,
-							Backend:  "upstream-default-backend",
+							Backend:  "upstream-default-backend-noncanary",
 						},
 					},
 				},
@@ -786,14 +842,19 @@ func TestMergeAlternativeBackends(t *testing.T) {
 						},
 					},
 				},
+				ParsedAnnotations: &annotations.Ingress{
+					Canary: canary.Config{
+						Enabled: true, // merge is only called with canary ingresses
+					},
+				},
 			},
 			map[string]*ingress.Backend{
-				"example-http-svc-80": {
-					Name:     "example-http-svc-80",
+				"example-http-svc-80-noncanary": {
+					Name:     "example-http-svc-80-noncanary",
 					NoServer: false,
 				},
-				"example-http-svc-canary-80": {
-					Name:     "example-http-svc-canary-80",
+				"example-http-svc-canary-80-canary": {
+					Name:     "example-http-svc-canary-80-canary",
 					NoServer: true,
 					TrafficShapingPolicy: ingress.TrafficShapingPolicy{
 						Weight: 20,
@@ -807,19 +868,19 @@ func TestMergeAlternativeBackends(t *testing.T) {
 						{
 							Path:     "/",
 							PathType: &pathTypePrefix,
-							Backend:  "example-http-svc-80",
+							Backend:  "example-http-svc-80-noncanary",
 						},
 					},
 				},
 			},
 			map[string]*ingress.Backend{
-				"example-http-svc-80": {
-					Name:                "example-http-svc-80",
+				"example-http-svc-80-noncanary": {
+					Name:                "example-http-svc-80-noncanary",
 					NoServer:            false,
-					AlternativeBackends: []string{"example-http-svc-canary-80"},
+					AlternativeBackends: []string{"example-http-svc-canary-80-canary"},
 				},
-				"example-http-svc-canary-80": {
-					Name:     "example-http-svc-canary-80",
+				"example-http-svc-canary-80-canary": {
+					Name:     "example-http-svc-canary-80-canary",
 					NoServer: true,
 					TrafficShapingPolicy: ingress.TrafficShapingPolicy{
 						Weight: 20,
@@ -833,7 +894,7 @@ func TestMergeAlternativeBackends(t *testing.T) {
 						{
 							Path:     "/",
 							PathType: &pathTypePrefix,
-							Backend:  "example-http-svc-80",
+							Backend:  "example-http-svc-80-noncanary",
 						},
 					},
 				},
@@ -872,14 +933,17 @@ func TestMergeAlternativeBackends(t *testing.T) {
 					},
 				},
 				ParsedAnnotations: &annotations.Ingress{
+					Canary: canary.Config{
+						Enabled: true,
+					},
 					SessionAffinity: sessionaffinity.Config{
 						CanaryBehavior: "sticky",
 					},
 				},
 			},
 			map[string]*ingress.Backend{
-				"example-http-svc-80": {
-					Name:     "example-http-svc-80",
+				"example-http-svc-80-noncanary": {
+					Name:     "example-http-svc-80-noncanary",
 					NoServer: false,
 					SessionAffinity: ingress.SessionAffinityConfig{
 						AffinityType: "cookie",
@@ -889,8 +953,8 @@ func TestMergeAlternativeBackends(t *testing.T) {
 						},
 					},
 				},
-				"example-http-svc-canary-80": {
-					Name:     "example-http-svc-canary-80",
+				"example-http-svc-canary-80-canary": {
+					Name:     "example-http-svc-canary-80-canary",
 					NoServer: true,
 					TrafficShapingPolicy: ingress.TrafficShapingPolicy{
 						Weight: 20,
@@ -904,16 +968,16 @@ func TestMergeAlternativeBackends(t *testing.T) {
 						{
 							Path:     "/",
 							PathType: &pathTypePrefix,
-							Backend:  "example-http-svc-80",
+							Backend:  "example-http-svc-80-noncanary",
 						},
 					},
 				},
 			},
 			map[string]*ingress.Backend{
-				"example-http-svc-80": {
-					Name:                "example-http-svc-80",
+				"example-http-svc-80-noncanary": {
+					Name:                "example-http-svc-80-noncanary",
 					NoServer:            false,
-					AlternativeBackends: []string{"example-http-svc-canary-80"},
+					AlternativeBackends: []string{"example-http-svc-canary-80-canary"},
 					SessionAffinity: ingress.SessionAffinityConfig{
 						AffinityType: "cookie",
 						AffinityMode: "balanced",
@@ -922,8 +986,8 @@ func TestMergeAlternativeBackends(t *testing.T) {
 						},
 					},
 				},
-				"example-http-svc-canary-80": {
-					Name:     "example-http-svc-canary-80",
+				"example-http-svc-canary-80-canary": {
+					Name:     "example-http-svc-canary-80-canary",
 					NoServer: true,
 					TrafficShapingPolicy: ingress.TrafficShapingPolicy{
 						Weight: 20,
@@ -944,7 +1008,7 @@ func TestMergeAlternativeBackends(t *testing.T) {
 						{
 							Path:     "/",
 							PathType: &pathTypePrefix,
-							Backend:  "example-http-svc-80",
+							Backend:  "example-http-svc-80-noncanary",
 						},
 					},
 				},
@@ -983,14 +1047,17 @@ func TestMergeAlternativeBackends(t *testing.T) {
 					},
 				},
 				ParsedAnnotations: &annotations.Ingress{
+					Canary: canary.Config{
+						Enabled: true,
+					},
 					SessionAffinity: sessionaffinity.Config{
 						CanaryBehavior: "", // In fact any value but 'legacy' would do the trick.
 					},
 				},
 			},
 			map[string]*ingress.Backend{
-				"example-http-svc-80": {
-					Name:     "example-http-svc-80",
+				"example-http-svc-80-noncanary": {
+					Name:     "example-http-svc-80-noncanary",
 					NoServer: false,
 					SessionAffinity: ingress.SessionAffinityConfig{
 						AffinityType: "cookie",
@@ -1000,8 +1067,8 @@ func TestMergeAlternativeBackends(t *testing.T) {
 						},
 					},
 				},
-				"example-http-svc-canary-80": {
-					Name:     "example-http-svc-canary-80",
+				"example-http-svc-canary-80-canary": {
+					Name:     "example-http-svc-canary-80-canary",
 					NoServer: true,
 					TrafficShapingPolicy: ingress.TrafficShapingPolicy{
 						Weight: 20,
@@ -1015,16 +1082,16 @@ func TestMergeAlternativeBackends(t *testing.T) {
 						{
 							Path:     "/",
 							PathType: &pathTypePrefix,
-							Backend:  "example-http-svc-80",
+							Backend:  "example-http-svc-80-noncanary",
 						},
 					},
 				},
 			},
 			map[string]*ingress.Backend{
-				"example-http-svc-80": {
-					Name:                "example-http-svc-80",
+				"example-http-svc-80-noncanary": {
+					Name:                "example-http-svc-80-noncanary",
 					NoServer:            false,
-					AlternativeBackends: []string{"example-http-svc-canary-80"},
+					AlternativeBackends: []string{"example-http-svc-canary-80-canary"},
 					SessionAffinity: ingress.SessionAffinityConfig{
 						AffinityType: "cookie",
 						AffinityMode: "balanced",
@@ -1033,8 +1100,8 @@ func TestMergeAlternativeBackends(t *testing.T) {
 						},
 					},
 				},
-				"example-http-svc-canary-80": {
-					Name:     "example-http-svc-canary-80",
+				"example-http-svc-canary-80-canary": {
+					Name:     "example-http-svc-canary-80-canary",
 					NoServer: true,
 					TrafficShapingPolicy: ingress.TrafficShapingPolicy{
 						Weight: 20,
@@ -1055,7 +1122,7 @@ func TestMergeAlternativeBackends(t *testing.T) {
 						{
 							Path:     "/",
 							PathType: &pathTypePrefix,
-							Backend:  "example-http-svc-80",
+							Backend:  "example-http-svc-80-noncanary",
 						},
 					},
 				},
@@ -1094,14 +1161,17 @@ func TestMergeAlternativeBackends(t *testing.T) {
 					},
 				},
 				ParsedAnnotations: &annotations.Ingress{
+					Canary: canary.Config{
+						Enabled: true,
+					},
 					SessionAffinity: sessionaffinity.Config{
 						CanaryBehavior: "legacy",
 					},
 				},
 			},
 			map[string]*ingress.Backend{
-				"example-http-svc-80": {
-					Name:     "example-http-svc-80",
+				"example-http-svc-80-noncanary": {
+					Name:     "example-http-svc-80-noncanary",
 					NoServer: false,
 					SessionAffinity: ingress.SessionAffinityConfig{
 						AffinityType: "cookie",
@@ -1111,8 +1181,8 @@ func TestMergeAlternativeBackends(t *testing.T) {
 						},
 					},
 				},
-				"example-http-svc-canary-80": {
-					Name:     "example-http-svc-canary-80",
+				"example-http-svc-canary-80-canary": {
+					Name:     "example-http-svc-canary-80-canary",
 					NoServer: true,
 					TrafficShapingPolicy: ingress.TrafficShapingPolicy{
 						Weight: 20,
@@ -1126,16 +1196,16 @@ func TestMergeAlternativeBackends(t *testing.T) {
 						{
 							Path:     "/",
 							PathType: &pathTypePrefix,
-							Backend:  "example-http-svc-80",
+							Backend:  "example-http-svc-80-noncanary",
 						},
 					},
 				},
 			},
 			map[string]*ingress.Backend{
-				"example-http-svc-80": {
-					Name:                "example-http-svc-80",
+				"example-http-svc-80-noncanary": {
+					Name:                "example-http-svc-80-noncanary",
 					NoServer:            false,
-					AlternativeBackends: []string{"example-http-svc-canary-80"},
+					AlternativeBackends: []string{"example-http-svc-canary-80-canary"},
 					SessionAffinity: ingress.SessionAffinityConfig{
 						AffinityType: "cookie",
 						AffinityMode: "balanced",
@@ -1144,8 +1214,8 @@ func TestMergeAlternativeBackends(t *testing.T) {
 						},
 					},
 				},
-				"example-http-svc-canary-80": {
-					Name:     "example-http-svc-canary-80",
+				"example-http-svc-canary-80-canary": {
+					Name:     "example-http-svc-canary-80-canary",
 					NoServer: true,
 					TrafficShapingPolicy: ingress.TrafficShapingPolicy{
 						Weight: 20,
@@ -1159,7 +1229,7 @@ func TestMergeAlternativeBackends(t *testing.T) {
 						{
 							Path:     "/",
 							PathType: &pathTypePrefix,
-							Backend:  "example-http-svc-80",
+							Backend:  "example-http-svc-80-noncanary",
 						},
 					},
 				},
@@ -1171,10 +1241,18 @@ func TestMergeAlternativeBackends(t *testing.T) {
 		t.Run(title, func(t *testing.T) {
 			mergeAlternativeBackends(tc.ingress, tc.upstreams, tc.servers)
 
+			numUpstreams := len(tc.upstreams)
+			numExpUpstreams := len(tc.expUpstreams)
+
+			if numUpstreams != numExpUpstreams {
+				t.Errorf("Number of upstreams %d is not what is expected %d", numUpstreams, numExpUpstreams)
+			}
+
 			for upsName, expUpstream := range tc.expUpstreams {
 				actualUpstream, ok := tc.upstreams[upsName]
 				if !ok {
 					t.Errorf("expected upstream %s to exist but it did not", upsName)
+					t.FailNow()
 				}
 
 				if !actualUpstream.Equal(expUpstream) {
@@ -1182,6 +1260,13 @@ func TestMergeAlternativeBackends(t *testing.T) {
 					t.Logf("expected upstream %s alternative backends: %s", expUpstream.Name, expUpstream.AlternativeBackends)
 					t.Errorf("upstream %s was not equal to what was expected", actualUpstream.Name)
 				}
+			}
+
+			numServers := len(tc.servers)
+			numExpServers := len(tc.expServers)
+
+			if numServers != numExpServers {
+				t.Errorf("Number of servers %d is not what is expected %d", numServers, numExpServers)
 			}
 
 			for serverName, expServer := range tc.expServers {

--- a/test/e2e/settings/proxy_host.go
+++ b/test/e2e/settings/proxy_host.go
@@ -34,7 +34,7 @@ var _ = framework.IngressNginxDescribe("Dynamic $proxy_host", func() {
 	})
 
 	ginkgo.It("should exist a proxy_host", func() {
-		upstreamName := fmt.Sprintf("%v-%v-80", f.Namespace, framework.EchoService)
+		upstreamName := fmt.Sprintf("%v-%v-80-noncanary", f.Namespace, framework.EchoService)
 		annotations := map[string]string{
 			"nginx.ingress.kubernetes.io/configuration-snippet": `more_set_headers "Custom-Header: $proxy_host"`,
 		}
@@ -55,7 +55,7 @@ var _ = framework.IngressNginxDescribe("Dynamic $proxy_host", func() {
 	})
 
 	ginkgo.It("should exist a proxy_host using the upstream-vhost annotation value", func() {
-		upstreamName := fmt.Sprintf("%v-%v-80", f.Namespace, framework.EchoService)
+		upstreamName := fmt.Sprintf("%v-%v-80-noncanary", f.Namespace, framework.EchoService)
 		upstreamVHost := "different.host"
 		annotations := map[string]string{
 			"nginx.ingress.kubernetes.io/upstream-vhost":        upstreamVHost,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR is mainly trying to address issue [#8004](https://github.com/kubernetes/ingress-nginx/issues/8004) where a second ingress resource will not work if it shares the same upstream as another ingress that is marked as canary.

The main reason for this is that in the current working model, upstreams are handled independently and upstreams that are discovered to be part of canaries are marked with `NoServer = true` that makes them unusable as upstreams due to [this piece of the code.](https://github.com/kubernetes/ingress-nginx/blob/fb72fcd81772fb3eca923897aec2d92fa5bdff41/internal/ingress/controller/controller.go#L665)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only
In the current model, there was always one upstream whose name was determined by the k8s service name/namespace from the Ingress object.

I now introduce another variation of whether the upstream came from a `canary` ingress or not. This way any non-canary Ingress object that references the same k8s service would map to a different entity and not overlap with any other Ingress that mentions the same k8s service as a canary.

The merging algorithm for marking canaries as alternate backends to their primary upstream remains mostly the same [since it is already called only for canary Ingress objects.](https://github.com/kubernetes/ingress-nginx/blob/fb72fcd81772fb3eca923897aec2d92fa5bdff41/internal/ingress/controller/controller.go#L782) 

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->
[#8004](https://github.com/kubernetes/ingress-nginx/issues/8004)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Fixing existing unit tests
- TODO e2e tests to be added that confirm new functionality
- Manual tests with local environment and adding various Ingress objects and running `/dbg backends all` within the controller.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes. - **TODO**
- [ ] All new and existing tests passed. - **TODO**
