### PR TITLE
Remove dind in ci tests

### DIFF
--- a/build/run-in-docker.sh
+++ b/build/run-in-docker.sh
@@ -62,10 +62,7 @@ else
   PLATFORM_FLAG=
 fi
 
-if [[ "$DOCKER_IN_DOCKER_ENABLED" == "true" ]]; then
-  /bin/bash -c "${FLAGS}"
-else
-  docker run                                            \
+docker run                                            \
     ${PLATFORM_FLAG} ${PLATFORM}                        \
     --tty                                               \
     --rm                                                \
@@ -81,4 +78,3 @@ else
     -w "/go/src/${PKG}"                                 \
     -u $(id -u ${USER}):$(id -g ${USER})                \
     ${E2E_IMAGE} /bin/bash -c "${FLAGS}"
-fi


### PR DESCRIPTION
## What this PR does / why we need it:
Something changed in CI tests and apparently presenting the DIND variable and wrapping bash first is not desired.

This is an attempt to fix it

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only
