### PR TITLE
expand CI testing for all stable versions of Kubernetes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -269,7 +269,7 @@ jobs:
 
     strategy:
       matrix:
-        k8s: [v1.24.4, v1.25.0]
+        k8s: [v1.23.10, v1.24.4, v1.25.0]
 
     steps:
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -128,6 +128,10 @@ jobs:
     if: |
       (needs.changes.outputs.charts == 'true')
 
+    strategy:
+      matrix:
+        k8s: [v1.23.10, v1.24.4, v1.25.0]
+
     steps:
 
       - name: Checkout
@@ -170,12 +174,12 @@ jobs:
           sudo mkdir -p $HOME/.kube
           sudo chmod -R 777 $HOME/.kube
 
-      - name: Create Kubernetes cluster
+      - name: Create Kubernetes ${{ matrix.k8s }} cluster
         id: kind
         uses: engineerd/setup-kind@aa272fe2a7309878ffc2a81c56cfe3ef108ae7d0 #v0.5.0
         with:
           version: v0.15.0
-          image: kindest/node:v1.25.0
+          image: kindest/node:${{ matrix.k8s }}
 
       - uses: geekyeggo/delete-artifact@b73cb986740e466292a536d0e32e2666c56fdeb3 # v1
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -130,7 +130,7 @@ jobs:
 
     strategy:
       matrix:
-        k8s: [v1.23.10, v1.24.4, v1.25.0]
+        k8s: [v1.23.12, v1.24.6, v1.25.2]
 
     steps:
 
@@ -212,7 +212,7 @@ jobs:
 
     strategy:
       matrix:
-        k8s: [v1.23.10, v1.24.4, v1.25.0]
+        k8s: [v1.23.12, v1.24.6, v1.25.2]
 
     steps:
 
@@ -269,7 +269,7 @@ jobs:
 
     strategy:
       matrix:
-        k8s: [v1.23.10, v1.24.4, v1.25.0]
+        k8s: [v1.23.12, v1.24.6, v1.25.2]
 
     steps:
 
@@ -408,7 +408,7 @@ jobs:
         uses: engineerd/setup-kind@aa272fe2a7309878ffc2a81c56cfe3ef108ae7d0 #v0.5.0
         with:
           version: v0.15.0
-          image: kindest/node:v1.25.0
+          image: kindest/node:v1.25.2
 
       - name: Set up Go 1.19.1
         id: go


### PR DESCRIPTION
## What this PR does / why we need it:
* Adds strategy to test against all stable versions to the Helm chart test to catch issues like the one fixed in #9074 
* Adds 1.23.x to the chroot test to have all workflows have the same strategy
* Update all workflows to the latest stable k8s release.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## How Has This Been Tested?
Draft for now to see if CI completes, I don't know how I could test these changes outside of this repo.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Added Release Notes.

```release-note
NONE
```
