### PR TITLE
Revert "fix: test-runner prow build"

### DIFF
--- a/images/test-runner/Makefile
+++ b/images/test-runner/Makefile
@@ -23,7 +23,7 @@ REGISTRY ?= local
 
 IMAGE = $(REGISTRY)/e2e-test-runner
 
-NGINX_BASE_IMAGE ?= $(shell cat $(DIR)/../../NGINX_BASE || cat "/home/prow/go/src/github.com/kubernetes/ingress-nginx/NGINX_BASE")
+NGINX_BASE_IMAGE ?= $(shell cat $(DIR)/../../NGINX_BASE)
 
 # required to enable buildx
 export DOCKER_CLI_EXPERIMENTAL=enabled
@@ -34,8 +34,6 @@ OUTPUT=
 PROGRESS=plain
 
 build: ensure-buildx
-	echo $(NGINX_BASE_IMAGE)
-	pwd
 	docker buildx build \
 		--platform=${PLATFORMS} $(OUTPUT) \
 		--progress=$(PROGRESS) \


### PR DESCRIPTION
This reverts commit 423008b75282616413b743321d60d3a9557a570e.
and
This reverts commit 92f81e7449fa5bce5777b2aba924373984fb8530.


Temporary workaround doesn't work, I'll look for help with sig-testing


/cc @rikatz @strongjz @longwuyuan 