### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/vulnerability-scans.yaml
+++ b/.github/workflows/vulnerability-scans.yaml
@@ -42,7 +42,7 @@ jobs:
           echo "${SHORT_TAGS[0]},${SHORT_TAGS[1]},${SHORT_TAGS[2]}"
           TAGS_JSON="[\"${SHORT_TAGS[0]}\",\"${SHORT_TAGS[1]}\",\"${SHORT_TAGS[2]}\"]"
           echo "${TAGS_JSON}"
-          echo "::set-output name=TAGS::${TAGS_JSON}"
+          echo "TAGS=${TAGS_JSON}" >> $GITHUB_OUTPUT
 
   scan:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Signed-off-by: jongwooo <jongwooo.han@gmail.com>

<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Update workflows to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow files that use `set-output` command through the following command:

```bash
$ find .github/workflows -name '*.yml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yml
echo "::set-output name=TAGS::${TAGS_JSON}"
```

**TO-BE**

```yml
echo "TAGS=${TAGS_JSON}" >> $GITHUB_OUTPUT
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes

fixes #9580 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] Added Release Notes.
