### PR TITLE
bump baseimage alpine to v3.16.2 for zlib CVE fix

### DIFF
--- a/NGINX_BASE
+++ b/NGINX_BASE
@@ -1,1 +1,1 @@
-registry.k8s.io/ingress-nginx/nginx:f0490cbfbf29a7a05caaac29998dde56173ac2bb@sha256:f0d8d32a20f8c1a7c98b504a03b162931d93edd60ecc2c745917a32e9e3e92ad
+registry.k8s.io/ingress-nginx/nginx:9fdbef829c327b95a3c6d6816a301df41bda997f@sha256:46c27294e467f46d0006ad1eb5fd3f7005eb3cbd00dd43be2ed9b02edfc6e828

--- a/test/e2e/settings/ocsp/ocsp.go
+++ b/test/e2e/settings/ocsp/ocsp.go
@@ -292,7 +292,7 @@ func ocspserveDeployment(namespace string) (*appsv1.Deployment, *corev1.Service)
 						Containers: []corev1.Container{
 							{
 								Name:  name,
-								Image: "registry.k8s.io/ingress-nginx/e2e-test-cfssl@sha256:c0bd134f1c7190079180e6d4fa2ba64c049961a49b96db20aa39fabc896d26d5",
+								Image: "registry.k8s.io/ingress-nginx/e2e-test-cfssl@sha256:c1b273763048944dd7d22d37adfc65be4fa6a5f6068204292573c6cdc5ea3457",
 								Command: []string{
 									"/bin/bash",
 									"-c",


### PR DESCRIPTION
## What this PR does / why we need it:
- This PR changes /NGINX_BASE to contain sha of new base image built on alpine v3.16.2 for fix of Critical zlib CVE

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
fixes #8933

## How Has This Been Tested?
- 
![image](https://user-images.githubusercontent.com/5085914/185510212-2b492144-5f35-437f-ba60-4d031fec64ae.png)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.