### PR TITLE
bump alpine to v3.16.2

### DIFF
--- a/docs/examples/customization/sysctl/patch.json
+++ b/docs/examples/customization/sysctl/patch.json
@@ -4,7 +4,7 @@
 			"spec": {
 				"initContainers": [{
 					"name": "sysctl",
-					"image": "alpine:3.16.1",
+					"image": "alpine:3.16.2",
 					"securityContext": {
 						"privileged": true
 					},

--- a/images/cfssl/rootfs/Dockerfile
+++ b/images/cfssl/rootfs/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.16.1
+FROM alpine:3.16.2
 
 RUN echo "@testing http://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
 RUN apk add --no-cache \

--- a/images/httpbin/rootfs/Dockerfile
+++ b/images/httpbin/rootfs/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.16.1
+FROM alpine:3.16.2
 
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8

--- a/images/nginx/rootfs/Dockerfile
+++ b/images/nginx/rootfs/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM alpine:3.16.1 as builder
+FROM alpine:3.16.2 as builder
 
 COPY . /
 
@@ -21,7 +21,7 @@ RUN apk update \
   && /build.sh
 
 # Use a multi-stage build
-FROM alpine:3.16.1
+FROM alpine:3.16.2
 
 ENV PATH=$PATH:/usr/local/luajit/bin:/usr/local/nginx/sbin:/usr/local/nginx/bin
 

--- a/images/opentelemetry/rootfs/Dockerfile
+++ b/images/opentelemetry/rootfs/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-FROM alpine:3.16.1 as base
+FROM alpine:3.16.2 as base
 
 RUN mkdir -p /opt/third_party/install
 COPY . /opt/third_party/
@@ -39,7 +39,7 @@ COPY --from=grpc /opt/third_party/install/ /usr
 COPY --from=otel-cpp /opt/third_party/install/ /usr
 RUN bash /opt/third_party/build.sh -n
 
-FROM alpine:3.16.1
+FROM alpine:3.16.2
 COPY --from=base /opt/third_party/init_module.sh /usr/local/bin/init_module.sh
 COPY --from=nginx /etc/nginx/modules /etc/nginx/modules
 COPY --from=nginx /opt/third_party/install/lib /etc/nginx/modules

--- a/rootfs/Dockerfile-chroot
+++ b/rootfs/Dockerfile-chroot
@@ -23,7 +23,7 @@ RUN apk update \
   && apk upgrade \
   && /chroot.sh
 
-FROM alpine:3.16.1
+FROM alpine:3.16.2
 
 ARG TARGETARCH
 ARG VERSION

--- a/test/e2e-image/Dockerfile
+++ b/test/e2e-image/Dockerfile
@@ -1,7 +1,7 @@
 ARG E2E_BASE_IMAGE
 FROM ${E2E_BASE_IMAGE} AS BASE
 
-FROM alpine:3.16.1
+FROM alpine:3.16.2
 
 RUN apk add -U --no-cache \
   ca-certificates \


### PR DESCRIPTION
## What this PR does / why we need it:
- This PR bumps alpine to v3.16.2 to fix CVE https://github.com/advisories/GHSA-cfmr-vrgj-vqwv
![image](https://user-images.githubusercontent.com/5085914/185289761-5896264e-9a4a-4693-b034-20e6361adaad.png)

- Related issue https://github.com/kubernetes/ingress-nginx/issues/8933
-
```
% grype `k -n ingress-nginx get po ingress-nginx-controller-6bf7bc7f94-czztm -o yaml | grep -i image:| grep -i registry | awk '{print $2}'`
 ✔ Vulnerability DB        [no update available]
 ✔ Pulled image            
 ✔ Loaded image            
 ✔ Parsed image            
 ✔ Cataloged packages      [120 packages]
 ✔ Scanned image           [7 vulnerabilities]
[0022]  WARN some package(s) are missing CPEs. This may result in missing vulnerabilities. You may autogenerate these using: --add-cpes-if-none
NAME                        INSTALLED   FIXED-IN    TYPE       VULNERABILITY   SEVERITY 
busybox                     1.35.0-r14  1.35.0-r15  apk        CVE-2022-30065  High      
google.golang.org/protobuf  v1.28.0                 go-module  CVE-2015-5237   High      
google.golang.org/protobuf  v1.28.0                 go-module  CVE-2021-22570  High      
ssl_client                  1.35.0-r14  1.35.0-r15  apk        CVE-2022-30065  High      
zlib                        1.2.12-r1   1.2.12-r2   apk        CVE-2022-37434  Critical  

```
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
fixes #8933

## How Has This Been Tested?
- Grype scan of aloine v3.16.2

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.