### PR TITLE
fixed multiple ginkgo versions

### DIFF
--- a/build/run-in-docker.sh
+++ b/build/run-in-docker.sh
@@ -77,7 +77,7 @@ if [[ "$DOCKER_IN_DOCKER_ENABLED" == "true" ]]; then
   echo "FLAGS=$FLAGS"
   go env
   set -x
-  go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo@v2.1.4
+  go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo@v2.5.1
   find / -type f -name ginkgo 2>/dev/null
   which ginkgo
   /bin/bash -c "${FLAGS}"

--- a/images/test-runner/rootfs/Dockerfile
+++ b/images/test-runner/rootfs/Dockerfile
@@ -49,7 +49,7 @@ ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
 
-RUN go install github.com/onsi/ginkgo/v2/ginkgo@v2.1.4  && go install golang.org/x/lint/golint@latest
+RUN go install github.com/onsi/ginkgo/v2/ginkgo@v2.5.1  && go install golang.org/x/lint/golint@latest
 
 ARG RESTY_CLI_VERSION
 ARG RESTY_CLI_SHA

--- a/test/e2e/run-chart-test.sh
+++ b/test/e2e/run-chart-test.sh
@@ -78,7 +78,7 @@ fi
 
 if [ "${SKIP_IMAGE_CREATION:-false}" = "false" ]; then
   if ! command -v ginkgo &> /dev/null; then
-    go get github.com/onsi/ginkgo/v2/ginkgo@v2.1.4
+    go get github.com/onsi/ginkgo/v2/ginkgo@v2.5.1
   fi
   echo "[dev-env] building image"
   make -C ${DIR}/../../ clean-image build image

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -79,7 +79,7 @@ fi
 
 if [ "${SKIP_IMAGE_CREATION:-false}" = "false" ]; then
   if ! command -v ginkgo &> /dev/null; then
-    go get github.com/onsi/ginkgo/v2/ginkgo@v2.1.4
+    go get github.com/onsi/ginkgo/v2/ginkgo@v2.5.1
   fi
 
   echo "[dev-env] building image"


### PR DESCRIPTION
## What this PR does / why we need it:
- ginkgo version was changed in /go.mod https://github.com/kubernetes/ingress-nginx/pull/9317
, without changing the hardcoded ginkgo version in the project's scripts
- This PR tries to set the ginkgo version to v2.5.1, in the scripts/code, where ginkgo version is hardcoded, to be consistent with the change in /go.mod
- In future, we should use this PR to understand, what files & lines to edit, for bumping ginkgo version in the project
- This will create new test-runner image, that will need to be promoted asap, to make progress on  #9321 
- Discovered this while running `make kind-e2e-test`
- After this PR, there are ginkgo feature deprecations, that need to be addressed in a follow-up PR. Example

```
You're using deprecated Ginkgo functionality:             
=============================================             
  --ginkgo.progress is deprecated .  The functionality provided by --progress was confusing and is no longer needed.  Use --show-node-events instead to see node entry and exit events included in the timeline of failed and verbose spe
cs.  Or you can run with -vv to always see all node events.  Lastly, --poll-progress-after and the PollProgressAfter decorator now provide a better mechanism for debugging specs that tend to get stuck.
  --ginkgo.slow-spec-threshold is deprecated --slow-spec-threshold has been deprecated and will be removed in a future version of Ginkgo.  This feature has proved to be more noisy than useful.  You can use --poll-progress-after, inst
ead, to get more actionable feedback about potentially slow specs and understand where they might be getting stuck.

To silence deprecations that can be silenced set the following environment variable:                                
  ACK_GINKGO_DEPRECATIONS=2.5.1  
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
- No issue created with direct reference but this is blocking #9321

## How Has This Been Tested?
- Tested locally. Non-functional tests are running

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Added Release Notes.

## Does my pull request need a release note?
Any user-visible or operator-visible change qualifies for a release note. This could be a:

- CLI change
- API change
- UI change
- configuration schema change
- behavioral change
- change in non-functional attributes such as efficiency or availability, availability of a new platform
- a warning about a deprecation
- fix of a previous Known Issue
- fix of a vulnerability (CVE)

No release notes are required for changes to the following:

- Tests
- Build infrastructure
- Fixes for unreleased bugs

For more tips on writing good release notes, check out the [Release Notes Handbook](https://github.com/kubernetes/sig-release/tree/master/release-team/role-handbooks/release-notes)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fixed multiple ginkgo versions
```

/triage accepted
/area stabilization

/assign @rikatz @tao12345666333 