### PR TITLE
replace deprecated topology key in example with current one

### DIFF
--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -272,7 +272,7 @@ controller:
   ##
   topologySpreadConstraints: []
     # - maxSkew: 1
-    #   topologyKey: failure-domain.beta.kubernetes.io/zone
+    #   topologyKey: topology.kubernetes.io/zone
     #   whenUnsatisfiable: DoNotSchedule
     #   labelSelector:
     #     matchLabels:


### PR DESCRIPTION
Signed-off-by: Francisco Robles Martín <f.robles.martin@pm.me>

## What this PR does / why we need it:
Replace the value in an example to not suggest using a deprecated key.  (https://kubernetes.io/docs/reference/labels-annotations-taints/#failure-domainbetakubernetesiozone)

Also the deprecation notice in k8s 1.17 changelog: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.17.md and the PR promoting the new labels: https://github.com/kubernetes/kubernetes/pull/81431

## Types of changes
- [X] Documentation only

## How Has This Been Tested?
No need for tests

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
