### PR TITLE
create new nginx base image

### DIFF
--- a/images/nginx/rootfs/Dockerfile
+++ b/images/nginx/rootfs/Dockerfile
@@ -33,41 +33,42 @@ COPY --from=builder /opt /opt
 COPY --from=builder /etc/nginx /etc/nginx
 COPY --from=builder entrypoint.sh /usr/local/entrypoint.sh
 
-RUN apk update \
+RUN chmod +x /usr/local/entrypoint.sh \
+  && apk update \
   && apk upgrade \
   && apk add -U --no-cache \
-    bash \
-    openssl \
-    pcre \
-    zlib \
-    geoip \
-    curl \
-    ca-certificates \
-    patch \
-    yajl \
-    lmdb \
-    libxml2 \
-    libmaxminddb \
-    yaml-cpp \
-    dumb-init \
-    nano \
-    tzdata \
+  bash \
+  openssl \
+  pcre \
+  zlib \
+  geoip \
+  curl \
+  ca-certificates \
+  patch \
+  yajl \
+  lmdb \
+  libxml2 \
+  libmaxminddb \
+  yaml-cpp \
+  dumb-init \
+  nano \
+  tzdata \
   && ln -s /usr/local/nginx/sbin/nginx /sbin/nginx \
   && adduser -S -D -H -u 101 -h /usr/local/nginx \
-    -s /sbin/nologin -G www-data -g www-data www-data \
+  -s /sbin/nologin -G www-data -g www-data www-data \
   && bash -eu -c ' \
   writeDirs=( \
-    /var/log/nginx \
-    /var/lib/nginx/body \
-    /var/lib/nginx/fastcgi \
-    /var/lib/nginx/proxy \
-    /var/lib/nginx/scgi \
-    /var/lib/nginx/uwsgi \
-    /var/log/audit \
+  /var/log/nginx \
+  /var/lib/nginx/body \
+  /var/lib/nginx/fastcgi \
+  /var/lib/nginx/proxy \
+  /var/lib/nginx/scgi \
+  /var/lib/nginx/uwsgi \
+  /var/log/audit \
   ); \
   for dir in "${writeDirs[@]}"; do \
-    mkdir -p ${dir}; \
-    chown -R www-data.www-data ${dir}; \
+  mkdir -p ${dir}; \
+  chown -R www-data.www-data ${dir}; \
   done'
 
 EXPOSE 80 443


### PR DESCRIPTION
## What this PR does / why we need it:
This PR is expected to create a new nginx base image.
The previous attempt was successful but a entrypoint.sh script was recently added as part of a OpenTelemetry PR and it was checked in without execute permissions. So tests are failing because container does not start and hence pods using the nginx base image, stay in CrashLoopBackoff state, forever.

https://github.com/kubernetes/ingress-nginx/pull/8403 fixes the permission but does not fire a cloud build for new image. Hence this PR is attempt to fire cloud build for new nginx base image.

https://github.com/kubernetes/ingress-nginx/pull/8394
https://github.com/kubernetes/ingress-nginx/pull/8386

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
fixes # fixes many issues currently open but all related to new release after v1.1.2

## How Has This Been Tested?
Not tested as all tests pull from gcr so this will be the litmus test on its own

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
