### PR TITLE
Remove nonexistent load flag from docker build commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,6 @@ image: clean-image ## Build image for a particular arch.
 	docker build \
 		${PLATFORM_FLAG} ${PLATFORM} \
 		--no-cache \
-		$(MAC_DOCKER_FLAGS) \
 		--pull \
 		--build-arg BASE_IMAGE="$(BASE_IMAGE)" \
 		--build-arg VERSION="$(TAG)" \
@@ -94,7 +93,6 @@ image-chroot: clean-chroot-image ## Build image for a particular arch.
 	echo "Building docker image ($(ARCH))..."
 	docker build \
 		--no-cache \
-		$(MAC_DOCKER_FLAGS) \
 		--pull \
 		--build-arg BASE_IMAGE="$(BASE_IMAGE)" \
 		--build-arg VERSION="$(TAG)" \
@@ -210,7 +208,6 @@ dev-env-stop: ## Deletes local Kubernetes cluster created by kind.
 live-docs: ## Build and launch a local copy of the documentation website in http://localhost:8000
 	@docker build ${PLATFORM_FLAG} ${PLATFORM} \
                   		--no-cache \
-                  		$(MAC_DOCKER_FLAGS) \
                   		 -t ingress-nginx-docs .github/actions/mkdocs
 	@docker run ${PLATFORM_FLAG} ${PLATFORM} --rm -it \
 		-p 8000:8000 \
@@ -250,6 +247,7 @@ release: ensure-buildx clean
 
 	docker buildx build \
 		--no-cache \
+		$(MAC_DOCKER_FLAGS) \
 		--push \
 		--pull \
 		--progress plain \
@@ -262,6 +260,7 @@ release: ensure-buildx clean
 
 	docker buildx build \
 		--no-cache \
+		$(MAC_DOCKER_FLAGS) \
 		--push \
 		--pull \
 		--progress plain \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
A nonexistent `--load` flag is currently being added to `docker build` commands in the main Makefile for the Darwin kernel. This PR moves this flag from `docker build` to `docker buildx build`, where the flag is in fact valid.

We need to fix this issue because it causes essential commands like `make dev-env` and `make image` fail for macOS users.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):
-->
fixes #8879 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I am currently facing this issue. 

```console
$ system:
2,3 GHz Intel Core i9 8-Core
macOS Monterey 12.6

$ uname -m
x86_64

$ uname -s
Darwin

$ docker --version
Docker version 20.10.17, build 100c701

$ go version
go version go1.19 darwin/amd64

$ kind version
kind v0.15.0 go1.19 darwin/amd64
```

make dev-env is working after this change: 
```console
$ make dev-env
...
MAC_OS=Darwin
GOARCH=amd64
...
Kubernetes cluster ready and ingress-nginx listening in localhost using ports 80 and 443
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] Added Release Notes.

## Does my pull request need a release note?
Any user-visible or operator-visible change qualifies for a release note. This could be a:

- CLI change
- API change
- UI change
- configuration schema change
- behavioral change
- change in non-functional attributes such as efficiency or availability, availability of a new platform
- a warning about a deprecation
- fix of a previous Known Issue
- fix of a vulnerability (CVE)

No release notes are required for changes to the following:

- Tests
- Build infrastructure
- Fixes for unreleased bugs

For more tips on writing good release notes, check out the [Release Notes Handbook](https://github.com/kubernetes/sig-release/tree/master/release-team/role-handbooks/release-notes)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
