### PR TITLE
feat: parametrize registry value for k8s.gcr.io

### DIFF
--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -7,10 +7,12 @@
 # nameOverride:
 # fullnameOverride:
 
+registry: k8s.gcr.io
+
 controller:
   name: controller
   image:
-    registry: k8s.gcr.io
+    registry: {{ tpl .Values.registry . }}
     image: ingress-nginx/controller
     # for backwards compatibility consider setting the full image url via the repository value below
     # use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail
@@ -585,7 +587,7 @@ controller:
     patch:
       enabled: true
       image:
-        registry: k8s.gcr.io
+        registry: {{ tpl .Values.registry . }}
         image: ingress-nginx/kube-webhook-certgen
         # for backwards compatibility consider setting the full image url via the repository value below
         # use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail
@@ -708,7 +710,7 @@ defaultBackend:
 
   name: defaultbackend
   image:
-    registry: k8s.gcr.io
+    registry: {{ tpl .Values.registry . }}
     image: defaultbackend-amd64
     # for backwards compatibility consider setting the full image url via the repository value below
     # use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
Unhardcode registry value k8s.gcr.io to allow deploying
the chart while pulling from custom containers registries.

For example, when deploting the chart on a private AWS EKS cluster,
its private AWS VPC might be allowed to only access AWS ECR
via configured service endpoints. Then pulling from k8s.gcr.io fails.
A solution would be to allow users make all images pulling from
ECR namespaces instead of k8s.gcr.io.

<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
TBD
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
