### PR TITLE
Missing controller.ingressClass in the documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -223,6 +223,7 @@ If you start Ingress-Nginx B with the command line argument `--watch-ingress-wit
   helm install ingress-nginx-2 ingress-nginx/ingress-nginx  \
   --namespace ingress-nginx-2 \
   --set controller.ingressClassResource.name=nginx-two \
+  --set controller.ingressClass=nginx-two \
   --set controller.ingressClassResource.controllerValue="example.com/ingress-nginx-2" \
   --set controller.ingressClassResource.enabled=true \
   --set controller.ingressClassByName=true
@@ -234,7 +235,9 @@ If you start Ingress-Nginx B with the command line argument `--watch-ingress-wit
   --namespace kube-system \
   --set controller.electionID=nginx-two-leader \
   --set controller.ingressClassResource.name=nginx-two \
+  --set controller.ingressClass=nginx-two \
   --set controller.ingressClassResource.controllerValue="example.com/ingress-nginx-2" \
   --set controller.ingressClassResource.enabled=true \
   --set controller.ingressClassByName=true
   ```
+  - Note, controller.ingressClassResource.name and controller.ingressClass have to be set with the value of the new class as the first is to create the IngressClass object and the other is to modify the deployment of the actuall ingress controller pod.


### PR DESCRIPTION

## What this PR does / why we need it:
The missing controller.ingressClass would set the deployment to the default class but the controller.ingressClassResource.name would set the creation of a new IngressClass object.

For now this needs to be done twice, could be a fix in the chart later on.
Without this, the instructions for multiple ingress controllers does not work.
Fixes #9292 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ x] Documentation only

## How Has This Been Tested?
This is just a documentation issue tested in #9292 
```release-note
NONE
```
