### PR TITLE
added note on digitalocean annotations

### DIFF
--- a/docs/deploy/index.md
+++ b/docs/deploy/index.md
@@ -299,6 +299,8 @@ More information with regard to Azure annotations for ingress controller can be 
 ```console
 kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.3.0/deploy/static/provider/do/deploy.yaml
 ```
+- By default the service object of the ingress-nginx-controller for Digital-Ocean, only configures one annotation. Its this one `service.beta.kubernetes.io/do-loadbalancer-enable-proxy-protocol: "true"`. While this makes the service functional, it was reported that the Digital-Ocean LoadBalancer graphs shows `no data`, unless a few other annotations are also configured. Some of these other annotations require values that can not be generic and hence not forced in a out-of-the-box installation. These annotations and a discussion on them is well documented in [this issue](https://github.com/kubernetes/ingress-nginx/issues/8965). Please refer to the issue to add annotations, with values specific to user, to get graphs of the DO-LB populated with data.
+
 
 #### Scaleway
 


### PR DESCRIPTION
## What this PR does / why we need it:
- This PR adds a note, to the Deployment docs for DigitalOcean, related to using DigitalOcean specific annotations, required for getting data populated in the DO LB Graphs
- One user asked for a change (#8965) to the manifest shipped by the project but the annotations take values that can not be generic
- Hence the note added, so that users can manually add the annotations after installation

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation only

## Which issue/s this PR fixes
fixes #8965 

## How Has This Been Tested?
- Nothing to test as docs

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

/triage-accepted
/area docs
/assign @tao12345666333 @strongjz 