### PR TITLE
Fix for buggy ingress sync with retries

### DIFF
--- a/cmd/nginx/flags.go
+++ b/cmd/nginx/flags.go
@@ -65,7 +65,7 @@ The parameter --controller-class has precedence over this.`)
 
 		ingressClassController = flags.String("controller-class", ingressclass.DefaultControllerName,
 			`Ingress Class Controller value this Ingress satisfies.
-The class of an Ingress object is set using the field IngressClassName in Kubernetes clusters version v1.19.0 or higher. The .spec.controller value of the IngressClass 
+The class of an Ingress object is set using the field IngressClassName in Kubernetes clusters version v1.19.0 or higher. The .spec.controller value of the IngressClass
 referenced in an Ingress Object should be the same value specified here to make this object be watched.`)
 
 		watchWithoutClass = flags.Bool("watch-ingress-without-class", false,
@@ -203,6 +203,8 @@ Takes the form "<host>:port". If not provided, no admission controller is starte
 		postShutdownGracePeriod = flags.Int("post-shutdown-grace-period", 10, "Seconds to wait after the nginx process has stopped before controller exits.")
 
 		deepInspector = flags.Bool("deep-inspect", true, "Enables ingress object security deep inspector")
+
+		dynamicConfigurationRetries = flags.Int("dynamic-configuration-retries", 15, "Number of times to retry failed dynamic configuration before failing to sync an ingress.")
 	)
 
 	flags.StringVar(&nginx.MaxmindMirror, "maxmind-mirror", "", `Maxmind mirror url (example: http://geoip.local/databases`)
@@ -303,35 +305,36 @@ https://blog.maxmind.com/2019/12/18/significant-changes-to-accessing-and-using-g
 	ngx_config.EnableSSLChainCompletion = *enableSSLChainCompletion
 
 	config := &controller.Configuration{
-		APIServerHost:              *apiserverHost,
-		KubeConfigFile:             *kubeConfigFile,
-		UpdateStatus:               *updateStatus,
-		ElectionID:                 *electionID,
-		EnableProfiling:            *profiling,
-		EnableMetrics:              *enableMetrics,
-		MetricsPerHost:             *metricsPerHost,
-		MetricsBuckets:             histogramBuckets,
-		MonitorMaxBatchSize:        *monitorMaxBatchSize,
-		DisableServiceExternalName: *disableServiceExternalName,
-		EnableSSLPassthrough:       *enableSSLPassthrough,
-		ResyncPeriod:               *resyncPeriod,
-		DefaultService:             *defaultSvc,
-		Namespace:                  *watchNamespace,
-		WatchNamespaceSelector:     namespaceSelector,
-		ConfigMapName:              *configMap,
-		TCPConfigMapName:           *tcpConfigMapName,
-		UDPConfigMapName:           *udpConfigMapName,
-		DisableFullValidationTest:  *disableFullValidationTest,
-		DefaultSSLCertificate:      *defSSLCertificate,
-		DeepInspector:              *deepInspector,
-		PublishService:             *publishSvc,
-		PublishStatusAddress:       *publishStatusAddress,
-		UpdateStatusOnShutdown:     *updateStatusOnShutdown,
-		ShutdownGracePeriod:        *shutdownGracePeriod,
-		PostShutdownGracePeriod:    *postShutdownGracePeriod,
-		UseNodeInternalIP:          *useNodeInternalIP,
-		SyncRateLimit:              *syncRateLimit,
-		HealthCheckHost:            *healthzHost,
+		APIServerHost:               *apiserverHost,
+		KubeConfigFile:              *kubeConfigFile,
+		UpdateStatus:                *updateStatus,
+		ElectionID:                  *electionID,
+		EnableProfiling:             *profiling,
+		EnableMetrics:               *enableMetrics,
+		MetricsPerHost:              *metricsPerHost,
+		MetricsBuckets:              histogramBuckets,
+		MonitorMaxBatchSize:         *monitorMaxBatchSize,
+		DisableServiceExternalName:  *disableServiceExternalName,
+		EnableSSLPassthrough:        *enableSSLPassthrough,
+		ResyncPeriod:                *resyncPeriod,
+		DefaultService:              *defaultSvc,
+		Namespace:                   *watchNamespace,
+		WatchNamespaceSelector:      namespaceSelector,
+		ConfigMapName:               *configMap,
+		TCPConfigMapName:            *tcpConfigMapName,
+		UDPConfigMapName:            *udpConfigMapName,
+		DisableFullValidationTest:   *disableFullValidationTest,
+		DefaultSSLCertificate:       *defSSLCertificate,
+		DeepInspector:               *deepInspector,
+		PublishService:              *publishSvc,
+		PublishStatusAddress:        *publishStatusAddress,
+		UpdateStatusOnShutdown:      *updateStatusOnShutdown,
+		ShutdownGracePeriod:         *shutdownGracePeriod,
+		PostShutdownGracePeriod:     *postShutdownGracePeriod,
+		UseNodeInternalIP:           *useNodeInternalIP,
+		SyncRateLimit:               *syncRateLimit,
+		HealthCheckHost:             *healthzHost,
+		DynamicConfigurationRetries: *dynamicConfigurationRetries,
 		ListenPorts: &ngx_config.ListenPorts{
 			Default:  *defServerPort,
 			Health:   *healthzPort,


### PR DESCRIPTION
This is a rebased version of PR 7086, against 1.1.2.  All code was developed originally by steinarvk-kolonial.

## What this PR does / why we need it:
NGINXController.syncIngress in internal/ingress/controller/controller.go is clearly intended to do retries with exponential backoff when calling configureDynamically(). However, due to what seems to be a bug, it won't do any retries. This bugfix contribution fixes that bug, so NGINXController.syncIngress will start doing retries according to the retry policy that seems to have been the original intent.

Per the documentation for wait.ExponentialBackoff, this function "stops and returns as soon as [...] the condition check returns true or an error". The previous implementation of the condition check always returned either true (success) or an error (failure) -- as such, retries would never actually trigger.

We've had issues with this "retry" loop on a real deployment on multiple occasions. This manifests as the nginx-controller failing to get healthy and getting stuck in a crashloop for minutes or hours with an errors akin to this:

`Unexpected failure reconfiguring NGINX:
"requeuing" err="Post \"http://127.0.0.1:10246/configuration/backends\": dial tcp 127.0.0.1:10246: connect: connection refused" key="initial-sync"`

The hope is that this bugfix will resolve this existing crash-on-startup bug by allowing more time (as much time as originally intended) for port 10246 to start listening.

Since the amount of time required will depend on configuration size, as noted in the pre-existing comment, I've also added a flag to control the number of retries.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes

possibly #4629 and/or #4742

## How Has This Been Tested?

steinarvk-kolonial previously tested.
Using a github action, I rebuilt based on 1.1.2 and tested it on my mixed arm64/amd64 cluster and it comes up without the previous failures.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
