### PR TITLE
fix: do not apply job-patch psp on Kubernetes 1.25 and newer

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -175,7 +175,7 @@ jobs:
         uses: engineerd/setup-kind@aa272fe2a7309878ffc2a81c56cfe3ef108ae7d0 #v0.5.0
         with:
           version: v0.15.0
-          image: kindest/node:v1.24.4
+          image: kindest/node:v1.25.0
 
       - uses: geekyeggo/delete-artifact@b73cb986740e466292a536d0e32e2666c56fdeb3 # v1
         with:

--- a/charts/ingress-nginx/templates/admission-webhooks/job-patch/psp.yaml
+++ b/charts/ingress-nginx/templates/admission-webhooks/job-patch/psp.yaml
@@ -1,3 +1,4 @@
+{{- if (semverCompare "<1.25.0-0" .Capabilities.KubeVersion.Version) }}
 {{- if and .Values.controller.admissionWebhooks.enabled .Values.controller.admissionWebhooks.patch.enabled .Values.podSecurityPolicy.enabled (empty .Values.controller.admissionWebhooks.existingPsp) -}}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
@@ -36,4 +37,5 @@ spec:
   - projected
   - secret
   - downwardAPI
+{{- end }}
 {{- end }}


### PR DESCRIPTION
## What this PR does / why we need it:
Followup of #9014

The if statement to skip PSP on Kubernetes >=1.25.0 was not added to the job-patch admission-webhook. I think it was missed by accident.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## How Has This Been Tested?

Previous behavior:
```console
# helm install --generate-name .
Error: INSTALLATION FAILED: failed pre-install: unable to build kubernetes object for deleting hook ingress-nginx/templates/admission-webhooks/job-patch/psp.yaml: resource mapping not found for name: "chart-1663750333-ingress-nginx-admission" namespace: "" from "": no matches for kind "PodSecurityPolicy" in version "policy/v1beta1"
ensure CRDs are installed first

```

After this fix:
```console
# helm install --generate-name
NAME: chart-1663750240
LAST DEPLOYED: Wed Sep 21 10:50:42 2022
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
The ingress-nginx controller has been installed.
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] Added Release Notes.

## Does my pull request need a release note?

```release-note
Added an if statement around the job-patch admission webhook PSP to ensure it being skipped on Kubernetes 1.25.0 and newer.
```
