### PR TITLE
Add reporter for all tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ on:
     inputs:
       run_e2e:
         description: 'Force e2e to run'
-        required: true
+        required: false
         type: boolean
 
 permissions:
@@ -73,6 +73,9 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     needs: changes
+    if: |
+      (needs.changes.outputs.go == 'true') || (needs.changes.outputs.charts == 'true') || ${{ inputs.run_e2e }} 
+
 
     steps:
 
@@ -268,10 +271,10 @@ jobs:
           make kind-e2e-test
 
       - name: Uplaod e2e junit-reports
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: success() || failure()
         with:
-          name: e2e-test-reports
+          name: e2e-test-reports-${{ matrix.k8s }}
           path: 'test/junitreports/report*.xml'
 
   kubernetes-chroot:
@@ -330,6 +333,13 @@ jobs:
         run: |
           kind get kubeconfig > $HOME/.kube/kind-config-kind
           make kind-e2e-test
+      
+      - name: Uplaod e2e junit-reports
+        uses: actions/upload-artifact@v3
+        if: success() || failure()
+        with:
+          name: e2e-test-reports-chroot-${{ matrix.k8s }}
+          path: 'test/junitreports/report*.xml'
 
 
   test-image-build:

--- a/.github/workflows/junit-reports.yaml
+++ b/.github/workflows/junit-reports.yaml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: dorny/test-reporter@v1
       with:
-        artifact: e2e-test-reports
-        name: JEST Tests                  # Name of the check run which will be created
+        artifact: /e2e-test-reports-(.*)/
+        name: JEST Tests $1                 # Name of the check run which will be created
         path: 'report*.xml'                     # Path to test results (inside artifact .zip)
         reporter: jest-junit              # Format of test results


### PR DESCRIPTION
Small change to make all tests report correctly, and CI to collect and show correctly as well

This will just export all reports, and allow those to be read by the other action that Long created :)


/kind feature
/triage accepted
/priority backlog