### PR TITLE
Fallback to ngx.var.scheme for redirectScheme with use-forward-headers when X-Forwarded-Proto is empty

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -591,7 +591,12 @@ http {
             end
 
             {{ if $cfg.UseForwardedHeaders }}
-            local redirectScheme = ngx.var.http_x_forwarded_proto
+            local redirectScheme
+            if not ngx.var.http_x_forwarded_proto then
+                redirectScheme = ngx.var.scheme
+            else
+                redirectScheme = ngx.var.http_x_forwarded_proto
+            end
             {{ else }}
             local redirectScheme = ngx.var.scheme
             {{ end }}


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Annotation **nginx.ingress.kubernetes.io/from-to-www-redirect** is broken from v1.1.2  with **use-forwarded-headers: true**, when X-Forwarded-Proto is empty (the response from the Nginx Ingress Controller is invalid: **Location: nil://www.demo.domain.tld**).

This PR uses original way as fallback (d v1.1.2), when X-Forwarded-Proto is empty.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

-->
fixes #8462 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Testing is described in #8462. 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
