### PR TITLE
Check real client IP for access when behind a proxy

### DIFF
--- a/pkg/apis/ingress/types.go
+++ b/pkg/apis/ingress/types.go
@@ -298,10 +298,16 @@ type Location struct {
 	// addresses or networks are allowed.
 	// +optional
 	Denylist ipdenylist.SourceRange `json:"denylist,omitempty"`
+	// Denylist ID is a unique variable index
+	// +optional
+	DenylistID string
 	// Whitelist indicates only connections from certain client
 	// addresses or networks are allowed.
 	// +optional
 	Whitelist ipwhitelist.SourceRange `json:"whitelist,omitempty"`
+	// Whitelist ID is a unique variable index
+	// +optional
+	WhitelistID string
 	// Proxy contains information about timeouts and buffer sizes
 	// to be used in connections against endpoints
 	// +optional

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -540,6 +540,34 @@ http {
     }
     {{ end }}
 
+    {{ range $variable := (buildDenylists $servers) }}
+    geo $denied_{{ $variable.ID }} {
+        default "false";
+
+        {{- range $trustedIP := $cfg.ProxyRealIPCIDR }}
+        proxy {{ $trustedIP }};
+        {{- end }}
+
+        {{- range $denylistIP := $variable.AccessList }}
+        {{ $denylistIP }} "true";
+        {{- end }}
+    }
+    {{ end }}
+
+    {{ range $variable := (buildWhitelists $servers) }}
+    geo $allowed_{{ $variable.ID }} {
+        default "false";
+
+        {{- range $trustedIP := $cfg.ProxyRealIPCIDR }}
+        proxy {{ $trustedIP }};
+        {{- end }}
+
+        {{- range $whitelistIP := $variable.AccessList }}
+        {{ $whitelistIP }} "true";
+        {{- end }}
+    }
+    {{ end }}
+
     {{/* build all the required rate limit zones. Each annotation requires a dedicated zone */}}
     {{/* 1MB -> 16 thousand 64-byte states or about 8 thousand 128-byte states */}}
     {{ range $zone := (buildRateLimitZones $servers) }}
@@ -1287,14 +1315,15 @@ stream {
             {{ buildModSecurityForLocation $all.Cfg $location }}
 
             {{ if isLocationAllowed $location }}
-            {{ if gt (len $location.Denylist.CIDR) 0 }}
-            {{ range $ip := $location.Denylist.CIDR }}
-            deny {{ $ip }};{{ end }}
+            {{ if gt (len $location.DenylistID) 0 }}
+            if ($denied_{{ $location.DenylistID }} = "true") {
+                return 403;
+            }
             {{ end }}
-            {{ if gt (len $location.Whitelist.CIDR) 0 }}
-            {{ range $ip := $location.Whitelist.CIDR }}
-            allow {{ $ip }};{{ end }}
-            deny all;
+            {{ if gt (len $location.WhitelistID) 0 }}
+            if ($allowed_{{ $location.WhitelistID }} = "false") {
+                return 403;
+            }
             {{ end }}
 
             {{ if $location.CorsConfig.CorsEnabled }}

--- a/test/e2e/settings/configmap_change.go
+++ b/test/e2e/settings/configmap_change.go
@@ -54,7 +54,7 @@ var _ = framework.DescribeSetting("Configmap change", func() {
 					checksum = match[1]
 				}
 
-				return strings.Contains(cfg, "allow 1.1.1.1;")
+				return strings.Contains(cfg, `1.1.1.1 "true";`)
 			})
 		assert.NotEmpty(ginkgo.GinkgoT(), checksum)
 


### PR DESCRIPTION
The module ngx_http_access_module allows limiting access to certain
*connecting* client addresses. When using it behind a proxy it would
then use the proxy IP instead of the real client IP, which is ultimately
the desired outcome.

By using the module ngx_http_geo_module we can explicitly specify what
are the proxy IPs thus allowing us to check the real client IP directly.

This implementation also creates unique geo variables to be used by
locations having the same set of whitelisted IPs. This can result in a
much smaller configuration file.

The nginx documentation also recommends the usage of geo variables when
having a lot of rules:
> In case of a lot of rules, the use of the ngx_http_geo_module module variables is preferable.

See:
- http://nginx.org/en/docs/http/ngx_http_access_module.html
- http://nginx.org/en/docs/http/ngx_http_geo_module.html

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## How Has This Been Tested?

Apart from the added test cases, we (Instapro Group) have been successfully running a custom image with those changes in our Kubernetes clusters for a couple of weeks.

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
