### PR TITLE
Fix example Helm chart values to enable custom http errors

### DIFF
--- a/docs/examples/customization/custom-errors/custom-default-backend.helm.values.yaml
+++ b/docs/examples/customization/custom-errors/custom-default-backend.helm.values.yaml
@@ -1,5 +1,6 @@
 controller:
-  custom-http-errors: "404,503"
+  config:
+    custom-http-errors: "404,503"
 defaultBackend:
   enabled: true
   image:


### PR DESCRIPTION
## What this PR does / why we need it:
It seems custom-http-errors must be part of the controllers config, so adding the config key here.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
Deployed it to our Kubernetes and with this change it works.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
