### PR TITLE
Set grpc :authority header from request header

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -1343,12 +1343,10 @@ stream {
             {{ end }}
 
             {{/* By default use vhost as Host to upstream, but allow overrides */}}
-            {{ if not (eq $proxySetHeader "grpc_set_header") }}
             {{ if not (empty $location.UpstreamVhost) }}
             {{ $proxySetHeader }} Host                   {{ $location.UpstreamVhost | quote }};
             {{ else }}
             {{ $proxySetHeader }} Host                   $best_http_host;
-            {{ end }}
             {{ end }}
 
             # Pass the extracted client certificate to the backend

--- a/test/e2e/annotations/grpc.go
+++ b/test/e2e/annotations/grpc.go
@@ -120,6 +120,7 @@ var _ = framework.DescribeAnnotation("backend-protocol - GRPC", func() {
 
 		metadata := res.GetMetadata()
 		assert.Equal(ginkgo.GinkgoT(), metadata["content-type"].Values[0], "application/grpc")
+		assert.Equal(ginkgo.GinkgoT(), metadata[":authority"].Values[0], host)
 	})
 
 	ginkgo.It("authorization metadata should be overwritten by external auth response headers", func() {


### PR DESCRIPTION
## What this PR does / why we need it:

This is to fix that the `:authority` header by default is set to `upstream_balancer`, this PR sets `:authority` header from request `:authority` header.

Note using in nginx  http2 `:authority` header merged with the Host header concept, so `grpc_set_header Host $http_host` actually sets `:authority` together with Host header

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

Note this is breaking change 

1. If people don't have `grpc_set_header Host` in `configuration_snippet`, it means the `:authority` header will change from `upstream_balancer` to the request `:authority` header. This part I think it's fine because no one will rely on the `:authority` header to be `upstream_balancer`
2. if people have `grpc_set_header Host` in `configuration_snippet`, they will need to change it back to use `nginx.ingress.kubernetes.io/upstream-vhost` annotation 

## Which issue/s this PR fixes

fixes #8843

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Haven't got time to run it yet, will run ingress nginx e2e test

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
