### PR TITLE
remove GIT_TAG from cloud build yaml

### DIFF
--- a/images/nginx/cloudbuild.yaml
+++ b/images/nginx/cloudbuild.yaml
@@ -9,7 +9,7 @@ steps:
     env:
       - DOCKER_CLI_EXPERIMENTAL=enabled
       - BASE_REF=$_PULL_BASE_REF
-      - TAG=$_GIT_TAG
+      - TAG=$_PULL_BASE_SHA
       - REGISTRY=gcr.io/k8s-staging-ingress-nginx
       - HOME=/root
     args:
@@ -20,3 +20,4 @@ steps:
 substitutions:
   _GIT_TAG: "12345"
   _PULL_BASE_REF: "master"
+  _PULL_BASE_SHA: '12345'


### PR DESCRIPTION
Signed-off-by: James Strong <strong.james.e@gmail.com>

Last Nginx build used controller tag, removing that from the cloudbuild yaml

`gcr.io/k8s-staging-ingress-nginx/nginx:v20220325-controller-v1.1.2-26-g529844886@sha256:7ccc42a11f321c975ccfb3d446581665602796d652f49795e1fb91fe445f2de3`