### PR TITLE
added fixes for make dev-env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,8 +54,9 @@ ifneq ($(PLATFORM),)
 endif
 
 MAC_OS = $(shell uname -s)
+
 ifeq ($(MAC_OS), Darwin)
-	MAC_DOCKER_FLAGS="--load"
+	MAC_DOCKER_FLAGS=
 else
 	MAC_DOCKER_FLAGS=
 endif

--- a/build/build.sh
+++ b/build/build.sh
@@ -49,6 +49,7 @@ echo "Building targets for ${ARCH}, generated targets in ${TARGETS_DIR} director
 
 echo "Building ${PKG}/cmd/nginx"
 
+git config --add safe.directory /go/src/k8s.io/ingress-nginx
 ${GO_BUILD_CMD} \
   -trimpath -ldflags="-buildid= -w -s \
     -X ${PKG}/version.RELEASE=${TAG} \

--- a/build/run-in-docker.sh
+++ b/build/run-in-docker.sh
@@ -65,12 +65,14 @@ fi
 
 USER=${USER:-nobody}
 
+MAC_OS="`uname -s`"
 MAC_OS="${MAC_OS:-}"
 if [[ ${MAC_OS} == "Darwin" ]]; then
 	MAC_DOCKER_FLAGS=""
 else
 	MAC_DOCKER_FLAGS="-u $(id -u ${USER}):$(id -g ${USER})" #idk why mac/git fails on the gobuild if these are presented to dockerrun.sh script
 fi
+echo "MAC_OS = ${MAC_OS}, MAC_OS_FLAGS = ${MAC_DOCKER_FLAGS}"
 
 echo "..printing env & other vars to stdout"
 echo "HOSTNAME=`hostname`"


### PR DESCRIPTION
## What this PR does / why we need it:
- There are 2 problems to be solved
  - Since git 2.35.2, git warns about a directory being unsafe. Its explained here https://stackoverflow.com/questions/71901632/fatal-error-unsafe-repository-home-repon-is-owned-by-someone-else . This was not happening before. This is breaking builds when run in DIND. Because the user that did the checkout will be random user
  - A env variable `MAC_OS` is set in the Makefile. It gets it value from `uname -s`. Since Makefile will be on Mac_OS, in case of a Mac laptop, the value is et to `Darwin`. But then in the next steps DIND is used and that is all linux but the env var "MAC_OS" still persists with value "Darwin". This populates another variable called `MAC_DOCKER_FLAGS` with a value of `--load`. That is invalid for DIND as its all linux. This breaks the build. The chats and the issue have the screenshots and logs
  - https://github.com/kubernetes/ingress-nginx/issues/8797
- This PR temporarily empties the `MAC_OS` variable value 
- This PR also intends to permanently inset the command  `git config --add safe.directory ....` to avoid breaking any build that uses git version 2.35 and above
 
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes

fixes #8797 

## How Has This Been Tested?
- Tested  locally on a Mac laptop with Colima proving docker

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
