### PR TITLE
Fixed the k8s version supported for 1.x helm chart.

### DIFF
--- a/docs/deploy/index.md
+++ b/docs/deploy/index.md
@@ -428,5 +428,5 @@ Ingress Controller; but if you're using an old version of Kubernetes (1.18 or ea
 of the NGINX Ingress Controller (e.g. version 0.49).
 
 The Helm chart of the NGINX Ingress Controller switched to version 1 in version 4 of the chart. In other words, if 
-you're running Kubernetes 1.19 or earlier, you should use version 3.X of the chart (this can be done by adding 
+you're running Kubernetes 1.18 or earlier, you should use version 3.X of the chart (this can be done by adding 
 `--version='<4'` to the `helm install` command).


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
This just fix a incorrect Kubernetes version mentioned in the documentation for the helm chart compatibility. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation only
