### PR TITLE
Don't error log when no OCSP responder URL exists

### DIFF
--- a/rootfs/etc/nginx/lua/certificate.lua
+++ b/rootfs/etc/nginx/lua/certificate.lua
@@ -120,8 +120,12 @@ end
 -- While this has no functional implications, it generates extra load on OCSP servers.
 local function fetch_and_cache_ocsp_response(uid, der_cert)
   local url, err = ocsp.get_ocsp_responder_from_der_chain(der_cert)
-  if not url then
+  if not url and err then
     ngx.log(ngx.ERR, "could not extract OCSP responder URL: ", err)
+    return
+  end
+  if not url and not err then
+    ngx.log(ngx.DEBUG, "no OCSP responder URL returned")
     return
   end
 


### PR DESCRIPTION

**What happened**:

With OCSP stapling support enabled, on every single request that serves a TLS certificate which does not contain OCSP information, the following error message is logged:
`[lua] certificate.lua:124: fetch_and_cache_ocsp_response(): could not extract OCSP responder URL: nil, context: ngx.timer, ...`


**What you expected to happen**:

An unset OCSP responder URL in a certificate should not be an error. Especially not on every request.


**NGINX Ingress controller version** (exec into the pod and run nginx-ingress-controller --version.):

NGINX Ingress controller
  Release:       v1.3.0
  Build:         2b7b74854d90ad9b4b96a5011b9e8b67d20bfb8f
  Repository:    https://github.com/kubernetes/ingress-nginx
  nginx version: nginx/1.19.10


**How to reproduce this issue**:

```
kind create cluster
kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/baremetal/deploy.yaml
echo "
  apiVersion: v1
  kind: ConfigMap
  metadata:
    name: ingress-nginx-controller
    namespace: ingress-nginx
  data:
    enable-ocsp: 'true'
" | kubectl apply -f -
POD_NAME=$(kubectl get pods -n ingress-nginx -l app.kubernetes.io/name=ingress-nginx,app.kubernetes.io/component=controller -o NAME)
kubectl exec -it -n ingress-nginx $POD_NAME -- curl -kH 'Host: foo.bar' https://localhost
kubectl -n ingress-nginx logs $POD_NAME
```

**Anything else we need to know**:

`ocsp.get_ocsp_responder_from_der_chain()` only returns a `nil` URL and error on `FFI_DECLINED`, which as far as I could tell is undocumented and seems to be the case when the call succeeded, but no such URL exists.

There's also a case where something is returned, but the error is also `"truncated"` that is being ignored.

Relevant OpenResty code: https://github.com/openresty/lua-resty-core/blob/v0.1.22/lib/ngx/ocsp.lua#L43-L70
