### PR TITLE
Fix defaultServer backend update for Ingress with defaultBackend.

### DIFF
--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -1207,17 +1207,15 @@ func (n *NGINXController) createServers(data []*ingress.Ingress,
 				// use backend specified in Ingress as the default backend for all its rules
 				un = backendUpstream.Name
 
-				// special "catch all" case, Ingress with a backend but no rule
 				defLoc := servers[defServerName].Locations[0]
-				defLoc.Backend = backendUpstream.Name
-				defLoc.Service = backendUpstream.Service
-				defLoc.Ingress = ing
-
 				if defLoc.IsDefBackend && len(ing.Spec.Rules) == 0 {
 					klog.V(2).Infof("Ingress %q defines a backend but no rule. Using it to configure the catch-all server %q", ingKey, defServerName)
 
 					defLoc.IsDefBackend = false
-
+					// special "catch all" case, Ingress with a backend but no rule
+					defLoc.Backend = backendUpstream.Name
+					defLoc.Service = backendUpstream.Service
+					defLoc.Ingress = ing
 					// TODO: Redirect and rewrite can affect the catch all behavior, skip for now
 					originalRedirect := defLoc.Redirect
 					originalRewrite := defLoc.Rewrite

--- a/test/e2e/ingress/without_host.go
+++ b/test/e2e/ingress/without_host.go
@@ -93,5 +93,13 @@ var _ = framework.IngressNginxDescribe("[Ingress] definition without host", func
 			WithHeader("Host", "only-backend").
 			Expect().
 			Status(http.StatusOK)
+		// Following assertion added with respect to issue https://github.com/kubernetes/ingress-nginx/issues/8823
+		// This check ensure that ingress having defaultBackend with rules should only be added as default backend
+		// for the host mentioned in rule. It should not affect the default catch-all server_name _ block.
+		f.HTTPTestClient().
+			GET("/").
+			WithHeader("Host", "only-backend-doesnotexist").
+			Expect().
+			Status(http.StatusNotFound)
 	})
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In this PR we have fixed default server backend get updated in case of Ingress resource defined with `One or More than one Rule`. Ideally, this should happen only incase when Ingress resource is defined with `Zero` rules.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->
#8823
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I have tested it by running cluster locally using Kind.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
