### PR TITLE
set ld-musl-path

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -31,8 +31,6 @@ LABEL org.opencontainers.image.revision="${COMMIT_SHA}"
 
 LABEL build_id="${BUILD_ID}"
 
-ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/modules_mount/etc/nginx/modules/modules
-
 WORKDIR  /etc/nginx
 
 RUN apk update \
@@ -61,7 +59,12 @@ RUN bash -xeu -c ' \
   for dir in "${writeDirs[@]}"; do \
     mkdir -p ${dir}; \
     chown -R www-data.www-data ${dir}; \
-  done'
+  done' \
+  # LD_LIBRARY_PATH does not work so below is needed for  opentelemetry/other modules
+  # Put libs of newer modules under `/modules_mount/<other>/lib` and add that path below
+  # Could get complicated arch specific paths become a need
+  && echo "/lib:/usr/lib:/usr/local/lib:/modules_mount/otel/lib" > /etc/ld-musl-x86_64.path
+  
 
 RUN apk add --no-cache libcap \
   && setcap    cap_net_bind_service=+ep /nginx-ingress-controller \

--- a/rootfs/Dockerfile.chroot
+++ b/rootfs/Dockerfile.chroot
@@ -44,7 +44,6 @@ LABEL build_id="${BUILD_ID}"
 ENV LUA_PATH="/usr/local/share/luajit-2.1.0-beta3/?.lua;/usr/local/share/lua/5.1/?.lua;/usr/local/lib/lua/?.lua;;"
 ENV LUA_CPATH="/usr/local/lib/lua/?/?.so;/usr/local/lib/lua/?.so;;"
 ENV PATH=$PATH:/usr/local/luajit/bin:/usr/local/nginx/sbin:/usr/local/nginx/bin
-ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/modules_mount/etc/nginx/modules/modules
 
 RUN apk update \
   && apk upgrade \
@@ -81,7 +80,11 @@ RUN bash -xeu -c ' \
   for dir in "${writeDirs[@]}"; do \
     mkdir -p ${dir}; \
     chown -R www-data.www-data ${dir}; \
-  done'
+  done' \
+  # LD_LIBRARY_PATH does not work so below is needed for  opentelemetry/other modules
+  # Put libs of newer modules under `/modules_mount/<other>/lib` and add that path below
+  # Could get complicated arch specific paths become a need
+  && echo "/lib:/usr/lib:/usr/local/lib:/modules_mount/otel/lib" > /etc/ld-musl-x86_64.path
 
 RUN apk add --no-cache libcap \
   && setcap    cap_sys_chroot,cap_net_bind_service=+ep /nginx-ingress-controller \


### PR DESCRIPTION
## What this PR does / why we need it:
- LD_LIBRARY_PATH does not work on alpine.
- Creating a file `/etc/ld-musl-<arch>.path` with the path(s) works
- This config is moved from base nginx image to the controller image
- This is needed for the linker to work with libraries needed by extra_modules
- extra_modules are optionally enabled (for eg. opentelemetry module)
- extra_module related libraries are not built/shipped with the controller image
- extra_module  libraries are built/shipped in their own image
- When extra_module is enabled, the controller pod is launched with a sidecar/initcontainer to obtain these libraries
- The extra_module libraries are copied from sidecar/initcontainers to the controller container
-  The copied libraries are not put in /usr/lib but to a custom location like /modules_mount/otel/lib, hence this need 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
- Several Opentelemetry issues and PR are related but none created specifically for this. This was discussed in community meeting on June 23, 2022

## How Has This Been Tested?
- Can be tested only after building because pulls nginx base image so am still working on local build and test for that as it requires change to code where base-image sha is hardcoded

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
