### PR TITLE
Backporting controllerValue from main

### DIFF
--- a/charts/ingress-nginx/Chart.yaml
+++ b/charts/ingress-nginx/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ingress-nginx
 # When the version is modified, please make sure the artifacthub.io/changes list is updated
 # Also update CHANGELOG.md
-version: 3.41.0
+version: 3.41.1
 appVersion: 0.51.0
 home: https://github.com/kubernetes/ingress-nginx
 description: Ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer

--- a/charts/ingress-nginx/templates/controller-daemonset.yaml
+++ b/charts/ingress-nginx/templates/controller-daemonset.yaml
@@ -83,6 +83,9 @@ spec:
             - --publish-service={{ template "ingress-nginx.controller.publishServicePath" . }}
           {{- end }}
             - --election-id={{ .Values.controller.electionID }}
+          {{- if .Values.controller.ingressClassResource.enabled }}
+            - --controller-class={{ .Values.controller.ingressClassResource.controllerValue }}
+          {{- end }}
             - --ingress-class={{ .Values.controller.ingressClass }}
             - --configmap={{ .Release.Namespace }}/{{ include "ingress-nginx.controller.fullname" . }}
           {{- if .Values.tcp }}

--- a/charts/ingress-nginx/templates/controller-deployment.yaml
+++ b/charts/ingress-nginx/templates/controller-deployment.yaml
@@ -87,6 +87,9 @@ spec:
             - --publish-service={{ template "ingress-nginx.controller.publishServicePath" . }}
           {{- end }}
             - --election-id={{ .Values.controller.electionID }}
+          {{- if .Values.controller.ingressClassResource.enabled }}
+            - --controller-class={{ .Values.controller.ingressClassResource.controllerValue }}
+          {{- end }}
             - --ingress-class={{ .Values.controller.ingressClass }}
             - --configmap=$(POD_NAMESPACE)/{{ include "ingress-nginx.controller.fullname" . }}
           {{- if .Values.tcp }}

--- a/charts/ingress-nginx/templates/controller-ingressclass.yaml
+++ b/charts/ingress-nginx/templates/controller-ingressclass.yaml
@@ -18,6 +18,6 @@ metadata:
     ingressclass.kubernetes.io/is-default-class: "true"
 {{- end }}
 spec:
-  controller: k8s.io/ingress-nginx
+  controller: {{ .Values.controller.ingressClassResource.controllerValue }}
   {{ template "ingressClass.parameters" . }}
 {{- end }}

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -92,8 +92,14 @@ controller:
   # This section refers to the creation of the IngressClass resource
   # IngressClass resources are supported since k8s >= 1.18
   ingressClassResource:
-    enabled: false
+    # -- Name of the ingressClass
+    name: nginx
+    # -- Is this ingressClass enabled or not
+    enabled: true
+    # -- Is this the default ingressClass for the cluster
     default: false
+    # -- Controller-value of the controller that is processing this ingressClass
+    controllerValue: "k8s.io/ingress-nginx"
 
     # Parameters is a link to a custom resource containing additional
     # configuration for the controller. This is optional if the controller


### PR DESCRIPTION
 M charts/ingress-nginx/Chart.yaml
 M charts/ingress-nginx/templates/controller-daemonset.yaml
 M charts/ingress-nginx/templates/controller-deployment.yaml
 M charts/ingress-nginx/templates/controller-ingressclass.yaml
 M charts/ingress-nginx/values.yaml

-- This message was automatically generated by 'git auto'

Signed-off-by: Guillem Parera <g.parera@avoristravel.com>

## What this PR does / why we need it:
Backporting option to add controllerValue in ingressClass resource. In this version, if ingressClassResource is enabled is always created with a default controller value: k8s.io/nginx-default. So it's not possible to have 2 ingress-nginx controller using ingressClass in the same cluster.

