### PR TITLE
added junitreports to ginkgo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,5 @@ images/fastcgi-helloserver/rootfs/fastcgi-helloserver
 cmd/plugin/release/ingress-nginx.yaml
 cmd/plugin/release/*.tar.gz
 cmd/plugin/release/LICENSE
+
+test/junitreports

--- a/test/e2e-image/e2e.sh
+++ b/test/e2e-image/e2e.sh
@@ -34,23 +34,39 @@ ginkgo_args=(
   "-timeout=75m"
 )
 
+# Variable for the prefix of report filenames
+reportFileNamePrefix="report-e2e-test-suite"
+
 echo -e "${BGREEN}Running e2e test suite (FOCUS=${FOCUS})...${NC}"
 ginkgo "${ginkgo_args[@]}"               \
   -focus="${FOCUS}"                  \
   -skip="\[Serial\]|\[MemoryLeak\]"  \
   -nodes="${E2E_NODES}" \
+  --junit-report=$reportFileNamePrefix.xml \
   /e2e.test
+# Create configMap out of a compressed report file for extraction later
 
 echo -e "${BGREEN}Running e2e test suite with tests that require serial execution...${NC}"
 ginkgo "${ginkgo_args[@]}"   \
   -focus="\[Serial\]"    \
   -skip="\[MemoryLeak\]" \
+  --junit-report=$reportFileNamePrefix-serial.xml \
   /e2e.test
+# Create configMap out of a compressed report file for extraction later
 
 if [[ ${E2E_CHECK_LEAKS} != "" ]]; then
   echo -e "${BGREEN}Running e2e test suite with tests that check for memory leaks...${NC}"
   ginkgo "${ginkgo_args[@]}"    \
     -focus="\[MemoryLeak\]" \
     -skip="\[Serial\]" \
+    --junit-report=$reportFileNamePrefix-memleak.xml \
     /e2e.test
+# Create configMap out of a compressed report file for extraction later
 fi
+
+for rFile in `ls $reportFileNamePrefix*` 
+do
+  gzip -k $rFile
+  kubectl create cm $rFile.gz --from-file $rFile.gz
+  kubectl label cm $rFile.gz junitreport=true
+done


### PR DESCRIPTION
## What this PR does / why we need it:
- Development work is slow & hard when too much resources are spent on getting e2e-test feedback for code iterations
- Automated reports that provide quick accurate feedback with appropriate details to take action are needed
- This PR enables the functionality of ginkgo to generate junit-reports, for the e2e-tests
- This requirement is/was described in #9321
- This is very crude now. The reports get compressed and stored in configMaps because the e2e pod dies after test
- But the cluster remains a little longer so reports are extracted out of the configMap
- The pending work here is  ;
  - smart iteration on the list of configMaps to extract the report for persistence
  - integrate reports into GHActions
- Important Tips from @rikatz 
```
Get the cmNames list using labels here, interact over data values map and use the key name as the file name.
Eg:

- k get cm -l content=report
- Use jq to iteract over the list
- iteract over data of each cm
- Key = filename, value = data

I know this is an initial PR, but if possible:

- apply gz over report.xml so we don’t hit k8s/etcd limit of 2mb per cm
- encode the gz as base64
- then you revert on the other side
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
fixes #9321 

## How Has This Been Tested?
- Tested it locally with `make kind-e2e-test`

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Added Release Notes.

## Does my pull request need a release note?
Any user-visible or operator-visible change qualifies for a release note. This could be a:

- CLI change
- API change
- UI change
- configuration schema change
- behavioral change
- change in non-functional attributes such as efficiency or availability, availability of a new platform
- a warning about a deprecation
- fix of a previous Known Issue
- fix of a vulnerability (CVE)

No release notes are required for changes to the following:

- Tests
- Build infrastructure
- Fixes for unreleased bugs

For more tips on writing good release notes, check out the [Release Notes Handbook](https://github.com/kubernetes/sig-release/tree/master/release-team/role-handbooks/release-notes)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
added junitreport to ginkgo
```

/triage accepted
/area stabilization
/priority important-soon

/assign @rikatz 