### PR TITLE
Remove the 'ingress-ready' node selector and blocking master node scheduling from kind manifests

### DIFF
--- a/build/dev-env.sh
+++ b/build/dev-env.sh
@@ -77,7 +77,6 @@ nodes:
     kind: InitConfiguration
     nodeRegistration:
       kubeletExtraArgs:
-        node-labels: "ingress-ready=true"
         authorization-mode: "AlwaysAllow"
   extraPortMappings:
   - containerPort: 80

--- a/deploy/static/provider/kind/1.19/deploy.yaml
+++ b/deploy/static/provider/kind/1.19/deploy.yaml
@@ -512,7 +512,6 @@ spec:
           readOnly: true
       dnsPolicy: ClusterFirst
       nodeSelector:
-        ingress-ready: "true"
         kubernetes.io/os: linux
       serviceAccountName: ingress-nginx
       terminationGracePeriodSeconds: 0

--- a/deploy/static/provider/kind/1.19/deploy.yaml
+++ b/deploy/static/provider/kind/1.19/deploy.yaml
@@ -515,10 +515,6 @@ spec:
         kubernetes.io/os: linux
       serviceAccountName: ingress-nginx
       terminationGracePeriodSeconds: 0
-      tolerations:
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-        operator: Equal
       volumes:
       - name: webhook-cert
         secret:

--- a/deploy/static/provider/kind/1.20/deploy.yaml
+++ b/deploy/static/provider/kind/1.20/deploy.yaml
@@ -518,7 +518,6 @@ spec:
           readOnly: true
       dnsPolicy: ClusterFirst
       nodeSelector:
-        ingress-ready: "true"
         kubernetes.io/os: linux
       serviceAccountName: ingress-nginx
       terminationGracePeriodSeconds: 0

--- a/deploy/static/provider/kind/1.20/deploy.yaml
+++ b/deploy/static/provider/kind/1.20/deploy.yaml
@@ -521,10 +521,6 @@ spec:
         kubernetes.io/os: linux
       serviceAccountName: ingress-nginx
       terminationGracePeriodSeconds: 0
-      tolerations:
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-        operator: Equal
       volumes:
       - name: webhook-cert
         secret:

--- a/deploy/static/provider/kind/1.21/deploy.yaml
+++ b/deploy/static/provider/kind/1.21/deploy.yaml
@@ -518,7 +518,6 @@ spec:
           readOnly: true
       dnsPolicy: ClusterFirst
       nodeSelector:
-        ingress-ready: "true"
         kubernetes.io/os: linux
       serviceAccountName: ingress-nginx
       terminationGracePeriodSeconds: 0

--- a/deploy/static/provider/kind/1.21/deploy.yaml
+++ b/deploy/static/provider/kind/1.21/deploy.yaml
@@ -521,10 +521,6 @@ spec:
         kubernetes.io/os: linux
       serviceAccountName: ingress-nginx
       terminationGracePeriodSeconds: 0
-      tolerations:
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-        operator: Equal
       volumes:
       - name: webhook-cert
         secret:

--- a/deploy/static/provider/kind/1.22/deploy.yaml
+++ b/deploy/static/provider/kind/1.22/deploy.yaml
@@ -518,7 +518,6 @@ spec:
           readOnly: true
       dnsPolicy: ClusterFirst
       nodeSelector:
-        ingress-ready: "true"
         kubernetes.io/os: linux
       serviceAccountName: ingress-nginx
       terminationGracePeriodSeconds: 0

--- a/deploy/static/provider/kind/1.22/deploy.yaml
+++ b/deploy/static/provider/kind/1.22/deploy.yaml
@@ -521,10 +521,6 @@ spec:
         kubernetes.io/os: linux
       serviceAccountName: ingress-nginx
       terminationGracePeriodSeconds: 0
-      tolerations:
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-        operator: Equal
       volumes:
       - name: webhook-cert
         secret:

--- a/deploy/static/provider/kind/1.23/deploy.yaml
+++ b/deploy/static/provider/kind/1.23/deploy.yaml
@@ -518,7 +518,6 @@ spec:
           readOnly: true
       dnsPolicy: ClusterFirst
       nodeSelector:
-        ingress-ready: "true"
         kubernetes.io/os: linux
       serviceAccountName: ingress-nginx
       terminationGracePeriodSeconds: 0

--- a/deploy/static/provider/kind/1.23/deploy.yaml
+++ b/deploy/static/provider/kind/1.23/deploy.yaml
@@ -521,10 +521,6 @@ spec:
         kubernetes.io/os: linux
       serviceAccountName: ingress-nginx
       terminationGracePeriodSeconds: 0
-      tolerations:
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-        operator: Equal
       volumes:
       - name: webhook-cert
         secret:

--- a/deploy/static/provider/kind/deploy.yaml
+++ b/deploy/static/provider/kind/deploy.yaml
@@ -519,7 +519,6 @@ spec:
           readOnly: true
       dnsPolicy: ClusterFirst
       nodeSelector:
-        ingress-ready: "true"
         kubernetes.io/os: linux
       serviceAccountName: ingress-nginx
       terminationGracePeriodSeconds: 0

--- a/deploy/static/provider/kind/deploy.yaml
+++ b/deploy/static/provider/kind/deploy.yaml
@@ -522,10 +522,6 @@ spec:
         kubernetes.io/os: linux
       serviceAccountName: ingress-nginx
       terminationGracePeriodSeconds: 0
-      tolerations:
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-        operator: Equal
       volumes:
       - name: webhook-cert
         secret:

--- a/hack/manifest-templates/provider/kind/values.yaml
+++ b/hack/manifest-templates/provider/kind/values.yaml
@@ -10,9 +10,6 @@ controller:
   service:
     type: NodePort
   watchIngressWithoutClass: true
-
-  nodeSelector:
-    ingress-ready: "true"
   tolerations:
     - key: "node-role.kubernetes.io/master"
       operator: "Equal"

--- a/hack/manifest-templates/provider/kind/values.yaml
+++ b/hack/manifest-templates/provider/kind/values.yaml
@@ -10,11 +10,6 @@ controller:
   service:
     type: NodePort
   watchIngressWithoutClass: true
-  tolerations:
-    - key: "node-role.kubernetes.io/master"
-      operator: "Equal"
-      effect: "NoSchedule"
-
   publishService:
     enabled: false
   extraArgs:


### PR DESCRIPTION
The node selector doesn't exist on any other deployment manifest type.
It becomes confusing when someone tries to deploy the nginx-ingress on
a kind cluster and then it won't work out of the box.
This change makes it much easier to use ingress-nginx with kind.

If someone still wants to use a node taint, they're free to apply the
nodeSelector to the deployments with kustomize.

<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
It makes it easier to use ingress-nginx with kind clusters. If someone still wants to use
nodeselectors they're free to do so with kustomize, but a regular kind user
should not be expected to label their nodes unless that's their use-case.

Also this change increases consistency across deployment targets, because this node-selector only exists for kind clusters, without good reason.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have deployed the manifests to kind.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
