### PR TITLE
removed deprecated http2maxfield http2maxheader http2maxrequests fields in log

### DIFF
--- a/docs/user-guide/nginx-configuration/configmap.md
+++ b/docs/user-guide/nginx-configuration/configmap.md
@@ -53,9 +53,6 @@ The following table shows a configuration option's name, type, and the default v
 |[ignore-invalid-headers](#ignore-invalid-headers)|bool|true|
 |[retry-non-idempotent](#retry-non-idempotent)|bool|"false"|
 |[error-log-level](#error-log-level)|string|"notice"|
-|[http2-max-field-size](#http2-max-field-size)|string|"4k"|
-|[http2-max-header-size](#http2-max-header-size)|string|"16k"|
-|[http2-max-requests](#http2-max-requests)|int|1000|
 |[http2-max-concurrent-streams](#http2-max-concurrent-streams)|int|128|
 |[hsts](#hsts)|bool|"true"|
 |[hsts-include-subdomains](#hsts-include-subdomains)|bool|"true"|

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -213,20 +213,6 @@ type Configuration struct {
 	// Log levels above are listed in the order of increasing severity
 	ErrorLogLevel string `json:"error-log-level,omitempty"`
 
-	// https://nginx.org/en/docs/http/ngx_http_v2_module.html#http2_max_field_size
-	// HTTP2MaxFieldSize Limits the maximum size of an HPACK-compressed request header field
-	HTTP2MaxFieldSize string `json:"http2-max-field-size,omitempty"`
-
-	// https://nginx.org/en/docs/http/ngx_http_v2_module.html#http2_max_header_size
-	// HTTP2MaxHeaderSize Limits the maximum size of the entire request header list after HPACK decompression
-	HTTP2MaxHeaderSize string `json:"http2-max-header-size,omitempty"`
-
-	// http://nginx.org/en/docs/http/ngx_http_v2_module.html#http2_max_requests
-	// HTTP2MaxRequests Sets the maximum number of requests (including push requests) that can be served
-	// through one HTTP/2 connection, after which the next client request will lead to connection closing
-	// and the need of establishing a new connection.
-	HTTP2MaxRequests int `json:"http2-max-requests,omitempty"`
-
 	// http://nginx.org/en/docs/http/ngx_http_v2_module.html#http2_max_concurrent_streams
 	// Sets the maximum number of concurrent HTTP/2 streams in a connection.
 	HTTP2MaxConcurrentStreams int `json:"http2-max-concurrent-streams,omitempty"`
@@ -812,9 +798,6 @@ func NewDefault() Configuration {
 		ComputeFullForwardedFor:          false,
 		ProxyAddOriginalURIHeader:        false,
 		GenerateRequestID:                true,
-		HTTP2MaxFieldSize:                "4k",
-		HTTP2MaxHeaderSize:               "16k",
-		HTTP2MaxRequests:                 1000,
 		HTTP2MaxConcurrentStreams:        128,
 		HTTPRedirectCode:                 308,
 		HSTS:                             true,

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -296,9 +296,6 @@ http {
     client_body_buffer_size         {{ $cfg.ClientBodyBufferSize }};
     client_body_timeout             {{ $cfg.ClientBodyTimeout }}s;
 
-    http2_max_field_size            {{ $cfg.HTTP2MaxFieldSize }};
-    http2_max_header_size           {{ $cfg.HTTP2MaxHeaderSize }};
-    http2_max_requests              {{ $cfg.HTTP2MaxRequests }};
     http2_max_concurrent_streams    {{ $cfg.HTTP2MaxConcurrentStreams }};
 
     types_hash_max_size             2048;


### PR DESCRIPTION
## What this PR does / why we need it:
Duplicate of https://github.com/kubernetes/ingress-nginx/pull/8073 but don't know if contributor of 8073 is still active. So either close this one and  merge 8073 (if rebased).

Or close 8073 and merge this one.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
fixes #7261

## How Has This Been Tested?
Locally on clone of fork. Warning was not printed to logs

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.