### PR TITLE
add lint on chart before release

### DIFF
--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -25,6 +25,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
 
+      - name: Run Artifact Hub lint
+        run: |
+          wget https://github.com/artifacthub/hub/releases/download/v1.5.0/ah_1.5.0_linux_amd64.tar.gz
+          echo 'ad0e44c6ea058ab6b85dbf582e88bad9fdbc64ded0d1dd4edbac65133e5c87da *ah_1.5.0_linux_amd64.tar.gz' | shasum -c
+          tar -xzvf ah_1.5.0_linux_amd64.tar.gz ah
+          ./ah lint -p charts/ingress-nginx || exit 1
+          rm -f ./ah ./ah_1.5.0_linux_amd64.tar.gz
+
+      - name: Lint
+        run: |
+          ./build/run-in-docker.sh ./hack/verify-chart-lint.sh
+
       - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
         id: filter
         with:


### PR DESCRIPTION
Signed-off-by: James Strong <strong.james.e@gmail.com>

<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
In case someone pushes directly to main, the helm chart should be linted before release. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
premature release issues
