### PR TITLE
integrated junit-reports with ghactions-part1-of-2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -267,6 +267,12 @@ jobs:
           kind get kubeconfig > $HOME/.kube/kind-config-kind
           make kind-e2e-test
 
+      - name: Uplaod e2e junit-reports
+        uses: actions/upload-artifact@v2
+        if: success() || failure()
+        with:
+          name: e2e-test-reports
+          path: 'test/junitreports/report*.xml'
 
   kubernetes-chroot:
     name: Kubernetes chroot

--- a/.github/workflows/junit-reports.yaml
+++ b/.github/workflows/junit-reports.yaml
@@ -1,0 +1,16 @@
+name: 'E2E Test Report'
+on:
+  workflow_run:
+    workflows: ['CI']                     # runs after CI workflow
+    types:
+      - completed
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: dorny/test-reporter@v1
+      with:
+        artifact: e2e-test-reports
+        name: JEST Tests                  # Name of the check run which will be created
+        path: 'report*.xml'                     # Path to test results (inside artifact .zip)
+        reporter: jest-junit              # Format of test results

--- a/build/run-e2e-suite.sh
+++ b/build/run-e2e-suite.sh
@@ -99,6 +99,7 @@ cd $reportsDir
 #for cmName in `k get cm -l junitreport=true -o json | jq  '.items[].binaryData | keys[]' | tr '\"' ' '`
 #do
 #
+#
 # kubectl get cm -l junitreport=true -o json | jq -r  '[.items[].binaryData | to_entries[] | {"key": .key, "value": .value  }] | from_entries'
 #
 


### PR DESCRIPTION
## What this PR does / why we need it:
- In #9350 , the junit-reports were generated during e2e-tests
- In this PR we are integrating those junit-reports into ghactions
- This is based on https://github.com/marketplace/actions/test-reporter docs/examples

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
fixes #9360 

## How Has This Been Tested?
- Can only be tested in GHAction pipeline so need to look at CI in Actions tab when this PR is submitted

## Checklist:
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Added Release Notes.

## Does my pull request need a release note?
Any user-visible or operator-visible change qualifies for a release note. This could be a:

- CLI change
- API change
- UI change
- configuration schema change
- behavioral change
- change in non-functional attributes such as efficiency or availability, availability of a new platform
- a warning about a deprecation
- fix of a previous Known Issue
- fix of a vulnerability (CVE)

No release notes are required for changes to the following:

- Tests
- Build infrastructure
- Fixes for unreleased bugs

For more tips on writing good release notes, check out the [Release Notes Handbook](https://github.com/kubernetes/sig-release/tree/master/release-team/role-handbooks/release-notes)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
PLACE RELEASE NOTES HERE
```

/area stabilization
/triage accepted
/priority important-soon
