### PR TITLE
Absolete config flags in nginx 

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -300,9 +300,12 @@ http {
     client_body_timeout             {{ $cfg.ClientBodyTimeout }}s;
 
     http2_max_field_size            {{ $cfg.HTTP2MaxFieldSize }};
-    http2_max_header_size           {{ $cfg.HTTP2MaxHeaderSize }};
-    http2_max_requests              {{ $cfg.HTTP2MaxRequests }};
     http2_max_concurrent_streams    {{ $cfg.HTTP2MaxConcurrentStreams }};
+    {{ if and (gt $http2_max_header_size 0) (gt $http2_max_requests 0) }}
+        http2_max_header_size           {{ $cfg.HTTP2MaxHeaderSize }};
+        http2_max_requests              {{ $cfg.HTTP2MaxRequests }};
+    {{ end }}
+
 
     types_hash_max_size             2048;
     server_names_hash_max_size      {{ $cfg.ServerNameHashMaxSize }};

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -299,12 +299,17 @@ http {
     client_body_buffer_size         {{ $cfg.ClientBodyBufferSize }};
     client_body_timeout             {{ $cfg.ClientBodyTimeout }}s;
 
-    http2_max_field_size            {{ $cfg.HTTP2MaxFieldSize }};
     http2_max_concurrent_streams    {{ $cfg.HTTP2MaxConcurrentStreams }};
-    {{ if and (gt $http2_max_header_size 0) (gt $http2_max_requests 0) }}
+
+    {{ if and (gt $http2_max_header_size 0) (gt $http2_max_field_size 0) }}
         http2_max_header_size           {{ $cfg.HTTP2MaxHeaderSize }};
+        http2_max_field_size            {{ $cfg.HTTP2MaxFieldSize }};
+    {{ end }}
+
+    {{ if (gt $http2_max_requests 0) }}
         http2_max_requests              {{ $cfg.HTTP2MaxRequests }};
     {{ end }}
+
 
 
     types_hash_max_size             2048;


### PR DESCRIPTION
## What this PR does / why we need it:
This is a followup on #8073. Nginx is giving warning about deprecated parameters being used. large_client_header_buffers and keepalive_requests which are the fix for the warning and are already included in the config template. So to fix the warning and keep old configuration working, we can check if somebody is setting the http2_max_header_size, http2_max_field_size and http2_max_requests to 0 and when so, then these parameters would not be included in the file.  

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes

fixes #7261

## How Has This Been Tested?

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Added Release Notes.