### PR TITLE
fix: make use of sed portable for BSD and GNU

### DIFF
--- a/hack/generate-deploy-scripts.sh
+++ b/hack/generate-deploy-scripts.sh
@@ -55,11 +55,11 @@ do
       --namespace ingress-nginx \
       --kube-version ${K8S_VERSION} \
       > $MANIFEST
-    sed -i '' '/app.kubernetes.io\/managed-by: Helm/d' $MANIFEST
-    sed -i '' '/helm.sh/d' $MANIFEST
+    sed -i.bak '/app.kubernetes.io\/managed-by: Helm/d' $MANIFEST
+    sed -i.bak '/helm.sh/d' $MANIFEST
 
     kustomize --load-restrictor=LoadRestrictionsNone build . > ${OUTPUT_DIR}/deploy.yaml
-    rm $MANIFEST
+    rm $MANIFEST $MANIFEST.bak
     cd ~-
     # automatically generate the (unsupported) kustomization.yaml for each target
     sed "s_{TARGET}_${TARGET}_" $TEMPLATE_DIR/static-kustomization-template.yaml > ${OUTPUT_DIR}/kustomization.yaml
@@ -68,7 +68,7 @@ do
     if [[ ${K8S_VERSION} = ${K8S_DEFAULT_VERSION} ]]
     then
       cp ${OUTPUT_DIR}/*.yaml ${OUTPUT_DIR}/../
-      sed -i "s/^/#GENERATED FOR K8S ${K8S_VERSION}\n/" ${OUTPUT_DIR}/../deploy.yaml
+      sed -i.bak "s/^/#GENERATED FOR K8S ${K8S_VERSION}\n/" ${OUTPUT_DIR}/../deploy.yaml && rm ${OUTPUT_DIR}/../deploy.yaml.bak
     fi
   done
 done


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
This PR makes the use of `sed` in the `hack/generate-deploy-scripts.sh` portable across both GNU and BSD variants of `sed`.

See: https://stackoverflow.com/a/22084103/9439227

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->
fixes #8828

## How Has This Been Tested?
Tested locally with both `GNU sed` and `BSD sed`.
Did not test in some kind of container as the script should work on a native environment standalone.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
