### PR TITLE
update nginx base image to new alpine 3.14.4 build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ endif
 
 REGISTRY ?= gcr.io/k8s-staging-ingress-nginx
 
-BASE_IMAGE ?= k8s.gcr.io/ingress-nginx/nginx:v20210926-g5662db450@sha256:1ef404b5e8741fe49605a1f40c3fdd8ef657aecdb9526ea979d1672eeabd0cd9
+BASE_IMAGE ?= k8s.gcr.io/ingress-nginx/nginx:9960efe1e9a9c6e944967b52e1a8a7b7b659874d@sha256:99f079bc9e418b450e0902ea78e86c70315dad3a420871d29e812c55cc0beea1
 
 GOARCH=$(ARCH)
 

--- a/images/echo/Makefile
+++ b/images/echo/Makefile
@@ -36,7 +36,7 @@ build: ensure-buildx
 		--platform=${PLATFORMS} $(OUTPUT) \
 		--progress=$(PROGRESS) \
 		--pull \
-		--build-arg BASE_IMAGE=k8s.gcr.io/ingress-nginx/nginx:v20210926-g5662db450@sha256:1ef404b5e8741fe49605a1f40c3fdd8ef657aecdb9526ea979d1672eeabd0cd9 \
+		--build-arg BASE_IMAGE=k8s.gcr.io/ingress-nginx/nginx:9960efe1e9a9c6e944967b52e1a8a7b7b659874d@sha256:99f079bc9e418b450e0902ea78e86c70315dad3a420871d29e812c55cc0beea1 \
 		--build-arg LUAROCKS_VERSION=3.8.0 \
 		--build-arg LUAROCKS_SHA=ab6612ca9ab87c6984871d2712d05525775e8b50172701a0a1cabddf76de2be7 \
 		-t $(IMAGE):$(TAG) rootfs

--- a/images/nginx/README.md
+++ b/images/nginx/README.md
@@ -20,6 +20,6 @@ This image provides a default configuration file with no backend servers.
 _Using docker_
 
 ```console
-docker run -v /some/nginx.conf:/etc/nginx/nginx.conf:ro k8s.gcr.io/ingress-nginx/nginx:v20210926-g5662db450@sha256:1ef404b5e8741fe49605a1f40c3fdd8ef657aecdb9526ea979d1672eeabd0cd9
+docker run -v /some/nginx.conf:/etc/nginx/nginx.conf:ro k8s.gcr.io/ingress-nginx/nginx:9960efe1e9a9c6e944967b52e1a8a7b7b659874d@sha256:99f079bc9e418b450e0902ea78e86c70315dad3a420871d29e812c55cc0beea1
 ```
 

--- a/images/nginx/rc.yaml
+++ b/images/nginx/rc.yaml
@@ -38,7 +38,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: k8s.gcr.io/ingress-nginx/nginx:v20210926-g5662db450@sha256:1ef404b5e8741fe49605a1f40c3fdd8ef657aecdb9526ea979d1672eeabd0cd9
+          image: k8s.gcr.io/ingress-nginx/nginx:9960efe1e9a9c6e944967b52e1a8a7b7b659874d@sha256:99f079bc9e418b450e0902ea78e86c70315dad3a420871d29e812c55cc0beea1
           ports:
             - containerPort: 80
             - containerPort: 443

--- a/images/test-runner/Makefile
+++ b/images/test-runner/Makefile
@@ -23,7 +23,7 @@ REGISTRY ?= local
 
 IMAGE = $(REGISTRY)/e2e-test-runner
 
-NGINX_BASE_IMAGE ?= k8s.gcr.io/ingress-nginx/nginx:v20210926-g5662db450@sha256:1ef404b5e8741fe49605a1f40c3fdd8ef657aecdb9526ea979d1672eeabd0cd9
+NGINX_BASE_IMAGE ?= k8s.gcr.io/ingress-nginx/nginx:9960efe1e9a9c6e944967b52e1a8a7b7b659874d@sha256:99f079bc9e418b450e0902ea78e86c70315dad3a420871d29e812c55cc0beea1
 
 # required to enable buildx
 export DOCKER_CLI_EXPERIMENTAL=enabled

--- a/test/e2e-image/Dockerfile
+++ b/test/e2e-image/Dockerfile
@@ -1,6 +1,6 @@
 FROM k8s.gcr.io/ingress-nginx/e2e-test-runner:v20220110-gfd820db46@sha256:273f7d9b1b2297cd96b4d51600e45d932186a1cc79d00d179dfb43654112fe8f AS BASE
 
-FROM alpine:3.12
+FROM alpine:3.14.4
 
 RUN apk add -U --no-cache \
     ca-certificates \

--- a/test/e2e/framework/deployment.go
+++ b/test/e2e/framework/deployment.go
@@ -38,7 +38,7 @@ const SlowEchoService = "slow-echo"
 const HTTPBinService = "httpbin"
 
 // NginxBaseImage use for testing
-const NginxBaseImage = "k8s.gcr.io/ingress-nginx/nginx:v20210926-g5662db450@sha256:1ef404b5e8741fe49605a1f40c3fdd8ef657aecdb9526ea979d1672eeabd0cd9"
+const NginxBaseImage = "k8s.gcr.io/ingress-nginx/nginx:9960efe1e9a9c6e944967b52e1a8a7b7b659874d@sha256:99f079bc9e418b450e0902ea78e86c70315dad3a420871d29e812c55cc0beea1"
 
 type deploymentOptions struct {
 	namespace string


### PR DESCRIPTION
Signed-off-by: James Strong <strong.james.e@gmail.com>

Update nginx base image for controller build 

## What this PR does / why we need it:

https://github.com/kubernetes/ingress-nginx/pull/8394
https://github.com/kubernetes/ingress-nginx/pull/8386

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes

https://github.com/kubernetes/ingress-nginx/issues/8339
https://github.com/kubernetes/ingress-nginx/issues/8321

## How Has This Been Tested?

Update nginx base image to `k8s.gcr.io/ingress-nginx/nginx:9960efe1e9a9c6e944967b52e1a8a7b7b659874d@sha256:99f079bc9e418b450e0902ea78e86c70315dad3a420871d29e812c55cc0beea1` 

