### PR TITLE
changed baseimage sha & bumped ginkgo to 2.1.4 in test

### DIFF
--- a/NGINX_BASE
+++ b/NGINX_BASE
@@ -1,1 +1,1 @@
-registry.k8s.io/ingress-nginx/nginx:e1a16f6e74ef43cdfd59de75b3394d6b20ef7645@sha256:283c8c6132ebaeb155c927ea6e8ae0cd834a4a05d4807eceafa1b6e44d875911
+registry.k8s.io/ingress-nginx/nginx:18ee046b432502aedfed9321f0a9b50bfc009a67@sha256:b555a13dcc9165157a61b2279ed7f309e406c3267c93472cb6967215eacf4ab3

--- a/build/run-in-docker.sh
+++ b/build/run-in-docker.sh
@@ -86,7 +86,7 @@ if [[ "$DOCKER_IN_DOCKER_ENABLED" == "true" ]]; then
   echo "FLAGS=$FLAGS"
   go env
   set -x
-  go install -mod=mod github.com/onsi/ginkgo/ginkgo@v1.16.4
+  go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo@v2.1.4
   find / -type f -name ginkgo 2>/dev/null
   which ginkgo
   /bin/bash -c "${FLAGS}"

--- a/images/nginx/rc.yaml
+++ b/images/nginx/rc.yaml
@@ -38,7 +38,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: registry.k8s.io/ingress-nginx/nginx:0ff500c23f34e939305de709cb6d47da34b66611@sha256:15f91034a03550dfab6ec50a7be4abbb683d087e234ad7fef5adedef54e46a5a
+          image: registry.k8s.io/ingress-nginx/nginx:18ee046b432502aedfed9321f0a9b50bfc009a67@sha256:b555a13dcc9165157a61b2279ed7f309e406c3267c93472cb6967215eacf4ab3
           ports:
             - containerPort: 80
             - containerPort: 443

--- a/test/e2e/run-chart-test.sh
+++ b/test/e2e/run-chart-test.sh
@@ -78,7 +78,7 @@ fi
 
 if [ "${SKIP_IMAGE_CREATION:-false}" = "false" ]; then
   if ! command -v ginkgo &> /dev/null; then
-    go get github.com/onsi/ginkgo/ginkgo@v1.16.4
+    go get github.com/onsi/ginkgo/v2/ginkgo@v2.1.4
   fi
   echo "[dev-env] building image"
   make -C ${DIR}/../../ clean-image build image

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -79,7 +79,7 @@ fi
 
 if [ "${SKIP_IMAGE_CREATION:-false}" = "false" ]; then
   if ! command -v ginkgo &> /dev/null; then
-    go get github.com/onsi/ginkgo/ginkgo@v1.16.4
+    go get github.com/onsi/ginkgo/v2/ginkgo@v2.1.4
   fi
 
   echo "[dev-env] building image"


### PR DESCRIPTION
## What this PR does / why we need it:
- new base-image was promoted today after https://github.com/kubernetes/ingress-nginx/pull/8858
- so this PR changes the sha in file /NGINX_BASE
- also in the PR https://github.com/kubernetes/ingress-nginx/pull/8830, gingko was not bumped in tests so bumped ginkgo where ever ginkgo was still on v1.X

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
- No issues created but related to CVEs, move to ginkgo v2 etc

## How Has This Been Tested?
- Will be tested in CI and make targets

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

/triage-accepted
/area stabilisation
/assign @rikatz @strongjz @tao12345666333 