### PR TITLE
Add protocol prefix to Metrics port (Helm)

### DIFF
--- a/charts/ingress-nginx/templates/controller-daemonset.yaml
+++ b/charts/ingress-nginx/templates/controller-daemonset.yaml
@@ -114,7 +114,7 @@ spec:
               {{- end }}
           {{- end }}
           {{- if .Values.controller.metrics.enabled }}
-            - name: metrics
+            - name: http-metrics
               containerPort: {{ .Values.controller.metrics.port }}
               protocol: TCP
           {{- end }}

--- a/charts/ingress-nginx/templates/controller-deployment.yaml
+++ b/charts/ingress-nginx/templates/controller-deployment.yaml
@@ -118,7 +118,7 @@ spec:
               {{- end }}
           {{- end }}
           {{- if .Values.controller.metrics.enabled }}
-            - name: metrics
+            - name: http-metrics
               containerPort: {{ .Values.controller.metrics.port }}
               protocol: TCP
           {{- end }}

--- a/charts/ingress-nginx/templates/controller-service-metrics.yaml
+++ b/charts/ingress-nginx/templates/controller-service-metrics.yaml
@@ -31,10 +31,10 @@ spec:
   externalTrafficPolicy: {{ .Values.controller.metrics.service.externalTrafficPolicy }}
 {{- end }}
   ports:
-    - name: metrics
+    - name: http-metrics
       port: {{ .Values.controller.metrics.service.servicePort }}
       protocol: TCP
-      targetPort: metrics
+      targetPort: http-metrics
     {{- $setNodePorts := (or (eq .Values.controller.metrics.service.type "NodePort") (eq .Values.controller.metrics.service.type "LoadBalancer")) }}
     {{- if (and $setNodePorts (not (empty .Values.controller.metrics.service.nodePort))) }}
       nodePort: {{ .Values.controller.metrics.service.nodePort }}

--- a/charts/ingress-nginx/templates/controller-servicemonitor.yaml
+++ b/charts/ingress-nginx/templates/controller-servicemonitor.yaml
@@ -14,7 +14,7 @@ metadata:
   {{- end }}
 spec:
   endpoints:
-    - port: metrics
+    - port: http-metrics
       interval: {{ .Values.controller.metrics.serviceMonitor.scrapeInterval }}
     {{- if .Values.controller.metrics.serviceMonitor.honorLabels }}
       honorLabels: true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
Kiali/Istio uses protocol prefixed ports for discovering service mesh metrics. The port for the controller metrics service was missing the necessary port prefix.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
fixes #8660 
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Deployed Kiali, Istio, and ingress-controller (using helm chart), ingress-controller was installed within the Istio mesh. Checking Kiali UI, the service now shows as green instead of red.


### Metrics Service Describe
```
Name:              ingress-controller-ingress-nginx-controller-metrics
Namespace:         ingress-nginx
Labels:            app.kubernetes.io/component=controller
                   app.kubernetes.io/instance=ingress-controller
                   app.kubernetes.io/managed-by=Helm
                   app.kubernetes.io/name=ingress-nginx
                   app.kubernetes.io/part-of=ingress-nginx
                   app.kubernetes.io/version=1.2.1
                   helm.sh/chart=ingress-nginx-4.1.3
Annotations:       meta.helm.sh/release-name: ingress-controller
                   meta.helm.sh/release-namespace: ingress-nginx
Selector:          app.kubernetes.io/component=controller,app.kubernetes.io/instance=ingress-controller,app.kubernetes.io/name=ingress-nginx
Type:              ClusterIP
IP Family Policy:  SingleStack
IP Families:       IPv4
IP:                10.96.244.30
IPs:               10.96.244.30
Port:              http-metrics  10254/TCP
TargetPort:        http-metrics/TCP
Endpoints:         10.244.0.118:10254
Session Affinity:  None
Events:            <none>
```

### Ports of controller deployment
```
ports:
- containerPort: 80
  name: http
  protocol: TCP
- containerPort: 443
  name: https
  protocol: TCP
- containerPort: 10254
  name: http-metrics
  protocol: TCP
```

### Kiali UI showing metrics service
![Screen Shot 2022-06-02 at 7 18 21 AM](https://user-images.githubusercontent.com/91502735/171868700-4608ac5b-1f85-4ab4-8981-019d7705c19f.png)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
