### PR TITLE
Allow use of pipe (or condition) in nginx regex

### DIFF
--- a/pkg/util/ingress/ingress.go
+++ b/pkg/util/ingress/ingress.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	alphaNumericChars = `\-\.\_\~a-zA-Z0-9/`
-	regexEnabledChars = `\^\$\[\]\(\)\{\}\*\+`
+	regexEnabledChars = `\^\$\[\]\(\)\{\}\*\+\|`
 )
 
 var (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
After commit c1413e6079b nginx regex with "OR" condition considered as invalid, error message appears in controller logs:
 `ingress foo/bar contains invalid path /foo/(docs|redoc|token)`
This happens because "pipe" character is not in the allowed regex char set, refer to:
`pkg/util/ingress/ingress.go:35`


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
add ingress with regex specific path, e.g.  "/(foo|bar)"

## Checklist:
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [x] All new and existing tests passed.
