### PR TITLE
Allow to pass a target test

### DIFF
--- a/test/test-lua.sh
+++ b/test/test-lua.sh
@@ -25,14 +25,23 @@ set -o pipefail
 
 BUSTED_ARGS="-v --pattern=_test"
 
-resty \
-  -I ./rootfs/etc/nginx/lua \
-  --shdict "configuration_data 5M" \
-  --shdict "certificate_data 16M" \
-  --shdict "certificate_servers 1M" \
-  --shdict "ocsp_response_cache 1M" \
-  --shdict "balancer_ewma 1M" \
-  --shdict "balancer_ewma_last_touched_at 1M" \
-  --shdict "balancer_ewma_locks 512k" \
-  --shdict "global_throttle_cache 5M" \
-  ./rootfs/etc/nginx/lua/test/run.lua ${BUSTED_ARGS} ./rootfs/etc/nginx/lua/test/ ./rootfs/etc/nginx/lua/plugins/**/test
+SHDICT_ARGS=(
+    "-I" "./rootfs/etc/nginx/lua"
+    "--shdict" "configuration_data 5M"
+    "--shdict" "certificate_data 16M"
+    "--shdict" "certificate_servers 1M"
+    "--shdict" "ocsp_response_cache 1M"
+    "--shdict" "balancer_ewma 1M"
+    "--shdict" "quota_tracker 1M"
+    "--shdict" "high_throughput_tracker 1M"
+    "--shdict" "balancer_ewma_last_touched_at 1M"
+    "--shdict" "balancer_ewma_locks 512k"
+    "--shdict" "global_throttle_cache 5M"
+    "./rootfs/etc/nginx/lua/test/run.lua"
+)
+
+if [ $# -eq 0 ]; then
+    resty "${SHDICT_ARGS[@]}" ./rootfs/etc/nginx/lua/test/ ./rootfs/etc/nginx/lua/plugins/**/test
+else
+    resty "${SHDICT_ARGS[@]}" $@
+fi


### PR DESCRIPTION
This PR makes the feedback loop faster, allowing to run `test/test-lua.sh rootfs/etc/nginx/lua/test/your_test.lua` without having to wait for the full test suite.

@ElvinEfendi
cc @plantfansam