### PR TITLE
bumped go version to 1.18.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,11 +69,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
 
-      - name: Set up Go 1.17
+      - name: Set up Go 1.18
         id: go
         uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2
         with:
-          go-version: '1.17.6'
+          go-version: '1.18.2'
 
       - name: Set up Docker Buildx
         id: buildx
@@ -133,7 +133,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2
         with:
-          go-version: '1.17.6'
+          go-version: '1.18.2'
 
       - name: cache
         uses: actions/download-artifact@f023be2c48cc18debc3bacd34cb396e0295e2869 # v2
@@ -403,12 +403,12 @@ jobs:
           version: v0.11.1
           image: kindest/node:v1.21.1
 
-      - name: Set up Go 1.17
+      - name: Set up Go 1.18
         id: go
         if: ${{ steps.filter-images.outputs.kube-webhook-certgen == 'true' }}
         uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2
         with:
-          go-version: '1.17.6'
+          go-version: '1.18.2'
 
       - name: kube-webhook-certgen image build
         if: ${{ steps.filter-images.outputs.kube-webhook-certgen == 'true' }}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/ingress-nginx
 
-go 1.17
+go 1.18
 
 require (
 	github.com/armon/go-proxyproto v0.0.0-20210323213023-7e956b284f0a

--- a/images/custom-error-pages/rootfs/Dockerfile
+++ b/images/custom-error-pages/rootfs/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.17-alpine as builder
+FROM golang:1.18.2-alpine as builder
 RUN apk add git
 
 WORKDIR /go/src/k8s.io/ingress-nginx/images/custom-error-pages

--- a/images/custom-error-pages/rootfs/go.mod
+++ b/images/custom-error-pages/rootfs/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/ingress-nginx/custom-error-pages
 
-go 1.17
+go 1.18
 
 require github.com/prometheus/client_golang v1.11.0
 

--- a/images/ext-auth-example-authsvc/rootfs/Dockerfile
+++ b/images/ext-auth-example-authsvc/rootfs/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17.6-alpine3.15 as builder
+FROM golang:1.18.2-alpine3.15 as builder
 RUN mkdir /authsvc
 WORKDIR /authsvc
 COPY . ./

--- a/images/ext-auth-example-authsvc/rootfs/go.mod
+++ b/images/ext-auth-example-authsvc/rootfs/go.mod
@@ -1,8 +1,7 @@
 module example.com/authsvc
 
-go 1.17
+go 1.18
 
-require (
-	github.com/google/uuid v1.1.2 // indirect
-	k8s.io/apimachinery v0.23.1 // indirect
-)
+require k8s.io/apimachinery v0.23.1
+
+require github.com/google/uuid v1.1.2 // indirect

--- a/images/kube-webhook-certgen/rootfs/Dockerfile
+++ b/images/kube-webhook-certgen/rootfs/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=$BUILDPLATFORM golang:1.16 as builder
+FROM --platform=$BUILDPLATFORM golang:1.18.2 as builder
 ARG BUILDPLATFORM
 ARG TARGETARCH
 

--- a/images/kube-webhook-certgen/rootfs/go.mod
+++ b/images/kube-webhook-certgen/rootfs/go.mod
@@ -1,14 +1,48 @@
 module github.com/jet/kube-webhook-certgen
 
-go 1.16
+go 1.18
 
 require (
 	github.com/onrik/logrus v0.9.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.1.3
-	github.com/tidwall/gjson v1.14.0 // indirect
 	k8s.io/api v0.22.6
 	k8s.io/apimachinery v0.22.6
 	k8s.io/client-go v0.22.6
 	k8s.io/kube-aggregator v0.22.6
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/evanphx/json-patch v4.11.0+incompatible // indirect
+	github.com/go-logr/logr v0.4.0 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/go-cmp v0.5.5 // indirect
+	github.com/google/gofuzz v1.1.0 // indirect
+	github.com/googleapis/gnostic v0.5.5 // indirect
+	github.com/imdario/mergo v0.3.5 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/json-iterator/go v1.1.11 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/tidwall/gjson v1.14.0 // indirect
+	golang.org/x/net v0.0.0-20211209124913-491a49abca63 // indirect
+	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect
+	golang.org/x/sys v0.0.0-20210616094352-59db8d763f22 // indirect
+	golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d // indirect
+	golang.org/x/text v0.3.6 // indirect
+	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
+	google.golang.org/appengine v1.6.5 // indirect
+	google.golang.org/protobuf v1.26.0 // indirect
+	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+	k8s.io/klog/v2 v2.9.0 // indirect
+	k8s.io/kube-openapi v0.0.0-20211109043538-20434351676c // indirect
+	k8s.io/utils v0.0.0-20210819203725-bdf08cb9a70a // indirect
+	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
+	sigs.k8s.io/yaml v1.2.0 // indirect
 )

--- a/images/test-runner/Makefile
+++ b/images/test-runner/Makefile
@@ -39,7 +39,7 @@ build: ensure-buildx
 		--progress=$(PROGRESS) \
 		--pull \
 		--build-arg BASE_IMAGE=$(NGINX_BASE_IMAGE) \
-		--build-arg GOLANG_VERSION=1.17.6 \
+		--build-arg GOLANG_VERSION=1.18.2 \
 		--build-arg ETCD_VERSION=3.4.3-0 \
 		--build-arg K8S_RELEASE=v1.21.3 \
 		--build-arg RESTY_CLI_VERSION=0.27 \


### PR DESCRIPTION
## What this PR does / why we need it:
- This PR bumps the go version used in the project to v1.18.1, from v1.17.6

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
fixes #8577 

## How Has This Been Tested?
- Will be tested in CI when controller image is rebuilt

## Checklist:
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.