### PR TITLE
Add `limit-blocklist` annotation for specifying IPs to be rate-limited

### DIFF
--- a/docs/user-guide/nginx-configuration/annotations.md
+++ b/docs/user-guide/nginx-configuration/annotations.md
@@ -526,7 +526,7 @@ These annotations define limits on connections and transmission rates.  These ca
 * `nginx.ingress.kubernetes.io/limit-rate-after`: initial number of kilobytes after which the further transmission of a response to a given connection will be rate limited. This feature must be used with [proxy-buffering](#proxy-buffering) enabled.
 * `nginx.ingress.kubernetes.io/limit-rate`: number of kilobytes per second allowed to send to a given connection.  The zero value disables rate limiting. This feature must be used with [proxy-buffering](#proxy-buffering) enabled.
 * `nginx.ingress.kubernetes.io/limit-whitelist`: client IP source ranges to be excluded from rate-limiting. The value is a comma separated list of CIDRs.
-* `nginx.ingress.kubernetes.io/limit-blacklist`: client IP source ranges to be included for rate-limiting. The value is a comma separated list of CIDRs. Overrides any configuration specified in `limit-whitelist`.
+* `nginx.ingress.kubernetes.io/limit-blocklist`: client IP source ranges to be included for rate-limiting. The value is a comma separated list of CIDRs. Overrides any configuration specified in `limit-whitelist`.
 
 If you specify multiple annotations in a single Ingress rule, limits are applied in the order `limit-connections`, `limit-rpm`, `limit-rps`.
 

--- a/docs/user-guide/nginx-configuration/annotations.md
+++ b/docs/user-guide/nginx-configuration/annotations.md
@@ -526,6 +526,7 @@ These annotations define limits on connections and transmission rates.  These ca
 * `nginx.ingress.kubernetes.io/limit-rate-after`: initial number of kilobytes after which the further transmission of a response to a given connection will be rate limited. This feature must be used with [proxy-buffering](#proxy-buffering) enabled.
 * `nginx.ingress.kubernetes.io/limit-rate`: number of kilobytes per second allowed to send to a given connection.  The zero value disables rate limiting. This feature must be used with [proxy-buffering](#proxy-buffering) enabled.
 * `nginx.ingress.kubernetes.io/limit-whitelist`: client IP source ranges to be excluded from rate-limiting. The value is a comma separated list of CIDRs.
+* `nginx.ingress.kubernetes.io/limit-blacklist`: client IP source ranges to be included for rate-limiting. The value is a comma separated list of CIDRs. Overrides any configuration specified in `limit-whitelist`.
 
 If you specify multiple annotations in a single Ingress rule, limits are applied in the order `limit-connections`, `limit-rpm`, `limit-rps`.
 

--- a/internal/ingress/annotations/ratelimit/main.go
+++ b/internal/ingress/annotations/ratelimit/main.go
@@ -60,7 +60,7 @@ type Config struct {
 
 	Whitelist []string `json:"whitelist"`
 
-	Blacklist []string `json:"blacklist"`
+	Blocklist []string `json:"blocklist"`
 }
 
 // Equal tests for equality between two RateLimit types
@@ -95,11 +95,11 @@ func (rt1 *Config) Equal(rt2 *Config) bool {
 	if len(rt1.Whitelist) != len(rt2.Whitelist) {
 		return false
 	}
-	if len(rt1.Blacklist) != len(rt2.Blacklist) {
+	if len(rt1.Blocklist) != len(rt2.Blocklist) {
 		return false
 	}
 
-	return sets.StringElementsMatch(rt1.Blacklist, rt2.Blacklist)
+	return sets.StringElementsMatch(rt1.Blocklist, rt2.Blocklist)
 }
 
 // Zone returns information about the NGINX rate limit (limit_req_zone)
@@ -172,8 +172,8 @@ func (a ratelimit) Parse(ing *networking.Ingress) (interface{}, error) {
 		return nil, err
 	}
 
-	valBlacklist, _ := parser.GetStringAnnotation("limit-blacklist", ing)
-	cidrsBlacklist, err := net.ParseCIDRs(valBlacklist)
+	valBlocklist, _ := parser.GetStringAnnotation("limit-blocklist", ing)
+	cidrsBlocklist, err := net.ParseCIDRs(valBlocklist)
 	if err != nil {
 		return nil, err
 	}
@@ -214,7 +214,7 @@ func (a ratelimit) Parse(ing *networking.Ingress) (interface{}, error) {
 		Name:           zoneName,
 		ID:             encode(zoneName),
 		Whitelist:      cidrsWhitelist,
-		Blacklist:      cidrsBlacklist,
+		Blocklist:      cidrsBlocklist,
 	}, nil
 }
 

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -520,9 +520,9 @@ http {
     {{ range $rl := (filterRateLimits $servers ) }}
     # Ratelimit {{ $rl.Name }}
     geo $remote_addr $whitelist_{{ $rl.ID }} {
-        {{- if $rl.Blacklist -}}
+        {{- if $rl.Blocklist -}}
         default 1;
-        {{ range $ip := $rl.Blacklist }}
+        {{ range $ip := $rl.Blocklist }}
         {{ $ip }} 0;{{ end }}
         {{- else -}}
         default 0;

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -520,9 +520,15 @@ http {
     {{ range $rl := (filterRateLimits $servers ) }}
     # Ratelimit {{ $rl.Name }}
     geo $remote_addr $whitelist_{{ $rl.ID }} {
+        {{- if $rl.Blacklist -}}
+        default 1;
+        {{ range $ip := $rl.Blacklist }}
+        {{ $ip }} 0;{{ end }}
+        {{- else -}}
         default 0;
         {{ range $ip := $rl.Whitelist }}
         {{ $ip }} 1;{{ end }}
+        {{- end -}}
     }
 
     # Ratelimit {{ $rl.Name }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This adds a new annotation `nginx.ingress.kubernetes.io/limit-blocklist` for configuring the list of IPs to be explicitly included for rate-limiting. Any non blocklisted IPs are to be excluded from rate-limiting. This provides an inverse of the functionality currently supported by `nginx.ingress.kubernetes.io/limit-whitelist`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in a local Kubernetes cluster with `kind` by creating `Ingress` resources with both the old and newly introduced annotation. After applying the manifest, the `nginx.conf` inside the pod was checked to confirm that the configuration changes get applied as expected.  

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [X] I have added unit and/or e2e tests to cover my changes.
- [X] All new and existing tests passed.
- [X] Added Release Notes.

## Does my pull request need a release note?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add new annotation nginx.ingress.kubernetes.io/limit-blocklist for specifying IPs to be rate-limited
```
