### PR TITLE
move tests to gh actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,6 +75,63 @@ jobs:
           # G307 TODO: Deferring unsafe method "Close"
           args: -exclude=G109,G601,G104,G204,G304,G306,G307 -tests=false -exclude-dir=test -exclude-dir=images/  -exclude-dir=docs/ ./...
 
+  lint:
+    runs-on: ubuntu-latest
+    needs: changes
+    if: |
+      (needs.changes.outputs.go == 'true')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
+      
+      - name: Set up Go
+        id: go
+        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
+        with:
+          go-version: '1.19'
+          check-latest: true
+
+      - name: Run Lint
+        run: ./hack/verify-golint.sh
+
+  gofmt:
+    runs-on: ubuntu-latest
+    needs: changes
+    if: |
+      (needs.changes.outputs.go == 'true')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
+      
+      - name: Set up Go
+        id: go
+        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
+        with:
+          go-version: '1.19'
+          check-latest: true
+
+      - name: Run go-fmt
+        run: ./hack/verify-gofmt.sh
+
+  test-go:
+    runs-on: ubuntu-latest
+    needs: changes
+    if: |
+      (needs.changes.outputs.go == 'true')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
+      
+      - name: Set up Go
+        id: go
+        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
+        with:
+          go-version: '1.19'
+          check-latest: true
+
+      - name: Run test
+        run: make test
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,7 @@ test:  ## Run go unit tests.
 		COMMIT_SHA=$(COMMIT_SHA) \
 		REPO_INFO=$(REPO_INFO) \
 		TAG=$(TAG) \
+		GOFLAGS="-buildvcs=false" \
 		test/test.sh
 
 .PHONY: lua-test

--- a/internal/ingress/annotations/authreq/main.go
+++ b/internal/ingress/annotations/authreq/main.go
@@ -149,7 +149,8 @@ func ValidHeader(header string) bool {
 // ValidCacheDuration checks if the provided string is a valid cache duration
 // spec: [code ...] [time ...];
 // with: code is an http status code
-//       time must match the time regex and may appear multiple times, e.g. `1h 30m`
+//
+//	time must match the time regex and may appear multiple times, e.g. `1h 30m`
 func ValidCacheDuration(duration string) bool {
 	elements := strings.Split(duration, " ")
 	seenDuration := false

--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -75,8 +75,8 @@ type Template struct {
 	bp *BufferPool
 }
 
-//NewTemplate returns a new Template instance or an
-//error if the specified template file contains errors
+// NewTemplate returns a new Template instance or an
+// error if the specified template file contains errors
 func NewTemplate(file string) (*Template, error) {
 	data, err := os.ReadFile(file)
 	if err != nil {
@@ -287,9 +287,10 @@ var (
 // escapeLiteralDollar will replace the $ character with ${literal_dollar}
 // which is made to work via the following configuration in the http section of
 // the template:
-// geo $literal_dollar {
-//     default "$";
-// }
+//
+//	geo $literal_dollar {
+//	    default "$";
+//	}
 func escapeLiteralDollar(input interface{}) string {
 	inputStr, ok := input.(string)
 	if !ok {

--- a/internal/ingress/resolver/mock.go
+++ b/internal/ingress/resolver/mock.go
@@ -41,7 +41,8 @@ func (m Mock) GetSecret(string) (*apiv1.Secret, error) {
 
 // GetAuthCertificate resolves a given secret name into an SSL certificate.
 // The secret must contain 3 keys named:
-//   ca.crt: contains the certificate chain used for authentication
+//
+//	ca.crt: contains the certificate chain used for authentication
 func (m Mock) GetAuthCertificate(string) (*AuthSSLCert, error) {
 	return nil, nil
 }

--- a/pkg/util/runtime/cpu_linux.go
+++ b/pkg/util/runtime/cpu_linux.go
@@ -33,7 +33,8 @@ import (
 // NumCPU returns the number of logical CPUs usable by the current process.
 // If CPU cgroups limits are configured, use cfs_quota_us / cfs_period_us
 // as formula
-//  https://www.kernel.org/doc/Documentation/scheduler/sched-bwc.txt
+//
+//	https://www.kernel.org/doc/Documentation/scheduler/sched-bwc.txt
 func NumCPU() int {
 	cpus := runtime.NumCPU()
 

--- a/rootfs/chroot.sh
+++ b/rootfs/chroot.sh
@@ -40,7 +40,6 @@ for dir in "${writeDirs[@]}"; do
   chown -R www-data.www-data ${dir};
 done
 
-
 mkdir -p  /chroot/lib /chroot/proc /chroot/usr /chroot/bin /chroot/dev /chroot/run 
 cp /etc/passwd /etc/group /chroot/etc/
 cp -a /usr/* /chroot/usr/

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -189,7 +189,7 @@ func CreateIngressClass(namespace string, c kubernetes.Interface) (string, error
 	return ic.Name, nil
 }
 
-//deleteIngressClass deletes an IngressClass and its related ClusterRole* objects
+// deleteIngressClass deletes an IngressClass and its related ClusterRole* objects
 func deleteIngressClass(c kubernetes.Interface, ingressclass string) error {
 	var err error
 	grace := int64(0)
@@ -215,7 +215,7 @@ func deleteIngressClass(c kubernetes.Interface, ingressclass string) error {
 	return nil
 }
 
-//GetIngressClassName returns the default IngressClassName given a namespace
+// GetIngressClassName returns the default IngressClassName given a namespace
 func GetIngressClassName(namespace string) *string {
 	icname := fmt.Sprintf("ic-%s", namespace)
 	return &icname


### PR DESCRIPTION
In an effort to reduce a bit of k8s org usage, we are moving tests, lints, etc to gh actions