### PR TITLE
updated dev-env specs for K8S and dev-image tag

### DIFF
--- a/build/dev-env.sh
+++ b/build/dev-env.sh
@@ -24,7 +24,7 @@ set -o pipefail
 
 DIR=$(cd $(dirname "${BASH_SOURCE}") && pwd -P)
 
-export TAG=1.0.0-dev
+export TAG=1.1.3-dev
 export REGISTRY=${REGISTRY:-ingress-controller}
 
 DEV_IMAGE=${REGISTRY}/controller:${TAG}
@@ -36,7 +36,7 @@ if ! command -v kind &> /dev/null; then
 fi
 
 if ! command -v kubectl &> /dev/null; then
-  echo "Please install kubectl 1.15 or higher"
+  echo "Please install kubectl 1.19 or higher"
   exit 1
 fi
 
@@ -46,14 +46,14 @@ if ! command -v helm &> /dev/null; then
 fi
 
 HELM_VERSION=$(helm version 2>&1 | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+') || true
-if [[ ${HELM_VERSION} < "v3.0.0" ]]; then
-  echo "Please upgrade helm to v3.0.0 or higher"
+if [[ ${HELM_VERSION} < "v3.8.0" ]]; then
+  echo "Please upgrade helm to v3.8.0 or higher"
   exit 1
 fi
 
 KUBE_CLIENT_VERSION=$(kubectl version --client --short | awk '{print $3}' | cut -d. -f2) || true
-if [[ ${KUBE_CLIENT_VERSION} -lt 14 ]]; then
-  echo "Please update kubectl to 1.15 or higher"
+if [[ ${KUBE_CLIENT_VERSION} -lt 18 ]]; then
+  echo "Please update kubectl to 1.19 or higher"
   exit 1
 fi
 
@@ -61,7 +61,7 @@ echo "[dev-env] building image"
 make build image
 docker tag "${REGISTRY}/controller:${TAG}" "${DEV_IMAGE}"
 
-export K8S_VERSION=${K8S_VERSION:-v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6}
+export K8S_VERSION=${K8S_VERSION:-v1.23.5}
 
 KIND_CLUSTER_NAME="ingress-nginx-dev"
 


### PR DESCRIPTION
## What this PR does / why we need it:
- Developer quick-start is documented here https://kubernetes.github.io/ingress-nginx/developer-guide/getting-started/#local-build
- For developers, this PR updates the dev-env specs to ; 
  - K8s v1.23.4
  - dev-image tag v1.1.2-dev
  - kubectl v1.19.x
  - helm v3.8.x

Currently ;
  - K8S version is 1.21
  - dev-image tag is 1.0.0-dev
  - kubectl v1.15 or higher
  - helm v3.0.0 or higher

https://github.com/kubernetes/ingress-nginx/issues/8369

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes

fixes #8369 

## How Has This Been Tested?
Tested in local clone of fork

## Checklist:
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.