### PR TITLE
Added possibility to use ssl-conf-command directive

### DIFF
--- a/docs/user-guide/nginx-configuration/configmap.md
+++ b/docs/user-guide/nginx-configuration/configmap.md
@@ -82,6 +82,7 @@ The following table shows a configuration option's name, type, and the default v
 |[plugins](#plugins)|[]string| |
 |[reuse-port](#reuse-port)|bool|"true"|
 |[server-tokens](#server-tokens)|bool|"false"|
+|[ssl-conf-command](#ssl-conf-command)|string|""|
 |[ssl-ciphers](#ssl-ciphers)|string|"ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384"|
 |[ssl-ecdh-curve](#ssl-ecdh-curve)|string|"auto"|
 |[ssl-dh-param](#ssl-dh-param)|string|""|
@@ -562,6 +563,12 @@ Activates plugins installed in `/etc/nginx/lua/plugins`. Refer to [ingress-nginx
 ## server-tokens
 
 Send NGINX Server header in responses and display NGINX version in error pages. _**default:**_ is disabled
+
+## ssl-conf-command
+
+The directive [SSL-Conf-Command](http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_conf_command) sets arbitrary OpenSSL configuration. The commands are specified in the format understood by the OpenSSL library.
+
+The default conf command is: "empty".
 
 ## ssl-ciphers
 

--- a/docs/user-guide/nginx-configuration/configmap.md
+++ b/docs/user-guide/nginx-configuration/configmap.md
@@ -565,6 +565,7 @@ Activates plugins installed in `/etc/nginx/lua/plugins`. Refer to [ingress-nginx
 Send NGINX Server header in responses and display NGINX version in error pages. _**default:**_ is disabled
 
 ## ssl-conf-command
+(!) Note that configuring OpenSSL directly might result in unexpected behavior.
 
 The directive [SSL-Conf-Command](http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_conf_command) sets arbitrary OpenSSL configuration. The commands are specified in the format understood by the OpenSSL library.
 

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -337,6 +337,10 @@ type Configuration struct {
 	// Default: false
 	ShowServerTokens bool `json:"server-tokens"`
 
+    // Allows configuration of arbitrary OpenSSL configuration
+	// http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_conf_command
+    SSLConfCommand string `json:"ssl-conf-command,omitempty"`
+
 	// Enabled ciphers list to enabled. The ciphers are specified in the format understood by
 	// the OpenSSL library
 	// http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_ciphers
@@ -842,6 +846,7 @@ func NewDefault() Configuration {
 		ReusePort:                        true,
 		ShowServerTokens:                 false,
 		SSLBufferSize:                    sslBufferSize,
+		SSLConfCommand:                   "",
 		SSLCiphers:                       sslCiphers,
 		SSLECDHCurve:                     "auto",
 		SSLProtocols:                     sslProtocols,

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -337,9 +337,9 @@ type Configuration struct {
 	// Default: false
 	ShowServerTokens bool `json:"server-tokens"`
 
-    // Allows configuration of arbitrary OpenSSL configuration
+	// Allows configuration of arbitrary OpenSSL configuration
 	// http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_conf_command
-    SSLConfCommand string `json:"ssl-conf-command,omitempty"`
+	SSLConfCommand string `json:"ssl-conf-command,omitempty"`
 
 	// Enabled ciphers list to enabled. The ciphers are specified in the format understood by
 	// the OpenSSL library

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -451,6 +451,11 @@ http {
     ssl_buffer_size {{ $cfg.SSLBufferSize }};
 
     {{ if not (empty $cfg.SSLCiphers) }}
+    # allow to specify specific openssl commands
+    ssl_conf_command {{ $cfg.SSLConfCommand }};
+    {{ end }}
+
+    {{ if not (empty $cfg.SSLCiphers) }}
     # allow configuring custom ssl ciphers
     ssl_ciphers '{{ $cfg.SSLCiphers }}';
     ssl_prefer_server_ciphers on;

--- a/test/e2e/settings/ssl_conf_command.go
+++ b/test/e2e/settings/ssl_conf_command.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package settings
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/onsi/ginkgo"
+
+	"k8s.io/ingress-nginx/test/e2e/framework"
+)
+
+var _ = framework.DescribeSetting("ssl-conf-command", func() {
+	f := framework.NewDefaultFramework("ssl-conf-command")
+
+	ginkgo.It("Add ssl conf command", func() {
+		wlKey := "ssl-conf-command"
+		wlValue := "Ciphersuites TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256"
+
+		f.UpdateNginxConfigMapData(wlKey, wlValue)
+
+		f.WaitForNginxConfiguration(func(cfg string) bool {
+			return strings.Contains(cfg, fmt.Sprintf("ssl-conf-command '%s';", wlValue))
+		})
+	})
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
It allows setting OpenSSL configuration commands, like the ciphersuites one for example.
This can help to adjust/tweak OpenSSL settings.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
Modification of the code, then compiled and uploaded the image to the Test-Environment.

**RESULTS:**

_Configmap configuration:_
```
ssl-conf-command: Ciphersuites TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256
```
_After Deployment, the nginx.conf looks like this:_
```
# allow to specify specific openssl commands
ssl_conf_command Ciphersuites TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256;
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
