### PR TITLE
Fix indentation on serviceAccount annotation

### DIFF
--- a/charts/ingress-nginx/templates/controller-serviceaccount.yaml
+++ b/charts/ingress-nginx/templates/controller-serviceaccount.yaml
@@ -12,7 +12,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   {{- if .Values.serviceAccount.annotations }}
   annotations:
-  {{- toYaml .Values.serviceAccount.annotations | indent 4 }}
+  {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- end }}


### PR DESCRIPTION
## What this PR does / why we need it:

When adding an annotation to the controllers' serviceAccount with those values:
```
serviceAccount:
  annotations:
    eks.amazonaws.com/role-arn: arn:aws:iam::1234567890:role/my_role
```

We have the following error:
```
Error: YAML parse error on ingress-nginx/templates/controller-serviceaccount.yaml: error converting YAML to JSON: yaml: line 14: mapping values are not allowed in this context
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [?] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes

N/A

## How Has This Been Tested?

Running ```helm template .``` provides the expected output.

Successfully deployed in a cluster.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Added Release Notes.

