### PR TITLE
fix: add MAC_OS variable for static-check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,6 +146,7 @@ clean: ## Remove .gocache directory.
 .PHONY: static-check
 static-check: ## Run verification script for boilerplate, codegen, gofmt, golint, lualint and chart-lint.
 	@build/run-in-docker.sh \
+	    MAC_OS=$(MAC_OS) \
 		hack/verify-all.sh
 
 ###############################


### PR DESCRIPTION
We need pass MAC_OS variable to the script.

https://github.com/kubernetes/ingress-nginx/runs/7263808149?check_suite_focus=true#step:5:5


/cc @strongjz 