### PR TITLE
bumped kubectl in test-runner to v1.24.0

### DIFF
--- a/build/dev-env.sh
+++ b/build/dev-env.sh
@@ -36,7 +36,7 @@ if ! command -v kind &> /dev/null; then
 fi
 
 if ! command -v kubectl &> /dev/null; then
-  echo "Please install kubectl 1.15 or higher"
+  echo "Please install kubectl 1.24.0 or higher"
   exit 1
 fi
 
@@ -46,14 +46,14 @@ if ! command -v helm &> /dev/null; then
 fi
 
 HELM_VERSION=$(helm version 2>&1 | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+') || true
-if [[ ${HELM_VERSION} < "v3.0.0" ]]; then
-  echo "Please upgrade helm to v3.0.0 or higher"
+if [[ ${HELM_VERSION} < "v3.9.0" ]]; then
+  echo "Please upgrade helm to v3.9.0 or higher"
   exit 1
 fi
 
 KUBE_CLIENT_VERSION=$(kubectl version --client --short 2>/dev/null | grep Client | awk '{print $3}' | cut -d. -f2) || true
-if [[ ${KUBE_CLIENT_VERSION} -lt 14 ]]; then
-  echo "Please update kubectl to 1.15 or higher"
+if [[ ${KUBE_CLIENT_VERSION} -lt 24 ]]; then
+  echo "Please update kubectl to 1.24.2 or higher"
   exit 1
 fi
 
@@ -61,7 +61,7 @@ echo "[dev-env] building image"
 make build image
 docker tag "${REGISTRY}/controller:${TAG}" "${DEV_IMAGE}"
 
-export K8S_VERSION=${K8S_VERSION:-v1.21.12@sha256:f316b33dd88f8196379f38feb80545ef3ed44d9197dca1bfd48bcb1583210207}
+export K8S_VERSION=${K8S_VERSION:-v1.24.2@sha256:1f0cee2282f43150b52dc7933183ed96abdcfc8d293f30ec07082495874876f1}
 
 KIND_CLUSTER_NAME="ingress-nginx-dev"
 

--- a/images/test-runner/Makefile
+++ b/images/test-runner/Makefile
@@ -41,7 +41,7 @@ build: ensure-buildx
 		--build-arg BASE_IMAGE=$(NGINX_BASE_IMAGE) \
 		--build-arg GOLANG_VERSION=1.18.2 \
 		--build-arg ETCD_VERSION=3.4.3-0 \
-		--build-arg K8S_RELEASE=v1.21.3 \
+		--build-arg K8S_RELEASE=v1.24.2 \
 		--build-arg RESTY_CLI_VERSION=0.27 \
 		--build-arg RESTY_CLI_SHA=e5f4f3128af49ba5c4d039d0554e5ae91bbe05866f60eccfa96d3653274bff90 \
 		--build-arg LUAROCKS_VERSION=3.8.0 \
@@ -49,7 +49,7 @@ build: ensure-buildx
 		--build-arg CHART_TESTING_VERSION=3.0.0 \
 		--build-arg YAML_LINT_VERSION=1.13.0 \
 		--build-arg YAMALE_VERSION=1.8.0 \
-		--build-arg HELM_VERSION=v3.4.2 \
+		--build-arg HELM_VERSION=v3.9.0 \
 		-t $(IMAGE):$(TAG) rootfs
 
 # push the cross built image


### PR DESCRIPTION
## What this PR does / why we need it:
- test-runner image still uses kubectl v1.21
- we added support for K8S v1.24
- hence bumped kubectl also to v1.24

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
fixes #8800 

## How Has This Been Tested?
- Can only be tested in CI as that is where it needs to be verified

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

/assign @rikatz @tao12345666333 @strongjz 