### PR TITLE
Removed helm specific labels for manifests under deploy folder

### DIFF
--- a/deploy/static/provider/aws/1.19/deploy.yaml
+++ b/deploy/static/provider/aws/1.19/deploy.yaml
@@ -13,28 +13,21 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 ---
@@ -44,11 +37,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 rules:
@@ -125,17 +116,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 rules:
@@ -152,11 +138,9 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 rules:
 - apiGroups:
@@ -218,17 +202,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 rules:
 - apiGroups:
@@ -245,11 +224,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 roleRef:
@@ -264,17 +241,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 roleRef:
@@ -291,11 +263,9 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -309,17 +279,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -338,11 +303,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 ---
@@ -356,11 +319,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -386,11 +347,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller-admission
   namespace: ingress-nginx
 spec:
@@ -410,11 +369,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -521,17 +478,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-create
   namespace: ingress-nginx
 spec:
@@ -540,11 +492,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-create
     spec:
       containers:
@@ -575,17 +525,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-patch
   namespace: ingress-nginx
 spec:
@@ -594,11 +539,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-patch
     spec:
       containers:
@@ -634,11 +577,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
@@ -649,11 +590,9 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 webhooks:
 - admissionReviewVersions:

--- a/deploy/static/provider/aws/1.20/deploy.yaml
+++ b/deploy/static/provider/aws/1.20/deploy.yaml
@@ -13,28 +13,21 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 ---
@@ -44,11 +37,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 rules:
@@ -125,17 +116,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 rules:
@@ -152,11 +138,9 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 rules:
 - apiGroups:
@@ -218,17 +202,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 rules:
 - apiGroups:
@@ -245,11 +224,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 roleRef:
@@ -264,17 +241,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 roleRef:
@@ -291,11 +263,9 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -309,17 +279,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -338,11 +303,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 ---
@@ -356,11 +319,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -391,11 +352,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller-admission
   namespace: ingress-nginx
 spec:
@@ -416,11 +375,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -527,17 +484,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-create
   namespace: ingress-nginx
 spec:
@@ -546,11 +498,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-create
     spec:
       containers:
@@ -581,17 +531,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-patch
   namespace: ingress-nginx
 spec:
@@ -600,11 +545,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-patch
     spec:
       containers:
@@ -640,11 +583,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
@@ -655,11 +596,9 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 webhooks:
 - admissionReviewVersions:

--- a/deploy/static/provider/aws/1.21/deploy.yaml
+++ b/deploy/static/provider/aws/1.21/deploy.yaml
@@ -13,28 +13,21 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 ---
@@ -44,11 +37,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 rules:
@@ -125,17 +116,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 rules:
@@ -152,11 +138,9 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 rules:
 - apiGroups:
@@ -218,17 +202,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 rules:
 - apiGroups:
@@ -245,11 +224,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 roleRef:
@@ -264,17 +241,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 roleRef:
@@ -291,11 +263,9 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -309,17 +279,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -338,11 +303,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 ---
@@ -356,11 +319,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -391,11 +352,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller-admission
   namespace: ingress-nginx
 spec:
@@ -416,11 +375,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -527,17 +484,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-create
   namespace: ingress-nginx
 spec:
@@ -546,11 +498,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-create
     spec:
       containers:
@@ -581,17 +531,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-patch
   namespace: ingress-nginx
 spec:
@@ -600,11 +545,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-patch
     spec:
       containers:
@@ -640,11 +583,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
@@ -655,11 +596,9 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 webhooks:
 - admissionReviewVersions:

--- a/deploy/static/provider/aws/1.22/deploy.yaml
+++ b/deploy/static/provider/aws/1.22/deploy.yaml
@@ -13,28 +13,21 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 ---
@@ -44,11 +37,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 rules:
@@ -125,17 +116,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 rules:
@@ -152,11 +138,9 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 rules:
 - apiGroups:
@@ -218,17 +202,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 rules:
 - apiGroups:
@@ -245,11 +224,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 roleRef:
@@ -264,17 +241,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 roleRef:
@@ -291,11 +263,9 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -309,17 +279,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -338,11 +303,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 ---
@@ -356,11 +319,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -391,11 +352,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller-admission
   namespace: ingress-nginx
 spec:
@@ -416,11 +375,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -527,17 +484,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-create
   namespace: ingress-nginx
 spec:
@@ -546,11 +498,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-create
     spec:
       containers:
@@ -581,17 +531,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-patch
   namespace: ingress-nginx
 spec:
@@ -600,11 +545,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-patch
     spec:
       containers:
@@ -640,11 +583,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
@@ -655,11 +596,9 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 webhooks:
 - admissionReviewVersions:

--- a/deploy/static/provider/aws/1.23/deploy.yaml
+++ b/deploy/static/provider/aws/1.23/deploy.yaml
@@ -13,28 +13,21 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 ---
@@ -44,11 +37,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 rules:
@@ -125,17 +116,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 rules:
@@ -152,11 +138,9 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 rules:
 - apiGroups:
@@ -218,17 +202,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 rules:
 - apiGroups:
@@ -245,11 +224,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 roleRef:
@@ -264,17 +241,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 roleRef:
@@ -291,11 +263,9 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -309,17 +279,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -338,11 +303,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 ---
@@ -356,11 +319,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -391,11 +352,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller-admission
   namespace: ingress-nginx
 spec:
@@ -416,11 +375,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -527,17 +484,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-create
   namespace: ingress-nginx
 spec:
@@ -546,11 +498,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-create
     spec:
       containers:
@@ -581,17 +531,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-patch
   namespace: ingress-nginx
 spec:
@@ -600,11 +545,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-patch
     spec:
       containers:
@@ -640,11 +583,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
@@ -655,11 +596,9 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 webhooks:
 - admissionReviewVersions:

--- a/deploy/static/provider/aws/deploy.yaml
+++ b/deploy/static/provider/aws/deploy.yaml
@@ -14,28 +14,21 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 ---
@@ -45,11 +38,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 rules:
@@ -126,17 +117,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 rules:
@@ -153,11 +139,9 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 rules:
 - apiGroups:
@@ -219,17 +203,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 rules:
 - apiGroups:
@@ -246,11 +225,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 roleRef:
@@ -265,17 +242,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 roleRef:
@@ -292,11 +264,9 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -310,17 +280,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -339,11 +304,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 ---
@@ -357,11 +320,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -392,11 +353,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller-admission
   namespace: ingress-nginx
 spec:
@@ -417,11 +376,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -528,17 +485,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-create
   namespace: ingress-nginx
 spec:
@@ -547,11 +499,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-create
     spec:
       containers:
@@ -582,17 +532,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-patch
   namespace: ingress-nginx
 spec:
@@ -601,11 +546,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-patch
     spec:
       containers:
@@ -641,11 +584,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
@@ -656,11 +597,9 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 webhooks:
 - admissionReviewVersions:

--- a/deploy/static/provider/aws/nlb-with-tls-termination/1.19/deploy.yaml
+++ b/deploy/static/provider/aws/nlb-with-tls-termination/1.19/deploy.yaml
@@ -13,28 +13,21 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 ---
@@ -44,11 +37,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 rules:
@@ -125,17 +116,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 rules:
@@ -152,11 +138,9 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 rules:
 - apiGroups:
@@ -218,17 +202,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 rules:
 - apiGroups:
@@ -245,11 +224,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 roleRef:
@@ -264,17 +241,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 roleRef:
@@ -291,11 +263,9 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -309,17 +279,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -345,11 +310,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 ---
@@ -365,11 +328,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -395,11 +356,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller-admission
   namespace: ingress-nginx
 spec:
@@ -419,11 +378,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -533,17 +490,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-create
   namespace: ingress-nginx
 spec:
@@ -552,11 +504,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-create
     spec:
       containers:
@@ -587,17 +537,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-patch
   namespace: ingress-nginx
 spec:
@@ -606,11 +551,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-patch
     spec:
       containers:
@@ -646,11 +589,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
@@ -661,11 +602,9 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 webhooks:
 - admissionReviewVersions:

--- a/deploy/static/provider/aws/nlb-with-tls-termination/1.20/deploy.yaml
+++ b/deploy/static/provider/aws/nlb-with-tls-termination/1.20/deploy.yaml
@@ -13,28 +13,21 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 ---
@@ -44,11 +37,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 rules:
@@ -125,17 +116,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 rules:
@@ -152,11 +138,9 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 rules:
 - apiGroups:
@@ -218,17 +202,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 rules:
 - apiGroups:
@@ -245,11 +224,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 roleRef:
@@ -264,17 +241,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 roleRef:
@@ -291,11 +263,9 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -309,17 +279,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -345,11 +310,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 ---
@@ -365,11 +328,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -400,11 +361,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller-admission
   namespace: ingress-nginx
 spec:
@@ -425,11 +384,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -539,17 +496,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-create
   namespace: ingress-nginx
 spec:
@@ -558,11 +510,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-create
     spec:
       containers:
@@ -593,17 +543,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-patch
   namespace: ingress-nginx
 spec:
@@ -612,11 +557,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-patch
     spec:
       containers:
@@ -652,11 +595,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
@@ -667,11 +608,9 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 webhooks:
 - admissionReviewVersions:

--- a/deploy/static/provider/aws/nlb-with-tls-termination/1.21/deploy.yaml
+++ b/deploy/static/provider/aws/nlb-with-tls-termination/1.21/deploy.yaml
@@ -13,28 +13,21 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 ---
@@ -44,11 +37,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 rules:
@@ -125,17 +116,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 rules:
@@ -152,11 +138,9 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 rules:
 - apiGroups:
@@ -218,17 +202,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 rules:
 - apiGroups:
@@ -245,11 +224,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 roleRef:
@@ -264,17 +241,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 roleRef:
@@ -291,11 +263,9 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -309,17 +279,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -345,11 +310,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 ---
@@ -365,11 +328,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -400,11 +361,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller-admission
   namespace: ingress-nginx
 spec:
@@ -425,11 +384,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -539,17 +496,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-create
   namespace: ingress-nginx
 spec:
@@ -558,11 +510,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-create
     spec:
       containers:
@@ -593,17 +543,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-patch
   namespace: ingress-nginx
 spec:
@@ -612,11 +557,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-patch
     spec:
       containers:
@@ -652,11 +595,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
@@ -667,11 +608,9 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 webhooks:
 - admissionReviewVersions:

--- a/deploy/static/provider/aws/nlb-with-tls-termination/1.22/deploy.yaml
+++ b/deploy/static/provider/aws/nlb-with-tls-termination/1.22/deploy.yaml
@@ -13,28 +13,21 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 ---
@@ -44,11 +37,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 rules:
@@ -125,17 +116,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 rules:
@@ -152,11 +138,9 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 rules:
 - apiGroups:
@@ -218,17 +202,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 rules:
 - apiGroups:
@@ -245,11 +224,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 roleRef:
@@ -264,17 +241,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 roleRef:
@@ -291,11 +263,9 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -309,17 +279,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -345,11 +310,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 ---
@@ -365,11 +328,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -400,11 +361,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller-admission
   namespace: ingress-nginx
 spec:
@@ -425,11 +384,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -539,17 +496,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-create
   namespace: ingress-nginx
 spec:
@@ -558,11 +510,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-create
     spec:
       containers:
@@ -593,17 +543,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-patch
   namespace: ingress-nginx
 spec:
@@ -612,11 +557,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-patch
     spec:
       containers:
@@ -652,11 +595,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
@@ -667,11 +608,9 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 webhooks:
 - admissionReviewVersions:

--- a/deploy/static/provider/aws/nlb-with-tls-termination/1.23/deploy.yaml
+++ b/deploy/static/provider/aws/nlb-with-tls-termination/1.23/deploy.yaml
@@ -13,28 +13,21 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 ---
@@ -44,11 +37,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 rules:
@@ -125,17 +116,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 rules:
@@ -152,11 +138,9 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 rules:
 - apiGroups:
@@ -218,17 +202,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 rules:
 - apiGroups:
@@ -245,11 +224,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 roleRef:
@@ -264,17 +241,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 roleRef:
@@ -291,11 +263,9 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -309,17 +279,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -345,11 +310,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 ---
@@ -365,11 +328,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -400,11 +361,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller-admission
   namespace: ingress-nginx
 spec:
@@ -425,11 +384,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -539,17 +496,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-create
   namespace: ingress-nginx
 spec:
@@ -558,11 +510,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-create
     spec:
       containers:
@@ -593,17 +543,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-patch
   namespace: ingress-nginx
 spec:
@@ -612,11 +557,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-patch
     spec:
       containers:
@@ -652,11 +595,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
@@ -667,11 +608,9 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 webhooks:
 - admissionReviewVersions:

--- a/deploy/static/provider/aws/nlb-with-tls-termination/deploy.yaml
+++ b/deploy/static/provider/aws/nlb-with-tls-termination/deploy.yaml
@@ -14,28 +14,21 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 ---
@@ -45,11 +38,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 rules:
@@ -126,17 +117,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 rules:
@@ -153,11 +139,9 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 rules:
 - apiGroups:
@@ -219,17 +203,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 rules:
 - apiGroups:
@@ -246,11 +225,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 roleRef:
@@ -265,17 +242,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 roleRef:
@@ -292,11 +264,9 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -310,17 +280,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -346,11 +311,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 ---
@@ -366,11 +329,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -401,11 +362,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller-admission
   namespace: ingress-nginx
 spec:
@@ -426,11 +385,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -540,17 +497,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-create
   namespace: ingress-nginx
 spec:
@@ -559,11 +511,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-create
     spec:
       containers:
@@ -594,17 +544,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-patch
   namespace: ingress-nginx
 spec:
@@ -613,11 +558,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-patch
     spec:
       containers:
@@ -653,11 +596,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
@@ -668,11 +609,9 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 webhooks:
 - admissionReviewVersions:

--- a/deploy/static/provider/baremetal/1.19/deploy.yaml
+++ b/deploy/static/provider/baremetal/1.19/deploy.yaml
@@ -13,28 +13,21 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 ---
@@ -44,11 +37,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 rules:
@@ -125,17 +116,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 rules:
@@ -152,11 +138,9 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 rules:
 - apiGroups:
@@ -218,17 +202,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 rules:
 - apiGroups:
@@ -245,11 +224,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 roleRef:
@@ -264,17 +241,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 roleRef:
@@ -291,11 +263,9 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -309,17 +279,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -338,11 +303,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 ---
@@ -352,11 +315,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -381,11 +342,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller-admission
   namespace: ingress-nginx
 spec:
@@ -405,11 +364,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -515,17 +472,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-create
   namespace: ingress-nginx
 spec:
@@ -534,11 +486,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-create
     spec:
       containers:
@@ -569,17 +519,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-patch
   namespace: ingress-nginx
 spec:
@@ -588,11 +533,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-patch
     spec:
       containers:
@@ -628,11 +571,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
@@ -643,11 +584,9 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 webhooks:
 - admissionReviewVersions:

--- a/deploy/static/provider/baremetal/1.20/deploy.yaml
+++ b/deploy/static/provider/baremetal/1.20/deploy.yaml
@@ -13,28 +13,21 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 ---
@@ -44,11 +37,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 rules:
@@ -125,17 +116,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 rules:
@@ -152,11 +138,9 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 rules:
 - apiGroups:
@@ -218,17 +202,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 rules:
 - apiGroups:
@@ -245,11 +224,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 roleRef:
@@ -264,17 +241,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 roleRef:
@@ -291,11 +263,9 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -309,17 +279,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -338,11 +303,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 ---
@@ -352,11 +315,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -386,11 +347,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller-admission
   namespace: ingress-nginx
 spec:
@@ -411,11 +370,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -521,17 +478,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-create
   namespace: ingress-nginx
 spec:
@@ -540,11 +492,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-create
     spec:
       containers:
@@ -575,17 +525,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-patch
   namespace: ingress-nginx
 spec:
@@ -594,11 +539,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-patch
     spec:
       containers:
@@ -634,11 +577,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
@@ -649,11 +590,9 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 webhooks:
 - admissionReviewVersions:

--- a/deploy/static/provider/baremetal/1.21/deploy.yaml
+++ b/deploy/static/provider/baremetal/1.21/deploy.yaml
@@ -13,28 +13,21 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 ---
@@ -44,11 +37,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 rules:
@@ -125,17 +116,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 rules:
@@ -152,11 +138,9 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 rules:
 - apiGroups:
@@ -218,17 +202,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 rules:
 - apiGroups:
@@ -245,11 +224,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 roleRef:
@@ -264,17 +241,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 roleRef:
@@ -291,11 +263,9 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -309,17 +279,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -338,11 +303,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 ---
@@ -352,11 +315,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -386,11 +347,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller-admission
   namespace: ingress-nginx
 spec:
@@ -411,11 +370,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -521,17 +478,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-create
   namespace: ingress-nginx
 spec:
@@ -540,11 +492,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-create
     spec:
       containers:
@@ -575,17 +525,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-patch
   namespace: ingress-nginx
 spec:
@@ -594,11 +539,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-patch
     spec:
       containers:
@@ -634,11 +577,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
@@ -649,11 +590,9 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 webhooks:
 - admissionReviewVersions:

--- a/deploy/static/provider/baremetal/1.22/deploy.yaml
+++ b/deploy/static/provider/baremetal/1.22/deploy.yaml
@@ -13,28 +13,21 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 ---
@@ -44,11 +37,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 rules:
@@ -125,17 +116,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 rules:
@@ -152,11 +138,9 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 rules:
 - apiGroups:
@@ -218,17 +202,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 rules:
 - apiGroups:
@@ -245,11 +224,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 roleRef:
@@ -264,17 +241,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 roleRef:
@@ -291,11 +263,9 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -309,17 +279,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -338,11 +303,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 ---
@@ -352,11 +315,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -386,11 +347,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller-admission
   namespace: ingress-nginx
 spec:
@@ -411,11 +370,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -521,17 +478,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-create
   namespace: ingress-nginx
 spec:
@@ -540,11 +492,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-create
     spec:
       containers:
@@ -575,17 +525,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-patch
   namespace: ingress-nginx
 spec:
@@ -594,11 +539,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-patch
     spec:
       containers:
@@ -634,11 +577,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
@@ -649,11 +590,9 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 webhooks:
 - admissionReviewVersions:

--- a/deploy/static/provider/baremetal/1.23/deploy.yaml
+++ b/deploy/static/provider/baremetal/1.23/deploy.yaml
@@ -13,28 +13,21 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 ---
@@ -44,11 +37,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 rules:
@@ -125,17 +116,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 rules:
@@ -152,11 +138,9 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 rules:
 - apiGroups:
@@ -218,17 +202,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 rules:
 - apiGroups:
@@ -245,11 +224,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 roleRef:
@@ -264,17 +241,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 roleRef:
@@ -291,11 +263,9 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -309,17 +279,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -338,11 +303,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 ---
@@ -352,11 +315,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -386,11 +347,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller-admission
   namespace: ingress-nginx
 spec:
@@ -411,11 +370,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -521,17 +478,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-create
   namespace: ingress-nginx
 spec:
@@ -540,11 +492,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-create
     spec:
       containers:
@@ -575,17 +525,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-patch
   namespace: ingress-nginx
 spec:
@@ -594,11 +539,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-patch
     spec:
       containers:
@@ -634,11 +577,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
@@ -649,11 +590,9 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 webhooks:
 - admissionReviewVersions:

--- a/deploy/static/provider/baremetal/deploy.yaml
+++ b/deploy/static/provider/baremetal/deploy.yaml
@@ -14,28 +14,21 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 ---
@@ -45,11 +38,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 rules:
@@ -126,17 +117,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 rules:
@@ -153,11 +139,9 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 rules:
 - apiGroups:
@@ -219,17 +203,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 rules:
 - apiGroups:
@@ -246,11 +225,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 roleRef:
@@ -265,17 +242,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 roleRef:
@@ -292,11 +264,9 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -310,17 +280,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -339,11 +304,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 ---
@@ -353,11 +316,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -387,11 +348,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller-admission
   namespace: ingress-nginx
 spec:
@@ -412,11 +371,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -522,17 +479,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-create
   namespace: ingress-nginx
 spec:
@@ -541,11 +493,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-create
     spec:
       containers:
@@ -576,17 +526,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-patch
   namespace: ingress-nginx
 spec:
@@ -595,11 +540,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-patch
     spec:
       containers:
@@ -635,11 +578,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
@@ -650,11 +591,9 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 webhooks:
 - admissionReviewVersions:

--- a/deploy/static/provider/cloud/1.19/deploy.yaml
+++ b/deploy/static/provider/cloud/1.19/deploy.yaml
@@ -13,28 +13,21 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 ---
@@ -44,11 +37,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 rules:
@@ -125,17 +116,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 rules:
@@ -152,11 +138,9 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 rules:
 - apiGroups:
@@ -218,17 +202,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 rules:
 - apiGroups:
@@ -245,11 +224,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 roleRef:
@@ -264,17 +241,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 roleRef:
@@ -291,11 +263,9 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -309,17 +279,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -338,11 +303,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 ---
@@ -352,11 +315,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -382,11 +343,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller-admission
   namespace: ingress-nginx
 spec:
@@ -406,11 +365,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -517,17 +474,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-create
   namespace: ingress-nginx
 spec:
@@ -536,11 +488,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-create
     spec:
       containers:
@@ -571,17 +521,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-patch
   namespace: ingress-nginx
 spec:
@@ -590,11 +535,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-patch
     spec:
       containers:
@@ -630,11 +573,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
@@ -645,11 +586,9 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 webhooks:
 - admissionReviewVersions:

--- a/deploy/static/provider/cloud/1.20/deploy.yaml
+++ b/deploy/static/provider/cloud/1.20/deploy.yaml
@@ -13,28 +13,21 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 ---
@@ -44,11 +37,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 rules:
@@ -125,17 +116,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 rules:
@@ -152,11 +138,9 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 rules:
 - apiGroups:
@@ -218,17 +202,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 rules:
 - apiGroups:
@@ -245,11 +224,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 roleRef:
@@ -264,17 +241,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 roleRef:
@@ -291,11 +263,9 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -309,17 +279,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -338,11 +303,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 ---
@@ -352,11 +315,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -387,11 +348,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller-admission
   namespace: ingress-nginx
 spec:
@@ -412,11 +371,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -523,17 +480,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-create
   namespace: ingress-nginx
 spec:
@@ -542,11 +494,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-create
     spec:
       containers:
@@ -577,17 +527,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-patch
   namespace: ingress-nginx
 spec:
@@ -596,11 +541,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-patch
     spec:
       containers:
@@ -636,11 +579,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
@@ -651,11 +592,9 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 webhooks:
 - admissionReviewVersions:

--- a/deploy/static/provider/cloud/1.21/deploy.yaml
+++ b/deploy/static/provider/cloud/1.21/deploy.yaml
@@ -13,28 +13,21 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 ---
@@ -44,11 +37,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 rules:
@@ -125,17 +116,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 rules:
@@ -152,11 +138,9 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 rules:
 - apiGroups:
@@ -218,17 +202,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 rules:
 - apiGroups:
@@ -245,11 +224,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 roleRef:
@@ -264,17 +241,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 roleRef:
@@ -291,11 +263,9 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -309,17 +279,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -338,11 +303,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 ---
@@ -352,11 +315,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -387,11 +348,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller-admission
   namespace: ingress-nginx
 spec:
@@ -412,11 +371,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -523,17 +480,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-create
   namespace: ingress-nginx
 spec:
@@ -542,11 +494,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-create
     spec:
       containers:
@@ -577,17 +527,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-patch
   namespace: ingress-nginx
 spec:
@@ -596,11 +541,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-patch
     spec:
       containers:
@@ -636,11 +579,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
@@ -651,11 +592,9 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 webhooks:
 - admissionReviewVersions:

--- a/deploy/static/provider/cloud/1.22/deploy.yaml
+++ b/deploy/static/provider/cloud/1.22/deploy.yaml
@@ -13,28 +13,21 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 ---
@@ -44,11 +37,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 rules:
@@ -125,17 +116,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 rules:
@@ -152,11 +138,9 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 rules:
 - apiGroups:
@@ -218,17 +202,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 rules:
 - apiGroups:
@@ -245,11 +224,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 roleRef:
@@ -264,17 +241,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 roleRef:
@@ -291,11 +263,9 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -309,17 +279,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -338,11 +303,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 ---
@@ -352,11 +315,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -387,11 +348,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller-admission
   namespace: ingress-nginx
 spec:
@@ -412,11 +371,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -523,17 +480,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-create
   namespace: ingress-nginx
 spec:
@@ -542,11 +494,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-create
     spec:
       containers:
@@ -577,17 +527,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-patch
   namespace: ingress-nginx
 spec:
@@ -596,11 +541,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-patch
     spec:
       containers:
@@ -636,11 +579,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
@@ -651,11 +592,9 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 webhooks:
 - admissionReviewVersions:

--- a/deploy/static/provider/cloud/1.23/deploy.yaml
+++ b/deploy/static/provider/cloud/1.23/deploy.yaml
@@ -13,28 +13,21 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 ---
@@ -44,11 +37,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 rules:
@@ -125,17 +116,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 rules:
@@ -152,11 +138,9 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 rules:
 - apiGroups:
@@ -218,17 +202,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 rules:
 - apiGroups:
@@ -245,11 +224,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 roleRef:
@@ -264,17 +241,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 roleRef:
@@ -291,11 +263,9 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -309,17 +279,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -338,11 +303,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 ---
@@ -352,11 +315,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -387,11 +348,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller-admission
   namespace: ingress-nginx
 spec:
@@ -412,11 +371,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -523,17 +480,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-create
   namespace: ingress-nginx
 spec:
@@ -542,11 +494,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-create
     spec:
       containers:
@@ -577,17 +527,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-patch
   namespace: ingress-nginx
 spec:
@@ -596,11 +541,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-patch
     spec:
       containers:
@@ -636,11 +579,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
@@ -651,11 +592,9 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 webhooks:
 - admissionReviewVersions:

--- a/deploy/static/provider/cloud/deploy.yaml
+++ b/deploy/static/provider/cloud/deploy.yaml
@@ -14,28 +14,21 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 ---
@@ -45,11 +38,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 rules:
@@ -126,17 +117,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 rules:
@@ -153,11 +139,9 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 rules:
 - apiGroups:
@@ -219,17 +203,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 rules:
 - apiGroups:
@@ -246,11 +225,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 roleRef:
@@ -265,17 +242,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 roleRef:
@@ -292,11 +264,9 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -310,17 +280,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -339,11 +304,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 ---
@@ -353,11 +316,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -388,11 +349,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller-admission
   namespace: ingress-nginx
 spec:
@@ -413,11 +372,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -524,17 +481,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-create
   namespace: ingress-nginx
 spec:
@@ -543,11 +495,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-create
     spec:
       containers:
@@ -578,17 +528,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-patch
   namespace: ingress-nginx
 spec:
@@ -597,11 +542,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-patch
     spec:
       containers:
@@ -637,11 +580,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
@@ -652,11 +593,9 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 webhooks:
 - admissionReviewVersions:

--- a/deploy/static/provider/do/1.19/deploy.yaml
+++ b/deploy/static/provider/do/1.19/deploy.yaml
@@ -13,28 +13,21 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 ---
@@ -44,11 +37,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 rules:
@@ -125,17 +116,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 rules:
@@ -152,11 +138,9 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 rules:
 - apiGroups:
@@ -218,17 +202,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 rules:
 - apiGroups:
@@ -245,11 +224,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 roleRef:
@@ -264,17 +241,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 roleRef:
@@ -291,11 +263,9 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -309,17 +279,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -339,11 +304,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 ---
@@ -355,11 +318,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -385,11 +346,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller-admission
   namespace: ingress-nginx
 spec:
@@ -409,11 +368,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -520,17 +477,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-create
   namespace: ingress-nginx
 spec:
@@ -539,11 +491,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-create
     spec:
       containers:
@@ -574,17 +524,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-patch
   namespace: ingress-nginx
 spec:
@@ -593,11 +538,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-patch
     spec:
       containers:
@@ -633,11 +576,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
@@ -648,11 +589,9 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 webhooks:
 - admissionReviewVersions:

--- a/deploy/static/provider/do/1.20/deploy.yaml
+++ b/deploy/static/provider/do/1.20/deploy.yaml
@@ -13,28 +13,21 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 ---
@@ -44,11 +37,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 rules:
@@ -125,17 +116,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 rules:
@@ -152,11 +138,9 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 rules:
 - apiGroups:
@@ -218,17 +202,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 rules:
 - apiGroups:
@@ -245,11 +224,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 roleRef:
@@ -264,17 +241,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 roleRef:
@@ -291,11 +263,9 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -309,17 +279,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -339,11 +304,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 ---
@@ -355,11 +318,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -390,11 +351,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller-admission
   namespace: ingress-nginx
 spec:
@@ -415,11 +374,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -526,17 +483,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-create
   namespace: ingress-nginx
 spec:
@@ -545,11 +497,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-create
     spec:
       containers:
@@ -580,17 +530,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-patch
   namespace: ingress-nginx
 spec:
@@ -599,11 +544,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-patch
     spec:
       containers:
@@ -639,11 +582,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
@@ -654,11 +595,9 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 webhooks:
 - admissionReviewVersions:

--- a/deploy/static/provider/do/1.21/deploy.yaml
+++ b/deploy/static/provider/do/1.21/deploy.yaml
@@ -13,28 +13,21 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 ---
@@ -44,11 +37,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 rules:
@@ -125,17 +116,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 rules:
@@ -152,11 +138,9 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 rules:
 - apiGroups:
@@ -218,17 +202,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 rules:
 - apiGroups:
@@ -245,11 +224,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 roleRef:
@@ -264,17 +241,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 roleRef:
@@ -291,11 +263,9 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -309,17 +279,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -339,11 +304,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 ---
@@ -355,11 +318,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -390,11 +351,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller-admission
   namespace: ingress-nginx
 spec:
@@ -415,11 +374,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -526,17 +483,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-create
   namespace: ingress-nginx
 spec:
@@ -545,11 +497,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-create
     spec:
       containers:
@@ -580,17 +530,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-patch
   namespace: ingress-nginx
 spec:
@@ -599,11 +544,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-patch
     spec:
       containers:
@@ -639,11 +582,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
@@ -654,11 +595,9 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 webhooks:
 - admissionReviewVersions:

--- a/deploy/static/provider/do/1.22/deploy.yaml
+++ b/deploy/static/provider/do/1.22/deploy.yaml
@@ -13,28 +13,21 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 ---
@@ -44,11 +37,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 rules:
@@ -125,17 +116,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 rules:
@@ -152,11 +138,9 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 rules:
 - apiGroups:
@@ -218,17 +202,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 rules:
 - apiGroups:
@@ -245,11 +224,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 roleRef:
@@ -264,17 +241,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 roleRef:
@@ -291,11 +263,9 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -309,17 +279,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -339,11 +304,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 ---
@@ -355,11 +318,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -390,11 +351,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller-admission
   namespace: ingress-nginx
 spec:
@@ -415,11 +374,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -526,17 +483,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-create
   namespace: ingress-nginx
 spec:
@@ -545,11 +497,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-create
     spec:
       containers:
@@ -580,17 +530,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-patch
   namespace: ingress-nginx
 spec:
@@ -599,11 +544,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-patch
     spec:
       containers:
@@ -639,11 +582,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
@@ -654,11 +595,9 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 webhooks:
 - admissionReviewVersions:

--- a/deploy/static/provider/do/1.23/deploy.yaml
+++ b/deploy/static/provider/do/1.23/deploy.yaml
@@ -13,28 +13,21 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 ---
@@ -44,11 +37,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 rules:
@@ -125,17 +116,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 rules:
@@ -152,11 +138,9 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 rules:
 - apiGroups:
@@ -218,17 +202,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 rules:
 - apiGroups:
@@ -245,11 +224,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 roleRef:
@@ -264,17 +241,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 roleRef:
@@ -291,11 +263,9 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -309,17 +279,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -339,11 +304,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 ---
@@ -355,11 +318,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -390,11 +351,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller-admission
   namespace: ingress-nginx
 spec:
@@ -415,11 +374,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -526,17 +483,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-create
   namespace: ingress-nginx
 spec:
@@ -545,11 +497,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-create
     spec:
       containers:
@@ -580,17 +530,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-patch
   namespace: ingress-nginx
 spec:
@@ -599,11 +544,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-patch
     spec:
       containers:
@@ -639,11 +582,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
@@ -654,11 +595,9 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 webhooks:
 - admissionReviewVersions:

--- a/deploy/static/provider/do/deploy.yaml
+++ b/deploy/static/provider/do/deploy.yaml
@@ -14,28 +14,21 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 ---
@@ -45,11 +38,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 rules:
@@ -126,17 +117,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 rules:
@@ -153,11 +139,9 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 rules:
 - apiGroups:
@@ -219,17 +203,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 rules:
 - apiGroups:
@@ -246,11 +225,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 roleRef:
@@ -265,17 +242,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 roleRef:
@@ -292,11 +264,9 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -310,17 +280,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -340,11 +305,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 ---
@@ -356,11 +319,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -391,11 +352,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller-admission
   namespace: ingress-nginx
 spec:
@@ -416,11 +375,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -527,17 +484,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-create
   namespace: ingress-nginx
 spec:
@@ -546,11 +498,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-create
     spec:
       containers:
@@ -581,17 +531,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-patch
   namespace: ingress-nginx
 spec:
@@ -600,11 +545,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-patch
     spec:
       containers:
@@ -640,11 +583,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
@@ -655,11 +596,9 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 webhooks:
 - admissionReviewVersions:

--- a/deploy/static/provider/exoscale/1.19/deploy.yaml
+++ b/deploy/static/provider/exoscale/1.19/deploy.yaml
@@ -13,28 +13,21 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 ---
@@ -44,11 +37,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 rules:
@@ -125,17 +116,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 rules:
@@ -152,11 +138,9 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 rules:
 - apiGroups:
@@ -218,17 +202,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 rules:
 - apiGroups:
@@ -245,11 +224,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 roleRef:
@@ -264,17 +241,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 roleRef:
@@ -291,11 +263,9 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -309,17 +279,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -338,11 +303,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 ---
@@ -362,11 +325,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -392,11 +353,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller-admission
   namespace: ingress-nginx
 spec:
@@ -416,11 +375,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -527,17 +484,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-create
   namespace: ingress-nginx
 spec:
@@ -546,11 +498,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-create
     spec:
       containers:
@@ -581,17 +531,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-patch
   namespace: ingress-nginx
 spec:
@@ -600,11 +545,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-patch
     spec:
       containers:
@@ -640,11 +583,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
@@ -655,11 +596,9 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 webhooks:
 - admissionReviewVersions:

--- a/deploy/static/provider/exoscale/1.20/deploy.yaml
+++ b/deploy/static/provider/exoscale/1.20/deploy.yaml
@@ -13,28 +13,21 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 ---
@@ -44,11 +37,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 rules:
@@ -125,17 +116,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 rules:
@@ -152,11 +138,9 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 rules:
 - apiGroups:
@@ -218,17 +202,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 rules:
 - apiGroups:
@@ -245,11 +224,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 roleRef:
@@ -264,17 +241,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 roleRef:
@@ -291,11 +263,9 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -309,17 +279,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -338,11 +303,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 ---
@@ -362,11 +325,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -397,11 +358,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller-admission
   namespace: ingress-nginx
 spec:
@@ -422,11 +381,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -533,17 +490,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-create
   namespace: ingress-nginx
 spec:
@@ -552,11 +504,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-create
     spec:
       containers:
@@ -587,17 +537,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-patch
   namespace: ingress-nginx
 spec:
@@ -606,11 +551,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-patch
     spec:
       containers:
@@ -646,11 +589,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
@@ -661,11 +602,9 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 webhooks:
 - admissionReviewVersions:

--- a/deploy/static/provider/exoscale/1.21/deploy.yaml
+++ b/deploy/static/provider/exoscale/1.21/deploy.yaml
@@ -13,28 +13,21 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 ---
@@ -44,11 +37,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 rules:
@@ -125,17 +116,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 rules:
@@ -152,11 +138,9 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 rules:
 - apiGroups:
@@ -218,17 +202,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 rules:
 - apiGroups:
@@ -245,11 +224,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 roleRef:
@@ -264,17 +241,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 roleRef:
@@ -291,11 +263,9 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -309,17 +279,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -338,11 +303,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 ---
@@ -362,11 +325,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -397,11 +358,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller-admission
   namespace: ingress-nginx
 spec:
@@ -422,11 +381,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -533,17 +490,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-create
   namespace: ingress-nginx
 spec:
@@ -552,11 +504,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-create
     spec:
       containers:
@@ -587,17 +537,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-patch
   namespace: ingress-nginx
 spec:
@@ -606,11 +551,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-patch
     spec:
       containers:
@@ -646,11 +589,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
@@ -661,11 +602,9 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 webhooks:
 - admissionReviewVersions:

--- a/deploy/static/provider/exoscale/1.22/deploy.yaml
+++ b/deploy/static/provider/exoscale/1.22/deploy.yaml
@@ -13,28 +13,21 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 ---
@@ -44,11 +37,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 rules:
@@ -125,17 +116,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 rules:
@@ -152,11 +138,9 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 rules:
 - apiGroups:
@@ -218,17 +202,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 rules:
 - apiGroups:
@@ -245,11 +224,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 roleRef:
@@ -264,17 +241,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 roleRef:
@@ -291,11 +263,9 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -309,17 +279,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -338,11 +303,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 ---
@@ -362,11 +325,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -397,11 +358,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller-admission
   namespace: ingress-nginx
 spec:
@@ -422,11 +381,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -533,17 +490,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-create
   namespace: ingress-nginx
 spec:
@@ -552,11 +504,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-create
     spec:
       containers:
@@ -587,17 +537,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-patch
   namespace: ingress-nginx
 spec:
@@ -606,11 +551,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-patch
     spec:
       containers:
@@ -646,11 +589,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
@@ -661,11 +602,9 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 webhooks:
 - admissionReviewVersions:

--- a/deploy/static/provider/exoscale/1.23/deploy.yaml
+++ b/deploy/static/provider/exoscale/1.23/deploy.yaml
@@ -13,28 +13,21 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 ---
@@ -44,11 +37,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 rules:
@@ -125,17 +116,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 rules:
@@ -152,11 +138,9 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 rules:
 - apiGroups:
@@ -218,17 +202,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 rules:
 - apiGroups:
@@ -245,11 +224,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 roleRef:
@@ -264,17 +241,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 roleRef:
@@ -291,11 +263,9 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -309,17 +279,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -338,11 +303,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 ---
@@ -362,11 +325,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -397,11 +358,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller-admission
   namespace: ingress-nginx
 spec:
@@ -422,11 +381,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -533,17 +490,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-create
   namespace: ingress-nginx
 spec:
@@ -552,11 +504,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-create
     spec:
       containers:
@@ -587,17 +537,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-patch
   namespace: ingress-nginx
 spec:
@@ -606,11 +551,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-patch
     spec:
       containers:
@@ -646,11 +589,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
@@ -661,11 +602,9 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 webhooks:
 - admissionReviewVersions:

--- a/deploy/static/provider/exoscale/deploy.yaml
+++ b/deploy/static/provider/exoscale/deploy.yaml
@@ -14,28 +14,21 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 ---
@@ -45,11 +38,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 rules:
@@ -126,17 +117,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 rules:
@@ -153,11 +139,9 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 rules:
 - apiGroups:
@@ -219,17 +203,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 rules:
 - apiGroups:
@@ -246,11 +225,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 roleRef:
@@ -265,17 +242,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 roleRef:
@@ -292,11 +264,9 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -310,17 +280,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -339,11 +304,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 ---
@@ -363,11 +326,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -398,11 +359,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller-admission
   namespace: ingress-nginx
 spec:
@@ -423,11 +382,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -534,17 +491,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-create
   namespace: ingress-nginx
 spec:
@@ -553,11 +505,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-create
     spec:
       containers:
@@ -588,17 +538,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-patch
   namespace: ingress-nginx
 spec:
@@ -607,11 +552,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-patch
     spec:
       containers:
@@ -647,11 +590,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
@@ -662,11 +603,9 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 webhooks:
 - admissionReviewVersions:

--- a/deploy/static/provider/kind/1.19/deploy.yaml
+++ b/deploy/static/provider/kind/1.19/deploy.yaml
@@ -13,28 +13,21 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 ---
@@ -44,11 +37,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 rules:
@@ -125,17 +116,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 rules:
@@ -152,11 +138,9 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 rules:
 - apiGroups:
@@ -218,17 +202,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 rules:
 - apiGroups:
@@ -245,11 +224,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 roleRef:
@@ -264,17 +241,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 roleRef:
@@ -291,11 +263,9 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -309,17 +279,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -338,11 +303,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 ---
@@ -352,11 +315,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -381,11 +342,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller-admission
   namespace: ingress-nginx
 spec:
@@ -405,11 +364,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -528,17 +485,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-create
   namespace: ingress-nginx
 spec:
@@ -547,11 +499,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-create
     spec:
       containers:
@@ -582,17 +532,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-patch
   namespace: ingress-nginx
 spec:
@@ -601,11 +546,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-patch
     spec:
       containers:
@@ -641,11 +584,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
@@ -656,11 +597,9 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 webhooks:
 - admissionReviewVersions:

--- a/deploy/static/provider/kind/1.20/deploy.yaml
+++ b/deploy/static/provider/kind/1.20/deploy.yaml
@@ -13,28 +13,21 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 ---
@@ -44,11 +37,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 rules:
@@ -125,17 +116,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 rules:
@@ -152,11 +138,9 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 rules:
 - apiGroups:
@@ -218,17 +202,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 rules:
 - apiGroups:
@@ -245,11 +224,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 roleRef:
@@ -264,17 +241,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 roleRef:
@@ -291,11 +263,9 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -309,17 +279,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -338,11 +303,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 ---
@@ -352,11 +315,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -386,11 +347,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller-admission
   namespace: ingress-nginx
 spec:
@@ -411,11 +370,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -534,17 +491,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-create
   namespace: ingress-nginx
 spec:
@@ -553,11 +505,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-create
     spec:
       containers:
@@ -588,17 +538,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-patch
   namespace: ingress-nginx
 spec:
@@ -607,11 +552,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-patch
     spec:
       containers:
@@ -647,11 +590,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
@@ -662,11 +603,9 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 webhooks:
 - admissionReviewVersions:

--- a/deploy/static/provider/kind/1.21/deploy.yaml
+++ b/deploy/static/provider/kind/1.21/deploy.yaml
@@ -13,28 +13,21 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 ---
@@ -44,11 +37,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 rules:
@@ -125,17 +116,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 rules:
@@ -152,11 +138,9 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 rules:
 - apiGroups:
@@ -218,17 +202,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 rules:
 - apiGroups:
@@ -245,11 +224,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 roleRef:
@@ -264,17 +241,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 roleRef:
@@ -291,11 +263,9 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -309,17 +279,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -338,11 +303,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 ---
@@ -352,11 +315,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -386,11 +347,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller-admission
   namespace: ingress-nginx
 spec:
@@ -411,11 +370,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -534,17 +491,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-create
   namespace: ingress-nginx
 spec:
@@ -553,11 +505,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-create
     spec:
       containers:
@@ -588,17 +538,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-patch
   namespace: ingress-nginx
 spec:
@@ -607,11 +552,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-patch
     spec:
       containers:
@@ -647,11 +590,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
@@ -662,11 +603,9 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 webhooks:
 - admissionReviewVersions:

--- a/deploy/static/provider/kind/1.22/deploy.yaml
+++ b/deploy/static/provider/kind/1.22/deploy.yaml
@@ -13,28 +13,21 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 ---
@@ -44,11 +37,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 rules:
@@ -125,17 +116,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 rules:
@@ -152,11 +138,9 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 rules:
 - apiGroups:
@@ -218,17 +202,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 rules:
 - apiGroups:
@@ -245,11 +224,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 roleRef:
@@ -264,17 +241,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 roleRef:
@@ -291,11 +263,9 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -309,17 +279,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -338,11 +303,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 ---
@@ -352,11 +315,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -386,11 +347,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller-admission
   namespace: ingress-nginx
 spec:
@@ -411,11 +370,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -534,17 +491,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-create
   namespace: ingress-nginx
 spec:
@@ -553,11 +505,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-create
     spec:
       containers:
@@ -588,17 +538,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-patch
   namespace: ingress-nginx
 spec:
@@ -607,11 +552,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-patch
     spec:
       containers:
@@ -647,11 +590,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
@@ -662,11 +603,9 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 webhooks:
 - admissionReviewVersions:

--- a/deploy/static/provider/kind/1.23/deploy.yaml
+++ b/deploy/static/provider/kind/1.23/deploy.yaml
@@ -13,28 +13,21 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 ---
@@ -44,11 +37,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 rules:
@@ -125,17 +116,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 rules:
@@ -152,11 +138,9 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 rules:
 - apiGroups:
@@ -218,17 +202,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 rules:
 - apiGroups:
@@ -245,11 +224,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 roleRef:
@@ -264,17 +241,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 roleRef:
@@ -291,11 +263,9 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -309,17 +279,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -338,11 +303,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 ---
@@ -352,11 +315,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -386,11 +347,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller-admission
   namespace: ingress-nginx
 spec:
@@ -411,11 +370,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -534,17 +491,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-create
   namespace: ingress-nginx
 spec:
@@ -553,11 +505,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-create
     spec:
       containers:
@@ -588,17 +538,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-patch
   namespace: ingress-nginx
 spec:
@@ -607,11 +552,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-patch
     spec:
       containers:
@@ -647,11 +590,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
@@ -662,11 +603,9 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 webhooks:
 - admissionReviewVersions:

--- a/deploy/static/provider/kind/deploy.yaml
+++ b/deploy/static/provider/kind/deploy.yaml
@@ -14,28 +14,21 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 ---
@@ -45,11 +38,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 rules:
@@ -126,17 +117,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 rules:
@@ -153,11 +139,9 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 rules:
 - apiGroups:
@@ -219,17 +203,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 rules:
 - apiGroups:
@@ -246,11 +225,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 roleRef:
@@ -265,17 +242,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 roleRef:
@@ -292,11 +264,9 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -310,17 +280,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -339,11 +304,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 ---
@@ -353,11 +316,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -387,11 +348,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller-admission
   namespace: ingress-nginx
 spec:
@@ -412,11 +371,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -535,17 +492,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-create
   namespace: ingress-nginx
 spec:
@@ -554,11 +506,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-create
     spec:
       containers:
@@ -589,17 +539,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-patch
   namespace: ingress-nginx
 spec:
@@ -608,11 +553,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-patch
     spec:
       containers:
@@ -648,11 +591,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
@@ -663,11 +604,9 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 webhooks:
 - admissionReviewVersions:

--- a/deploy/static/provider/scw/1.19/deploy.yaml
+++ b/deploy/static/provider/scw/1.19/deploy.yaml
@@ -13,28 +13,21 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 ---
@@ -44,11 +37,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 rules:
@@ -125,17 +116,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 rules:
@@ -152,11 +138,9 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 rules:
 - apiGroups:
@@ -218,17 +202,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 rules:
 - apiGroups:
@@ -245,11 +224,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 roleRef:
@@ -264,17 +241,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 roleRef:
@@ -291,11 +263,9 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -309,17 +279,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -339,11 +304,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 ---
@@ -355,11 +318,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -385,11 +346,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller-admission
   namespace: ingress-nginx
 spec:
@@ -409,11 +368,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -520,17 +477,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-create
   namespace: ingress-nginx
 spec:
@@ -539,11 +491,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-create
     spec:
       containers:
@@ -574,17 +524,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-patch
   namespace: ingress-nginx
 spec:
@@ -593,11 +538,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-patch
     spec:
       containers:
@@ -633,11 +576,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
@@ -648,11 +589,9 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 webhooks:
 - admissionReviewVersions:

--- a/deploy/static/provider/scw/1.20/deploy.yaml
+++ b/deploy/static/provider/scw/1.20/deploy.yaml
@@ -13,28 +13,21 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 ---
@@ -44,11 +37,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 rules:
@@ -125,17 +116,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 rules:
@@ -152,11 +138,9 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 rules:
 - apiGroups:
@@ -218,17 +202,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 rules:
 - apiGroups:
@@ -245,11 +224,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 roleRef:
@@ -264,17 +241,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 roleRef:
@@ -291,11 +263,9 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -309,17 +279,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -339,11 +304,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 ---
@@ -355,11 +318,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -390,11 +351,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller-admission
   namespace: ingress-nginx
 spec:
@@ -415,11 +374,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -526,17 +483,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-create
   namespace: ingress-nginx
 spec:
@@ -545,11 +497,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-create
     spec:
       containers:
@@ -580,17 +530,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-patch
   namespace: ingress-nginx
 spec:
@@ -599,11 +544,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-patch
     spec:
       containers:
@@ -639,11 +582,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
@@ -654,11 +595,9 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 webhooks:
 - admissionReviewVersions:

--- a/deploy/static/provider/scw/1.21/deploy.yaml
+++ b/deploy/static/provider/scw/1.21/deploy.yaml
@@ -13,28 +13,21 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 ---
@@ -44,11 +37,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 rules:
@@ -125,17 +116,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 rules:
@@ -152,11 +138,9 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 rules:
 - apiGroups:
@@ -218,17 +202,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 rules:
 - apiGroups:
@@ -245,11 +224,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 roleRef:
@@ -264,17 +241,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 roleRef:
@@ -291,11 +263,9 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -309,17 +279,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -339,11 +304,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 ---
@@ -355,11 +318,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -390,11 +351,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller-admission
   namespace: ingress-nginx
 spec:
@@ -415,11 +374,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -526,17 +483,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-create
   namespace: ingress-nginx
 spec:
@@ -545,11 +497,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-create
     spec:
       containers:
@@ -580,17 +530,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-patch
   namespace: ingress-nginx
 spec:
@@ -599,11 +544,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-patch
     spec:
       containers:
@@ -639,11 +582,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
@@ -654,11 +595,9 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 webhooks:
 - admissionReviewVersions:

--- a/deploy/static/provider/scw/1.22/deploy.yaml
+++ b/deploy/static/provider/scw/1.22/deploy.yaml
@@ -13,28 +13,21 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 ---
@@ -44,11 +37,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 rules:
@@ -125,17 +116,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 rules:
@@ -152,11 +138,9 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 rules:
 - apiGroups:
@@ -218,17 +202,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 rules:
 - apiGroups:
@@ -245,11 +224,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 roleRef:
@@ -264,17 +241,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 roleRef:
@@ -291,11 +263,9 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -309,17 +279,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -339,11 +304,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 ---
@@ -355,11 +318,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -390,11 +351,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller-admission
   namespace: ingress-nginx
 spec:
@@ -415,11 +374,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -526,17 +483,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-create
   namespace: ingress-nginx
 spec:
@@ -545,11 +497,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-create
     spec:
       containers:
@@ -580,17 +530,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-patch
   namespace: ingress-nginx
 spec:
@@ -599,11 +544,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-patch
     spec:
       containers:
@@ -639,11 +582,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
@@ -654,11 +595,9 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 webhooks:
 - admissionReviewVersions:

--- a/deploy/static/provider/scw/1.23/deploy.yaml
+++ b/deploy/static/provider/scw/1.23/deploy.yaml
@@ -13,28 +13,21 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 ---
@@ -44,11 +37,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 rules:
@@ -125,17 +116,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 rules:
@@ -152,11 +138,9 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 rules:
 - apiGroups:
@@ -218,17 +202,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 rules:
 - apiGroups:
@@ -245,11 +224,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 roleRef:
@@ -264,17 +241,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 roleRef:
@@ -291,11 +263,9 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -309,17 +279,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -339,11 +304,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 ---
@@ -355,11 +318,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -390,11 +351,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller-admission
   namespace: ingress-nginx
 spec:
@@ -415,11 +374,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -526,17 +483,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-create
   namespace: ingress-nginx
 spec:
@@ -545,11 +497,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-create
     spec:
       containers:
@@ -580,17 +530,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-patch
   namespace: ingress-nginx
 spec:
@@ -599,11 +544,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-patch
     spec:
       containers:
@@ -639,11 +582,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
@@ -654,11 +595,9 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 webhooks:
 - admissionReviewVersions:

--- a/deploy/static/provider/scw/deploy.yaml
+++ b/deploy/static/provider/scw/deploy.yaml
@@ -14,28 +14,21 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 ---
@@ -45,11 +38,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 rules:
@@ -126,17 +117,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 rules:
@@ -153,11 +139,9 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 rules:
 - apiGroups:
@@ -219,17 +203,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 rules:
 - apiGroups:
@@ -246,11 +225,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
   namespace: ingress-nginx
 roleRef:
@@ -265,17 +242,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
   namespace: ingress-nginx
 roleRef:
@@ -292,11 +264,9 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -310,17 +280,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -340,11 +305,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 ---
@@ -356,11 +319,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -391,11 +352,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller-admission
   namespace: ingress-nginx
 spec:
@@ -416,11 +375,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -527,17 +484,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-create
   namespace: ingress-nginx
 spec:
@@ -546,11 +498,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-create
     spec:
       containers:
@@ -581,17 +531,12 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission-patch
   namespace: ingress-nginx
 spec:
@@ -600,11 +545,9 @@ spec:
       labels:
         app.kubernetes.io/component: admission-webhook
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/version: 1.1.2
-        helm.sh/chart: ingress-nginx-4.0.18
       name: ingress-nginx-admission-patch
     spec:
       containers:
@@ -640,11 +583,9 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
@@ -655,11 +596,9 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-webhook
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.1.2
-    helm.sh/chart: ingress-nginx-4.0.18
   name: ingress-nginx-admission
 webhooks:
 - admissionReviewVersions:

--- a/hack/generate-deploy-scripts.sh
+++ b/hack/generate-deploy-scripts.sh
@@ -53,11 +53,12 @@ do
       --values values.yaml \
       --namespace ingress-nginx \
       --kube-version ${K8S_VERSION} \
-      > $MANIFEST
+      | grep -v 'app.kubernetes.io/managed-by: Helm' | grep -v 'helm.sh' > $MANIFEST
     kustomize --load-restrictor=LoadRestrictionsNone build . > ${OUTPUT_DIR}/deploy.yaml
     rm $MANIFEST
     cd ~-
     # automatically generate the (unsupported) kustomization.yaml for each target
+    echo "sed "s_{TARGET}_${TARGET}_" $TEMPLATE_DIR/static-kustomization-template.yaml > ${OUTPUT_DIR}/kustomization.yaml"
     sed "s_{TARGET}_${TARGET}_" $TEMPLATE_DIR/static-kustomization-template.yaml > ${OUTPUT_DIR}/kustomization.yaml
 
     # DEFAULT VERSION HANDLING


### PR DESCRIPTION
Removes helm chart specific labels from deployment manifests residing under /deploy
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
We need this PR as it removes helm chart specific labels from deployment manifests residing under /deploy. Also it fixes the issue number #8375

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #8375 
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
