### PR TITLE
Replace SIGTERM by SIGQUIT in waitshutdown to enable connection draining

### DIFF
--- a/cmd/waitshutdown/main.go
+++ b/cmd/waitshutdown/main.go
@@ -26,7 +26,7 @@ import (
 )
 
 func main() {
-	err := exec.Command("bash", "-c", "pkill -SIGTERM -f nginx-ingress-controller").Run()
+	err := exec.Command("bash", "-c", "pkill -SIGQUIT -f nginx-ingress-controller").Run()
 	if err != nil {
 		klog.ErrorS(err, "terminating ingress controller")
 		os.Exit(1)


### PR DESCRIPTION
## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->

SIGTERM kill nginx processus without draining connection because it is a "fast shutdown".

As waitshutdown is called in the prestop lifecycle hook, immediately when we ask  for pod termination, it means we don't 
wait any time for draining existing connections which will be immediately dropped. 

Use SIGQUIT which waits connections to end before terminating nginx processus. 

References :
http://nginx.org/en/docs/control.html
https://medium.com/codecademy-engineering/kubernetes-nginx-and-zero-downtime-in-production-2c910c6a5ed8

<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Start nginx 
```
docker run -p 8080:80 nginx 
```
Open a telnet ongoing connection
```
telnet 127.0.0.1 8080
```
Send a SIGTERM
```
pkill -SIGTERM -f nginx
```
Observe that connection is immediately terminated and nginx process are killed.
Restart nginx container and the telnet command.
Send a SIGQUIT
```
pkill -SIGQUIT -f nginx
```
Observe that the connection is not terminated and all nginx process are not killed (only idle nginx are terminated)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
