### PR TITLE
Add auth-signin-snippet annotation

### DIFF
--- a/docs/user-guide/nginx-configuration/annotations.md
+++ b/docs/user-guide/nginx-configuration/annotations.md
@@ -37,6 +37,7 @@ You can add these Kubernetes annotations to specific Ingress objects to customiz
 |[nginx.ingress.kubernetes.io/auth-keepalive-timeout](#external-authentication)|number|
 |[nginx.ingress.kubernetes.io/auth-proxy-set-headers](#external-authentication)|string|
 |[nginx.ingress.kubernetes.io/auth-snippet](#external-authentication)|string|
+|[nginx.ingress.kubernetes.io/auth-signin-snippet](#external-authentication)|string|
 |[nginx.ingress.kubernetes.io/enable-global-auth](#external-authentication)|"true" or "false"|
 |[nginx.ingress.kubernetes.io/backend-protocol](#backend-protocol)|string|HTTP,HTTPS,GRPC,GRPCS,AJP|
 |[nginx.ingress.kubernetes.io/canary](#canary)|"true" or "false"|
@@ -502,6 +503,25 @@ nginx.ingress.kubernetes.io/auth-snippet: |
 
 !!! example
     Please check the [external-auth](../../examples/auth/external-auth/README.md) example.
+* `nginx.ingress.kubernetes.io/auth-signin-snippet`:
+  `<Auth_Signin_Snippet>` to specify a custom snippet to use with external authentication in gerenal and with OAUTH in particular to apply additional configuration when `nginx.ingress.kubernetes.io/auth-signin` is executed, e.g.
+
+```yaml
+nginx.ingress.kubernetes.io/auth-url: https://$host/oauth2/auth
+nginx.ingress.kubernetes.io/auth-signin: "https://$host/oauth2/start?rd=$escaped_request_uri"
+nginx.ingress.kubernetes.io/auth-signin-snippet: |
+    set $do401 "";
+    if ($http_accept ~= "text/html" ) {
+        set $do401 "${do401}1";
+    }
+    if ($request_method = GET) {
+        set $do401 "${do401}1";
+    }
+    if ($do401 == "11") {
+        return 401; 
+    }
+```
+> Note: `nginx.ingress.kubernetes.io/auth-signin-snippet` is an optional annotation. However, it may only be used in conjunction with `nginx.ingress.kubernetes.io/auth-signin` and will be ignored if `nginx.ingress.kubernetes.io/auth-signin` is not set
 
 #### Global External Authentication
 

--- a/go.mod
+++ b/go.mod
@@ -70,6 +70,7 @@ require (
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.19.5 // indirect
 	github.com/go-openapi/swag v0.19.14 // indirect
+	github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 // indirect
 	github.com/godbus/dbus/v5 v5.0.6 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.2.0 // indirect
@@ -80,6 +81,7 @@ require (
 	github.com/google/gnostic v0.5.7-v3refs // indirect
 	github.com/google/go-cmp v0.5.8 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
+	github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/google/uuid v1.2.0 // indirect
 	github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -212,6 +212,8 @@ github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh
 github.com/go-openapi/swag v0.19.14 h1:gm3vOOXfiuw5i9p5N9xJvfjvuofpyvLA9Wr6QfK5Fng=
 github.com/go-openapi/swag v0.19.14/go.mod h1:QYRuS/SOXUCsnplDa677K7+DxSOj6IPNl/eQntq43wQ=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 h1:p104kn46Q8WdvHunIJ9dAyjPVtrBPhSr3KT2yUst43I=
+github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/godbus/dbus/v5 v5.0.6 h1:mkgN1ofwASrYnJ5W6U/BxG15eXXXjirgZc7CLqkcaro=
 github.com/godbus/dbus/v5 v5.0.6/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
@@ -303,6 +305,7 @@ github.com/google/pprof v0.0.0-20210122040257-d980be63207e/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210226084205-cbba55b83ad5/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210601050228-01bbb1931b22/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210609004039-a478d1d731e9/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
+github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 h1:K6RDEckDVWvDI9JAJYCmNdQXq6neHJOYx3V6jnqNEec=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=

--- a/internal/ingress/annotations/authreq/main.go
+++ b/internal/ingress/annotations/authreq/main.go
@@ -42,6 +42,7 @@ type Config struct {
 	ResponseHeaders        []string          `json:"responseHeaders,omitempty"`
 	RequestRedirect        string            `json:"requestRedirect"`
 	AuthSnippet            string            `json:"authSnippet"`
+	AuthSigninSnippet      string            `json:"authSigninSnippet"`
 	AuthCacheKey           string            `json:"authCacheKey"`
 	AuthCacheDuration      []string          `json:"authCacheDuration"`
 	KeepaliveConnections   int               `json:"keepaliveConnections"`
@@ -205,6 +206,11 @@ func (a authReq) Parse(ing *networking.Ingress) (interface{}, error) {
 		klog.V(3).InfoS("auth-signin annotation is undefined and will not be set")
 	}
 
+	signInSnippet, err := parser.GetStringAnnotation("auth-signin-snippet", ing)
+	if err != nil {
+		klog.V(3).InfoS("auth-signin-snippet annotation is undefined and will not be set")
+	}
+
 	signInRedirectParam, err := parser.GetStringAnnotation("auth-signin-redirect-param", ing)
 	if err != nil {
 		klog.V(3).Infof("auth-signin-redirect-param annotation is undefined and will not be set")
@@ -313,6 +319,7 @@ func (a authReq) Parse(ing *networking.Ingress) (interface{}, error) {
 		ResponseHeaders:        responseHeaders,
 		RequestRedirect:        requestRedirect,
 		AuthSnippet:            authSnippet,
+		AuthSigninSnippet:      signInSnippet,
 		AuthCacheKey:           authCacheKey,
 		AuthCacheDuration:      authCacheDuration,
 		KeepaliveConnections:   keepaliveConnections,

--- a/internal/ingress/annotations/authreq/main_test.go
+++ b/internal/ingress/annotations/authreq/main_test.go
@@ -92,21 +92,23 @@ func TestAnnotations(t *testing.T) {
 		method                 string
 		requestRedirect        string
 		authSnippet            string
+		authSigninSnippet      string
 		authCacheKey           string
 		authAlwaysSetCookie    bool
 		expErr                 bool
 	}{
-		{"empty", "", "", "", "", "", "", "", false, true},
-		{"no scheme", "bar", "bar", "", "", "", "", "", false, true},
-		{"invalid host", "http://", "http://", "", "", "", "", "", false, true},
-		{"invalid host (multiple dots)", "http://foo..bar.com", "http://foo..bar.com", "", "", "", "", "", false, true},
-		{"valid URL", "http://bar.foo.com/external-auth", "http://bar.foo.com/external-auth", "", "", "", "", "", false, false},
-		{"valid URL - send body", "http://foo.com/external-auth", "http://foo.com/external-auth", "", "POST", "", "", "", false, false},
-		{"valid URL - send body", "http://foo.com/external-auth", "http://foo.com/external-auth", "", "GET", "", "", "", false, false},
-		{"valid URL - request redirect", "http://foo.com/external-auth", "http://foo.com/external-auth", "", "GET", "http://foo.com/redirect-me", "", "", false, false},
-		{"auth snippet", "http://foo.com/external-auth", "http://foo.com/external-auth", "", "", "", "proxy_set_header My-Custom-Header 42;", "", false, false},
-		{"auth cache ", "http://foo.com/external-auth", "http://foo.com/external-auth", "", "", "", "", "$foo$bar", false, false},
-		{"redirect param", "http://bar.foo.com/external-auth", "http://bar.foo.com/external-auth", "origUrl", "", "", "", "", true, false},
+		{"empty", "", "", "", "", "", "", "", "", false, true},
+		{"no scheme", "bar", "bar", "", "", "", "", "", "", false, true},
+		{"invalid host", "http://", "http://", "", "", "", "", "", "", false, true},
+		{"invalid host (multiple dots)", "http://foo..bar.com", "http://foo..bar.com", "", "", "", "", "", "", false, true},
+		{"valid URL", "http://bar.foo.com/external-auth", "http://bar.foo.com/external-auth", "", "", "", "", "", "", false, false},
+		{"valid URL - send body", "http://foo.com/external-auth", "http://foo.com/external-auth", "", "POST", "", "", "", "", false, false},
+		{"valid URL - send body", "http://foo.com/external-auth", "http://foo.com/external-auth", "", "GET", "", "", "", "", false, false},
+		{"valid URL - request redirect", "http://foo.com/external-auth", "http://foo.com/external-auth", "", "GET", "http://foo.com/redirect-me", "", "", "", false, false},
+		{"auth snippet", "http://foo.com/external-auth", "http://foo.com/external-auth", "", "", "", "proxy_set_header My-Custom-Header 42;", "", "", false, false},
+		{"auth signin snippet", "http://foo.com/external-auth", "http://foo.com/external-auth", "", "", "", "", "proxy_set_header My-Custom-Auth-Redirect-Header 401;", "", false, false},
+		{"auth cache ", "http://foo.com/external-auth", "http://foo.com/external-auth", "", "", "", "", "", "$foo$bar", false, false},
+		{"redirect param", "http://bar.foo.com/external-auth", "http://bar.foo.com/external-auth", "origUrl", "", "", "", "", "", true, false},
 	}
 
 	for _, test := range tests {
@@ -116,6 +118,7 @@ func TestAnnotations(t *testing.T) {
 		data[parser.GetAnnotationWithPrefix("auth-method")] = fmt.Sprintf("%v", test.method)
 		data[parser.GetAnnotationWithPrefix("auth-request-redirect")] = test.requestRedirect
 		data[parser.GetAnnotationWithPrefix("auth-snippet")] = test.authSnippet
+		data[parser.GetAnnotationWithPrefix("auth-signin-snippet")] = test.authSigninSnippet
 		data[parser.GetAnnotationWithPrefix("auth-cache-key")] = test.authCacheKey
 		data[parser.GetAnnotationWithPrefix("auth-always-set-cookie")] = boolToString(test.authAlwaysSetCookie)
 
@@ -151,6 +154,9 @@ func TestAnnotations(t *testing.T) {
 		}
 		if u.AuthSnippet != test.authSnippet {
 			t.Errorf("%v: expected \"%v\" but \"%v\" was returned", test.title, test.authSnippet, u.AuthSnippet)
+		}
+		if u.AuthSigninSnippet != test.authSigninSnippet {
+			t.Errorf("%v: expected \"%v\" but \"%v\" was returned", test.title, test.authSigninSnippet, u.AuthSigninSnippet)
 		}
 		if u.AuthCacheKey != test.authCacheKey {
 			t.Errorf("%v: expected \"%v\" but \"%v\" was returned", test.title, test.authCacheKey, u.AuthCacheKey)

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -1178,6 +1178,11 @@ stream {
             modsecurity off;
             {{ end }}
 
+            {{ if not (empty $externalAuth.AuthSigninSnippet) }}
+            # auth-signin-snippet from annotation
+            {{ $externalAuth.AuthSigninSnippet }}
+            {{ end }}
+
             return 302 {{ buildAuthSignURL $externalAuth.SigninURL $externalAuth.SigninURLRedirectParam }};
         }
         {{ end }}


### PR DESCRIPTION
We use the annotations nginx.ingress.kubernetes.io/auth-signin and nginx.ingress.kubernetes.io/auth-url to authorize requests.

When an unauthenticated request is detected and nginx.ingress.kubernetes.io/auth-url is called we need the possibility to include our own nginx configuration in the nginx location and return something else than “just” the 301 to the URI in nginx.ingress.kubernetes.io/auth-signin.

A concrete use case is that we want a redirect to the nginx.ingress.kubernetes.io/auth-signin URL only when an HTML page is requested (e.g. HTTP header accept: text/html is present). If an API call is made, the status code 401 should be returned instead of a redirect.

---- 8< ----
set $do401 “”;
if ($http_accept ~= “text/html” ) {
  set $do401 “${do401}1”;
}
if ($request_method = GET) {
  set $do401 “${do401}1”;
}
if ($do401 == “11”) {
  return 401; 
}
---- >8 ----

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
None

## How Has This Been Tested?
Test environment has been setup with a vanilla Kubernetes in our datacenter. Patched ingress-nginx and a deployment of our software with a ingress resource annotated with auth-url, auth-sigin and auth-signin-snippet have been deployed.
Request with browser and api client have been made. All has been as before except that XHR requests with invalid token got an 401 response instead of the unwanted 301.

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [x] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] Added Release Notes.

```release-note
Add new annotation nginx.ingress.kubernetes.io/auth-signin-snippet for External Auth
```