### PR TITLE
Add section to troubleshooting docs for failure to listen on port

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -322,6 +322,8 @@ One possible reason for this error is lack of permission to bind to the port.  P
 1. In the image, the /nginx-ingress-controller file has the cap_net_bind_service capability added (e.g. via [setcap](https://man7.org/linux/man-pages/man8/setcap.8.html)) 
 2. The NET_BIND_SERVICE capability is added to the container in the containerSecurityContext of the deployment.
 
+If encountering this on one/some node(s) and not on others, try to purge and pull a fresh copy of the image to the affected node(s), in case there has been corruption of the underlying layers to lose the capability on the executable.
+
 ### Create a test pod
 The /nginx-ingress-controller process exits/crashes when encountering this error, making it difficult to troubleshoot what is happening inside the container.  To get around this, start an equivalent container running "sleep 3600", and exec into it for further troubleshooting.  For example:
 ```yaml
@@ -378,7 +380,53 @@ Try to manually run the controller process:
 ```console
 $ /nginx-ingress-controller
 ```
+You should get the same error as from the ingress controller pod logs.
+
 Confirm the capabilities are properly surfacing into the pod:
 ```console
 $ grep CapBnd /proc/1/status
+CapBnd: 0000000000000400
+```
+The above value has only net_bind_service enabled (per security context in YAML which adds that and drops all). If you get a different value, then you can decode it on another linux box (capsh not available in this container) like below, and then figure out why specified capabilities are not propagating into the pod/container.
+```console
+$ capsh --decode=0000000000000400
+0x0000000000000400=cap_net_bind_service
+```
+
+## Create a test pod as root
+(Note, this may be restricted by PodSecurityPolicy, PodSecurityAdmission/Standards, OPA Gatekeeper, etc. in which case you will need to do the appropriate workaround for testing, e.g. deploy in a new namespace without the restrictions.)
+To test further you may want to install additional utilities, etc.  Modify the pod yaml by:
+* changing runAsUser from 101 to 0
+* removing the "drop..ALL" section from the capabilities.
+
+Some things to try after shelling into this container:
+
+Try running the controller as the www-data (101) user:
+```console
+$ chmod 4755 /nginx-ingress-controller
+$ /nginx-ingress-controller
+```
+Examine the errors to see if there is still an issue listening on the port or if it passed that and moved on to other expected errors due to running out of context.
+
+Install the libcap package and check capabilities on the file:
+```console
+$ apk add libcap
+(1/1) Installing libcap (2.50-r0)
+Executing busybox-1.33.1-r7.trigger
+OK: 26 MiB in 41 packages
+$ getcap /nginx-ingress-controller
+/nginx-ingress-controller cap_net_bind_service=ep
+```
+(if missing, see above about purging image on the server and re-pulling)
+
+Strace the executable to see what system calls are being executed when it fails:
+```console
+$ apk add strace
+(1/1) Installing strace (5.12-r0)
+Executing busybox-1.33.1-r7.trigger
+OK: 28 MiB in 42 packages
+$ strace /nginx-ingress-controller
+execve("/nginx-ingress-controller", ["/nginx-ingress-controller"], 0x7ffeb9eb3240 /* 131 vars */) = 0
+arch_prctl(ARCH_SET_FS, 0x29ea690)      = 0
+...
 ```


### PR DESCRIPTION
## What this PR does / why we need it:
Does not fix an issue, but was requested in the comments of #8461 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation only

## Which issue/s this PR fixes
N/A

## How Has This Been Tested?
The only test was to ask in the comments of #8461 whether this is the desired type of info.

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Added Release Notes.

## Does my pull request need a release note?
Any user-visible or operator-visible change qualifies for a release note. This could be a:

- CLI change
- API change
- UI change
- configuration schema change
- behavioral change
- change in non-functional attributes such as efficiency or availability, availability of a new platform
- a warning about a deprecation
- fix of a previous Known Issue
- fix of a vulnerability (CVE)

No release notes are required for changes to the following:

- Tests
- Build infrastructure
- Fixes for unreleased bugs

For more tips on writing good release notes, check out the [Release Notes Handbook](https://github.com/kubernetes/sig-release/tree/master/release-team/role-handbooks/release-notes)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
