### PR TITLE
add --global flag to git --add safe.directory command"

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -49,7 +49,28 @@ echo "Building targets for ${ARCH}, generated targets in ${TARGETS_DIR} director
 
 echo "Building ${PKG}/cmd/nginx"
 
-git config --add safe.directory /go/src/k8s.io/ingress-nginx
+hostname
+uname -a
+cat /etc/os-release
+git version
+#gitMinorVersion=`git version | cut -f2 -d"."`
+#if [[ $gitMinorVersion > 35 ]]; then
+echo "Value in gitSafeDir = `git config safe.directory`"
+if [[ `git config safe.directory` == *ingress-nginx* ]]; then
+    echo "safedir is set"
+else
+	echo "safedir is not set"
+	pwd
+    ls -ltha
+    id
+    whoami
+    git status
+    git config -l
+    git config --add safe.directory /go/src/k8s.io/ingress-nginx
+fi
+#else
+#    echo "Git safedir check not needed"
+#fi  
 ${GO_BUILD_CMD} \
   -trimpath -ldflags="-buildid= -w -s \
     -X ${PKG}/version.RELEASE=${TAG} \
@@ -74,4 +95,5 @@ ${GO_BUILD_CMD} \
     -X ${PKG}/version.COMMIT=${COMMIT_SHA} \
     -X ${PKG}/version.REPO=${REPO_INFO}" \
   -o "${TARGETS_DIR}/wait-shutdown" "${PKG}/cmd/waitshutdown"
+
 


### PR DESCRIPTION
- Currently `make dev-env` is broken if run on Intel Mac and being tracked in https://github.com/kubernetes/ingress-nginx/issues/8879
- But there is another minor bug in the build.sh. Described below 
- Since git 2.35.2, git warns about a directory being unsafe. Its explained here https://stackoverflow.com/questions/71901632/fatal-error-unsafe-repository-home-repon-is-owned-by-someone-else . This was not happening before. This is breaking builds when run in DIND. Because the user that did the checkout will be random user
- The fix was already merged in https://github.com/kubernetes/ingress-nginx/pull/8804 but without the `--global` flag
- This PR adds the `--global` flag as absense of this flag is breaking `make image` on laptop/local
- But adding the `--global` flag breaks CI tests as the `.gitconfig` in the $HOME of user running PROW job is not writable by user running job

/triage accepted
/area stabilization
/assign @strongjz @tao12345666333

/priority important-soon