### PR TITLE
Implement parseFloat for annotations

### DIFF
--- a/internal/ingress/annotations/parser/main.go
+++ b/internal/ingress/annotations/parser/main.go
@@ -80,6 +80,18 @@ func (a ingAnnotations) parseInt(name string) (int, error) {
 	return 0, errors.ErrMissingAnnotations
 }
 
+func (a ingAnnotations) parseFloat32(name string) (float32, error) {
+	val, ok := a[name]
+	if ok {
+		i, err := strconv.ParseFloat(val, 32)
+		if err != nil {
+			return 0, errors.NewInvalidAnnotationContent(name, val)
+		}
+		return float32(i), nil
+	}
+	return 0, errors.ErrMissingAnnotations
+}
+
 func checkAnnotation(name string, ing *networking.Ingress) error {
 	if ing == nil || len(ing.GetAnnotations()) == 0 {
 		return errors.ErrMissingAnnotations
@@ -120,6 +132,16 @@ func GetIntAnnotation(name string, ing *networking.Ingress) (int, error) {
 		return 0, err
 	}
 	return ingAnnotations(ing.GetAnnotations()).parseInt(v)
+}
+
+// GetFloatAnnotation extracts a float32 from an Ingress annotation
+func GetFloatAnnotation(name string, ing *networking.Ingress) (float32, error) {
+	v := GetAnnotationWithPrefix(name)
+	err := checkAnnotation(v, ing)
+	if err != nil {
+		return 0, err
+	}
+	return ingAnnotations(ing.GetAnnotations()).parseFloat32(v)
 }
 
 // GetAnnotationWithPrefix returns the prefix of ingress annotations

--- a/internal/ingress/annotations/parser/main_test.go
+++ b/internal/ingress/annotations/parser/main_test.go
@@ -130,6 +130,47 @@ rewrite (?i)/arcgis/services/Utilities/Geometry/GeometryServer(.*)$ /arcgis/serv
 	}
 }
 
+func TestGetFloatAnnotation(t *testing.T) {
+	ing := buildIngress()
+
+	_, err := GetFloatAnnotation("", nil)
+	if err == nil {
+		t.Errorf("expected error but retuned nil")
+	}
+
+	tests := []struct {
+		name   string
+		field  string
+		value  string
+		exp    float32
+		expErr bool
+	}{
+		{"valid - A", "string", "1.5", 1.5, false},
+		{"valid - B", "string", "2", 2, false},
+		{"valid - C", "string", "100.0", 100, false},
+	}
+
+	data := map[string]string{}
+	ing.SetAnnotations(data)
+
+	for _, test := range tests {
+		data[GetAnnotationWithPrefix(test.field)] = test.value
+
+		s, err := GetFloatAnnotation(test.field, ing)
+		if test.expErr {
+			if err == nil {
+				t.Errorf("%v: expected error but retuned nil", test.name)
+			}
+			continue
+		}
+		if s != test.exp {
+			t.Errorf("%v: expected \"%v\" but \"%v\" was returned", test.name, test.exp, s)
+		}
+
+		delete(data, test.field)
+	}
+}
+
 func TestGetIntAnnotation(t *testing.T) {
 	ing := buildIngress()
 


### PR DESCRIPTION
We are working on a new balancer implementation in the Shopify fork (to be upstreamed soon) and we need to pass an annotation that is a float.

An alternative is to use `int` annotation multiplied by `100` but we thought it would be more user-friendly to have support for floats in configuration.

@ElvinEfendi 