### PR TITLE
feat(configmap): expose gzip-disable

### DIFF
--- a/docs/user-guide/nginx-configuration/configmap.md
+++ b/docs/user-guide/nginx-configuration/configmap.md
@@ -103,6 +103,7 @@ The following table shows a configuration option's name, type, and the default v
 |[brotli-min-length](#brotli-min-length)|int|20|
 |[brotli-types](#brotli-types)|string|"application/xml+rss application/atom+xml application/javascript application/x-javascript application/json application/rss+xml application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/svg+xml image/x-icon text/css text/javascript text/plain text/x-component"|
 |[use-http2](#use-http2)|bool|"true"|
+|[gzip-disable](#gzip-disable)|string|""|
 |[gzip-level](#gzip-level)|int|1|
 |[gzip-min-length](#gzip-min-length)|int|256|
 |[gzip-types](#gzip-types)|string|"application/atom+xml application/javascript application/x-javascript application/json application/rss+xml application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/svg+xml image/x-icon text/css text/javascript text/plain text/x-component"|
@@ -714,6 +715,10 @@ _**default:**_ `application/xml+rss application/atom+xml application/javascript 
 ## use-http2
 
 Enables or disables [HTTP/2](https://nginx.org/en/docs/http/ngx_http_v2_module.html) support in secure connections.
+
+## gzip-disable
+
+Disables gzipping of responses for requests with "User-Agent" header fields matching any of the specified regular expressions. The special mask `msie6` corresponds to the regular expression `MSIE [4-6]\.`, but works faster.
 
 ## gzip-level
 

--- a/docs/user-guide/nginx-configuration/configmap.md
+++ b/docs/user-guide/nginx-configuration/configmap.md
@@ -104,6 +104,7 @@ The following table shows a configuration option's name, type, and the default v
 |[brotli-types](#brotli-types)|string|"application/xml+rss application/atom+xml application/javascript application/x-javascript application/json application/rss+xml application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/svg+xml image/x-icon text/css text/javascript text/plain text/x-component"|
 |[use-http2](#use-http2)|bool|"true"|
 |[gzip-level](#gzip-level)|int|1|
+|[gzip-min-length](#gzip-min-length)|int|256|
 |[gzip-types](#gzip-types)|string|"application/atom+xml application/javascript application/x-javascript application/json application/rss+xml application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/svg+xml image/x-icon text/css text/javascript text/plain text/x-component"|
 |[worker-processes](#worker-processes)|string|`<Number of CPUs>`|
 |[worker-cpu-affinity](#worker-cpu-affinity)|string|""|

--- a/docs/user-guide/nginx-configuration/configmap.md
+++ b/docs/user-guide/nginx-configuration/configmap.md
@@ -718,7 +718,7 @@ Enables or disables [HTTP/2](https://nginx.org/en/docs/http/ngx_http_v2_module.h
 
 ## gzip-disable
 
-Disables gzipping of responses for requests with "User-Agent" header fields matching any of the specified regular expressions. The special mask `msie6` corresponds to the regular expression `MSIE [4-6]\.`, but works faster.
+Disables [gzipping](http://nginx.org/en/docs/http/ngx_http_gzip_module.html#gzip_disable) of responses for requests with "User-Agent" header fields matching any of the specified regular expressions.
 
 ## gzip-level
 

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -438,6 +438,11 @@ type Configuration struct {
 	// Default: true
 	UseHTTP2 bool `json:"use-http2,omitempty"`
 
+	// Disables gzipping of responses for requests with "User-Agent" header fields matching any of
+	// the specified regular expressions.
+	// http://nginx.org/en/docs/http/ngx_http_gzip_module.html#gzip_disable
+	GzipDisable string `json:"gzip-disable,omitempty"`
+
 	// gzip Compression Level that will be used
 	GzipLevel int `json:"gzip-level,omitempty"`
 
@@ -794,7 +799,6 @@ func NewDefault() Configuration {
 	defGlobalExternalAuth := GlobalExternalAuth{"", "", "", "", "", append(defResponseHeaders, ""), "", "", "", []string{}, map[string]string{}, false}
 
 	cfg := Configuration{
-
 		AllowSnippetAnnotations:          true,
 		AllowBackendServerHeader:         false,
 		AnnotationValueWordBlocklist:     "",

--- a/internal/ingress/controller/template/configmap_test.go
+++ b/internal/ingress/controller/template/configmap_test.go
@@ -64,6 +64,7 @@ func TestMergeConfigMapToStruct(t *testing.T) {
 		"access-log-path":               "/var/log/test/access.log",
 		"error-log-path":                "/var/log/test/error.log",
 		"use-gzip":                      "false",
+		"gzip-disable":                  "msie6",
 		"gzip-level":                    "9",
 		"gzip-min-length":               "1024",
 		"gzip-types":                    "text/html",
@@ -87,6 +88,7 @@ func TestMergeConfigMapToStruct(t *testing.T) {
 	def.ProxyReadTimeout = 1
 	def.ProxySendTimeout = 2
 	def.UseProxyProtocol = true
+	def.GzipDisable = "msie6"
 	def.GzipLevel = 9
 	def.GzipMinLength = 1024
 	def.GzipTypes = "text/html"

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -336,6 +336,9 @@ http {
     {{ if $cfg.UseGzip }}
     gzip on;
     gzip_comp_level {{ $cfg.GzipLevel }};
+    {{- if ne $cfg.GzipDisable "" }}
+    gzip_disable "{{ $cfg.GzipDisable }}";
+    {{- end }}
     gzip_http_version 1.1;
     gzip_min_length {{ $cfg.GzipMinLength}};
     gzip_types {{ $cfg.GzipTypes }};

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -336,7 +336,7 @@ http {
     {{ if $cfg.UseGzip }}
     gzip on;
     gzip_comp_level {{ $cfg.GzipLevel }};
-    {{- if ne $cfg.GzipDisable "" }}
+    {{- if $cfg.GzipDisable }}
     gzip_disable "{{ $cfg.GzipDisable }}";
     {{- end }}
     gzip_http_version 1.1;

--- a/test/e2e/settings/gzip.go
+++ b/test/e2e/settings/gzip.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package settings
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/onsi/ginkgo/v2"
+
+	"k8s.io/ingress-nginx/internal/ingress/controller/config"
+	"k8s.io/ingress-nginx/test/e2e/framework"
+)
+
+var _ = framework.DescribeSetting("gzip", func() {
+	f := framework.NewDefaultFramework("gzip")
+
+	ginkgo.It("should be disabled by default", func() {
+		f.WaitForNginxConfiguration(
+			func(cfg string) bool {
+				return !strings.Contains(cfg, "gzip on;")
+			})
+	})
+
+	ginkgo.It("should be enabled with default settings", func() {
+		f.UpdateNginxConfigMapData("use-gzip", "true")
+
+		f.WaitForNginxConfiguration(
+			func(cfg string) bool {
+				defaultCfg := config.NewDefault()
+				return strings.Contains(cfg, "gzip on;") &&
+					strings.Contains(cfg, fmt.Sprintf("gzip_comp_level %d;", defaultCfg.GzipLevel)) &&
+					!strings.Contains(cfg, "gzip_disable") &&
+					strings.Contains(cfg, "gzip_http_version 1.1;") &&
+					strings.Contains(cfg, fmt.Sprintf("gzip_min_length %d;", defaultCfg.GzipMinLength)) &&
+					strings.Contains(cfg, fmt.Sprintf("gzip_types %s;", defaultCfg.GzipTypes)) &&
+					strings.Contains(cfg, "gzip_proxied any;") &&
+					strings.Contains(cfg, "gzip_vary on;")
+			})
+	})
+
+	ginkgo.It("should set gzip_comp_level to 4", func() {
+		f.UpdateNginxConfigMapData("use-gzip", "true")
+		f.UpdateNginxConfigMapData("gzip-level", "4")
+
+		f.WaitForNginxConfiguration(
+			func(cfg string) bool {
+				return strings.Contains(cfg, "gzip on;") &&
+					strings.Contains(cfg, "gzip_comp_level 4;")
+			})
+	})
+
+	ginkgo.It("should set gzip_disable to msie6", func() {
+		f.UpdateNginxConfigMapData("use-gzip", "true")
+		f.UpdateNginxConfigMapData("gzip-disable", "msie6")
+
+		f.WaitForNginxConfiguration(
+			func(cfg string) bool {
+				return strings.Contains(cfg, "gzip on;") &&
+					strings.Contains(cfg, `gzip_disable "msie6";`)
+			})
+	})
+
+	ginkgo.It("should set gzip_min_length to 100", func() {
+		f.UpdateNginxConfigMapData("use-gzip", "true")
+		f.UpdateNginxConfigMapData("gzip-min-length", "100")
+
+		f.WaitForNginxConfiguration(
+			func(cfg string) bool {
+				return strings.Contains(cfg, "gzip on;") &&
+					strings.Contains(cfg, "gzip_min_length 100;")
+			})
+	})
+
+	ginkgo.It("should set gzip_types to application/javascript", func() {
+		f.UpdateNginxConfigMapData("use-gzip", "true")
+		f.UpdateNginxConfigMapData("gzip-types", "application/javascript")
+
+		f.WaitForNginxConfiguration(
+			func(cfg string) bool {
+				return strings.Contains(cfg, "gzip on;") &&
+					strings.Contains(cfg, "gzip_types application/javascript;")
+			})
+	})
+})


### PR DESCRIPTION
## What this PR does / why we need it:

This PR expose the settings `gzip_disable` of the NGINX [`gzip`](http://nginx.org/en/docs/http/ngx_http_gzip_module.html#gzip_disable) module.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## How Has This Been Tested?

Unit & E2E tests have been added to cover the feature.

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [x] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.

```release-note
Adds gzip-disable configuration
```