### PR TITLE
fix null ports

### DIFF
--- a/internal/ingress/controller/endpointslices.go
+++ b/internal/ingress/controller/endpointslices.go
@@ -84,8 +84,8 @@ func getEndpointsFromSlices(s *corev1.Service, port *corev1.ServicePort, proto c
 	// loop over all endpointSlices generated for service
 	for _, eps := range epss {
 		var ports []int32
-		if len(eps.Ports) == 0 {
-			// When ports is empty, it indicates that there are no defined ports, using svc targePort <- this could be wrong
+		if len(eps.Ports) == 0 && port.TargetPort.Type == intstr.Int {
+			// When ports is empty, it indicates that there are no defined ports, using svc targePort if it's a number
 			klog.V(3).Infof("No ports found on endpointSlice, using service TargetPort %v for Service %q", port.String(), svcKey)
 			ports = append(ports, port.TargetPort.IntVal)
 		} else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
If service is matching multiple deployments and these deployments has different port specification we will end up with endpointslice with unset port. 
The case is as follows:
deployment-1:        
```  
ports:
- containerPort: 8080
  protocol: TCP
  # name not defined
```
deployment-2:
```
ports:
- containerPort: 8080
  name: nginx # name defined
  protocol: TCP
```
svc:
```
ports:
- port: 8080
  protocol: TCP
  targetPort: nginx
```
```
kubectl -n echoheaders get endpointslices 
NAME                            ADDRESSTYPE   PORTS     ENDPOINTS                     AGE
echoheaders-echoheaders-8kbbk   IPv4          8080      100.122.38.23   149m
echoheaders-echoheaders-z5gs5   IPv4          <unset>   100.122.38.24   64m
```
```
kubectl -n echoheaders get ep 
NAME                      ENDPOINTS            AGE
echoheaders-echoheaders   100.122.38.23:8080   692d
```
There was no issue with endpoints, because there were just valid endpoints in this case. This PR will preserve previous behaviour and will ignore pods from misconfigured deployment.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
fixes #9141
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Added Release Notes.

## Does my pull request need a release note?
Any user-visible or operator-visible change qualifies for a release note. This could be a:

- CLI change
- API change
- UI change
- configuration schema change
- behavioral change
- change in non-functional attributes such as efficiency or availability, availability of a new platform
- a warning about a deprecation
- fix of a previous Known Issue
- fix of a vulnerability (CVE)

No release notes are required for changes to the following:

- Tests
- Build infrastructure
- Fixes for unreleased bugs

For more tips on writing good release notes, check out the [Release Notes Handbook](https://github.com/kubernetes/sig-release/tree/master/release-team/role-handbooks/release-notes)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Ignore endpointslice with no ports, caused by misconfigured deployments. Provides same behavior as was former with endpoints.   
```
