### PR TITLE
prometheus metric: upstream_latency_seconds

### DIFF
--- a/rootfs/etc/nginx/lua/monitor.lua
+++ b/rootfs/etc/nginx/lua/monitor.lua
@@ -47,6 +47,7 @@ local function metrics()
     responseLength = tonumber(ngx.var.bytes_sent) or -1,
 
     upstreamLatency = tonumber(ngx.var.upstream_connect_time) or -1,
+    upstreamHeaderTime = tonumber(ngx.var.upstream_header_time) or -1,
     upstreamResponseTime = tonumber(ngx.var.upstream_response_time) or -1,
     upstreamResponseLength = tonumber(ngx.var.upstream_response_length) or -1,
     --upstreamStatus = ngx.var.upstream_status or "-",

--- a/rootfs/etc/nginx/lua/test/monitor_test.lua
+++ b/rootfs/etc/nginx/lua/test/monitor_test.lua
@@ -93,7 +93,8 @@ describe("Monitor", function()
 
         upstream_addr = "10.10.0.1",
         upstream_connect_time = "0.01",
-        upstream_response_time = "0.02",
+        upstream_header_time = "0.02",
+        upstream_response_time = "0.03",
         upstream_response_length = "456",
         upstream_status = "200",
       }
@@ -125,7 +126,8 @@ describe("Monitor", function()
           responseLength = 512,
 
           upstreamLatency = 0.01,
-          upstreamResponseTime = 0.02,
+          upstreamHeaderTime = 0.02,
+          upstreamResponseTime = 0.03,
           upstreamResponseLength = 456,
         },
         {
@@ -143,7 +145,8 @@ describe("Monitor", function()
           responseLength = 512,
 
           upstreamLatency = 0.01,
-          upstreamResponseTime = 0.02,
+          upstreamHeaderTime = 0.02,
+          upstreamResponseTime = 0.03,
           upstreamResponseLength = 456,
         },
       })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
Expose nginx `upstream_header_time` metric to prometheus. Without it, we can't see upstream response latency. `upstream_response_time` is actually affected by client speed.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
none

## How Has This Been Tested?
```
$ make test
$ make lua-test
$ make kind-e2e-test
```

Earlier, I've built custom image using this Dockerfile:
```
FROM quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.21.0
USER root
RUN sed -i s/upstream_connect_time/upstream_header_time/g /etc/nginx/lua/monitor.lua
USER www-data
```
It was running in production for a year.
<img width="1017" alt="image" src="https://user-images.githubusercontent.com/100317/175044766-d3a7b85c-88c0-4a32-b718-976775c94266.png">

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Known issues:
There is inconsistency in metrics naming and metric types:
* `_request_duration_seconds` (histogram)
* `_response_duration_seconds` (histogram)
* `_ingress_upstream_latency_seconds` (summary)
* `_ingress_upstream_header_seconds` (summary)

I don't know which naming convention is preferred. Anyway, to fix this inconsistency, we need to duplicate two of these metrics to have backward compatibility. And this should be done in separate PR.