### PR TITLE
Add Maxmind GeoIP2 db extention flag

### DIFF
--- a/cmd/nginx/flags.go
+++ b/cmd/nginx/flags.go
@@ -213,6 +213,7 @@ Takes the form "<host>:port". If not provided, no admission controller is starte
 	flags.StringVar(&nginx.MaxmindMirror, "maxmind-mirror", "", `Maxmind mirror url (example: http://geoip.local/databases`)
 	flags.StringVar(&nginx.MaxmindLicenseKey, "maxmind-license-key", "", `Maxmind license key to download GeoLite2 Databases.
 https://blog.maxmind.com/2019/12/18/significant-changes-to-accessing-and-using-geolite2-databases`)
+	flags.StringVar(&nginx.MaxmindDBExtention, "maxmind-db-extension", "tar.gz", `Maxmind DB Extensions (suffix) for downloadable files (example: tar.gz)`)
 	flags.StringVar(&nginx.MaxmindEditionIDs, "maxmind-edition-ids", "GeoLite2-City,GeoLite2-ASN", `Maxmind edition ids to download GeoLite2 Databases.`)
 	flags.IntVar(&nginx.MaxmindRetriesCount, "maxmind-retries-count", 1, "Number of attempts to download the GeoIP DB.")
 	flags.DurationVar(&nginx.MaxmindRetriesTimeout, "maxmind-retries-timeout", time.Second*0, "Maxmind downloading delay between 1st and 2nd attempt, 0s - do not retry to download if something went wrong.")

--- a/internal/nginx/maxmind_test.go
+++ b/internal/nginx/maxmind_test.go
@@ -27,6 +27,7 @@ func resetForTesting() {
 	MaxmindEditionIDs = ""
 	MaxmindEditionFiles = []string{}
 	MaxmindMirror = ""
+	MaxmindDBExtention = "tar.gz"
 }
 
 func TestGeoLite2DBExists(t *testing.T) {
@@ -71,5 +72,24 @@ func TestGeoLite2DBExists(t *testing.T) {
 				t.Errorf("config.MaxmindEditionFiles = %v, want %v", *config, tt.wantFiles)
 			}
 		})
+	}
+}
+
+func TestMaxmindURLValidation(t *testing.T) {
+	maxmindLicenseKey := ""
+	maxmindMirror := ""
+
+	validTar := "https://download.maxmind.com/app/geoip_download?license_key=&edition_id=GeoIP-City&suffix=tar.gz"
+	validMMDB := "https://download.maxmind.com/app/geoip_download?license_key=&edition_id=GeoIP-City&suffix=mmdb"
+
+	dbName := "GeoIP-City"
+	url := createURL(maxmindMirror, maxmindLicenseKey, dbName, "tar.gz")
+	if url != validTar {
+		t.Errorf("nginx.MaxmindDowbloadURL = %v, want %v", url, validTar)
+	}
+
+	url = createURL(maxmindMirror, maxmindLicenseKey, dbName, "mmdb")
+	if url != validMMDB {
+		t.Errorf("nginx.MaxmindDowbloadURL = %v, want %v", url, validMMDB)
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Add flag for maxmind db extension. You can download mmdb or tar.gz files.
You can use this flag with maxmind mirror and geoipupdate

Why? You can use [geoipupdate](https://github.com/maxmind/geoipupdate) and nginx for serve static files in your local mirror, but geoipupdate will save files with mmdb extension. This PR can resolve that problem and you can chose mmdb files extensions (e.q mmdb, zip, etc). With mirror you can avoid API limits in MaxMind.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
