### PR TITLE
Fix OpenTelemetry build

### DIFF
--- a/images/opentelemetry/rootfs/Dockerfile
+++ b/images/opentelemetry/rootfs/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-FROM alpine:3.15.0 as builder
+FROM alpine:3.14.4 as builder
 
 COPY . /
 

--- a/images/opentelemetry/rootfs/build.sh
+++ b/images/opentelemetry/rootfs/build.sh
@@ -20,11 +20,11 @@ set -o pipefail
 
 export NGINX_VERSION=1.19.10
 
-# Check for recent changes: https://github.com/open-telemetry/opentelemetry-cpp/compare/v1.0.0...main
-export OPENTELEMETRY_CPP_VERSION=1.0.0
+# Check for recent changes: https://github.com/open-telemetry/opentelemetry-cpp/compare/v1.2.0...main
+export OPENTELEMETRY_CPP_VERSION=1.2.0
 
-# Check for recent changes: https://github.com/open-telemetry/opentelemetry-cpp-contrib/compare/f4850...main
-export OPENTELEMETRY_CONTRIB_COMMIT=f48500884b1b32efc456790bbcdc2e6cf7a8e630
+# Check for recent changes: https://github.com/open-telemetry/opentelemetry-cpp-contrib/compare/2656a4...main
+export OPENTELEMETRY_CONTRIB_COMMIT=2656a4072e257b6794da86ddd1b773b49f5517b3
 
 export BUILD_PATH=/tmp/build
 
@@ -63,7 +63,7 @@ get_src()
 get_src e8d0290ff561986ad7cd6c33307e12e11b137186c4403a6a5ccdb4914c082d88 \
         "https://nginx.org/download/nginx-$NGINX_VERSION.tar.gz"
 
-get_src 45c52498788e47131b20a4786dbb08f4390b8cb419bd3d61c88b503cafff3324 \
+get_src 360cdcbd1a235ec62119cc53956b2d31b6ff5f41d44415be53acc544709d58b8 \
         "https://github.com/open-telemetry/opentelemetry-cpp-contrib/archive/$OPENTELEMETRY_CONTRIB_COMMIT.tar.gz"
 
 # improve compilation times

--- a/images/opentelemetry/rootfs/init_module.sh
+++ b/images/opentelemetry/rootfs/init_module.sh
@@ -18,4 +18,5 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+mkdir -p /modules_mount/etc/nginx/modules
 cp -R /etc/nginx/modules /modules_mount/etc/nginx/modules


### PR DESCRIPTION
## What this PR does / why we need it:

This downgrades the OpenTelemetry image to alpine 3.14, so we can build it.
It also upgrades opentelemetry-cpp and opentelemetry-cpp-contrib to their latest versions.
Finally, it makes sures the modules directory exists before moving the plugin to the appropriate place.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
* Fixes #8348
* Related to #8381
* Related to #8386

## How Has This Been Tested?

I manually built this image and ran the command.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
