### PR TITLE
Update helm chart changelog to show that kubernetes v1.21.x is no longer supported

### DIFF
--- a/charts/ingress-nginx/CHANGELOG.md
+++ b/charts/ingress-nginx/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents all notable changes to [ingress-nginx](https://github.com/ku
 
 ### 4.3.0 
 - Support for Kubernetes v.1.25.0 was added and support for endpoint slices
-- Support for Kubernetes v1.20.0 was removed
+- Support for Kubernetes v1.20.0 and v1.21.0 was removed
 - [8890](https://github.com/kubernetes/ingress-nginx/pull/8890) migrate to endpointslices
 - [9059](https://github.com/kubernetes/ingress-nginx/pull/9059) kubewebhookcertgen sha change after go1191
 - [9046](https://github.com/kubernetes/ingress-nginx/pull/9046) Parameterize metrics port name


### PR DESCRIPTION
## What this PR does / why we need it:
Helm chart 4.3.0 no longer supports kubernetes v1.21 or v1.20, but only v1.20 was listed in the changelog.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation only

## How Has This Been Tested?
Documentation only update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Added Release Notes.

## Does my pull request need a release note?
Any user-visible or operator-visible change qualifies for a release note. This could be a:

- CLI change
- API change
- UI change
- configuration schema change
- behavioral change
- change in non-functional attributes such as efficiency or availability, availability of a new platform
- a warning about a deprecation
- fix of a previous Known Issue
- fix of a vulnerability (CVE)

No release notes are required for changes to the following:

- Tests
- Build infrastructure
- Fixes for unreleased bugs

For more tips on writing good release notes, check out the [Release Notes Handbook](https://github.com/kubernetes/sig-release/tree/master/release-team/role-handbooks/release-notes)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
PLACE RELEASE NOTES HERE 
```
