### PR TITLE
Move bowei to emeritus owner

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -8,3 +8,4 @@ reviewers:
 
 emeritus_approvers:
 - aledbf  # 2020-04-02
+- bowei # 2022-10-12

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -7,7 +7,6 @@ aliases:
   - thockin
 
   ingress-nginx-admins:
-  - bowei
   - rikatz
   - strongjz
 


### PR DESCRIPTION
Bowei did a lot of work during initial years of ingress-nginx, and we are thankful for that!

As he is really busy with other things, I discussed with him to move him to emeritus, so we won't be marked in reviews anymore.

Thanks @bowei !!