### PR TITLE
code clean for fsnotify

### DIFF
--- a/pkg/util/file/file_watcher.go
+++ b/pkg/util/file/file_watcher.go
@@ -72,8 +72,8 @@ func (f *OSFileWatcher) watch() error {
 		for {
 			select {
 			case event := <-watcher.Events:
-				if event.Op&fsnotify.Create == fsnotify.Create ||
-					event.Op&fsnotify.Write == fsnotify.Write {
+				if event.Has(fsnotify.Create) ||
+					event.Has(fsnotify.Write) {
 					if finfo, err := os.Lstat(event.Name); err != nil {
 						log.Printf("can not lstat file: %v\n", err)
 					} else if finfo.Mode()&os.ModeSymlink != 0 {


### PR DESCRIPTION
Signed-off-by: yanggang <gang.yang@daocloud.io>

/kind cleanup

Refer [fsnotify 1.6.0](https://github.com/fsnotify/fsnotify/releases/tag/v1.6.0) says.

```
This makes checking events a lot easier; for example:

  if event.Op&Write == Write && !(event.Op&Remove == Remove) {
  }
Becomes:

  if event.Has(Write) && !event.Has(Remove) {
  }

```
