### PR TITLE
Set grpc_bufer_size. Fixes #9363

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -1119,6 +1119,7 @@ stream {
             proxy_buffering                         {{ $location.Proxy.ProxyBuffering }};
             {{ end }}
             proxy_buffer_size                       {{ $location.Proxy.BufferSize }};
+            grpc_buffer_size                        {{ $location.Proxy.BufferSize }};
             proxy_buffers                           {{ $location.Proxy.BuffersNumber }} {{ $location.Proxy.BufferSize }};
             proxy_request_buffering                 {{ $location.Proxy.RequestBuffering }};
 


### PR DESCRIPTION
See https://github.com/kubernetes/ingress-nginx/issues/9363

According to the documentation at [configmap](https://docs.nginx.com/nginx-ingress-controller/configuration/global-configuration/configmap-resource), setting proxy-buffer-size will:

    Sets the value of the [proxy_buffer_size](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffer_size) and [grpc_buffer_size](https://nginx.org/en/docs/http/ngx_http_grpc_module.html#grpc_buffer_size) directives.

However, this is not the case. grpc_buffer_size is not set in nginx.conf.