### PR TITLE
Add CI check to ensure chart version gets bumped

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,6 +43,10 @@ jobs:
             charts:
               - 'charts/ingress-nginx/Chart.yaml'
               - 'charts/ingress-nginx/**/*'
+            chart_templates:
+              - 'charts/ingress-nginx/templates/**'
+            chart_yaml:
+              - 'charts/ingress-nginx/Chart.yaml'
 
   security:
     runs-on: ubuntu-latest
@@ -143,6 +147,11 @@ jobs:
       - name: Lint
         run: |
           ./build/run-in-docker.sh ./hack/verify-chart-lint.sh
+
+      - name: Ensure chart version was bumped if templates changed
+        if: (needs.changes.outputs.chart_templates == 'true') && (needs.changes.outputs.chart_yaml == 'false')
+        run: |
+          echo "Since you changed the helm chart, you must also increase the version in Chart.yaml"; exit 1
 
       - name: Run helm-docs
         run: |

--- a/charts/ingress-nginx/templates/controller-hpa.yaml
+++ b/charts/ingress-nginx/templates/controller-hpa.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.controller.autoscaling.enabled (or (eq .Values.controller.kind "Deployment") (eq .Values.controller.kind "Both")) -}}
 {{- if not .Values.controller.keda.enabled }}
-
+# FIXME: example change to trigger CI failure
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -49,4 +49,3 @@ spec:
   {{- end }}
 {{- end }}
 {{- end }}
-


### PR DESCRIPTION
## What this PR does / why we need it:

#8587 was merged without a chart version bump. If that is required, it should be checked by CI.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## How Has This Been Tested?
NOTE: I'm not sure if my new github actions code works; need to test it to simluate failure to bump the chart version. Then I'll remove that edit to `charts/ingress-nginx/templates/controller-hpa.yaml` before merging.

## Checklist:
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide

