### PR TITLE
Update cloud build time out 

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,6 +1,6 @@
 # See https://cloud.google.com/cloud-build/docs/build-config
 
-timeout: 1800s
+timeout: 18000s
 options:
   substitution_option: ALLOW_LOOSE
 steps:


### PR DESCRIPTION
Signed-off-by: James Strong <james.strong@chainguard.dev>

The 1.5.2 cloud build timed out at 30 mins, with chroot and regular controller it can take longer than 30 mins. 

```release-note
update ingress-nginx cloud build to 18000s 
```
