### PR TITLE
Increase build time out for fastcgi gcloud image build 

### DIFF
--- a/images/fastcgi-helloserver/cloudbuild.yaml
+++ b/images/fastcgi-helloserver/cloudbuild.yaml
@@ -1,4 +1,4 @@
-timeout: 600s
+timeout: 1800s
 options:
   substitution_option: ALLOW_LOOSE
 steps:


### PR DESCRIPTION
Signed-off-by: James Strong <james.strong@chainguard.dev>

```release-note
increase build time out for fastcgi gcloud image build 
```
