### PR TITLE
Add CAP_SYS_CHROOT to DS/PSP when needed

### DIFF
--- a/charts/ingress-nginx/templates/controller-daemonset.yaml
+++ b/charts/ingress-nginx/templates/controller-daemonset.yaml
@@ -82,14 +82,7 @@ spec:
         {{- end }}
           args:
             {{- include "ingress-nginx.params" . | nindent 12 }}
-          securityContext:
-            capabilities:
-                drop:
-                - ALL
-                add:
-                - NET_BIND_SERVICE
-            runAsUser: {{ .Values.controller.image.runAsUser }}
-            allowPrivilegeEscalation: {{ .Values.controller.image.allowPrivilegeEscalation }}
+          securityContext: {{ include "controller.containerSecurityContext" . | nindent 12 }}
           env:
             - name: POD_NAME
               valueFrom:

--- a/charts/ingress-nginx/templates/controller-psp.yaml
+++ b/charts/ingress-nginx/templates/controller-psp.yaml
@@ -12,6 +12,9 @@ metadata:
 spec:
   allowedCapabilities:
     - NET_BIND_SERVICE
+  {{- if .Values.controller.image.chroot }}
+    - SYS_CHROOT
+  {{- end }}
 {{- if .Values.controller.sysctls }}
   allowedUnsafeSysctls:
   {{- range $sysctl, $value := .Values.controller.sysctls }}


### PR DESCRIPTION
## What this PR does / why we need it:
When using chroot mode (--set controller.image.chroot=true) alongside podsecuritypolicies and a daemonset (--set podSecurityPolicy.enabled=true  --set controller.kind=DaemonSet), it doesn't work since the DS/PSP are missing the SYS_CHROOT capability. This PR fixes that.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
Fixes #8517 

## How Has This Been Tested?

```
helm template ./ingress-nginx --set podSecurityPolicy.enabled=true --set controller.image.chroot=true --set controller.kind=DaemonSet | grep -A 55 DaemonSet

helm template ./ingress-nginx --set podSecurityPolicy.enabled=true --set controller.image.chroot=true --set controller.kind=DaemonSet | grep -A 25 PodSecurityPolicy
```

## Checklist:
- [n/a] My change requires a change to the documentation.
- [n/a] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [n/a] I have added tests to cover my changes.
- [x] All new and existing tests passed.
