### PR TITLE
Revert "bump Alpine image in Dockerfile"

### DIFF
--- a/images/opentelemetry/rootfs/Dockerfile
+++ b/images/opentelemetry/rootfs/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-FROM alpine:3.15.0 as builder
+FROM alpine:3.14.2 as builder
 
 COPY . /
 


### PR DESCRIPTION
Reverts kubernetes/ingress-nginx#8350

There is a [problem with OpenTelemetry and Alpine 3.15](https://github.com/kubernetes/ingress-nginx/pull/8350#issuecomment-1072539220), so I am reverting this.

Logs when trying to docker build:
`#9 43.85 Using local nlohmann::json from submodule
#9 43.87 -- Using the single-header code from /tmp/build/opentelemetry-cpp-1.0.0/third_party/nlohmann-json/single_include/
#9 43.89 -- Found Protobuf: /usr/lib/libprotobuf.so (found version "3.18.1") 
#9 43.89 -- Found ZLIB: /lib/libz.so (found version "1.2.11") 
#9 43.92 -- Found OpenSSL: /usr/lib/libcrypto.so (found version "1.1.1n")  
#9 43.93 -- Could NOT find c-ares (missing: c-ares_DIR)
#9 43.93 -- Found c-ares: /usr/include (found version "1.18.1") 
#9 43.94 -- Found PkgConfig: /usr/bin/pkg-config (found version "1.8.0") 
#9 43.95 CMake Warning at /usr/lib/cmake/grpc/modules/Findre2.cmake:64 (message):
#9 43.95   Failed to find RE2.
#9 43.95 Call Stack (most recent call first):
#9 43.95   /usr/lib/cmake/grpc/gRPCConfig.cmake:21 (find_package)
#9 43.95   CMakeLists.txt:284 (find_package)
#9 43.95 
#9 43.95 
#9 43.95 PROTOBUF_PROTOC_EXECUTABLE=/usr/bin/protoc
#9 43.95 -- Performing Test check_cxx_compiler_flag_-Wno-type-limits
#9 44.00 -- Performing Test check_cxx_compiler_flag_-Wno-type-limits - Success
#9 44.00 -- Performing Test check_cxx_compiler_flag_-Wno-deprecated-declarations
#9 44.04 -- Performing Test check_cxx_compiler_flag_-Wno-deprecated-declarations - Success
#9 44.04 -- Performing Test check_cxx_compiler_flag_-Wno-unused-parameter
#9 44.09 -- Performing Test check_cxx_compiler_flag_-Wno-unused-parameter - Success
#9 44.10 -- Could NOT find CURL (missing: CURL_LIBRARY CURL_INCLUDE_DIR) 
#9 44.11 Building with nostd types...
#9 44.12 -- Could NOT find CURL (missing: CURL_LIBRARY CURL_INCLUDE_DIR) 
#9 44.14 CMake Warning at /usr/lib/cmake/grpc/modules/Findre2.cmake:64 (message):
#9 44.14   Failed to find RE2.
#9 44.14 Call Stack (most recent call first):
#9 44.14   /usr/lib/cmake/grpc/gRPCConfig.cmake:21 (find_package)
#9 44.14   exporters/otlp/CMakeLists.txt:16 (find_package)
#9 44.14 
#9 44.14 
#9 44.14 -- Configuring done
#9 44.15 CMake Error at exporters/otlp/CMakeLists.txt:17 (add_library):
#9 44.15   Target "opentelemetry_exporter_otlp_grpc" links to target "re2::re2" but
#9 44.15   the target was not found.  Perhaps a find_package() call is missing for an
#9 44.15   IMPORTED target, or an ALIAS target is missing?
#9 44.15 
#9 44.15 
#9 44.17 -- Generating done
#9 44.17 CMake Generate step failed.  Build files cannot be regenerated correctly.`

Docker build works fine with `FROM alpine:3.14.2`