### PR TITLE
Opentelemetry module build

### DIFF
--- a/images/opentelemetry/rootfs/CMakeLists.txt
+++ b/images/opentelemetry/rootfs/CMakeLists.txt
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.11 FATAL_ERROR)
+
+project(
+  dependencies
+  LANGUAGES CXX
+  VERSION 0.0.1)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_FLAGS "-O2")
+
+set(CMAKE_BUILD_TYPE
+    Release
+    CACHE STRING "Build type" FORCE)
+
+include(GNUInstallDirs)
+
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY
+    ${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR})
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY
+    ${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY
+    ${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_BINDIR})
+
+set(INSTALL_LIBDIR
+    ${CMAKE_INSTALL_LIBDIR}
+    CACHE PATH "directory for libraries")
+set(INSTALL_BINDIR
+    ${CMAKE_INSTALL_BINDIR}
+    CACHE PATH "directory for executables")
+set(INSTALL_INCLUDEDIR
+    ${CMAKE_INSTALL_INCLUDEDIR}
+    CACHE PATH "directory for header files")
+
+set(DEF_INSTALL_CMAKEDIR share/cmake/${PROJECT_NAME})
+set(INSTALL_CMAKEDIR
+    ${DEF_INSTALL_CMAKEDIR}
+    CACHE PATH "directory for CMake files")
+
+set_property(DIRECTORY PROPERTY EP_BASE ${CMAKE_BINARY_DIR}/subs)
+
+set(STAGED_INSTALL_PREFIX ${CMAKE_BINARY_DIR}/stage)
+message(STATUS "${PROJECT_NAME} staged install: ${STAGED_INSTALL_PREFIX}")
+
+find_package(OpenSSL REQUIRED)
+message("OpenSSL include dir: ${OPENSSL_INCLUDE_DIR}")
+message("OpenSSL libraries: ${OPENSSL_LIBRARIES}")
+
+set(GRPC_GIT_TAG
+    "v1.45.2"
+    CACHE STRING "gRPC version")
+
+include(ExternalProject)
+ExternalProject_Add(
+  gRPC
+  GIT_REPOSITORY https://github.com/grpc/grpc.git
+  GIT_TAG ${GRPC_GIT_TAG}
+  GIT_SHALLOW 1
+  UPDATE_COMMAND ""
+  CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
+             -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+             -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+             -DgRPC_SSL_PROVIDER=package
+             -DOPENSSL_ROOT_DIR=OpenSSL
+             -DgRPC_BUILD_TESTS=OFF
+             -DBUILD_SHARED_LIBS=ON
+             -DgRPC_INSTALL=ON
+  CMAKE_CACHE_ARGS -DCMAKE_CXX_FLAGS:STRING=${CMAKE_CXX_FLAGS}
+  TEST_AFTER_INSTALL 0
+  DOWNLOAD_NO_PROGRESS 1
+  LOG_CONFIGURE 1
+  LOG_BUILD 0
+  LOG_INSTALL 1)
+
+install(
+  DIRECTORY ${STAGED_INSTALL_PREFIX}/
+  DESTINATION .
+  USE_SOURCE_PERMISSIONS)

--- a/images/opentelemetry/rootfs/Dockerfile
+++ b/images/opentelemetry/rootfs/Dockerfile
@@ -13,16 +13,33 @@
 # limitations under the License.
 
 
-FROM alpine:3.14.6 as builder
+FROM alpine:3.14.6 as base
 
-COPY . /
+RUN mkdir -p /opt/third_party/install
+COPY . /opt/third_party/
 
+# install build tools
 RUN apk update \
 	&& apk upgrade \
 	&& apk add -U bash \
-	&& /build.sh
+	&& bash /opt/third_party/build.sh -p
 
-FROM alpine:3.14.6 
+# install gRPC
+FROM base as grpc
+RUN bash /opt/third_party/build.sh -g v1.43.2
 
-COPY --from=builder init_module.sh /usr/local/bin/init_module.sh
-COPY --from=builder /etc/nginx/modules /etc/nginx/modules
+# install OpenTelemetry-cpp
+FROM base as otel-cpp
+COPY --from=grpc /opt/third_party/install/ /usr
+RUN bash /opt/third_party/build.sh -o v1.3.0
+
+# install otel_ngx_module.so
+FROM base as nginx
+COPY --from=grpc /opt/third_party/install/ /usr
+COPY --from=otel-cpp /opt/third_party/install/ /usr
+RUN bash /opt/third_party/build.sh -n
+
+FROM alpine:3.14.6
+COPY --from=base /opt/third_party/init_module.sh /usr/local/bin/init_module.sh
+COPY --from=nginx /etc/nginx/modules /etc/nginx/modules
+COPY --from=nginx /opt/third_party/install/lib /usr/lib

--- a/images/opentelemetry/rootfs/build.sh
+++ b/images/opentelemetry/rootfs/build.sh
@@ -116,7 +116,7 @@ get_src()
   echo "Downloading $url"
 
   curl -sSL "$url" -o "$f"
-  # echo "$hash  $f" | sha256sum -c - || exit 10
+  echo "$hash  $f" | sha256sum -c - || exit 10
   tar xzf "$f"
   rm -rf "$f"
 }

--- a/images/opentelemetry/rootfs/build.sh
+++ b/images/opentelemetry/rootfs/build.sh
@@ -18,15 +18,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-export NGINX_VERSION=1.19.10
-
+export GRPC_GIT_TAG=${GRPC_GIT_TAG:="v1.43.2"}
 # Check for recent changes: https://github.com/open-telemetry/opentelemetry-cpp/compare/v1.2.0...main
-export OPENTELEMETRY_CPP_VERSION=1.2.0
-
-# Check for recent changes: https://github.com/open-telemetry/opentelemetry-cpp-contrib/compare/2656a4...main
-export OPENTELEMETRY_CONTRIB_COMMIT=2656a4072e257b6794da86ddd1b773b49f5517b3
-
-export BUILD_PATH=/tmp/build
+export OPENTELEMETRY_CPP_VERSION=${OPENTELEMETRY_CPP_VERSION:="1.2.0"}
+export INSTAL_DIR=/opt/third_party/install
+# improve compilation times
+CORES=$(($(grep -c ^processor /proc/cpuinfo) - 1))
 
 rm -rf \
    /var/cache/debconf/* \
@@ -35,15 +32,80 @@ rm -rf \
    /tmp/* \
    /var/tmp/*
 
-
-mkdir -p /etc/nginx
+export BUILD_PATH=/tmp/build
 mkdir --verbose -p "$BUILD_PATH"
-cd "$BUILD_PATH"
 
-apk add \
-  curl \
-  git \
-  build-base
+Help()
+{
+   # Display Help
+   echo "Add description of the script functions here."
+   echo
+   echo "Syntax: scriptTemplate [-h|g|o|n|p|]"
+   echo "options:"
+   echo "h     Print Help."
+   echo "g     gRPC git tag"
+   echo "o     OpenTelemetry git tag"
+   echo "n     install nginx"
+   echo "p     prepare"
+   echo
+}
+
+prepare()
+{
+  apk add \
+    linux-headers \
+    openssl \
+    curl-dev \
+    openssl-dev \
+    gtest-dev \
+    c-ares-dev \
+    pcre-dev \
+    curl \
+    git \
+    build-base
+}
+
+install_grpc()
+{
+  mkdir -p $BUILD_PATH/grpc
+  cd ${BUILD_PATH}/grpc
+  cmake -DCMAKE_INSTALL_PREFIX=${INSTAL_DIR} \
+    -DGRPC_GIT_TAG=${GRPC_GIT_TAG} /opt/third_party \
+    -DgRPC_BUILD_GRPC_NODE_PLUGIN=OFF \
+    -DgRPC_BUILD_GRPC_OBJECTIVE_C_PLUGIN=OFF \
+    -DgRPC_BUILD_GRPC_PHP_PLUGIN=OFF \
+    -DgRPC_BUILD_GRPC_PHP_PLUGIN=OFF \
+    -DgRPC_BUILD_GRPC_PYTHON_PLUGIN=OFF \
+    -DgRPC_BUILD_GRPC_RUBY_PLUGIN=OFF
+  cmake --build . -j ${CORES} --target all install
+}
+
+install_otel()
+{
+  cd ${BUILD_PATH}
+  export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:+LD_LIBRARY_PATH:}${INSTAL_DIR}/lib:/usr/local"
+  export PATH="${PATH}:${INSTAL_DIR}/bin"
+  git clone --recurse-submodules -j ${CORES} --depth=1 -b \
+    ${OPENTELEMETRY_CPP_VERSION} https://github.com/open-telemetry/opentelemetry-cpp.git opentelemetry-cpp-${OPENTELEMETRY_CPP_VERSION}
+  cd "opentelemetry-cpp-${OPENTELEMETRY_CPP_VERSION}"
+  mkdir -p .build
+  cd .build
+
+  cmake -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE  \
+        -DWITH_ZIPKIN=OFF \
+        -DWITH_JAEGER=OFF \
+        -DCMAKE_INSTALL_PREFIX=${INSTAL_DIR} \
+        -DBUILD_TESTING=OFF \
+        -DBUILD_SHARED_LIBS=ON \
+        -DWITH_OTLP=ON \
+        -DWITH_OTLP_GRPC=ON \
+        -DWITH_EXAMPLES=OFF \
+        -DWITH_ABSEIL=ON \
+        -DWITH_OTLP_HTTP=OFF \
+        ..
+  cmake --build . -j ${CORES} --target install
+}
 
 get_src()
 {
@@ -54,58 +116,105 @@ get_src()
   echo "Downloading $url"
 
   curl -sSL "$url" -o "$f"
-  echo "$hash  $f" | sha256sum -c - || exit 10
+  # echo "$hash  $f" | sha256sum -c - || exit 10
   tar xzf "$f"
   rm -rf "$f"
 }
 
+install_nginx()
+{
+  export NGINX_VERSION=1.19.10
 
-get_src e8d0290ff561986ad7cd6c33307e12e11b137186c4403a6a5ccdb4914c082d88 \
-        "https://nginx.org/download/nginx-$NGINX_VERSION.tar.gz"
+  # Check for recent changes: https://github.com/open-telemetry/opentelemetry-cpp-contrib/compare/2656a4...main
+  export OPENTELEMETRY_CONTRIB_COMMIT=6467ec2e4d67b08b44580b7eb7a298786f4eef91
 
-get_src 360cdcbd1a235ec62119cc53956b2d31b6ff5f41d44415be53acc544709d58b8 \
-        "https://github.com/open-telemetry/opentelemetry-cpp-contrib/archive/$OPENTELEMETRY_CONTRIB_COMMIT.tar.gz"
+  mkdir -p /etc/nginx
+  cd "$BUILD_PATH"
 
-# improve compilation times
-CORES=$(($(grep -c ^processor /proc/cpuinfo) - 1))
+  get_src 360cdcbd1a235ec62119cc53956b2d31b6ff5f41d44415be53acc544709d58b8 \
+          "https://github.com/open-telemetry/opentelemetry-cpp-contrib/archive/$OPENTELEMETRY_CONTRIB_COMMIT.tar.gz"
 
-export MAKEFLAGS=-j${CORES}
+  cd ${BUILD_PATH}/opentelemetry-cpp-contrib-${OPENTELEMETRY_CONTRIB_COMMIT}/instrumentation/nginx
+  mkdir -p build
+  cd build
+  cmake -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=${INSTAL_DIR} \
+    -DBUILD_SHARED_LIBS=ON \
+    -DNGINX_VERSION=${NGINX_VERSION} \
+    ..
+  cmake --build . -j ${CORES} --target install
 
-apk add \
-  protobuf-dev \
-  grpc \
-  grpc-dev \
-  gtest-dev \
-  c-ares-dev \
-  pcre-dev
+  mkdir -p /etc/nginx/modules
+  cp ${INSTAL_DIR}/otel_ngx_module.so /etc/nginx/modules/otel_ngx_module.so
 
-cd $BUILD_PATH
-git clone --recursive https://github.com/open-telemetry/opentelemetry-cpp opentelemetry-cpp-$OPENTELEMETRY_CPP_VERSION
-cd "opentelemetry-cpp-$OPENTELEMETRY_CPP_VERSION"
-git checkout v$OPENTELEMETRY_CPP_VERSION
-mkdir .build
-cd .build
+  mkdir -p ${INSTAL_DIR}/lib
+  cp /usr/lib/libopentelemetry_exporter_otlp_grpc.so* ${INSTAL_DIR}/lib
+  cp /usr/lib/libopentelemetry_otlp_recordable.so* ${INSTAL_DIR}/lib
+  cp /usr/lib/libprotobuf.so* ${INSTAL_DIR}/lib
+  cp /usr/lib/libopentelemetry_trace.so* ${INSTAL_DIR}/lib
+  cp /usr/lib/libopentelemetry_resources.so* ${INSTAL_DIR}/lib
+  cp /usr/lib/libopentelemetry_common.so* ${INSTAL_DIR}/lib
+  cp /usr/lib/libstdc++.so* ${INSTAL_DIR}/lib
 
-cmake -DCMAKE_BUILD_TYPE=Release \
-      -DBUILD_TESTING=OFF \
-      -DWITH_EXAMPLES=OFF \
-      -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
-      -DWITH_OTLP=ON \
-      -DWITH_OTLP_HTTP=OFF \
-      ..
-make
-make install
+  cp /usr/lib/libgrpc.so* ${INSTAL_DIR}/lib
+  cp /usr/lib/libgcc_s.so* ${INSTAL_DIR}/lib
+  cp /usr/lib/libgrpc++.so* ${INSTAL_DIR}/lib
+  cp /usr/lib/libabsl_bad_variant_access.so* ${INSTAL_DIR}/lib
+  cp /usr/lib/libabsl_synchronization.so* ${INSTAL_DIR}/lib
+  cp /usr/lib/libabsl_raw_hash_set.so* ${INSTAL_DIR}/lib
+  cp /usr/lib/libabsl_hash.so* ${INSTAL_DIR}/lib
+  cp /usr/lib/libabsl_statusor.so* ${INSTAL_DIR}/lib
+  cp /usr/lib/libgpr.so* ${INSTAL_DIR}/lib
+  cp /usr/lib/libupb.so* ${INSTAL_DIR}/lib
+  cp /usr/lib/libabsl_status.so* ${INSTAL_DIR}/lib
+  cp /usr/lib/libabsl_time.so* ${INSTAL_DIR}/lib
+  cp /usr/lib/libabsl_strings.so* ${INSTAL_DIR}/lib
+  cp /usr/lib/libabsl_stacktrace.so* ${INSTAL_DIR}/lib
+  cp /usr/lib/libabsl_symbolize.so* ${INSTAL_DIR}/lib
+  cp /usr/lib/libabsl_malloc_internal.so* ${INSTAL_DIR}/lib
+  cp /usr/lib/libabsl_base.so* ${INSTAL_DIR}/lib
+  cp /usr/lib/libabsl_spinlock_wait.so* ${INSTAL_DIR}/lib
+  cp /usr/lib/libabsl_raw_logging_internal.so* ${INSTAL_DIR}/lib
+  cp /usr/lib/libre2.so* ${INSTAL_DIR}/lib
+  cp /usr/lib/libaddress_sorting.so* ${INSTAL_DIR}/lib
+  cp /usr/lib/libabsl_cord.so* ${INSTAL_DIR}/lib
+  cp /usr/lib/libabsl_bad_optional_access.so* ${INSTAL_DIR}/lib
+  cp /usr/lib/libabsl_str_format_internal.so* ${INSTAL_DIR}/lib
+  cp /usr/lib/libabsl_throw_delegate.so* ${INSTAL_DIR}/lib
+  cp /usr/lib/libabsl_time_zone.so* ${INSTAL_DIR}/lib
+  cp /usr/lib/libabsl_city.so* ${INSTAL_DIR}/lib
+  cp /usr/lib/libabsl_low_level_hash.so* ${INSTAL_DIR}/lib
+  cp /usr/lib/libabsl_cordz_info.so* ${INSTAL_DIR}/lib
+  cp /usr/lib/libabsl_int128.so* ${INSTAL_DIR}/lib
+  cp /usr/lib/libabsl_strings_internal.so* ${INSTAL_DIR}/lib
+  cp /usr/lib/libabsl_debugging_internal.so* ${INSTAL_DIR}/lib
+  cp /usr/lib/libabsl_cord_internal.so* ${INSTAL_DIR}/lib
+  cp /usr/lib/libabsl_cordz_functions.so* ${INSTAL_DIR}/lib
+  cp /usr/lib/libabsl_cordz_handle.so* ${INSTAL_DIR}/lib
+  cp /usr/lib/libabsl_exponential_biased.so* ${INSTAL_DIR}/lib
+}
 
-# build nginx
-cd "$BUILD_PATH/nginx-$NGINX_VERSION"
-./configure \
-  --prefix=/usr/local/nginx \
-  --with-compat \
-  --add-dynamic-module=$BUILD_PATH/opentelemetry-cpp-contrib-$OPENTELEMETRY_CONTRIB_COMMIT/instrumentation/nginx
-
-make modules
-mkdir -p /etc/nginx/modules
-cp objs/otel_ngx_module.so /etc/nginx/modules/otel_ngx_module.so
-
-# remove .a files
-find /usr/local -name "*.a" -print | xargs /bin/rm
+while getopts ":hpng:o:" option; do
+   case $option in
+    h) # display Help
+         Help
+         exit;;
+    g) # install gRPC with git tag
+        GRPC_GIT_TAG=${OPTARG}
+        install_grpc
+        exit;;
+    o) # install OpenTelemetry tag
+        OPENTELEMETRY_CPP_VERSION=${OPTARG}
+        install_otel
+        exit;;
+    p) # prepare
+        prepare
+        exit;;
+    n) # install nginx
+        install_nginx
+        exit;;
+    \?)
+        Help
+        exit;;
+   esac
+done


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR Fixes #8437 by installing gRPC and OpenTelemetry-cpp using a pattern similar to https://github.com/open-telemetry/opentelemetry-cpp/pull/1382
The final image size is 48.9MB.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #8437
-->
fixes #8437

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
``` console
ldd otel_ngx_module.so 
        /lib/ld-musl-x86_64.so.1 (0x7fbfeb61f000)
        libopentelemetry_exporter_otlp_grpc.so => /usr/lib/libopentelemetry_exporter_otlp_grpc.so (0x7fbfeb557000)
        libprotobuf.so.3.18.1.0 => /usr/lib/libprotobuf.so.3.18.1.0 (0x7fbfeb25d000)
        libopentelemetry_trace.so => /usr/lib/libopentelemetry_trace.so (0x7fbfeb231000)
        libopentelemetry_resources.so => /usr/lib/libopentelemetry_resources.so (0x7fbfeb21e000)
        libabsl_bad_variant_access.so.2111.0.0 => /usr/lib/libabsl_bad_variant_access.so.2111.0.0 (0x7fbfeb219000)
        libstdc++.so.6 => /usr/lib/libstdc++.so.6 (0x7fbfeb078000)
        libgcc_s.so.1 => /usr/lib/libgcc_s.so.1 (0x7fbfeb05e000)
        libc.musl-x86_64.so.1 => /lib/ld-musl-x86_64.so.1 (0x7fbfeb61f000)
        libopentelemetry_otlp_recordable.so => /usr/lib/libopentelemetry_otlp_recordable.so (0x7fbfeb028000)
        libgrpc++.so.1.43 => /usr/lib/libgrpc++.so.1.43 (0x7fbfeaf59000)
        libabsl_synchronization.so.2111.0.0 => /usr/lib/libabsl_synchronization.so.2111.0.0 (0x7fbfeaf49000)
        libopentelemetry_common.so => /usr/lib/libopentelemetry_common.so (0x7fbfeaf44000)
        libgrpc.so.21 => /usr/lib/libgrpc.so.21 (0x7fbfeaa3d000)
        libabsl_raw_hash_set.so.2111.0.0 => /usr/lib/libabsl_raw_hash_set.so.2111.0.0 (0x7fbfeaa38000)
        libabsl_hash.so.2111.0.0 => /usr/lib/libabsl_hash.so.2111.0.0 (0x7fbfeaa33000)
        libabsl_statusor.so.2111.0.0 => /usr/lib/libabsl_statusor.so.2111.0.0 (0x7fbfeaa2d000)
        libgpr.so.21 => /usr/lib/libgpr.so.21 (0x7fbfeaa13000)
        libupb.so.21 => /usr/lib/libupb.so.21 (0x7fbfea9f2000)
        libabsl_status.so.2111.0.0 => /usr/lib/libabsl_status.so.2111.0.0 (0x7fbfea9e8000)
        libabsl_time.so.2111.0.0 => /usr/lib/libabsl_time.so.2111.0.0 (0x7fbfea9d1000)
        libabsl_strings.so.2111.0.0 => /usr/lib/libabsl_strings.so.2111.0.0 (0x7fbfea9b1000)
        libabsl_stacktrace.so.2111.0.0 => /usr/lib/libabsl_stacktrace.so.2111.0.0 (0x7fbfea9ac000)
        libabsl_symbolize.so.2111.0.0 => /usr/lib/libabsl_symbolize.so.2111.0.0 (0x7fbfea9a7000)
        libabsl_malloc_internal.so.2111.0.0 => /usr/lib/libabsl_malloc_internal.so.2111.0.0 (0x7fbfea9a1000)
        libabsl_base.so.2111.0.0 => /usr/lib/libabsl_base.so.2111.0.0 (0x7fbfea99b000)
        libabsl_spinlock_wait.so.2111.0.0 => /usr/lib/libabsl_spinlock_wait.so.2111.0.0 (0x7fbfea996000)
        libabsl_raw_logging_internal.so.2111.0.0 => /usr/lib/libabsl_raw_logging_internal.so.2111.0.0 (0x7fbfea991000)
        libre2.so.9 => /usr/lib/libre2.so.9 (0x7fbfea90c000)
        libssl.so.1.1 => /lib/libssl.so.1.1 (0x7fbfea88b000)
        libcrypto.so.1.1 => /lib/libcrypto.so.1.1 (0x7fbfea60a000)
        libaddress_sorting.so.21 => /usr/lib/libaddress_sorting.so.21 (0x7fbfea605000)
        libabsl_cord.so.2111.0.0 => /usr/lib/libabsl_cord.so.2111.0.0 (0x7fbfea5ed000)
        libabsl_bad_optional_access.so.2111.0.0 => /usr/lib/libabsl_bad_optional_access.so.2111.0.0 (0x7fbfea5e8000)
        libabsl_str_format_internal.so.2111.0.0 => /usr/lib/libabsl_str_format_internal.so.2111.0.0 (0x7fbfea5cc000)
        libabsl_throw_delegate.so.2111.0.0 => /usr/lib/libabsl_throw_delegate.so.2111.0.0 (0x7fbfea5c5000)
        libabsl_time_zone.so.2111.0.0 => /usr/lib/libabsl_time_zone.so.2111.0.0 (0x7fbfea5a6000)
        libabsl_city.so.2111.0.0 => /usr/lib/libabsl_city.so.2111.0.0 (0x7fbfea5a0000)
        libabsl_low_level_hash.so.2111.0.0 => /usr/lib/libabsl_low_level_hash.so.2111.0.0 (0x7fbfea59b000)
        libabsl_cordz_info.so.2111.0.0 => /usr/lib/libabsl_cordz_info.so.2111.0.0 (0x7fbfea593000)
        libabsl_int128.so.2111.0.0 => /usr/lib/libabsl_int128.so.2111.0.0 (0x7fbfea58b000)
        libabsl_strings_internal.so.2111.0.0 => /usr/lib/libabsl_strings_internal.so.2111.0.0 (0x7fbfea585000)
        libabsl_debugging_internal.so.2111.0.0 => /usr/lib/libabsl_debugging_internal.so.2111.0.0 (0x7fbfea57e000)
        libabsl_cord_internal.so.2111.0.0 => /usr/lib/libabsl_cord_internal.so.2111.0.0 (0x7fbfea565000)
        libabsl_cordz_functions.so.2111.0.0 => /usr/lib/libabsl_cordz_functions.so.2111.0.0 (0x7fbfea560000)
        libabsl_cordz_handle.so.2111.0.0 => /usr/lib/libabsl_cordz_handle.so.2111.0.0 (0x7fbfea55a000)
        libabsl_exponential_biased.so.2111.0.0 => /usr/lib/libabsl_exponential_biased.so.2111.0.0 (0x7fbfea555000)
Error relocating otel_ngx_module.so: ngx_http_get_indexed_variable: symbol not found
Error relocating otel_ngx_module.so: ngx_http_script_compile: symbol not found
Error relocating otel_ngx_module.so: ngx_palloc: symbol not found
Error relocating otel_ngx_module.so: ngx_pool_cleanup_add: symbol not found
Error relocating otel_ngx_module.so: ngx_regex_compile: symbol not found
Error relocating otel_ngx_module.so: ngx_http_add_variable: symbol not found
Error relocating otel_ngx_module.so: ngx_pcalloc: symbol not found
Error relocating otel_ngx_module.so: pcre_exec: symbol not found
Error relocating otel_ngx_module.so: ngx_array_create: symbol not found
Error relocating otel_ngx_module.so: ngx_http_script_run: symbol not found
Error relocating otel_ngx_module.so: ngx_http_script_variables_count: symbol not found
Error relocating otel_ngx_module.so: ngx_strncasecmp: symbol not found
Error relocating otel_ngx_module.so: ngx_atoi: symbol not found
Error relocating otel_ngx_module.so: ngx_array_push: symbol not found
Error relocating otel_ngx_module.so: ngx_conf_log_error: symbol not found
Error relocating otel_ngx_module.so: ngx_http_get_variable_index: symbol not found
Error relocating otel_ngx_module.so: ngx_log_error_core: symbol not found
Error relocating otel_ngx_module.so: ngx_http_core_module: symbol not found
Error relocating otel_ngx_module.so: ngx_http_module: symbol not found
Error relocating otel_ngx_module.so: ngx_conf_set_flag_slot: symbol not found
Error relocating otel_ngx_module.so: ngx_conf_set_flag_slot: symbol not found
Error relocating otel_ngx_module.so: ngx_conf_set_flag_slot: symbol not found
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
