### PR TITLE
Add geoname id value into $geoip2_*_geoname_id variables

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -184,8 +184,10 @@ http {
     geoip2 /etc/nginx/geoip/GeoLite2-Country.mmdb {
         $geoip2_country_code source=$remote_addr country iso_code;
         $geoip2_country_name source=$remote_addr country names en;
+        $geoip2_country_geoname_id source=$remote_addr country geoname_id;
         $geoip2_continent_code source=$remote_addr continent code;
         $geoip2_continent_name source=$remote_addr continent names en;
+        $geoip2_continent_geoname_id source=$remote_addr continent geoname_id;
     }
     {{ end }}
 
@@ -193,8 +195,10 @@ http {
     geoip2 /etc/nginx/geoip/GeoIP2-Country.mmdb {
         $geoip2_country_code source=$remote_addr country iso_code;
         $geoip2_country_name source=$remote_addr country names en;
+        $geoip2_country_geoname_id source=$remote_addr country geoname_id;
         $geoip2_continent_code source=$remote_addr continent code;
         $geoip2_continent_name source=$remote_addr continent names en;
+        $geoip2_continent_geoname_id source=$remote_addr continent geoname_id;
     }
     {{ end }}
 
@@ -202,7 +206,9 @@ http {
     geoip2 /etc/nginx/geoip/GeoLite2-City.mmdb {
         $geoip2_city_country_code source=$remote_addr country iso_code;
         $geoip2_city_country_name source=$remote_addr country names en;
+        $geoip2_city_country_geoname_id source=$remote_addr country geoname_id;
         $geoip2_city source=$remote_addr city names en;
+        $geoip2_city_geoname_id source=$remote_addr city geoname_id;
         $geoip2_postal_code source=$remote_addr postal code;
         $geoip2_dma_code source=$remote_addr location metro_code;
         $geoip2_latitude source=$remote_addr location latitude;
@@ -210,8 +216,10 @@ http {
         $geoip2_time_zone source=$remote_addr location time_zone;
         $geoip2_region_code source=$remote_addr subdivisions 0 iso_code;
         $geoip2_region_name source=$remote_addr subdivisions 0 names en;
+        $geoip2_region_geoname_id source=$remote_addr subdivisions 0 geoname_id;
         $geoip2_subregion_code source=$remote_addr subdivisions 1 iso_code;
         $geoip2_subregion_name source=$remote_addr subdivisions 1 names en;
+        $geoip2_subregion_geoname_id source=$remote_addr subdivisions 1 geoname_id;
     }
     {{ end }}
 
@@ -219,7 +227,9 @@ http {
     geoip2 /etc/nginx/geoip/GeoIP2-City.mmdb {
         $geoip2_city_country_code source=$remote_addr country iso_code;
         $geoip2_city_country_name source=$remote_addr country names en;
+        $geoip2_city_country_geoname_id source=$remote_addr country geoname_id;
         $geoip2_city source=$remote_addr city names en;
+        $geoip2_city_geoname_id source=$remote_addr city geoname_id;
         $geoip2_postal_code source=$remote_addr postal code;
         $geoip2_dma_code source=$remote_addr location metro_code;
         $geoip2_latitude source=$remote_addr location latitude;
@@ -227,8 +237,10 @@ http {
         $geoip2_time_zone source=$remote_addr location time_zone;
         $geoip2_region_code source=$remote_addr subdivisions 0 iso_code;
         $geoip2_region_name source=$remote_addr subdivisions 0 names en;
+        $geoip2_region_geoname_id source=$remote_addr subdivisions 0 geoname_id;
         $geoip2_subregion_code source=$remote_addr subdivisions 1 iso_code;
         $geoip2_subregion_name source=$remote_addr subdivisions 1 names en;
+        $geoip2_subregion_geoname_id source=$remote_addr subdivisions 1 geoname_id;
     }
     {{ end }}
 


### PR DESCRIPTION
## What this PR does / why we need it:
This PR adds geoip2 variables 

- $geoip2_city_geoname_id,
- $geoip2_subregion_geoname_id
- $geoip2_region_geoname_id
- $geoip2_city_country_geoname_id
- $geoip2_country_geoname_id
- $geoip2_continent_geoname_id

with [geoname](http://www.geonames.org/) ids information according to a source ip. Applications may get this value from nginx controller directly instead of using another geoip2 request.

## How Has This Been Tested?
Tested locally

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Added Release Notes.

```release-note
Adding geoname ids geoip variables
```
