### PR TITLE
added recommended flag to opentelemetry build

### DIFF
--- a/images/opentelemetry/rootfs/build.sh
+++ b/images/opentelemetry/rootfs/build.sh
@@ -92,6 +92,7 @@ cmake -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
       -DWITH_OTLP=ON \
       -DWITH_OTLP_HTTP=OFF \
+      -DBUILD_SHARED_LIBS=ON
       ..
 make
 make install


### PR DESCRIPTION
## What this PR does / why we need it:
- Opentelemetry module we build does not load.
- Upstream opentelemetry maintainers suggested we add the flag -DBUILD_SHARED_LIBS=on while compiling.
 https://github.com/open-telemetry/opentelemetry-cpp-contrib/issues/141
- This PR adds that flag
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
#8437 

## How Has This Been Tested?
By upstream and will test locally but the real test is in the CI only

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.