### PR TITLE
changed opentelemetry Dockerfile to alpine:3.14.4

### DIFF
--- a/images/opentelemetry/rootfs/Dockerfile
+++ b/images/opentelemetry/rootfs/Dockerfile
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 
-FROM alpine:3.15.0 as builder
+FROM alpine:3.14.4 as builder
 
 COPY . /
 
 RUN apk update \
-	&& apk upgrade \
-	&& apk add -U bash \
-	&& /build.sh
+  && apk upgrade \
+  && apk add -U bash \
+  && /build.sh
 
 FROM busybox:latest 
 


### PR DESCRIPTION
## What this PR does / why we need it:
- This PR changes the opentelemetry docker file to use alpine:3.14.4 
- Opentelemetry build is failing when using alpine:3.15.X
- New opentelemetry is occurring as part of new base-image build. And its failing https://github.com/kubernetes/ingress-nginx/pull/8356
- This PR will fix https://github.com/kubernetes/ingress-nginx/issues/8381 which in turn will fix https://github.com/kubernetes/ingress-nginx/pull/8356
- We need this asap because a openssl CVE was announced several days ago and there is a fix available but we have not yet released a patched controller because of these problems

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
fixes #8381

## How Has This Been Tested?
Tested in clone of fork

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
