### PR TITLE
add PodMonitoring support for Google Managed Prometheus

### DIFF
--- a/charts/ingress-nginx/Chart.yaml
+++ b/charts/ingress-nginx/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ingress-nginx
 # When the version is modified, make sure the artifacthub.io/changes list is updated
 # Also update CHANGELOG.md
-version: 4.2.5
+version: 4.2.6
 appVersion: 1.3.1
 home: https://github.com/kubernetes/ingress-nginx
 description: Ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer

--- a/charts/ingress-nginx/README.md
+++ b/charts/ingress-nginx/README.md
@@ -2,7 +2,7 @@
 
 [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer
 
-![Version: 4.2.5](https://img.shields.io/badge/Version-4.2.5-informational?style=flat-square) ![AppVersion: 1.3.1](https://img.shields.io/badge/AppVersion-1.3.1-informational?style=flat-square)
+![Version: 4.2.6](https://img.shields.io/badge/Version-4.2.6-informational?style=flat-square) ![AppVersion: 1.3.1](https://img.shields.io/badge/AppVersion-1.3.1-informational?style=flat-square)
 
 To use, add `ingressClassName: nginx` spec field or the `kubernetes.io/ingress.class: nginx` annotation to your Ingress resources.
 
@@ -89,6 +89,10 @@ The Nginx ingress controller can export Prometheus metrics, by setting `controll
 
 You can add Prometheus annotations to the metrics service using `controller.metrics.service.annotations`.
 Alternatively, if you use the Prometheus Operator, you can enable ServiceMonitor creation using `controller.metrics.serviceMonitor.enabled`. And set `controller.metrics.serviceMonitor.additionalLabels.release="prometheus"`. "release=prometheus" should match the label configured in the prometheus servicemonitor ( see `kubectl get servicemonitor prometheus-kube-prom-prometheus -oyaml -n prometheus`)
+
+#### PodMonitoring
+
+If you use the Google Managed Prometheus Operator, you can enable PodMonitoring. To enable PodMonitoring, you have to set `controller.metrics.podMonitoring.enabled`.
 
 ### ingress-nginx nginx\_status page/stats server
 
@@ -347,6 +351,11 @@ Kubernetes: `>=1.20.0-0`
 | controller.livenessProbe.timeoutSeconds | int | `1` |  |
 | controller.maxmindLicenseKey | string | `""` | Maxmind license key to download GeoLite2 Databases. # https://blog.maxmind.com/2019/12/18/significant-changes-to-accessing-and-using-geolite2-databases |
 | controller.metrics.enabled | bool | `false` |  |
+| controller.metrics.podMonitoring.enabled | bool | `false` |  |
+| controller.metrics.podMonitoring.additionalLabels | object | `{}` |   |
+| controller.metrics.podMonitoring.namespace | string | `""` |  |
+| controller.metrics.podMonitoring.scrapeInterval | string | `"60s"` |  |
+| controller.metrics.podMonitoring. | bool | `false` |  |
 | controller.metrics.port | int | `10254` |  |
 | controller.metrics.prometheusRule.additionalLabels | object | `{}` |  |
 | controller.metrics.prometheusRule.enabled | bool | `false` |  |

--- a/charts/ingress-nginx/README.md
+++ b/charts/ingress-nginx/README.md
@@ -355,7 +355,7 @@ Kubernetes: `>=1.20.0-0`
 | controller.metrics.podMonitoring.additionalLabels | object | `{}` |   |
 | controller.metrics.podMonitoring.namespace | string | `""` |  |
 | controller.metrics.podMonitoring.scrapeInterval | string | `"60s"` |  |
-| controller.metrics.podMonitoring. | bool | `false` |  |
+| controller.metrics.podMonitoring.portName | string | `"http-metrics"` |  |
 | controller.metrics.port | int | `10254` |  |
 | controller.metrics.prometheusRule.additionalLabels | object | `{}` |  |
 | controller.metrics.prometheusRule.enabled | bool | `false` |  |

--- a/charts/ingress-nginx/templates/controller-podmonitoring.yaml
+++ b/charts/ingress-nginx/templates/controller-podmonitoring.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.controller.metrics.enabled .Values.controller.metrics.podMonitoring.enabled -}}
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitoring
+metadata:
+  name: {{ include "ingress-nginx.controller.fullname" . }}
+{{- if .Values.controller.metrics.podMonitoring.namespace }}
+  namespace: {{ .Values.controller.metrics.podMonitoring.namespace | quote }}
+{{- end }}
+  labels:
+    {{- include "ingress-nginx.labels" . | nindent 4 }}
+    app.kubernetes.io/component: controller
+  {{- if .Values.controller.metrics.podMonitoring.additionalLabels }}
+    {{- toYaml .Values.controller.metrics.podMonitoring.additionalLabels | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "ingress-nginx.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: controller
+  endpoints:
+  - port: {{ .Values.controller.metrics.podMonitoring.portName }}
+    interval: {{ .Values.controller.metrics.podMonitoring.scrapeInterval }}
+{{- end }}

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -667,7 +667,7 @@ controller:
   metrics:
     port: 10254
     # if this port is changed, change healthz-port: in extraArgs: accordingly
-    enabled: false
+    enabled: true
 
     service:
       annotations: {}
@@ -704,6 +704,15 @@ controller:
       targetLabels: []
       relabelings: []
       metricRelabelings: []
+
+    podMonitoring:
+      enabled: false
+      additionalLabels: {}
+      ## The label to use to retrieve the job name from.
+      ## jobLabel: "app.kubernetes.io/name"
+      namespace: ""
+      scrapeInterval: 60s
+      portName: http-metrics
 
     prometheusRule:
       enabled: false

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -667,7 +667,7 @@ controller:
   metrics:
     port: 10254
     # if this port is changed, change healthz-port: in extraArgs: accordingly
-    enabled: true
+    enabled: false
 
     service:
       annotations: {}


### PR DESCRIPTION
Signed-off-by: 11425176+ptran32@users.noreply.github.com <11425176+ptran32@users.noreply.github.com>

This PR adds PodMonitoring support for [Google Managed Prometheus](https://cloud.google.com/stackdriver/docs/managed-prometheus/setup-managed)


## What this PR does / why we need it:

This PR is needed to query Prometheus metrics from Google Query UI . 

The PodMonitoring object is needed by Google Managed Prometheus in order to scrape metrics, then display them on Google Query UI.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
I looked through the open issues and couldn't find anyone else referencing this issue/case

## How Has This Been Tested?

- Clone locally the latest to date kubernetes/ingress-nginx Github repository (version: 4.2.6, appVersion: 1.3.1)
- Add/modify files included in this PR
- In values.yaml, set podMonitoring.enabled to true
- Run command: `helm install ingress-nginx .`
- Verify that all pods were running and PodMonitoring resource was created
- Verify that Prometheus metrics (eg: nginx_ingress_controller_nginx_process_requests_total) can be queried from Google Query UI

More informations about the tests:

1) kubectl describe podmonitoring

```
 kubectl describe podmonitoring

Name:         ingress-nginx-controller
Namespace:    default
Labels:       app.kubernetes.io/component=controller
              app.kubernetes.io/instance=ingress-nginx
              app.kubernetes.io/managed-by=Helm
              app.kubernetes.io/name=ingress-nginx
              app.kubernetes.io/part-of=ingress-nginx
              app.kubernetes.io/version=1.3.1
              helm.sh/chart=ingress-nginx-4.2.6
Annotations:  meta.helm.sh/release-name: ingress-nginx
              meta.helm.sh/release-namespace: default
API Version:  monitoring.googleapis.com/v1
Kind:         PodMonitoring
Metadata:
  Creation Timestamp:  2022-09-23T20:56:21Z
  Generation:          1
  Managed Fields:
    API Version:  monitoring.googleapis.com/v1
    Fields Type:  FieldsV1
    fieldsV1:
      f:metadata:
        f:annotations:
          .:
          f:meta.helm.sh/release-name:
          f:meta.helm.sh/release-namespace:
        f:labels:
          .:
          f:app.kubernetes.io/component:
          f:app.kubernetes.io/instance:
          f:app.kubernetes.io/managed-by:
          f:app.kubernetes.io/name:
          f:app.kubernetes.io/part-of:
          f:app.kubernetes.io/version:
          f:helm.sh/chart:
      f:spec:
        .:
        f:endpoints:
        f:selector:
          .:
          f:matchLabels:
            .:
            f:app.kubernetes.io/component:
            f:app.kubernetes.io/instance:
            f:app.kubernetes.io/name:
    Manager:      helm
    Operation:    Update
    Time:         2022-09-23T20:56:21Z
    API Version:  monitoring.googleapis.com/v1
    Fields Type:  FieldsV1
    fieldsV1:
      f:status:
        .:
        f:conditions:
        f:observedGeneration:
    Manager:         operator
    Operation:       Update
    Subresource:     status
    Time:            2022-09-23T20:56:21Z
  Resource Version:  69009
  UID:               b8075b1c-3819-497c-83f0-531c2b0bb76a
Spec:
  Endpoints:
    Interval:  60s
    Port:      http-metrics
  Selector:
    Match Labels:
      app.kubernetes.io/component:  controller
      app.kubernetes.io/instance:   ingress-nginx
      app.kubernetes.io/name:       ingress-nginx
  Target Labels:
    Metadata:
      pod
      container
Status:
  Conditions:
    Last Transition Time:  2022-09-23T20:56:21Z
    Last Update Time:      2022-09-23T20:56:21Z
    Status:                True
    Type:                  ConfigurationCreateSuccess
  Observed Generation:     1
Events:                    <none>
```

2) Screenshot with NGINX metrics retrievable from Google Query UI:

<img width="1161" alt="Screen Shot 2022-09-23 at 5 00 10 PM" src="https://user-images.githubusercontent.com/11425176/192056125-cae34eb3-5039-45de-a543-075f53382f7f.png">


**Test environment: 

Kubernetes version (GKE): 1.22.12-gke.300 
Helm version : v3.10.0
Google custom resource definition: [v0.7.0](https://raw.githubusercontent.com/GoogleCloudPlatform/prometheus-engine/v0.4.3-gke.0/manifests/setup.yaml)
Google Managed Prometheus Operator: [v.0.4.3](https://raw.githubusercontent.com/GoogleCloudPlatform/prometheus-engine/v0.4.3-gke.0/manifests/operator.yaml)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Added Release Notes.

## Does my pull request need a release note?
Any user-visible or operator-visible change qualifies for a release note. This could be a:

- CLI change
- API change
- UI change
- configuration schema change
- behavioral change
- change in non-functional attributes such as efficiency or availability, availability of a new platform
- a warning about a deprecation
- fix of a previous Known Issue
- fix of a vulnerability (CVE)

No release notes are required for changes to the following:

- Tests
- Build infrastructure
- Fixes for unreleased bugs

For more tips on writing good release notes, check out the [Release Notes Handbook](https://github.com/kubernetes/sig-release/tree/master/release-team/role-handbooks/release-notes)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
PLACE RELEASE NOTES HERE 
```
