### PR TITLE
Rework Ginkgo usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ TAG ?= $(shell cat TAG)
 
 # e2e settings
 # Allow limiting the scope of the e2e tests. By default run everything
-FOCUS ?= .*
+FOCUS ?=
 # number of parallel test
 E2E_NODES ?= 7
 # run e2e test suite with tests that check for memory leaks? (default is false)

--- a/internal/ingress/controller/store/store.go
+++ b/internal/ingress/controller/store/store.go
@@ -702,7 +702,6 @@ func New(
 		},
 	}
 
-	// TODO: add e2e test to verify that changes to one or more configmap trigger an update
 	changeTriggerUpdate := func(name string) bool {
 		return name == configmap || name == tcp || name == udp
 	}

--- a/internal/k8s/main.go
+++ b/internal/k8s/main.go
@@ -78,7 +78,7 @@ func GetNodeIPOrName(kubeClient clientset.Interface, name string, useInternalIP 
 var (
 	// IngressPodDetails hold information about the ingress-nginx pod
 	IngressPodDetails *PodInfo
-	// IngressNodeDetails old information about the node running ingress-nginx pod
+	// IngressNodeDetails hold information about the node running ingress-nginx pod
 	IngressNodeDetails *NodeInfo
 )
 

--- a/test/e2e-image/e2e.sh
+++ b/test/e2e-image/e2e.sh
@@ -14,70 +14,39 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
+set -eu
 
 NC='\e[0m'
 BGREEN='\e[32m'
 
-#SLOW_E2E_THRESHOLD=${SLOW_E2E_THRESHOLD:-"5s"}
-FOCUS=${FOCUS:-.*}
 E2E_NODES=${E2E_NODES:-5}
 E2E_CHECK_LEAKS=${E2E_CHECK_LEAKS:-""}
 
+reportFile="report-e2e-test-suite.xml"
 ginkgo_args=(
-  "-randomize-all"
-  "-flake-attempts=2"
-  "-fail-fast"
-  "--show-node-events"
+  "--fail-fast"
+  "--flake-attempts=2"
+  "--junit-report=${reportFile}"
+  "--nodes=${E2E_NODES}"
   "--poll-progress-after=180s"
-#  "-slow-spec-threshold=${SLOW_E2E_THRESHOLD}"
-  "-succinct"
-  "-timeout=75m"
+  "--randomize-all"
+  "--show-node-events"
+  "--succinct"
+  "--timeout=75m"
 )
 
-# Variable for the prefix of report filenames
-reportFileNamePrefix="report-e2e-test-suite"
-
-echo -e "${BGREEN}Running e2e test suite (FOCUS=${FOCUS})...${NC}"
-ginkgo "${ginkgo_args[@]}"               \
-  -focus="${FOCUS}"                  \
-  -skip="\[Serial\]|\[MemoryLeak\]|\[TopologyHints\]"  \
-  -nodes="${E2E_NODES}" \
-  --junit-report=$reportFileNamePrefix.xml \
-  /e2e.test
-# Create configMap out of a compressed report file for extraction later
-
-# Must be isolated, there is a collision if multiple helms tries to install same clusterRole at same time
-echo -e "${BGREEN}Running e2e test for topology aware hints...${NC}"
-ginkgo "${ginkgo_args[@]}" \
-  -focus="\[TopologyHints\]" \
-  -skip="\[Serial\]|\[MemoryLeak\]]" \
-  -nodes="${E2E_NODES}" \
-  --junit-report=$reportFileNamePrefix-topology.xml \
-  /e2e.test
-# Create configMap out of a compressed report file for extraction later
-
-echo -e "${BGREEN}Running e2e test suite with tests that require serial execution...${NC}"
-ginkgo "${ginkgo_args[@]}"   \
-  -focus="\[Serial\]"    \
-  -skip="\[MemoryLeak\]" \
-  --junit-report=$reportFileNamePrefix-serial.xml \
-  /e2e.test
-# Create configMap out of a compressed report file for extraction later
-
-if [[ ${E2E_CHECK_LEAKS} != "" ]]; then
-  echo -e "${BGREEN}Running e2e test suite with tests that check for memory leaks...${NC}"
-  ginkgo "${ginkgo_args[@]}"    \
-    -focus="\[MemoryLeak\]" \
-    -skip="\[Serial\]" \
-    --junit-report=$reportFileNamePrefix-memleak.xml \
-    /e2e.test
-# Create configMap out of a compressed report file for extraction later
+if [ -n "${FOCUS}" ]; then
+  ginkgo_args+=("--focus=${FOCUS}")
 fi
 
-for rFile in `ls $reportFileNamePrefix*` 
-do
-  gzip -k $rFile
-  kubectl create cm $rFile.gz --from-file $rFile.gz
-  kubectl label cm $rFile.gz junitreport=true
-done
+if [ -z "${E2E_CHECK_LEAKS}" ]; then
+  ginkgo_args+=("--skip=\[Memory Leak\]")
+fi
+
+echo -e "${BGREEN}Running e2e test suite...${NC}"
+(set -x; ginkgo "${ginkgo_args[@]}" /e2e.test)
+
+# Create configMap out of a compressed report file for extraction later
+gzip -k ${reportFile}
+kubectl create cm ${reportFile}.gz --from-file ${reportFile}.gz
+kubectl label cm ${reportFile}.gz junitreport=true

--- a/test/e2e-image/namespace-overlays/topology/values.yaml
+++ b/test/e2e-image/namespace-overlays/topology/values.yaml
@@ -20,12 +20,7 @@ controller:
     periodSeconds: 1
   service:
     type: NodePort
-  electionID: ingress-controller-leader
-  ingressClassResource:
-    # We will create and remove each IC/ClusterRole/ClusterRoleBinding per test so there's no conflict
-    enabled: false
   extraArgs:
-    tcp-services-configmap: $NAMESPACE/tcp-services
     # e2e tests do not require information about ingress status
     update-status: "false"
   terminationGracePeriodSeconds: 1
@@ -33,19 +28,6 @@ controller:
     enabled: false
 
   enableTopologyAwareRouting: true
-
-  # ulimit -c unlimited
-  # mkdir -p /tmp/coredump
-  # chmod a+rwx /tmp/coredump
-  # echo "/tmp/coredump/core.%e.%p.%h.%t" > /proc/sys/kernel/core_pattern
-  extraVolumeMounts:
-    - name: coredump
-      mountPath: /tmp/coredump
-
-  extraVolumes:
-    - name: coredump
-      hostPath:
-        path: /tmp/coredump
 
 rbac:
   create: true

--- a/test/e2e-image/namespace-overlays/topology/values.yaml
+++ b/test/e2e-image/namespace-overlays/topology/values.yaml
@@ -8,6 +8,7 @@ controller:
     digest:
     digestChroot:
   scope:
+    # Necessary to allow the ingress controller to get the topology information from the nodes
     enabled: false
   config:
     worker-processes: "1"

--- a/test/e2e/admission/admission.go
+++ b/test/e2e/admission/admission.go
@@ -40,7 +40,7 @@ var (
 	pathImplSpecific = networkingv1.PathTypeImplementationSpecific
 )
 
-var _ = framework.IngressNginxDescribe("[Serial] admission controller", func() {
+var _ = framework.IngressNginxDescribeSerial("[Admission] admission controller", func() {
 	f := framework.NewDefaultFramework("admission")
 
 	ginkgo.BeforeEach(func() {
@@ -49,7 +49,7 @@ var _ = framework.IngressNginxDescribe("[Serial] admission controller", func() {
 	})
 
 	ginkgo.AfterEach(func() {
-		err := uninstallChart(f)
+		err := f.UninstallChart()
 		assert.Nil(ginkgo.GinkgoT(), err, "uninstalling helm chart")
 	})
 
@@ -251,16 +251,6 @@ var _ = framework.IngressNginxDescribe("[Serial] admission controller", func() {
 		assert.Nil(ginkgo.GinkgoT(), err, "creating an invalid ingress with unknown class using kubectl")
 	})
 })
-
-func uninstallChart(f *framework.Framework) error {
-	cmd := exec.Command("helm", "uninstall", "--namespace", f.Namespace, "nginx-ingress")
-	_, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("unexpected error uninstalling ingress-nginx release: %v", err)
-	}
-
-	return nil
-}
 
 const (
 	validV1Ingress = `

--- a/test/e2e/admission/admission.go
+++ b/test/e2e/admission/admission.go
@@ -48,11 +48,6 @@ var _ = framework.IngressNginxDescribeSerial("[Admission] admission controller",
 		f.NewSlowEchoDeployment()
 	})
 
-	ginkgo.AfterEach(func() {
-		err := f.UninstallChart()
-		assert.Nil(ginkgo.GinkgoT(), err, "uninstalling helm chart")
-	})
-
 	ginkgo.It("reject ingress with global-rate-limit annotations when memcached is not configured", func() {
 		host := "admission-test"
 

--- a/test/e2e/annotations/fastcgi.go
+++ b/test/e2e/annotations/fastcgi.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -81,9 +80,7 @@ var _ = framework.DescribeAnnotation("backend-protocol - FastCGI", func() {
 			},
 		}
 
-		cm, err := f.EnsureConfigMap(configuration)
-		assert.Nil(ginkgo.GinkgoT(), err, "creating configmap")
-		assert.NotNil(ginkgo.GinkgoT(), cm, "expected a configmap but none returned")
+		f.EnsureConfigMap(configuration)
 
 		host := "fastcgi-params-configmap"
 

--- a/test/e2e/endpointslices/topology.go
+++ b/test/e2e/endpointslices/topology.go
@@ -40,12 +40,6 @@ var _ = framework.IngressNginxDescribeSerial("[TopologyHints] topology aware rou
 		f.NewEchoDeployment(framework.WithDeploymentReplicas(2), framework.WithSvcTopologyAnnotations())
 	})
 
-	ginkgo.AfterEach(func() {
-		// we need to uninstall chart because of clusterRole (controller.scope.enabled=false) which is not destroyed with namespace
-		err := f.UninstallChart()
-		assert.Nil(ginkgo.GinkgoT(), err, "uninstalling helm chart")
-	})
-
 	ginkgo.It("should return 200 when service has topology hints", func() {
 
 		annotations := make(map[string]string)

--- a/test/e2e/endpointslices/topology.go
+++ b/test/e2e/endpointslices/topology.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"os/exec"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,7 +32,7 @@ import (
 	"k8s.io/ingress-nginx/test/e2e/framework"
 )
 
-var _ = framework.IngressNginxDescribe("[TopologyHints] topology aware routing", func() {
+var _ = framework.IngressNginxDescribeSerial("[TopologyHints] topology aware routing", func() {
 	f := framework.NewDefaultFramework("topology")
 	host := "topology-svc.foo.com"
 
@@ -42,8 +41,8 @@ var _ = framework.IngressNginxDescribe("[TopologyHints] topology aware routing",
 	})
 
 	ginkgo.AfterEach(func() {
-		// we need to uninstall chart because of clusterRole which is not destroyed with namespace
-		err := uninstallChart(f)
+		// we need to uninstall chart because of clusterRole (controller.scope.enabled=false) which is not destroyed with namespace
+		err := f.UninstallChart()
 		assert.Nil(ginkgo.GinkgoT(), err, "uninstalling helm chart")
 	})
 
@@ -100,13 +99,3 @@ var _ = framework.IngressNginxDescribe("[TopologyHints] topology aware routing",
 		}
 	})
 })
-
-func uninstallChart(f *framework.Framework) error {
-	cmd := exec.Command("helm", "uninstall", "--namespace", f.Namespace, "nginx-ingress")
-	_, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("unexpected error uninstalling ingress-nginx release: %v", err)
-	}
-
-	return nil
-}

--- a/test/e2e/framework/exec.go
+++ b/test/e2e/framework/exec.go
@@ -152,6 +152,16 @@ func (f *Framework) KubectlProxy(port int) (int, *exec.Cmd, error) {
 	return -1, cmd, fmt.Errorf("failed to parse port from proxy stdout: %s", output)
 }
 
+func (f *Framework) UninstallChart() error {
+	cmd := exec.Command("helm", "uninstall", "--namespace", f.Namespace, "nginx-ingress")
+	_, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("unexpected error uninstalling ingress-nginx release: %v", err)
+	}
+
+	return nil
+}
+
 func startCmdAndStreamOutput(cmd *exec.Cmd) (stdout, stderr io.ReadCloser, err error) {
 	stdout, err = cmd.StdoutPipe()
 	if err != nil {

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -192,6 +192,11 @@ func IngressNginxDescribe(text string, body func()) bool {
 	return ginkgo.Describe(text, body)
 }
 
+// IngressNginxDescribeSerial wrapper function for ginkgo describe. Adds namespacing.
+func IngressNginxDescribeSerial(text string, body func()) bool {
+	return ginkgo.Describe(text, ginkgo.Serial, body)
+}
+
 // DescribeAnnotation wrapper function for ginkgo describe. Adds namespacing.
 func DescribeAnnotation(text string, body func()) bool {
 	return ginkgo.Describe("[Annotations] "+text, body)
@@ -200,11 +205,6 @@ func DescribeAnnotation(text string, body func()) bool {
 // DescribeSetting wrapper function for ginkgo describe. Adds namespacing.
 func DescribeSetting(text string, body func()) bool {
 	return ginkgo.Describe("[Setting] "+text, body)
-}
-
-// MemoryLeakIt is wrapper function for ginkgo It.  Adds "[MemoryLeak]" tag and makes static analysis easier.
-func MemoryLeakIt(text string, body interface{}) bool {
-	return ginkgo.It(text+" [MemoryLeak]", body)
 }
 
 // GetNginxIP returns the number of TCP port where NGINX is running

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -150,7 +150,11 @@ func (f *Framework) AfterEach() {
 
 	defer func(kubeClient kubernetes.Interface, ingressclass string) {
 		defer ginkgo.GinkgoRecover()
-		err := deleteIngressClass(kubeClient, ingressclass)
+
+		err := f.UninstallChart()
+		assert.Nil(ginkgo.GinkgoT(), err, "uninstalling helm chart")
+
+		err = deleteIngressClass(kubeClient, ingressclass)
 		assert.Nil(ginkgo.GinkgoT(), err, "deleting IngressClass")
 	}(f.KubeClientSet, f.IngressClass)
 

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -391,7 +391,7 @@ func (f *Framework) UpdateNginxConfigMapData(key string, value string) {
 }
 
 // WaitForReload calls the passed function and
-// asser it has caused at least 1 reload.
+// asserts it has caused at least 1 reload.
 func (f *Framework) WaitForReload(fn func()) {
 	initialReloadCount := getReloadCount(f.pod, f.Namespace, f.KubeClientSet)
 

--- a/test/e2e/framework/influxdb.go
+++ b/test/e2e/framework/influxdb.go
@@ -68,9 +68,7 @@ func (f *Framework) NewInfluxDBDeployment() {
 		},
 	}
 
-	cm, err := f.EnsureConfigMap(configuration)
-	assert.Nil(ginkgo.GinkgoT(), err, "creating an Influxdb deployment")
-	assert.NotNil(ginkgo.GinkgoT(), cm, "expected a configmap but none returned")
+	f.EnsureConfigMap(configuration)
 
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -136,7 +134,7 @@ func (f *Framework) NewInfluxDBDeployment() {
 
 	d := f.EnsureDeployment(deployment)
 
-	err = waitForPodsReady(f.KubeClientSet, DefaultTimeout, 1, f.Namespace, metav1.ListOptions{
+	err := waitForPodsReady(f.KubeClientSet, DefaultTimeout, 1, f.Namespace, metav1.ListOptions{
 		LabelSelector: fields.SelectorFromSet(fields.Set(d.Spec.Template.ObjectMeta.Labels)).String(),
 	})
 	assert.Nil(ginkgo.GinkgoT(), err, "waiting for influxdb pod to become ready")

--- a/test/e2e/leaks/lua_ssl.go
+++ b/test/e2e/leaks/lua_ssl.go
@@ -39,7 +39,7 @@ var _ = framework.IngressNginxDescribe("[Memory Leak] Dynamic Certificates", fun
 		f.NewEchoDeployment()
 	})
 
-	framework.MemoryLeakIt("should not leak memory from ingress SSL certificates or configuration updates", func() {
+	ginkgo.It("should not leak memory from ingress SSL certificates or configuration updates", func() {
 		hostCount := 1000
 		iterations := 10
 

--- a/test/e2e/run-chart-test.sh
+++ b/test/e2e/run-chart-test.sh
@@ -78,7 +78,7 @@ fi
 
 if [ "${SKIP_IMAGE_CREATION:-false}" = "false" ]; then
   if ! command -v ginkgo &> /dev/null; then
-    go get github.com/onsi/ginkgo/v2/ginkgo@v2.6.1
+    go install github.com/onsi/ginkgo/v2/ginkgo@v2.6.1
   fi
   echo "[dev-env] building image"
   make -C ${DIR}/../../ clean-image build image

--- a/test/e2e/run-kind-e2e.sh
+++ b/test/e2e/run-kind-e2e.sh
@@ -95,7 +95,7 @@ fi
 
 if [ "${SKIP_E2E_IMAGE_CREATION}" = "false" ]; then
   if ! command -v ginkgo &> /dev/null; then
-    go get github.com/onsi/ginkgo/v2/ginkgo@v2.6.1
+    go install github.com/onsi/ginkgo/v2/ginkgo@v2.6.1
   fi
 
   echo "[dev-env] .. done building controller images"

--- a/test/e2e/settings/configmap_change.go
+++ b/test/e2e/settings/configmap_change.go
@@ -73,5 +73,9 @@ var _ = framework.DescribeSetting("Configmap change", func() {
 				return strings.ContainsAny(cfg, "error_log  /var/log/nginx/error.log debug;")
 			})
 		assert.NotEqual(ginkgo.GinkgoT(), checksum, newChecksum)
+
+		logs, err := f.NginxLogs()
+		assert.Nil(ginkgo.GinkgoT(), err, "obtaining nginx logs")
+		assert.Contains(ginkgo.GinkgoT(), logs, "Backend successfully reloaded")
 	})
 })

--- a/test/e2e/settings/namespace_selector.go
+++ b/test/e2e/settings/namespace_selector.go
@@ -56,10 +56,6 @@ var _ = framework.IngressNginxDescribeSerial("[Flag] watch namespace selector", 
 	ginkgo.AfterEach(func() {
 		cleanupNamespace(notMatchedNs)
 		cleanupNamespace(matchedNs)
-
-		// we need to uninstall chart because of clusterRole (controller.scope.enabled=false) which is not destroyed with namespace
-		err := f.UninstallChart()
-		assert.Nil(ginkgo.GinkgoT(), err, "uninstalling helm chart")
 	})
 
 	ginkgo.Context("With specific watch-namespace-selector flags", func() {

--- a/test/e2e/settings/namespace_selector.go
+++ b/test/e2e/settings/namespace_selector.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/ingress-nginx/test/e2e/framework"
 )
 
-var _ = framework.IngressNginxDescribe("[Flag] watch namespace selector", func() {
+var _ = framework.IngressNginxDescribeSerial("[Flag] watch namespace selector", func() {
 	f := framework.NewDefaultFramework("namespace-selector")
 	notMatchedHost, matchedHost := "bar", "foo"
 	var notMatchedNs string
@@ -45,7 +45,7 @@ var _ = framework.IngressNginxDescribe("[Flag] watch namespace selector", func()
 
 	cleanupNamespace := func(ns string) {
 		err := framework.DeleteKubeNamespace(f.KubeClientSet, ns)
-		assert.Nil(ginkgo.GinkgoT(), err, "deleting temporarily crated namespace")
+		assert.Nil(ginkgo.GinkgoT(), err, "deleting temporarily created namespace")
 	}
 
 	ginkgo.BeforeEach(func() {
@@ -57,12 +57,9 @@ var _ = framework.IngressNginxDescribe("[Flag] watch namespace selector", func()
 		cleanupNamespace(notMatchedNs)
 		cleanupNamespace(matchedNs)
 
-		// cleanup clusterrole/clusterrolebinding created by installing chart with controller.scope.enabled=false
-		err := f.KubeClientSet.RbacV1().ClusterRoles().Delete(context.TODO(), "nginx-ingress", metav1.DeleteOptions{})
-		assert.Nil(ginkgo.GinkgoT(), err, "deleting clusterrole nginx-ingress")
-
-		err = f.KubeClientSet.RbacV1().ClusterRoleBindings().Delete(context.TODO(), "nginx-ingress", metav1.DeleteOptions{})
-		assert.Nil(ginkgo.GinkgoT(), err, "deleting clusterrolebinging nginx-ingress")
+		// we need to uninstall chart because of clusterRole (controller.scope.enabled=false) which is not destroyed with namespace
+		err := f.UninstallChart()
+		assert.Nil(ginkgo.GinkgoT(), err, "uninstalling helm chart")
 	})
 
 	ginkgo.Context("With specific watch-namespace-selector flags", func() {

--- a/test/e2e/settings/ocsp/ocsp.go
+++ b/test/e2e/settings/ocsp/ocsp.go
@@ -85,7 +85,7 @@ var _ = framework.DescribeSetting("OCSP", func() {
 		cfsslDB, err := os.ReadFile("empty.db")
 		assert.Nil(ginkgo.GinkgoT(), err)
 
-		cmap, err := f.EnsureConfigMap(&corev1.ConfigMap{
+		f.EnsureConfigMap(&corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "ocspserve",
 				Namespace: f.Namespace,
@@ -95,8 +95,6 @@ var _ = framework.DescribeSetting("OCSP", func() {
 				"db-config.json": []byte(`{"driver":"sqlite3","data_source":"/data/empty.db"}`),
 			},
 		})
-		assert.Nil(ginkgo.GinkgoT(), err)
-		assert.NotNil(ginkgo.GinkgoT(), cmap)
 
 		d, s := ocspserveDeployment(f.Namespace)
 		f.EnsureDeployment(d)


### PR DESCRIPTION
Currently Ginkgo is launched multiple times with different options to 
accomodate various use-cases. In particular, some specs needs to be run 
sequentially because non-namespaced objects are created that conflicts with
concurent Helm deployments. However Ginkgo is able to handle such cases
natively, in particular specs that needs to be run sequentially are
supported (Serial spec).

This change marks the specs that needs to be run sequentially as Serial 
specs and runs the whole test suite from a single Ginkgo invocation. As a
result, a single JUnit report is now generated.

As part of this change, the following controller error in the TopologyHints
test is fixed:
```
Error getting ConfigMap "$NAMESPACE/tcp-services": no object matching key
"$NAMESPACE/tcp-services" in local store
```

In addition, "go get" invocations are being replaced by "go install" because
the former performs changes in the go.sum and go.mod files.