### PR TITLE
Add libyear count badge to project's README

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -319,7 +319,7 @@ jobs:
           kind get kubeconfig > $HOME/.kube/kind-config-kind
           make kind-e2e-test
 
-      - name: Uplaod e2e junit-reports
+      - name: Upload e2e junit-reports
         uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
         if: success() || failure()
         with:
@@ -374,7 +374,7 @@ jobs:
           kind get kubeconfig > $HOME/.kube/kind-config-kind
           make kind-e2e-test
 
-      - name: Uplaod e2e junit-reports
+      - name: Upload e2e junit-reports
         uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
         if: success() || failure()
         with:
@@ -492,3 +492,38 @@ jobs:
         if: ${{ steps.filter-images.outputs.kube-webhook-certgen == 'true' }}
         run: |
           cd images/kube-webhook-certgen && make test test-e2e
+
+  libyear:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write  # for RubbaBoy/BYOB to write to "shields" branch
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
+
+      - name: Set up Go
+        id: go
+        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
+        with:
+          go-version: '1.19'
+          check-latest: true
+
+      - name: Install libyear
+        run: go install git.yetaga.in/alazyreader/libyear@latest
+
+      - name: Run libyear
+        id: libyear
+        run: |
+          LIBYEAR_COUNT=$(libyear -indirect | tail -1 | sed -e "s/total libyear count: //")
+          echo "LIBYEAR_COUNT=${LIBYEAR_COUNT}" >> $GITHUB_OUTPUT
+
+      - name: Update Libyear badge
+        uses: RubbaBoy/BYOB@v1.3.0
+        with:
+          NAME: libyear
+          COLOR: blue
+          LABEL: 'libyear count'
+          STATUS: ${{ steps.libyear.outputs.LIBYEAR_COUNT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -496,8 +496,7 @@ jobs:
   libyear:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write  # for RubbaBoy/BYOB to write to "shields" branch
+      contents: write # for RubbaBoy/BYOB to write to "shields" branch
 
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![GitHub license](https://img.shields.io/github/license/kubernetes/ingress-nginx.svg)](https://github.com/kubernetes/ingress-nginx/blob/main/LICENSE)
 [![GitHub stars](https://img.shields.io/github/stars/kubernetes/ingress-nginx.svg)](https://github.com/kubernetes/ingress-nginx/stargazers)
 [![GitHub stars](https://img.shields.io/badge/contributions-welcome-orange.svg)](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md)
-
+![Libyear Count](https://byob.yarr.is/kubernetes/ingress-nginx/libyear)
 
 ## Overview
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The above is done with the help of a new pipeline step. It uses [this libyear implementation](https://git.yetaga.in/alazyreader/libyear) to calculate how outdated each dependency (including indirect) is. 

I've chosen the above implementation instead of [this one](https://golangexample.com/a-libyear-implementation-for-go/) because it is able to check indirect dependencies. Also, it calculates the total count for us.

Then, it uses a GitHub Action called "Bring Your Own Badge". This action commits the count made by libyear to a ["shields" branch](https://github.com/jaehnri/ingress-nginx/tree/shields). This count is later referenced in the project's README.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->
fixes #8910 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I've created an equivalent PR in my fork. There, it is possible to see that [the badge is created](https://github.com/jaehnri/ingress-nginx/tree/libyear-badge) with the correct value.

I tried reducing the action's permissions. However, it needs to write to the shields branch, thus, requiring "write" to contents. 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [X] All new and existing tests passed.
- [ ] Added Release Notes.

## Does my pull request need a release note?
Any user-visible or operator-visible change qualifies for a release note. This could be a:

- CLI change
- API change
- UI change
- configuration schema change
- behavioral change
- change in non-functional attributes such as efficiency or availability, availability of a new platform
- a warning about a deprecation
- fix of a previous Known Issue
- fix of a vulnerability (CVE)

No release notes are required for changes to the following:

- Tests
- Build infrastructure
- Fixes for unreleased bugs

For more tips on writing good release notes, check out the [Release Notes Handbook](https://github.com/kubernetes/sig-release/tree/master/release-team/role-handbooks/release-notes)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
