### PR TITLE
added slim-sprig and pprof indirect dependency libs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -70,6 +70,7 @@ require (
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.19.5 // indirect
 	github.com/go-openapi/swag v0.19.14 // indirect
+	github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 // indirect
 	github.com/godbus/dbus/v5 v5.0.6 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.2.0 // indirect
@@ -80,6 +81,7 @@ require (
 	github.com/google/gnostic v0.5.7-v3refs // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
+	github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/google/uuid v1.2.0 // indirect
 	github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -167,6 +167,8 @@ github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh
 github.com/go-openapi/swag v0.19.14 h1:gm3vOOXfiuw5i9p5N9xJvfjvuofpyvLA9Wr6QfK5Fng=
 github.com/go-openapi/swag v0.19.14/go.mod h1:QYRuS/SOXUCsnplDa677K7+DxSOj6IPNl/eQntq43wQ=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 h1:p104kn46Q8WdvHunIJ9dAyjPVtrBPhSr3KT2yUst43I=
+github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/godbus/dbus/v5 v5.0.6 h1:mkgN1ofwASrYnJ5W6U/BxG15eXXXjirgZc7CLqkcaro=
 github.com/godbus/dbus/v5 v5.0.6/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
@@ -252,6 +254,7 @@ github.com/google/pprof v0.0.0-20210122040257-d980be63207e/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210226084205-cbba55b83ad5/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210601050228-01bbb1931b22/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210609004039-a478d1d731e9/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
+github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 h1:K6RDEckDVWvDI9JAJYCmNdQXq6neHJOYx3V6jnqNEec=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=


### PR DESCRIPTION
## What this PR does / why we need it:
- This PR is needed to solve a important problem that is described in https://github.com/kubernetes/ingress-nginx/issues/9342
- Basically 2 new indirect dependency libs need to be added to go.mod. They are
  - slim-sprig
  - pprof
- This is a based and originated from https://github.com/kubernetes/ingress-nginx/pull/9336
- Each time I try to run `make kind-e2e-test`, midway through the test, the `go.mod` and `go.sum` get modified with 2 new dependencies
```
% git diff
diff --git a/go.mod b/go.mod
index 91bda5845..329bdb6dc 100644
--- a/go.mod
+++ b/go.mod
@@ -70,6 +70,7 @@ require (
        github.com/go-openapi/jsonpointer v0.19.5 // indirect
        github.com/go-openapi/jsonreference v0.19.5 // indirect
        github.com/go-openapi/swag v0.19.14 // indirect
+       github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 // indirect
        github.com/godbus/dbus/v5 v5.0.6 // indirect
        github.com/gogo/protobuf v1.3.2 // indirect
        github.com/golang-jwt/jwt/v4 v4.2.0 // indirect
@@ -80,6 +81,7 @@ require (
        github.com/google/gnostic v0.5.7-v3refs // indirect
        github.com/google/go-cmp v0.5.9 // indirect
        github.com/google/gofuzz v1.1.0 // indirect
+       github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 // indirect
        github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
        github.com/google/uuid v1.2.0 // indirect
        github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 // indirect
diff --git a/go.sum b/go.sum
index f53cec3a6..1a2c91f5c 100644
--- a/go.sum
+++ b/go.sum
@@ -167,6 +167,8 @@ github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh
 github.com/go-openapi/swag v0.19.14 h1:gm3vOOXfiuw5i9p5N9xJvfjvuofpyvLA9Wr6QfK5Fng=
 github.com/go-openapi/swag v0.19.14/go.mod h1:QYRuS/SOXUCsnplDa677K7+DxSOj6IPNl/eQntq43wQ=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 h1:p104kn46Q8WdvHunIJ9dAyjPVtrBPhSr3KT2yUst43I=
+github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/godbus/dbus/v5 v5.0.6 h1:mkgN1ofwASrYnJ5W6U/BxG15eXXXjirgZc7CLqkcaro=
 github.com/godbus/dbus/v5 v5.0.6/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
@@ -252,6 +254,7 @@ github.com/google/pprof v0.0.0-20210122040257-d980be63207e/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210226084205-cbba55b83ad5/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210601050228-01bbb1931b22/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210609004039-a478d1d731e9/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
+github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 h1:K6RDEckDVWvDI9JAJYCmNdQXq6neHJOYx3V6jnqNEec=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=

```

- The reason is based around reasons explained in https://github.com/kubernetes/ingress-nginx/pull/9336 
- Now we figured out the root-cause why the files go.mod & go.sum change. The new dependecies are a indirect dependency of ginkgo v2.5.1 

```
% go mod graph | grep -i slim-sprig
k8s.io/ingress-nginx github.com/go-task/slim-sprig@v0.0.0-20210107165309-348f09dbbbc0
github.com/go-task/slim-sprig@v0.0.0-20210107165309-348f09dbbbc0 github.com/davecgh/go-spew@v1.1.1
github.com/go-task/slim-sprig@v0.0.0-20210107165309-348f09dbbbc0 github.com/stretchr/testify@v1.5.1
github.com/onsi/ginkgo/v2@v2.5.1 github.com/go-task/slim-sprig@v0.0.0-20210107165309-348f09dbbbc0
```
- Similarly for the `pprof` package 
```
% go mod graph | grep -i pprof | grep cloud
cloud.google.com/go@v0.65.0 github.com/google/pprof@v0.0.0-20200708004538-1a94d8640e99
cloud.google.com/go@v0.57.0 github.com/google/pprof@v0.0.0-20200430221834-fc25d7d30c6d
cloud.google.com/go@v0.56.0 github.com/google/pprof@v0.0.0-20200229191704-1ebb73c60ed3
cloud.google.com/go@v0.90.0 github.com/google/pprof@v0.0.0-20210720184732-4bb14d4b1be1
cloud.google.com/go@v0.62.0 github.com/google/pprof@v0.0.0-20200708004538-1a94d8640e99
cloud.google.com/go@v0.52.0 github.com/google/pprof@v0.0.0-20191218002539-d4f498aebedc
cloud.google.com/go@v0.53.0 github.com/google/pprof@v0.0.0-20200212024743-f11f1df84d12
cloud.google.com/go@v0.38.0 github.com/google/pprof@v0.0.0-20181206194817-3ea8567a2e57
cloud.google.com/go@v0.50.0 github.com/google/pprof@v0.0.0-20190515194954-54271f7e092f
cloud.google.com/go@v0.87.0 github.com/google/pprof@v0.0.0-20210609004039-a478d1d731e9
cloud.google.com/go@v0.44.2 github.com/google/pprof@v0.0.0-20190515194954-54271f7e092f
cloud.google.com/go@v0.44.1 github.com/google/pprof@v0.0.0-20190515194954-54271f7e092f
cloud.google.com/go@v0.45.1 github.com/google/pprof@v0.0.0-20190515194954-54271f7e092f
cloud.google.com/go@v0.46.3 github.com/google/pprof@v0.0.0-20190515194954-54271f7e092f
cloud.google.com/go@v0.54.0 github.com/google/pprof@v0.0.0-20200229191704-1ebb73c60ed3
cloud.google.com/go@v0.84.0 github.com/google/pprof@v0.0.0-20210601050228-01bbb1931b22
cloud.google.com/go@v0.83.0 github.com/google/pprof@v0.0.0-20210601050228-01bbb1931b22
cloud.google.com/go@v0.81.0 github.com/google/pprof@v0.0.0-20210226084205-cbba55b83ad5
cloud.google.com/go@v0.79.0 github.com/google/pprof@v0.0.0-20210226084205-cbba55b83ad5
cloud.google.com/go@v0.78.0 github.com/google/pprof@v0.0.0-20210122040257-d980be63207e
cloud.google.com/go@v0.74.0 github.com/google/pprof@v0.0.0-20201203190320-1bf35d6f28c2
cloud.google.com/go@v0.72.0 github.com/google/pprof@v0.0.0-20201023163331-3e6fc7fc9c4c
```
- This PR adds those 2 libs, "slim-sprig" & "pprof", to `go.mod` and hence to `go.sum` as well


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes

fixes #9342

## How Has This Been Tested?
- Tested locally with `make kind e2e-test`

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Added Release Notes.

## Does my pull request need a release note?
Any user-visible or operator-visible change qualifies for a release note. This could be a:

- CLI change
- API change
- UI change
- configuration schema change
- behavioral change
- change in non-functional attributes such as efficiency or availability, availability of a new platform
- a warning about a deprecation
- fix of a previous Known Issue
- fix of a vulnerability (CVE)

No release notes are required for changes to the following:

- Tests
- Build infrastructure
- Fixes for unreleased bugs

For more tips on writing good release notes, check out the [Release Notes Handbook](https://github.com/kubernetes/sig-release/tree/master/release-team/role-handbooks/release-notes)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
added slim-sprig and pprof indirect dependency libs
```

/triage accepted
/area stabilization
/priority important-soon

/assign @rikatz @tao12345666333 