### PR TITLE
bump to alpine-3.16.1

### DIFF
--- a/docs/examples/customization/sysctl/patch.json
+++ b/docs/examples/customization/sysctl/patch.json
@@ -4,7 +4,7 @@
 			"spec": {
 				"initContainers": [{
 					"name": "sysctl",
-					"image": "alpine:3.16.0",
+					"image": "alpine:3.16.1",
 					"securityContext": {
 						"privileged": true
 					},

--- a/images/cfssl/rootfs/Dockerfile
+++ b/images/cfssl/rootfs/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.16.0
+FROM alpine:3.16.1
 
 RUN echo "@testing http://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
 RUN apk add --no-cache \

--- a/images/httpbin/rootfs/Dockerfile
+++ b/images/httpbin/rootfs/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.16.0
+FROM alpine:3.16.1
 
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8

--- a/images/nginx/rootfs/Dockerfile
+++ b/images/nginx/rootfs/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM alpine:3.16.0 as builder
+FROM alpine:3.16.1 as builder
 
 COPY . /
 
@@ -21,7 +21,7 @@ RUN apk update \
   && /build.sh
 
 # Use a multi-stage build
-FROM alpine:3.16.0
+FROM alpine:3.16.1
 
 ENV PATH=$PATH:/usr/local/luajit/bin:/usr/local/nginx/sbin:/usr/local/nginx/bin
 

--- a/images/opentelemetry/rootfs/Dockerfile
+++ b/images/opentelemetry/rootfs/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-FROM alpine:3.16.0 as base
+FROM alpine:3.16.1 as base
 
 RUN mkdir -p /opt/third_party/install
 COPY . /opt/third_party/
@@ -39,7 +39,7 @@ COPY --from=grpc /opt/third_party/install/ /usr
 COPY --from=otel-cpp /opt/third_party/install/ /usr
 RUN bash /opt/third_party/build.sh -n
 
-FROM alpine:3.16.0
+FROM alpine:3.16.1
 COPY --from=base /opt/third_party/init_module.sh /usr/local/bin/init_module.sh
 COPY --from=nginx /etc/nginx/modules /etc/nginx/modules
 COPY --from=nginx /opt/third_party/install/lib /etc/nginx/modules

--- a/rootfs/Dockerfile-chroot
+++ b/rootfs/Dockerfile-chroot
@@ -23,7 +23,7 @@ RUN apk update \
   && apk upgrade \
   && /chroot.sh
 
-FROM alpine:3.16.0
+FROM alpine:3.16.1
 
 ARG TARGETARCH
 ARG VERSION

--- a/test/e2e-image/Dockerfile
+++ b/test/e2e-image/Dockerfile
@@ -1,7 +1,7 @@
 ARG E2E_BASE_IMAGE
 FROM ${E2E_BASE_IMAGE} AS BASE
 
-FROM alpine:3.16.0
+FROM alpine:3.16.1
 
 RUN apk add -U --no-cache \
   ca-certificates \


### PR DESCRIPTION
## What this PR does / why we need it:
- Because of 3-4 reasons, bumping base image to alpine v3.16.1
  - busybox and openssl CVE fix in alpine v3.16.1 
    ```
    % grype `k -n ingress-nginx get po ingress-nginx-controller-6bf7bc7f94-8f5s8 -o yaml |  grep -i registry | grep -v imageID | awk '{print $2}'`                                                                                                      
   ✔ Vulnerability DB        [updated]                                                                                                                                                                                                                
   ✔ Parsed image                                                                                                                                                                                                                                     
   ✔ Cataloged packages      [120 packages]                                                                                                                                                                                                           
   ✔ Scanned image           [5 vulnerabilities]                                                                                                                                                                                                      
  [0031]  WARN some package(s) are missing CPEs. This may result in missing vulnerabilities. You may autogenerate these   using: --add-cpes-if-none                                                                                                     
  NAME                        INSTALLED   FIXED-IN    TYPE       VULNERABILITY   SEVERITY                                                                                                                                                             
  busybox                     1.35.0-r14  1.35.0-r15  apk        CVE-2022-30065  High                                                                                                                                                                 
  google.golang.org/protobuf  v1.28.0                 go-module  CVE-2015-5237   High                                                                                                                                                                 
  google.golang.org/protobuf  v1.28.0                 go-module  CVE-2021-22570  High                                                                                                                                                                 
  ssl_client                  1.35.0-r14  1.35.0-r15  apk        CVE-2022-30065  High         
  % docker run  -it alpine:3.16.1 sh   
  % cat /etc/os-release 
  NAME="Alpine Linux"
  ID=alpine
  VERSION_ID=3.16.1
  PRETTY_NAME="Alpine Linux v3.16"
  HOME_URL="https://alpinelinux.org/"
  BUG_REPORT_URL="https://gitlab.alpinelinux.org/alpine/aports/-/issues"
  % apk list | grep -i busybox
  busybox-1.35.0-r15 x86_64 {busybox} (GPL-2.0-only) [installed]
  ssl_client-1.35.0-r15 x86_64 {busybox} (GPL-2.0-only) [installed]
   ```
- This  https://github.com/kubernetes/ingress-nginx/pull/8827 has already created a new base image in the staging registry

- The e2e-test-runner image is still on alpine v3.14.6 and I find `make dev-env` broken because `make build` is called with e2e-test-image built on alpine v3.14.6 whereas the controller is on alpine v3.16.0

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
- No issue created but all CVE issues are related

## How Has This Been Tested?
- Will be tested on cloudbuild

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

/triage-accepted
/kind bug
/assign @strongjz @tao12345666333 