### PR TITLE
update to baseiamge built after CI changes

### DIFF
--- a/NGINX_BASE
+++ b/NGINX_BASE
@@ -1,1 +1,1 @@
-registry.k8s.io/ingress-nginx/nginx:c5766dc011965f22fac2f4437e86d0fd9960a50c@sha256:94ff9b435a5f3f4570bbdaed4a3a523f63a54ce2ad6b132b5640bae2af5d9d90
+registry.k8s.io/ingress-nginx/nginx:f0490cbfbf29a7a05caaac29998dde56173ac2bb@sha256:f0d8d32a20f8c1a7c98b504a03b162931d93edd60ecc2c745917a32e9e3e92ad


### PR DESCRIPTION
- This PR updates base image to image built because of https://github.com/kubernetes/ingress-nginx/pull/8870  and promoted by https://github.com/kubernetes/k8s.io/pull/4018
- This image contains alpine v3.16.1 that has patches for busybox & ssl_client CVE
- This PR merge should fire cloudbuild of all other images because of https://github.com/kubernetes/test-infra/pull/26980  and https://github.com/kubernetes/test-infra/pull/26923 
- So multiple other images will need to be promoted and code changed to reference them, after this PR merges