### PR TITLE
feat(helm): Make cert-manager certs for validating webhook configurable

### DIFF
--- a/charts/ingress-nginx/README.md
+++ b/charts/ingress-nginx/README.md
@@ -237,8 +237,10 @@ As of version `1.26.0` of this chart, by simply not providing any clusterIP valu
 | controller.addHeaders | object | `{}` | Will add custom headers before sending response traffic to the client according to: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#add-headers |
 | controller.admissionWebhooks.annotations | object | `{}` |  |
 | controller.admissionWebhooks.certManager.admissionCert.duration | string | `""` |  |
+| controller.admissionWebhooks.certManager.admissionCert.extraConfig | object | `{"privateKey":{"algorithm":"ECDSA","size":256}}` | Extra configuration for the admission webhook certificate. Can contain anything a cert-manager's [`CertificateSpec`](https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.CertificateSpec) can. |
 | controller.admissionWebhooks.certManager.enabled | bool | `false` |  |
 | controller.admissionWebhooks.certManager.rootCert.duration | string | `""` |  |
+| controller.admissionWebhooks.certManager.rootCert.extraConfig | object | `{"privateKey":{"algorithm":"ECDSA","size":256}}` | Extra configuration for the admission webhook CA certificate. Can contain anything a cert-manager's [`CertificateSpec`](https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.CertificateSpec) can. |
 | controller.admissionWebhooks.certificate | string | `"/usr/local/certificates/cert"` |  |
 | controller.admissionWebhooks.createSecretJob.resources | object | `{}` |  |
 | controller.admissionWebhooks.createSecretJob.securityContext.allowPrivilegeEscalation | bool | `false` |  |

--- a/charts/ingress-nginx/templates/admission-webhooks/cert-manager.yaml
+++ b/charts/ingress-nginx/templates/admission-webhooks/cert-manager.yaml
@@ -26,6 +26,9 @@ spec:
   subject:
     organizations:
       - ingress-nginx
+  {{- with .Values.controller.admissionWebhooks.certManager.rootCert.extraConfig }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
 ---
 # Create an Issuer that uses the above generated CA certificate to issue certs
 apiVersion: cert-manager.io/v1
@@ -60,4 +63,7 @@ spec:
   subject:
     organizations:
       - ingress-nginx-admission
+  {{- with .Values.controller.admissionWebhooks.certManager.admissionCert.extraConfig }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
 {{- end -}}

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -639,12 +639,23 @@ controller:
       rootCert:
         # default to be 5y
         duration: ""
+        # -- Extra configuration for the admission webhook CA certificate. Can contain anything a cert-manager's [`CertificateSpec`](https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.CertificateSpec) can.
+        extraConfig:
+          privateKey:
+            algorithm: ECDSA
+            size: 256
+
       admissionCert:
         # default to be 1y
         duration: ""
         # issuerRef:
         #   name: "issuer"
         #   kind: "ClusterIssuer"
+        # -- Extra configuration for the admission webhook certificate. Can contain anything a cert-manager's [`CertificateSpec`](https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.CertificateSpec) can.
+        extraConfig:
+          privateKey:
+            algorithm: ECDSA
+            size: 256
   metrics:
     port: 10254
     portName: metrics


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR adds the possibility to tweak the configuration of the certificates requested from cert-manager for the validating webhook ([a recently added feature](/kubernetes/ingress-nginx/pull/9279)). And it immediately takes advantage of it to request the certificates to use EC (NIST P-256) keys (which are both shorter and less computationally expensive to verify than the default 2048bits RSA keys).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
By deploying the `Certificate` resources rendered by the modified chart to a cluster, to which the original `ingess-nginx` chart had been deployed previously, and verifying that the certificates generated by the cert-manager do indeed use the EC keys.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Added Release Notes.

## Does my pull request need a release note?
Yes/Perhaps

```release-note
It is now possible to tweak the configuration of the certificates requested from cert-manager for the validating webhook. This functionality is taken advantage of to request certificates using EC (NIST P-256) keys by default.```
