### PR TITLE
Update home page's FAQ to reflect an incompatibility with current cert-manager versions

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -226,6 +226,7 @@ If you start Ingress-Nginx B with the command line argument `--watch-ingress-wit
   --set controller.ingressClassResource.name=nginx-two \
   --set controller.ingressClassResource.controllerValue="example.com/ingress-nginx-2" \
   --set controller.ingressClassResource.enabled=true \
+  --set controller.ingressClass=nginx-two \
   --set controller.ingressClassByName=true
   ```
 - If you need to install yet another instance, then repeat the procedure to create a new namespace, change the values such as names & namespaces (for example from "-2" to "-3"), or anything else that meets your needs.


### PR DESCRIPTION
## What this PR does / why we need it:
Cert-Manager 1.7.1+ requires the `--ingress-class` parameter to be set to the new class name in a multi-controller scenario too, the `controller.ingressClassResource.name` value is not enough on its own.

See https://cert-manager.io/docs/installation/upgrading/ingress-class-compatibility/#notes-for-specific-ingress-controllers

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation only

## How Has This Been Tested?

Installed ingress-nginx and cert-manager on a bare metal k8s environment using their respective Helm charts. Observed that the http01 solver will not set the "new" `ingressClassName` field and exclusively use the old style annotation. Set both `ingressClass` and `ingressClassResource.name` in the Helm chart, only then observed cert-manager's Ingress to actually work.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
