### PR TITLE
make ClusterRole and ClusterRoleBinding uniq

### DIFF
--- a/charts/ingress-nginx/templates/clusterrole.yaml
+++ b/charts/ingress-nginx/templates/clusterrole.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- with .Values.controller.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  name: {{ include "ingress-nginx.fullname" . }}
+  name: {{ include "ingress-nginx.fullname" . }}-{{ .Release.Namespace }}
 rules:
   - apiGroups:
       - ""

--- a/charts/ingress-nginx/templates/clusterrolebinding.yaml
+++ b/charts/ingress-nginx/templates/clusterrolebinding.yaml
@@ -7,11 +7,11 @@ metadata:
     {{- with .Values.controller.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  name: {{ include "ingress-nginx.fullname" . }}
+  name: {{ include "ingress-nginx.fullname" . }}-{{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "ingress-nginx.fullname" . }}
+  name: {{ include "ingress-nginx.fullname" . }}-{{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
     name: {{ template "ingress-nginx.serviceAccountName" . }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
It creates uniq ClusterRoles and ClusterRoleBindings so multiple ingress-nginx ainstallations are not overwriting each other

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
Not sure for other installations but as the ClusterRole and ClusterRoleBinding is created now uniq I expect no issues


## Which issue/s this PR fixes
fixes #8936 

## How Has This Been Tested?
several clusters with more then 40 dedicated ingress-nginx rolled out with ArgoCD

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
