### PR TITLE
Migrate ginkgo to v2 in e2e-test-runner image

### DIFF
--- a/images/test-runner/rootfs/Dockerfile
+++ b/images/test-runner/rootfs/Dockerfile
@@ -49,7 +49,7 @@ ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
 
-RUN go install github.com/onsi/ginkgo/ginkgo@v1.16.5  && go install golang.org/x/lint/golint@latest
+RUN go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.4  && go install golang.org/x/lint/golint@latest
 
 ARG RESTY_CLI_VERSION
 ARG RESTY_CLI_SHA


### PR DESCRIPTION
## What this PR does / why we need it:
part of https://github.com/kubernetes/ingress-nginx/pull/8826,
as we are migrating ginkgo to v2, and the ginkgo in the test-runner is still with v1, we need to build a new image with ginkgo v2. We will revert this PR later once the image was built.

related comment:
https://github.com/kubernetes/ingress-nginx/pull/8826#issuecomment-1186707702

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
close https://github.com/kubernetes/ingress-nginx/issues/8819


## How Has This Been Tested?
[WIP ](https://github.com/kubernetes/ingress-nginx/pull/8826#issuecomment-1186707702)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
