### PR TITLE
create nsswitch-conf only if missing

### DIFF
--- a/images/test-runner/rootfs/Dockerfile
+++ b/images/test-runner/rootfs/Dockerfile
@@ -21,7 +21,13 @@ FROM registry.k8s.io/etcd:${ETCD_VERSION} as etcd
 
 FROM ${BASE_IMAGE}
 
-RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
+RUN set -eux; \
+	if [ -e /etc/nsswitch.conf ]; then \
+		grep '^hosts: files dns' /etc/nsswitch.conf; \
+	else \
+		echo 'hosts: files dns' > /etc/nsswitch.conf; \
+	fi
+
 
 COPY --from=GO   /usr/local/go /usr/local/go
 COPY --from=etcd /usr/local/bin/etcd /usr/local/bin/etcd


### PR DESCRIPTION
## What this PR does / why we need it:
- Test-runner image build failing at Dockerfile step to create nsswitch.conf
- Details are in the issue #9338 
- Maybe we don't need to create the nsswitch.conf as upstream may be doing it already
- We will know after this PR merges and cloudbuild is fired for test-runner image

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
- Expected to fix #9338 


## How Has This Been Tested?
- Can only be tested in cloudbuild because problem is in cloudbuild and local-build is not the same as cloudbuild

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] Added Release Notes.

## Does my pull request need a release note?
Any user-visible or operator-visible change qualifies for a release note. This could be a:

- CLI change
- API change
- UI change
- configuration schema change
- behavioral change
- change in non-functional attributes such as efficiency or availability, availability of a new platform
- a warning about a deprecation
- fix of a previous Known Issue
- fix of a vulnerability (CVE)

No release notes are required for changes to the following:

- Tests
- Build infrastructure
- Fixes for unreleased bugs

For more tips on writing good release notes, check out the [Release Notes Handbook](https://github.com/kubernetes/sig-release/tree/master/release-team/role-handbooks/release-notes)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
create nsswitch.conf only if missing
```

/triage accepted
/area stabilization

/assign @tao12345666333 @rikatz 