### PR TITLE
fixed broken helm version comparision

### DIFF
--- a/build/dev-env.sh
+++ b/build/dev-env.sh
@@ -45,9 +45,10 @@ if ! command -v helm &> /dev/null; then
   exit 1
 fi
 
-HELM_VERSION=$(helm version 2>&1 | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+') || true
-if [[ ${HELM_VERSION} < "v3.9.0" ]]; then
-  echo "Please upgrade helm to v3.9.0 or higher"
+HELM_VERSION=$(helm version 2>&1 | cut -f1 -d"," | grep -oE '[0-9]+\.[0-9]+\.[0-9]+') || true
+echo $HELM_VERSION
+if [[ ${HELM_VERSION} -lt 3.10.0 ]]; then
+  echo "Please upgrade helm to v3.10.0 or higher"
   exit 1
 fi
 


### PR DESCRIPTION
## What this PR does / why we need it:
- We look for helm version 3.9.x during `make dev-env`
- Helm version 3.10.X is latest
- The comparison and checking of helm version is broken
- This PR fixes the check for helm version

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
- No Issue created. This is for developers only so assumed can afford to skip creating issue

## How Has This Been Tested?
- Tested with `mke dev-env` locally

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] Added Release Notes.

## Does my pull request need a release note?
Any user-visible or operator-visible change qualifies for a release note. This could be a:

- CLI change
- API change
- UI change
- configuration schema change
- behavioral change
- change in non-functional attributes such as efficiency or availability, availability of a new platform
- a warning about a deprecation
- fix of a previous Known Issue
- fix of a vulnerability (CVE)

No release notes are required for changes to the following:

- Tests
- Build infrastructure
- Fixes for unreleased bugs

For more tips on writing good release notes, check out the [Release Notes Handbook](https://github.com/kubernetes/sig-release/tree/master/release-team/role-handbooks/release-notes)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Helm version comparision fix
```

/triage accepted
/area stabilization
/assign @tao12345666333 @strongjz @rikatz 