### PR TITLE
Avoid race conditions by copying the list before sorting

### DIFF
--- a/internal/ingress/annotations/ipwhitelist/main.go
+++ b/internal/ingress/annotations/ipwhitelist/main.go
@@ -62,18 +62,21 @@ func NewParser(r resolver.Resolver) parser.IngressAnnotation {
 // e.g. `18.0.0.0/8,56.0.0.0/8`
 func (a ipwhitelist) Parse(ing *networking.Ingress) (interface{}, error) {
 	defBackend := a.r.GetDefaultBackend()
-	sort.Strings(defBackend.WhitelistSourceRange)
+
+	defaultWhitelistSourceRange := make([]string, len(defBackend.WhitelistSourceRange))
+	copy(defaultWhitelistSourceRange, defBackend.WhitelistSourceRange)
+	sort.Strings(defaultWhitelistSourceRange)
 
 	val, err := parser.GetStringAnnotation("whitelist-source-range", ing)
 	// A missing annotation is not a problem, just use the default
 	if err == ing_errors.ErrMissingAnnotations {
-		return &SourceRange{CIDR: defBackend.WhitelistSourceRange}, nil
+		return &SourceRange{CIDR: defaultWhitelistSourceRange}, nil
 	}
 
 	values := strings.Split(val, ",")
 	ipnets, ips, err := net.ParseIPNets(values...)
 	if err != nil && len(ips) == 0 {
-		return &SourceRange{CIDR: defBackend.WhitelistSourceRange}, ing_errors.LocationDenied{
+		return &SourceRange{CIDR: defaultWhitelistSourceRange}, ing_errors.LocationDenied{
 			Reason: fmt.Errorf("the annotation does not contain a valid IP address or network: %w", err),
 		}
 	}


### PR DESCRIPTION
When creating several ingresses at the same time a race condition can happen by modifying a variable deep in another object. When this race condition is triggered the generated nginx configuration is broken:

```
nginx: [emerg] invalid parameter "8.8.8.8/32,8" in /tmp/nginx-cfg4027854160:671
nginx: configuration file /tmp/nginx-cfg4027854160 test failed
```

Once it happens, the controller won't ever be able to generate the configuration again. Thus the only option is to restart the process.

There is not really a good way to reproduce this issue. It happens quite sporadically every 2 or 3 days. However, after this fix has been applied, we haven't seen it happen after about 4 weeks.

In our setup, in many of our services we run end-to-end tests as part of our CI/CD pipelines. When running the tests we deploy several services. At least two of them create together about 60 ingresses. Reaching over 2k ingresses in peak times.

The Ingress Controller has a list of default whitelist source range with about 35 IPs including a few IPv6. About 10% of the Ingresses created also contain their own set of whitelist source range varying from 4 to 12 IPs.

<img width="1608" alt="Screenshot 2022-04-28 at 13 20 39" src="https://user-images.githubusercontent.com/28046/167753834-2a326819-3bbf-474f-96e5-5e6676ecc4fa.png">

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
