### PR TITLE
fixed deprecated ginkgo flags

### DIFF
--- a/test/e2e-image/e2e.sh
+++ b/test/e2e-image/e2e.sh
@@ -19,17 +19,17 @@ set -e
 NC='\e[0m'
 BGREEN='\e[32m'
 
-SLOW_E2E_THRESHOLD=${SLOW_E2E_THRESHOLD:-5}
+SLOW_E2E_THRESHOLD=${SLOW_E2E_THRESHOLD:-"5s"}
 FOCUS=${FOCUS:-.*}
 E2E_NODES=${E2E_NODES:-5}
 E2E_CHECK_LEAKS=${E2E_CHECK_LEAKS:-""}
 
 ginkgo_args=(
-  "-randomizeAllSpecs"
-  "-flakeAttempts=2"
-  "-failFast"
+  "-randomize-all"
+  "-flake-attempts=2"
+  "-fail-fast"
   "-progress"
-  "-slowSpecThreshold=${SLOW_E2E_THRESHOLD}"
+  "-slow-spec-threshold=${SLOW_E2E_THRESHOLD}"
   "-succinct"
   "-timeout=75m"
 )


### PR DESCRIPTION
## What this PR does / why we need it:
- We bumped ginkgo from v1.x to v2
- Tests print warnings like screenshot below
![image](https://user-images.githubusercontent.com/5085914/187017718-310d0199-7ae2-4452-bf0c-4fa3d8662d35.png)

- This PR changes the syntax for 3 ginkgo flags 
- This PR also changes value for one flag from type int to type string
- Changes are done as per recommendation in that message in the screenshot and URLs like https://onsi.github.io/ginkgo/#mental-model-how-ginkgo-handles-failure

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
- No issue created

## How Has This Been Tested?
- By running `FOCUS="no-auth-locations" make kind-e2e-test`

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Added Release Notes.

## Does my pull request need a release note?
Any user-visible or operator-visible change qualifies for a release note. This could be a:

- CLI change
- API change
- UI change
- configuration schema change
- behavioral change
- change in non-functional attributes such as efficiency or availability, availability of a new platform
- a warning about a deprecation
- fix of a previous Known Issue
- fix of a vulnerability (CVE)

No release notes are required for changes to the following:

- Tests
- Build infrastructure
- Fixes for unreleased bugs

For more tips on writing good release notes, check out the [Release Notes Handbook](https://github.com/kubernetes/sig-release/tree/master/release-team/role-handbooks/release-notes)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
/triage accepted
/area stabilization
/assign @tao12345666333 @rikatz 