### PR TITLE
updated testrunner image sha after bump to go1191

### DIFF
--- a/build/run-in-docker.sh
+++ b/build/run-in-docker.sh
@@ -38,7 +38,7 @@ function cleanup {
 }
 trap cleanup EXIT
 
-E2E_IMAGE=${E2E_IMAGE:-registry.k8s.io/ingress-nginx/e2e-test-runner:v20220823-ge19026fe4@sha256:038fc60379b6ce9a0134c2ff9134edccad1f8ecbd9c6ebed9660711d05b0ed95}
+E2E_IMAGE=${E2E_IMAGE:-registry.k8s.io/ingress-nginx/e2e-test-runner:v20220916-gd32f8c343@sha256:f3f26f1e2aef8b2013b731f041fd69bcd950d3118eecf4429551848f47305c0f}
 
 DOCKER_OPTS=${DOCKER_OPTS:-}
 DOCKER_IN_DOCKER_ENABLED=${DOCKER_IN_DOCKER_ENABLED:-}

--- a/docs/examples/customization/custom-errors/custom-default-backend.helm.values.yaml
+++ b/docs/examples/customization/custom-errors/custom-default-backend.helm.values.yaml
@@ -6,7 +6,7 @@ defaultBackend:
   image:
     registry: registry.k8s.io
     image: ingress-nginx/nginx-errors
-    tag: "1.3.0"
+    tag: "v20220916-gd32f8c343@sha256:09c421ac743bace19ab77979b82186941c5125c95e62cdb40bdf41293b5c275c"
   extraVolumes:
   - name: custom-error-pages
     configMap:

--- a/docs/examples/customization/custom-errors/custom-default-backend.yaml
+++ b/docs/examples/customization/custom-errors/custom-default-backend.yaml
@@ -36,7 +36,7 @@ spec:
     spec:
       containers:
       - name: nginx-error-server
-        image: registry.k8s.io/ingress-nginx/nginx-errors:1.3.0
+        image: registry.k8s.io/ingress-nginx/nginx-errors:v20220916-gd32f8c343@sha256:09c421ac743bace19ab77979b82186941c5125c95e62cdb40bdf41293b5c275c
         ports:
         - containerPort: 8080
         # Setting the environment variable DEBUG we can see the headers sent 

--- a/test/e2e-image/Makefile
+++ b/test/e2e-image/Makefile
@@ -1,6 +1,6 @@
 
 DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
-E2E_BASE_IMAGE="registry.k8s.io/ingress-nginx/e2e-test-runner:v20220823-ge19026fe4@sha256:038fc60379b6ce9a0134c2ff9134edccad1f8ecbd9c6ebed9660711d05b0ed95"
+E2E_BASE_IMAGE="registry.k8s.io/ingress-nginx/e2e-test-runner:v20220916-gd32f8c343@sha256:f3f26f1e2aef8b2013b731f041fd69bcd950d3118eecf4429551848f47305c0f"
 
 image:
 	echo "..entered Makefile in /test/e2e-image"


### PR DESCRIPTION
## What this PR does / why we need it:
- A new testrunner image was promoted as per https://github.com/kubernetes/k8s.io/pull/4230
- The new testrunner image contains go v1.19.1
- Testrunner image is used in local, prow and cloudbuild builds of the binary named `nginx-ingress-controller`, located in the root `/` path of the controller image
- Current release v1.3.1 binary is compiled with go v1.18.2 even though the project code is bumped to go v1.19.0 all over
- This is because at the time of compiling the said binary, the updated testrunner image was not promoted hence not updated in main
- So this PR updates main with the sha of the new testrunner image, that contains go v1.191
```
% docker run --rm registry.k8s.io/ingress-nginx/e2e-test-runner:v20220916-gd32f8c343@sha256:f3f26f1e2aef8b2013b731f041fd69bcd950d3118eecf4429551848f47305c0f go version
go version go1.19.1 linux/amd64
```
- Now when we update tag and compile the controller's main binary executable, it should compile using go v1.19.1
- A new nginx-errors image and a new kube-webhook-certgen image also were created. This PR updates main with the nginx-errors sha as its only in .md files
- The kube-webhook-certgen image sha will be updted when we are ready to change the chart values.yaml as it requires a Chart version bump because helm-docs has to be run to generate and merge a new README for the chart

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
- Multiple related issues but not create one issue specifically for this

## How Has This Been Tested?
- Locally like this
```
[~/Documents/github/longwuyuan/ingress-nginx] change-images-sha-for-go1191
% k -n ingress-nginx get po ingress-nginx-controller-db4855c8c-lwgn2 -o yaml | grep -i image:
    image: gcr.io/k8s-staging-ingress-nginx/controller:1.0.0-dev
    image: gcr.io/k8s-staging-ingress-nginx/controller:1.0.0-dev
[~/Documents/github/longwuyuan/ingress-nginx] change-images-sha-for-go1191
% k -n ingress-nginx exec -ti ingress-nginx-controller-db4855c8c-lwgn2 -- sh
/etc/nginx $ strings /nginx-ingress-controller | grep 'go1\.'
go1.19.1
vendor/golang.org/x/crypto/internal/poly1305/bits_go1.13.go
go1.19.1
/etc/nginx $ 

```
- The current v1.3.1 controller shows go v1.18.1 like so ;
```
% kind get clusters 
ingress-nginx-dev
kind
[~/Documents/github/longwuyuan/ingress-nginx] change-images-sha-for-go1191
% k config get-contexts 
CURRENT   NAME                     CLUSTER                  AUTHINFO                 NAMESPACE
*         kind-ingress-nginx-dev   kind-ingress-nginx-dev   kind-ingress-nginx-dev   
          kind-kind                kind-kind                kind-kind                
[~/Documents/github/longwuyuan/ingress-nginx] change-images-sha-for-go1191
% k config use-context kind-kind 
Switched to context "kind-kind".
[~/Documents/github/longwuyuan/ingress-nginx] change-images-sha-for-go1191
% helm ls -A
NAME            NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                   APP VERSION
ingress-nginx   ingress-nginx   1               2022-09-08 15:57:55.587871553 +0530 IST deployed        ingress-nginx-4.2.5     1.3.1      
[~/Documents/github/longwuyuan/ingress-nginx] change-images-sha-for-go1191
% k -n ingress-nginx exec -ti ingress-nginx-controller-7bf78659d-tctjg -- sh
/etc/nginx $ /nginx-ingress-controller --version
-------------------------------------------------------------------------------
NGINX Ingress controller
  Release:       v1.3.1
  Build:         92534fa2ae799b502882c8684db13a25cde68155
  Repository:    https://github.com/kubernetes/ingress-nginx
  nginx version: nginx/1.19.10

-------------------------------------------------------------------------------

/etc/nginx $ strings /nginx-ingress-controller | grep 'go1\.'
go1.18.2
vendor/golang.org/x/crypto/internal/poly1305/bits_go1.13.go
go1.18.2
/etc/nginx $ 

```


## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Added Release Notes.

## Does my pull request need a release note?
Any user-visible or operator-visible change qualifies for a release note. This could be a:

- CLI change
- API change
- UI change
- configuration schema change
- behavioral change
- change in non-functional attributes such as efficiency or availability, availability of a new platform
- a warning about a deprecation
- fix of a previous Known Issue
- fix of a vulnerability (CVE)

No release notes are required for changes to the following:

- Tests
- Build infrastructure
- Fixes for unreleased bugs

For more tips on writing good release notes, check out the [Release Notes Handbook](https://github.com/kubernetes/sig-release/tree/master/release-team/role-handbooks/release-notes)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Changed e2e-image sha to new image that contains go v1.19.1 
```
