### PR TITLE
tracking host executing kind-e2e-test

### DIFF
--- a/build/run-in-docker.sh
+++ b/build/run-in-docker.sh
@@ -62,22 +62,18 @@ else
   PLATFORM_FLAG=
 fi
 
-echo "..printing env & other vars to stdout"
-echo "HOSTNAME=`hostname`"
-uname -a
-env
 echo "DIND_ENABLED=$DOCKER_IN_DOCKER_ENABLED"
-echo "done..printing env & other vars to stdout"
 
 if [[ "$DOCKER_IN_DOCKER_ENABLED" == "true" ]]; then
   echo "..reached DIND check TRUE block, inside run-in-docker.sh"
   echo "FLAGS=$FLAGS"
-  go env
   set -x
   go install -mod=mod github.com/onsi/ginkgo/ginkgo@v1.16.4 
-  find / -type f -name ginkgo 2>/dev/null
   which ginkgo
+  echo "..printing hostname"
+  hostname && uname -a && pwd && ls -l && ls -l /bin/bash 
   /bin/bash -c "${FLAGS}"
+  echo "exit-code_for_bash-c_ginkgo_build=$?"
   set +x
 else
   echo "..reached DIND check ELSE block, inside run-in-docker.sh"

--- a/test/e2e-image/Makefile
+++ b/test/e2e-image/Makefile
@@ -4,6 +4,8 @@ DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 image:
 	echo "..entered Makefile in /test/e2e-image"
 	echo "..calling Make target <<e2e-test-binary>> in /Makefile from inside /test/e2e-image/Makefile"
+	echo "..printing hostname"
+	hostname && uname -a && pwd && ls -l
 	make -C $(DIR)/../../ e2e-test-binary
 	echo "..done building e2e-test-binary from /test/e2e-image/Makefile"
 

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -60,6 +60,10 @@ if [ "${SKIP_CLUSTER_CREATION:-false}" = "false" ]; then
 
   export K8S_VERSION=${K8S_VERSION:-v1.21.10@sha256:84709f09756ba4f863769bdcabe5edafc2ada72d3c8c44d6515fc581b66b029c}
 
+  echo "..printing hostname"
+  touch foobar-debug
+  hostname && uname -a && pwd && ls -l 
+
   kind create cluster \
     --verbosity=${KIND_LOG_LEVEL} \
     --name ${KIND_CLUSTER_NAME} \
@@ -77,9 +81,13 @@ if [ "${SKIP_IMAGE_CREATION:-false}" = "false" ]; then
   fi
 
   echo "[dev-env] building image"
+  echo "..printing hostname"
+  hostname && uname -a && pwd && ls -l 
   make -C ${DIR}/../../ clean-image build image image-chroot
   echo "[dev-env] .. done building controller images"
   echo "[dev-env] now building e2e-image.."
+  echo "..printing hostname"
+  hostname && uname -a && pwd && ls -l 
   make -C ${DIR}/../e2e-image image
   echo "[dev-env] ..done building e2e-image"
 fi


### PR DESCRIPTION
## What this PR does / why we need it:
- Testgrid continues failure #8552 
- From the multiple changes we know DIND is enabled and scripts are calling each other via Makefiles
- But now the failure is at executing `bash -c ginkgo build ./test/e2e`
- So this PR puts debug statements that will track hostname & pwd at multiple stages
- We hope to see if different stages run in different containers/ hosts etc
- 
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
Related to #8552 

## How Has This Been Tested?
Can only be tested in prow on testgrid

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
