### PR TITLE
added debug to run-in-docker.sh

### DIFF
--- a/build/run-in-docker.sh
+++ b/build/run-in-docker.sh
@@ -62,9 +62,17 @@ else
   PLATFORM_FLAG=
 fi
 
+env && hostname && uname -a
+echo "DIND_ENABLED=$DOCKER_IN_DOCKER_ENABLED"
+echo "FLAGS=$FLAGS"
+echo "PLATFORM=$PLATFORM"
+echo "PLATFORM_FLAG=$PLATFORM_FLAG"
+
 if [[ "$DOCKER_IN_DOCKER_ENABLED" == "true" ]]; then
+  echo "..reached DIND check TRUE block, inside run-in-docker.sh. Checking environ"
   /bin/bash -c "${FLAGS}"
 else
+  echo "..reached DIND check ELSE block, inside run-in-docker.sh. Checking environ"
   docker run                                            \
     ${PLATFORM_FLAG} ${PLATFORM}                        \
     --tty                                               \


### PR DESCRIPTION
## What this PR does / why we need it:
- This PR adds a bash echo statement and a bash env command to the script /build/run-in-docker.sh
- The script /build/run-in-docker.sh works in CI but fails in test grid #8552 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
Related to #8552

## How Has This Been Tested?
- Local test are not related.
- CI tests are not related
- Only can be tested in testgrid's prow job

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

/assign @rikatz 