### PR TITLE
bump go to v1.19.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,11 +70,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
 
-      - name: Set up Go 1.19.0
+      - name: Set up Go 1.19.1
         id: go
         uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f # v3.2.0
         with:
-          go-version: '1.19.0'
+          go-version: '1.19.1'
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@8b122486cedac8393e77aa9734c3528886e4a1a8 #v2.0.0
@@ -136,7 +136,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f # v3.2.0
         with:
-          go-version: '1.19.0'
+          go-version: '1.19.1'
 
       - name: cache
         uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # v3
@@ -406,12 +406,12 @@ jobs:
           version: v0.15.0
           image: kindest/node:v1.25.0
 
-      - name: Set up Go 1.19.0
+      - name: Set up Go 1.19.1
         id: go
         if: ${{ steps.filter-images.outputs.kube-webhook-certgen == 'true' }}
         uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f # v3.2.0
         with:
-          go-version: '1.19.0'
+          go-version: '1.19.1'
 
       - name: kube-webhook-certgen image build
         if: ${{ steps.filter-images.outputs.kube-webhook-certgen == 'true' }}

--- a/.github/workflows/plugin.yaml
+++ b/.github/workflows/plugin.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f # v3.2.0
         with:
-          go-version: 1.19.0
+          go-version: 1.19.1
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@ff11ca24a9b39f2d36796d1fbd7a4e39c182630a # v3.0.0

--- a/images/custom-error-pages/rootfs/Dockerfile
+++ b/images/custom-error-pages/rootfs/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.19.0-alpine as builder
+FROM golang:1.19.1-alpine as builder
 RUN apk add git
 
 WORKDIR /go/src/k8s.io/ingress-nginx/images/custom-error-pages

--- a/images/ext-auth-example-authsvc/rootfs/Dockerfile
+++ b/images/ext-auth-example-authsvc/rootfs/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.0-alpine3.16 as builder
+FROM golang:1.19.1-alpine3.16 as builder
 RUN mkdir /authsvc
 WORKDIR /authsvc
 COPY . ./

--- a/images/kube-webhook-certgen/rootfs/Dockerfile
+++ b/images/kube-webhook-certgen/rootfs/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=$BUILDPLATFORM golang:1.19.0 as builder
+FROM --platform=$BUILDPLATFORM golang:1.19.1 as builder
 ARG BUILDPLATFORM
 ARG TARGETARCH
 

--- a/images/test-runner/Makefile
+++ b/images/test-runner/Makefile
@@ -39,7 +39,7 @@ build: ensure-buildx
 		--progress=$(PROGRESS) \
 		--pull \
 		--build-arg BASE_IMAGE=$(NGINX_BASE_IMAGE) \
-		--build-arg GOLANG_VERSION=1.19.0 \
+		--build-arg GOLANG_VERSION=1.19.1 \
 		--build-arg ETCD_VERSION=3.4.3-0 \
 		--build-arg K8S_RELEASE=v1.24.2 \
 		--build-arg RESTY_CLI_VERSION=0.27 \


### PR DESCRIPTION
## What this PR does / why we need it:
- This PR bumps golang to v1.19.1
- The context is vast
  - Controller v1.3.1 got released with the controller binary compiled using go v1.18
  - So now we bump to go v1.19.1 which fixes https://www.cvedetails.com/cve/CVE-2022-27664
  - And we have to make sure that the test-runner image that will get as a result of this PR is promoted first and then also make sure that the sha of the new test-runner image is updated in the `main` branch scripts and other files. If this is not done then we will once again get a binary compiled with go v1.18

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
- Fixes multiple tracking issues but will not list them here to avoid them autoclosing on this PR merging. Need to verify manually before closing those issues

## How Has This Been Tested?
- Will test locally after images are built

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] Added Release Notes.

## Does my pull request need a release note?
Any user-visible or operator-visible change qualifies for a release note. This could be a:

- CLI change
- API change
- UI change
- configuration schema change
- behavioral change
- change in non-functional attributes such as efficiency or availability, availability of a new platform
- a warning about a deprecation
- fix of a previous Known Issue
- fix of a vulnerability (CVE)

No release notes are required for changes to the following:

- Tests
- Build infrastructure
- Fixes for unreleased bugs

For more tips on writing good release notes, check out the [Release Notes Handbook](https://github.com/kubernetes/sig-release/tree/master/release-team/role-handbooks/release-notes)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Bump golang to v1.19.1. Required to ship controller binary compiled with go v1.19. Also required for patching against https://www.cvedetails.com/cve/CVE-2022-27664  
```

/triage accepted
/assign @tao12345666333 @rikatz @strongjz 