### PR TITLE
Add warning feature in admission code

### DIFF
--- a/internal/admission/controller/main_test.go
+++ b/internal/admission/controller/main_test.go
@@ -38,6 +38,11 @@ func (ftc failTestChecker) CheckIngress(ing *networking.Ingress) error {
 	return nil
 }
 
+func (ftc failTestChecker) CheckWarning(ing *networking.Ingress) ([]string, error) {
+	ftc.t.Error("checker should not be called")
+	return nil, nil
+}
+
 type testChecker struct {
 	t   *testing.T
 	err error
@@ -48,6 +53,13 @@ func (tc testChecker) CheckIngress(ing *networking.Ingress) error {
 		tc.t.Errorf("CheckIngress should be called with %v ingress, but got %v", testIngressName, ing.ObjectMeta.Name)
 	}
 	return tc.err
+}
+
+func (tc testChecker) CheckWarning(ing *networking.Ingress) ([]string, error) {
+	if ing.ObjectMeta.Name != testIngressName {
+		tc.t.Errorf("CheckWarning should be called with %v ingress, but got %v", testIngressName, ing.ObjectMeta.Name)
+	}
+	return nil, tc.err
 }
 
 func TestHandleAdmission(t *testing.T) {

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -232,8 +232,8 @@ func (n *NGINXController) syncIngress(interface{}) error {
 	return nil
 }
 
-// GetWarnings returns a list of warnings a Ingress gets when being created.
-// The warnings are going to be used in admission webhook, and they represent
+// GetWarnings returns a list of warnings an Ingress gets when being created.
+// The warnings are going to be used in an admission webhook, and they represent
 // a list of messages that users need to be aware (like deprecation notices)
 // when creating a new ingress object
 func (n *NGINXController) CheckWarning(ing *networking.Ingress) ([]string, error) {

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -232,6 +232,16 @@ func (n *NGINXController) syncIngress(interface{}) error {
 	return nil
 }
 
+// GetWarnings returns a list of warnings a Ingress gets when being created.
+// The warnings are going to be used in admission webhook, and they represent
+// a list of messages that users need to be aware (like deprecation notices)
+// when creating a new ingress object
+func (n *NGINXController) CheckWarning(ing *networking.Ingress) ([]string, error) {
+	warnings := make([]string, 0)
+
+	return warnings, nil
+}
+
 // CheckIngress returns an error in case the provided ingress, when added
 // to the current configuration, generates an invalid configuration
 func (n *NGINXController) CheckIngress(ing *networking.Ingress) error {


### PR DESCRIPTION

## What this PR does / why we need it:
While discussing about some features to be deprecated, it came as an idea we could use controller-runtime warning feature to tell users something is going to be deprecated in a future.

This is not going to be useful on that specific case (deprecated configmap things) but still it's good to have this available

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

TODO: Maybe add some e2e tests is going to be good