### PR TITLE
Change ingress_upstream_latency_seconds metrics type to Histogram

### DIFF
--- a/deploy/grafana/dashboards/request-handling-performance.json
+++ b/deploy/grafana/dashboards/request-handling-performance.json
@@ -854,13 +854,31 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum (\n  rate(\n      nginx_ingress_controller_ingress_upstream_latency_seconds_sum {\n        ingress =~ \"$ingress\",\n      }[5m]\n)) / sum (\n  rate(\n      nginx_ingress_controller_ingress_upstream_latency_seconds_count {\n        ingress =~ \"$ingress\",\n      }[5m]\n  )\n)\n",
+          "expr": "histogram_quantile(\n  0.5,\n  sum by (le)(\n    rate(\n      nginx_ingress_controller_ingress_upstream_latency_seconds_bucket{\n        ingress =~ \"$ingress\"\n      }[5m]\n    )\n  )\n)",
           "hide": false,
           "instant": false,
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "average",
+          "legendFormat": ".5",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(\n  .95,\n  sum by (le)(\n    rate(\n      nginx_ingress_controller_ingress_upstream_latency_seconds_bucket{\n        ingress =~ \"$ingress\"\n      }[5m]\n    )\n  )\n)",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": ".9",
           "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(\n  .99,\n  sum by (le)(\n    rate(\n      nginx_ingress_controller_ingress_upstream_latency_seconds_bucket{\n        ingress =~ \"$ingress\"\n      }[5m]\n    )\n  )\n)",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": ".99",
+          "refId": "C"
         }
       ],
       "thresholds": [],

--- a/internal/ingress/metric/collectors/socket.go
+++ b/internal/ingress/metric/collectors/socket.go
@@ -75,7 +75,7 @@ type SocketCollector struct {
 	responseLength *prometheus.HistogramVec
 
 	upstreamHeaderTime *prometheus.SummaryVec
-	upstreamLatency    *prometheus.SummaryVec
+	upstreamLatency    *prometheus.HistogramVec
 
 	bytesSent *prometheus.HistogramVec
 
@@ -219,13 +219,13 @@ func NewSocketCollector(pod, namespace, class string, metricsPerHost, reportStat
 			[]string{"ingress", "namespace", "service", "canary"},
 		),
 
-		upstreamLatency: prometheus.NewSummaryVec(
-			prometheus.SummaryOpts{
+		upstreamLatency: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
 				Name:        "ingress_upstream_latency_seconds",
 				Help:        "Upstream service latency per Ingress",
 				Namespace:   PrometheusNamespace,
+				Buckets:     buckets.TimeBuckets,
 				ConstLabels: constLabels,
-				Objectives:  defObjectives,
 			},
 			[]string{"ingress", "namespace", "service", "canary"},
 		),


### PR DESCRIPTION
Change metrics `ingress_upstream_latency_seconds` type from `Summary` to `Histogram`, and both change the example grafana dashboard to use new metrics type.

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It fixes #8285, and may fixes #8228.

We have met this problem in benchmark and production environment.

When use `Summary` metric type with a heavy load , the `Summary` need to recalculate the quantitate, which is expensive and not lock-free. It will block other metric requests, consume large amount of memory, and get OOM killed.


Change `Summary` to lock-free `Histogram` would solve the problem. But introduce breaking change.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
fixes #8285 and #8228


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Create a cluster, and install `nginx-ingress-controller` with only 1 replica.
- Add some backends and Ingress rule.
```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: nginx-dep
spec:
  replicas: 1
  selector:
    matchLabels:
      app: nginx
  template:
    metadata:
      labels:
        app: nginx
    spec:
      containers:
      - name: nginx
        image: nginx
        resources:
          limits:
            memory: "128Mi"
            cpu: "500m"
        ports:
        - containerPort: 80
---
apiVersion: v1
kind: Service
metadata:
  name: nginx-svc
spec:
  type: ClusterIP
  selector:
    app: nginx
  ports:
  - port: 80
    targetPort: 80
---
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: test-ingress-example
  labels:
    name: test-ingress-example
spec:
  rules:
  - host: test.example.com
    http:
      paths:
      - pathType: Prefix
        path: /
        backend:
          service:
            name: nginx-svc
            port:
              number: 80 
```
- Run `wrk` with template below to benchmark it. Replace `<Controller Endpoint IP>` to real endpoint IP.
```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: alpine
spec:
  selector:
    matchLabels:
      app: alpine
  replicas: 3
  template:
    metadata:
      labels:
        app: alpine
    spec:
      containers:
      - name: wrk
        image: alpine:latest
        command: 
          - "sh"
          - "-c"
          - |
            mount -o remount rw /proc/sys
            sysctl -w net.core.somaxconn=65535
            sysctl -w net.ipv4.ip_local_port_range="1024 65535"
            apk update
            apk add bash curl wrk
            echo <Controller Endpoint IP> test.example.com >> /etc/hosts
            wrk --timeout 20s -d 20m -c 1024 -t 1024 http://test.example.com
        securityContext:
          capabilities:
              drop:
              - ALL
              add:
              - SYS_ADMIN
```
- Observe the memory usage of controller pod.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
