### PR TITLE
Disable warning "Aliases already configured" for multi-ingress definitions not containing server-alias annotation

### DIFF
--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -1287,7 +1287,7 @@ func (n *NGINXController) createServers(data []*ingress.Ingress,
 				if aliases := allAliases[host]; len(aliases) == 0 {
 					allAliases[host] = anns.Aliases
 				}
-			} else {
+			} else if len(anns.Aliases) != 0 {
 				klog.Warningf("Aliases already configured for server %q, skipping (Ingress %q)", host, ingKey)
 			}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
We've investigated our NGINX Controller logs and identified that the warning log "Aliases already configured for server" is not correct under specific circumstances.

Having multiple ingresses for the same host (when only one ingress contains the annotation `nginx.ingress.kubernetes.io/server-alias`) results in logging this warning for each ingress specified, even though the other ingresses do not contain the `server-alias` annotation.

This PR adds a simple `if` condition which checks, if the ingresses contain a `server-alias` annotation: Only if the server-aliases are already specified for a host by any ingress and another ingress for this host specifies additional server aliases, then this warning should be logged.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
None
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
We deployed our locally built NGINX controller with the code change specified in this PR into our local development Kubernetes cluster. As we have multiple ingresses for one host (with only one ingress containing the `server-alias` annotation), we did not see this warning anymore. For testing purposes we temporarily added the `server-alias` annotation to another ingress, and got the warning logged for this ingress.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [x] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed. (Only e2e-tests; we were not able to get the unit tests running)
- [ ] Added Release Notes.

## Does my pull request need a release note?
Any user-visible or operator-visible change qualifies for a release note. This could be a:

- CLI change
- API change
- UI change
- configuration schema change
- behavioral change
- change in non-functional attributes such as efficiency or availability, availability of a new platform
- a warning about a deprecation
- fix of a previous Known Issue
- fix of a vulnerability (CVE)

No release notes are required for changes to the following:

- Tests
- Build infrastructure
- Fixes for unreleased bugs

For more tips on writing good release notes, check out the [Release Notes Handbook](https://github.com/kubernetes/sig-release/tree/master/release-team/role-handbooks/release-notes)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
