### PR TITLE
added step to install ginkgo if DIND environ

### DIFF
--- a/build/run-in-docker.sh
+++ b/build/run-in-docker.sh
@@ -70,6 +70,7 @@ echo "PLATFORM_FLAG=$PLATFORM_FLAG"
 
 if [[ "$DOCKER_IN_DOCKER_ENABLED" == "true" ]]; then
   echo "..reached DIND check TRUE block, inside run-in-docker.sh. Checking environ"
+  go get github.com/onsi/ginkgo/ginkgo@v1.16.4
   /bin/bash -c "${FLAGS}"
 else
   echo "..reached DIND check ELSE block, inside run-in-docker.sh. Checking environ"


### PR DESCRIPTION
## What this PR does / why we need it:
- Added a command to install ginkgo in /build/run-in-docker.sh, if DIND_ENABLED="true"
- The command `bash -c ginkgo ./test/e2e`, very likely executes in GHActions-CI, with ginkgo installed. But same command in testgrid (#8552) fails, with error as `ginkgo not found`. Laptop/local runs don't enable DIND so can not be reproduced in local (unless you hardcode DIND to "true")
- Some bash echo statements were added in most recent PRs, to confirm that its indeed the `DOCKER_IN_DOCKERD_ENABLED="true"` if condition, in line 71 of the script `/build/run-in-docker.sh`, which caused the invocation of the command `bash -c ./test/e2e` 
- The same if condition flows to the `ELSE` part of the if condition on laptop/local where the command executed is `docker run ....` and not `ginkgo build`
- This PR is most likely only a workaround, which will only fix the current  `ginkgo not found` error in testgrid. Its not certain that the testgrid job will complete successfully in subsequent steps because the e2e binary will get built and exist only in that current environment. If Prow job sequence changes environment then the e2e binary will be missing. Its not easy to run testgrid prow job locally. So will fix issues if any when they come up. But the testgrid job run after this PR merges will provide lots of important feedback.
- Long term solution is to find out where this originated and fix the root cause

Copy pasting part of the logs from testgrid job run. Note the bash echo statements that show the environment and the flow entering the if condition where DIND is checked.
```
[dev-env] .. done building controller images
[643](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A643)
[dev-env] now building e2e-image..
[644](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A644)
..entered Makefile in /test/e2e-image
[645](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A645)
..calling Make target <<e2e-test-binar>>y in /Makefile from inside /test/e2e-image/Makefile
[646](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A646)
SHELL=/bin/bash -o pipefail -o errexit
[647](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A647)
KUBERNETES_SERVICE_PORT_HTTPS=443
[648](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A648)
DOCKER_IN_DOCKER_NFT_ENABLED=false
[649](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A649)
KUBERNETES_SERVICE_PORT=443
[650](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A650)
JOB_TYPE=periodic
[651](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A651)
KRTE_IMAGE=gcr.io/k8s-staging-test-infra/krte:v20220427-c2db0f69b7-master
[652](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A652)
CONTAINER=docker
[653](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A653)
BOSKOS_METRICS_SERVICE_PORT=9090
[654](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A654)
HOSTNAME=fc4ba769-cfaa-11ec-81f8-b27f6066c97f
[655](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A655)
BOSKOS_PORT_80_TCP_ADDR=10.63.250.132
[656](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A656)
ENTRYPOINT_OPTIONS={"timeout":3600000000000,"grace_period":900000000000,"artifact_dir":"/logs/artifacts","args":["wrapper.sh","bash","-c","curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C \"${PATH%%:*}/\" \u0026\u0026 make kind-e2e-test"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}
[657](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A657)
COMMA=,
[658](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A658)
CLOUDSDK_CORE_DISABLE_PROMPTS=1
[659](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A659)
PLATFORMS=amd64 arm arm64 s390x
[660](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A660)
BOSKOS_METRICS_SERVICE_HOST=10.63.252.110
[661](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A661)
MAKEFILE_LIST= Makefile
[662](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A662)
TAG=1.0.0-dev
[663](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A663)
REGISTRY=ingress-controller
[664](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A664)
GNUMAKEFLAGS=
[665](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A665)
SPACE= 
[666](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A666)
DOCKER_IN_DOCKER_IPV6_ENABLED=false
[667](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A667)
PWD=/home/prow/go/src/k8s.io/ingress-nginx
[668](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A668)
BOSKOS_SERVICE_PORT=80
[669](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A669)
SOURCE_DATE_EPOCH=1652091319
[670](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A670)
BOSKOS_SERVICE_HOST=10.63.250.132
[671](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A671)
KIND_CLUSTER_NAME=ingress-nginx-dev
[672](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A672)
BUILD_NUMBER=1523683302307794944
[673](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A673)
GOARCH=amd64
[674](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A674)
CURDIR=/home/prow/go/src/k8s.io/ingress-nginx
[675](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A675)
DOCKER_IN_DOCKER_ENABLED=true
[676](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A676)
HOME=/root
[677](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A677)
ARTIFACTS=/logs/artifacts
[678](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A678)
KUBERNETES_PORT_443_TCP=tcp://10.63.240.1:443
[679](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A679)
BOSKOS_METRICS_PORT_9090_TCP_PORT=9090
[680](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A680)
PROW_JOB_ID=fc4ba769-cfaa-11ec-81f8-b27f6066c97f
[681](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A681)
JOB_NAME=ci-ingress-nginx-e2e-main
[682](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A682)
BOSKOS_SERVICE_PORT_DEFAULT=80
[683](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A683)
BOSKOS_PORT_80_TCP_PORT=80
[684](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A684)
COMMIT_SHA=git-b9410c86f
[685](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A685)
DOCKER_CLI_EXPERIMENTAL=enabled
[686](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A686)
REPO_INFO=https://github.com/kubernetes/ingress-nginx
[687](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A687)
MFLAGS=-s
[688](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A688)
BOSKOS_METRICS_PORT_9090_TCP_PROTO=tcp
[689](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A689)
BOSKOS_METRICS_SERVICE_PORT_METRICS=9090
[690](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A690)
BOSKOS_PORT=tcp://10.63.250.132:80
[691](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A691)
BOSKOS_PORT_80_TCP=tcp://10.63.250.132:80
[692](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A692)
MAKEFLAGS=s
[693](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A693)
HOST_ARCH=amd64
[694](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A694)
BOSKOS_PORT_80_TCP_PROTO=tcp
[695](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A695)
E2E_CHECK_LEAKS=
[696](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A696)
E2E_NODES=7
[697](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A697)
ARCH=amd64
[698](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A698)
BOSKOS_METRICS_PORT_9090_TCP_ADDR=10.63.252.110
[699](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A699)
EMPTY=
[700](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A700)
GOPROXY=https://proxy.golang.org/
[701](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A701)
SHLVL=2
[702](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A702)
MAKELEVEL=3
[703](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A703)
KUBERNETES_PORT_443_TCP_PROTO=tcp
[704](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A704)
KUBERNETES_PORT_443_TCP_ADDR=10.63.240.1
[705](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A705)
JOB_SPEC={"type":"periodic","job":"ci-ingress-nginx-e2e-main","buildid":"1523683302307794944","prowjobid":"fc4ba769-cfaa-11ec-81f8-b27f6066c97f","extra_refs":[{"org":"kubernetes","repo":"ingress-nginx","base_ref":"main","path_alias":"k8s.io/ingress-nginx"}],"decoration_config":{"timeout":"1h0m0s","grace_period":"15m0s","utility_images":{"clonerefs":"gcr.io/k8s-prow/clonerefs:v20220506-6d355b2d97","initupload":"gcr.io/k8s-prow/initupload:v20220506-6d355b2d97","entrypoint":"gcr.io/k8s-prow/entrypoint:v20220506-6d355b2d97","sidecar":"gcr.io/k8s-prow/sidecar:v20220506-6d355b2d97"},"resources":{"clonerefs":{"requests":{"cpu":"100m"}},"initupload":{"requests":{"cpu":"100m"}},"place_entrypoint":{"requests":{"cpu":"100m"}},"sidecar":{"requests":{"cpu":"100m"}}},"gcs_configuration":{"bucket":"kubernetes-jenkins","path_strategy":"legacy","default_org":"kubernetes","default_repo":"kubernetes"},"gcs_credentials_secret":"service-account"}}
[706](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A706)
KUBECONFIG=/root/.kube/kind-config-ingress-nginx-dev
[707](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A707)
K8S_VERSION=v1.21.10@sha256:84709f09756ba4f863769bdcabe5edafc2ada72d3c8c44d6515fc581b66b029c
[708](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A708)
BAZEL_VERSION=
[709](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A709)
BOSKOS_METRICS_PORT=tcp://10.63.252.110:9090
[710](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A710)
BOSKOS_METRICS_PORT_9090_TCP=tcp://10.63.252.110:9090
[711](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A711)
KUBERNETES_SERVICE_HOST=10.63.240.1
[712](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A712)
KUBERNETES_PORT=tcp://10.63.240.1:443
[713](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A713)
KUBERNETES_PORT_443_TCP_PORT=443
[714](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A714)
PATH=/home/prow/go/bin:/home/prow/go/bin:/usr/local/go/bin:/google-cloud-sdk/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
[715](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A715)
CI=true
[716](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A716)
BUILD_ID=1523683302307794944
[717](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A717)
BASE_IMAGE=k8s.gcr.io/ingress-nginx/nginx:81c2afd975a6f9a9847184472286044d7d5296f6@sha256:a71ac64dd8cfd68341ba47dbdc4d8c2cb91325fce669875193ea0319118201b5
[718](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A718)
PKG=k8s.io/ingress-nginx
[719](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A719)
GOPATH=/home/prow/go
[720](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A720)
FOCUS=.*
[721](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A721)
_=/usr/bin/env
[722](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A722)
fc4ba769-cfaa-11ec-81f8-b27f6066c97f
[723](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A723)
Linux fc4ba769-cfaa-11ec-81f8-b27f6066c97f 5.4.0-1065-gke #68-Ubuntu SMP Wed Mar 2 14:58:37 UTC 2022 x86_64 GNU/Linux
[724](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A724)
DIND_ENABLED=true
[725](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A725)
FLAGS=ginkgo build ./test/e2e
[726](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A726)
PLATFORM=
[727](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A727)
PLATFORM_FLAG=
[728](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A728)
..reached DIND check TRUE block, inside run-in-docker.sh. Checking environ
[729](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A729)
/bin/bash: ginkgo: command not found
[730](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A730)
make[2]: *** [Makefile:156: e2e-test-binary] Error 127
[731](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A731)
make[1]: *** [Makefile:7: image] Error 2
[732](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A732)
Deleting cluster "ingress-nginx-dev" ...
[733](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-ingress-nginx-e2e-main/1523683302307794944#1:build-log.txt%3A733)
make: *** [Makefile:203: kind-e2e-test] Error 2
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
Related to #8552 

## How Has This Been Tested?
Can only be tested on testgrig prow job runs

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.