### PR TITLE
Fix print-e2e-suite

### DIFF
--- a/hack/print-e2e-suite.sh
+++ b/hack/print-e2e-suite.sh
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if [ -n "$DEBUG" ]; then
-	set -x
+if [ "$DEBUG" == "true" ]; then
+  set -x
 fi
 
 set -o errexit
@@ -25,5 +25,6 @@ set -o pipefail
 DIR=$(cd $(dirname "${BASH_SOURCE}")/.. && pwd -P)
 
 $DIR/test/e2e/e2e.test \
-    -ginkgo.noColor \
-    -ginkgo.dryRun | sed "s|$DIR/|File: |g" | sed 's/•//g' | tail -n+5 | head -n-3
+    --ginkgo.no-color \
+    --ginkgo.v \
+    --ginkgo.dry-run | sed "s|$DIR/|File: |g" | sed 's/•//g' | tail -n+5 | head -n-3


### PR DESCRIPTION
Before:
```
$ make print-e2e-suite
Reached DIND check ELSE block, inside run-in-docker.sh
Compiled e2e.test
Reached DIND check ELSE block, inside run-in-docker.sh
+ set -o errexit
+ set -o nounset
+ set -o pipefail
+++ dirname hack/print-e2e-suite.sh
++ cd hack/..
++ pwd -P
+ DIR=/go/src/k8s.io/ingress-nginx
+ /go/src/k8s.io/ingress-nginx/test/e2e/e2e.test -ginkgo.noColor -ginkgo.dryRun
+ sed 's|/go/src/k8s.io/ingress-nginx/|File: |g'
+ sed s/•//g
+ + head -n-3tail -n+5

You're using deprecated Ginkgo functionality:
=============================================
  --ginkgo.dryRun is deprecated, use --ginkgo.dry-run instead
  Learn more at: https://onsi.github.io/ginkgo/MIGRATING_TO_V2#changed-command-line-flags
  --ginkgo.noColor is deprecated, use --ginkgo.no-color instead
  Learn more at: https://onsi.github.io/ginkgo/MIGRATING_TO_V2#changed-command-line-flags

To silence deprecations that can be silenced set the following environment variable:
  ACK_GINKGO_DEPRECATIONS=2.6.1

Will run 423 of 423 specs
```

After:
```
$ make print-e2e-suite
Reached DIND check ELSE block, inside run-in-docker.sh
Compiled e2e.test
Reached DIND check ELSE block, inside run-in-docker.sh

Will run 423 of 423 specs
------------------------------
[Annotations] service-upstream when using the default value (false) and enabling in the annotations should use the Service Cluster IP and Port
File: test/e2e/annotations/serviceupstream.go:41
 [0.000 seconds]
------------------------------
[...]
```