### PR TITLE
Add missing control char on regex validation

### DIFF
--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -305,6 +305,18 @@ func (n *NGINXController) CheckIngress(ing *networking.Ingress) error {
 
 	k8s.SetDefaultNGINXPathType(ing)
 
+	for _, rule := range ing.Spec.Rules {
+		if rule.HTTP == nil {
+			continue
+		}
+
+		for _, path := range rule.HTTP.Paths {
+			if !utilingress.IsSafePath(ing, path.Path) {
+				return fmt.Errorf("ingress contains invalid path: %s", path.Path)
+			}
+		}
+	}
+
 	allIngresses := n.store.ListIngresses()
 
 	filter := func(toCheck *ingress.Ingress) bool {

--- a/internal/ingress/controller/controller_test.go
+++ b/internal/ingress/controller/controller_test.go
@@ -339,6 +339,23 @@ func TestCheckIngress(t *testing.T) {
 				t.Errorf("with a new ingress without error, no error should be returned")
 			}
 		})
+
+		t.Run("When invalid path is passed to Ingress", func(t *testing.T) {
+			nginx.store = fakeIngressStore{
+				ingresses: []*ingress.Ingress{},
+			}
+			nginx.command = testNginxTestCommand{
+				t:   t,
+				err: nil,
+			}
+			ing.Spec.Rules[0].HTTP.Paths = append(ing.Spec.Rules[0].HTTP.Paths, networking.HTTPIngressPath{
+				Path: "/foo/bar/;xpto",
+			})
+			if err := nginx.CheckIngress(ing); err == nil {
+				t.Errorf("with an invalid path, ingress should be rejected")
+			}
+		})
+
 	})
 
 	t.Run("When the ingress is marked as deleted", func(t *testing.T) {

--- a/pkg/util/ingress/ingress.go
+++ b/pkg/util/ingress/ingress.go
@@ -252,7 +252,16 @@ func BuildRedirects(servers []*ingress.Server) []*redirect {
 func IsSafePath(copyIng *networkingv1.Ingress, path string) bool {
 	isRegex, _ := parser.GetBoolAnnotation("use-regex", copyIng)
 	isRewrite, _ := parser.GetBoolAnnotation("rewrite-target", copyIng)
-	if isRegex || isRewrite {
+	isImplSpecific := false
+	for _, rules := range copyIng.Spec.Rules {
+		for _, paths := range rules.HTTP.Paths {
+			if paths.PathType != nil && *paths.PathType == networkingv1.PathTypeImplementationSpecific {
+				isImplSpecific = true
+				break
+			}
+		}
+	}
+	if isRegex || isRewrite || isImplSpecific {
 		return pathRegexEnabled(path)
 	}
 	return pathAlphaNumeric(path)

--- a/pkg/util/ingress/ingress.go
+++ b/pkg/util/ingress/ingress.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	alphaNumericChars = `\-\.\_\~a-zA-Z0-9/`
-	regexEnabledChars = `\^\$\[\]\(\)\{\}\*\+`
+	regexEnabledChars = `\^\$\[\]\(\)\{\}\*\+\?\|`
 )
 
 var (
@@ -251,7 +251,8 @@ func BuildRedirects(servers []*ingress.Server) []*redirect {
 // It will behave differently if regex is enabled or not
 func IsSafePath(copyIng *networkingv1.Ingress, path string) bool {
 	isRegex, _ := parser.GetBoolAnnotation("use-regex", copyIng)
-	if isRegex {
+	isRewrite, _ := parser.GetBoolAnnotation("rewrite-target", copyIng)
+	if isRegex || isRewrite {
 		return pathRegexEnabled(path)
 	}
 	return pathAlphaNumeric(path)

--- a/pkg/util/ingress/ingress.go
+++ b/pkg/util/ingress/ingress.go
@@ -37,9 +37,9 @@ const (
 
 var (
 	// pathAlphaNumeric is a regex validation of something like "^/[a-zA-Z]+$" on path
-	pathAlphaNumeric = regexp.MustCompile("^/[" + alphaNumericChars + "]*$").MatchString
+	pathAlphaNumeric = regexp.MustCompile("^[/" + alphaNumericChars + "]*$").MatchString
 	// pathRegexEnabled is a regex validation of paths that may contain regex.
-	pathRegexEnabled = regexp.MustCompile("^/[" + alphaNumericChars + regexEnabledChars + "]*$").MatchString
+	pathRegexEnabled = regexp.MustCompile("^[/" + alphaNumericChars + regexEnabledChars + "]*$").MatchString
 )
 
 func GetRemovedHosts(rucfg, newcfg *ingress.Configuration) []string {

--- a/pkg/util/ingress/ingress_test.go
+++ b/pkg/util/ingress/ingress_test.go
@@ -195,6 +195,18 @@ func TestIsSafePath(t *testing.T) {
 			path:    "/foo/bar/(.+)",
 		},
 		{
+			name:    "should accept another regex path when regex is enabled",
+			want:    true,
+			copyIng: generateDumbIngressforPathTest(true),
+			path:    "/v1/?(.*)",
+		},
+		{
+			name:    "should accept more regex path when regex is enabled",
+			want:    true,
+			copyIng: generateDumbIngressforPathTest(true),
+			path:    "/something(/|$)(.*)",
+		},
+		{
 			name:    "should reject regex path when regex is enabled but the path is invalid",
 			want:    false,
 			copyIng: generateDumbIngressforPathTest(true),

--- a/pkg/util/ingress/ingress_test.go
+++ b/pkg/util/ingress/ingress_test.go
@@ -165,6 +165,12 @@ func TestIsSafePath(t *testing.T) {
 			path:    "",
 		},
 		{
+			name:    "should accept / path",
+			want:    true,
+			copyIng: generateDumbIngressforPathTest(false),
+			path:    "/",
+		},
+		{
 			name:    "should accept valid path with regex disabled",
 			want:    true,
 			copyIng: generateDumbIngressforPathTest(false),

--- a/pkg/util/ingress/ingress_test.go
+++ b/pkg/util/ingress/ingress_test.go
@@ -159,6 +159,12 @@ func TestIsSafePath(t *testing.T) {
 		want    bool
 	}{
 		{
+			name:    "should accept empty path",
+			want:    true,
+			copyIng: generateDumbIngressforPathTest(false),
+			path:    "",
+		},
+		{
 			name:    "should accept valid path with regex disabled",
 			want:    true,
 			copyIng: generateDumbIngressforPathTest(false),


### PR DESCRIPTION
## What this PR does / why we need it:
I forgot to add the "optional" (?) control char on regex validation, and enable the regex path when rewrite annotation is being used


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
Fixes #9464

## How Has This Been Tested?
Unit test based on user report

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Added Release Notes.

## Does my pull request need a release note?
Any user-visible or operator-visible change qualifies for a release note. This could be a:

- CLI change
- API change
- UI change
- configuration schema change
- behavioral change
- change in non-functional attributes such as efficiency or availability, availability of a new platform
- a warning about a deprecation
- fix of a previous Known Issue
- fix of a vulnerability (CVE)

No release notes are required for changes to the following:

- Tests
- Build infrastructure
- Fixes for unreleased bugs

For more tips on writing good release notes, check out the [Release Notes Handbook](https://github.com/kubernetes/sig-release/tree/master/release-team/role-handbooks/release-notes)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix regex validation on path
```
