### PR TITLE
force rebuild for curl cve

### DIFF
--- a/images/nginx/rootfs/build.sh
+++ b/images/nginx/rootfs/build.sh
@@ -177,7 +177,8 @@ apk add \
   mercurial \
   alpine-sdk \
   findutils \
-  curl ca-certificates \
+  curl \
+  ca-certificates \
   patch \
   libaio-dev \
   openssl \


### PR DESCRIPTION
Force a rebuild curl cve 

````bash 
gcr.io/k8s-staging-ingress-nginx/nginx:c648595cd73a2d605cd7d9575b72b367755c7ec8@sha256:a51abd4fd2beb5a93f88ff9859c930d0437250bef90118572ad1127c5b30dfa2 (alpine 3.17.0)
=======================================================================================================================================================================
Total: 4 (UNKNOWN: 4, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)

+---------+------------------+----------+-------------------+---------------+---------------------------------------+
| LIBRARY | VULNERABILITY ID | SEVERITY | INSTALLED VERSION | FIXED VERSION |                 TITLE                 |
+---------+------------------+----------+-------------------+---------------+---------------------------------------+
| curl    | CVE-2022-43551   | UNKNOWN  | 7.86.0-r1         | 7.87.0-r0     | -->avd.aquasec.com/nvd/cve-2022-43551 |
+         +------------------+          +                   +               +---------------------------------------+
|         | CVE-2022-43552   |          |                   |               | -->avd.aquasec.com/nvd/cve-2022-43552 |
+---------+------------------+          +                   +               +---------------------------------------+
| libcurl | CVE-2022-43551   |          |                   |               | -->avd.aquasec.com/nvd/cve-2022-43551 |
+         +------------------+          +                   +               +---------------------------------------+
|         | CVE-2022-43552   |          |                   |               | -->avd.aquasec.com/nvd/cve-2022-43552 |
+---------+------------------+----------+-------------------+---------------+---------------------------------------+
````

```release-note
rebuild nginx base container image to get new curl version 
```
