### PR TITLE
fix e2e resource leak when ginkgo exit before clear resource

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -121,11 +121,9 @@ func (f *Framework) CreateEnvironment() {
 }
 
 func (f *Framework) DestroyEnvironment() {
-	go func() {
-		defer ginkgo.GinkgoRecover()
-		err := DeleteKubeNamespace(f.KubeClientSet, f.Namespace)
-		assert.Nil(ginkgo.GinkgoT(), err, "deleting namespace %v", f.Namespace)
-	}()
+	defer ginkgo.GinkgoRecover()
+	err := DeleteKubeNamespace(f.KubeClientSet, f.Namespace)
+	assert.Nil(ginkgo.GinkgoT(), err, "deleting namespace %v", f.Namespace)
 }
 
 // BeforeEach gets a client and makes a namespace.
@@ -151,11 +149,9 @@ func (f *Framework) AfterEach() {
 	defer f.DestroyEnvironment()
 
 	defer func(kubeClient kubernetes.Interface, ingressclass string) {
-		go func() {
-			defer ginkgo.GinkgoRecover()
-			err := deleteIngressClass(kubeClient, ingressclass)
-			assert.Nil(ginkgo.GinkgoT(), err, "deleting IngressClass")
-		}()
+		defer ginkgo.GinkgoRecover()
+		err := deleteIngressClass(kubeClient, ingressclass)
+		assert.Nil(ginkgo.GinkgoT(), err, "deleting IngressClass")
 	}(f.KubeClientSet, f.IngressClass)
 
 	if !ginkgo.CurrentSpecReport().Failed() {


### PR DESCRIPTION
if ginkgo e2e program exit before the goroutine (started in defer statement) clear resources, the e2e test resources will be leave uncleared，so we should clear resource in main program

## What this PR does / why we need it:
clear e2e test resources

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
tested in our e2e test environment

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] Added Release Notes.

## Does my pull request need a release note?
No 
