### PR TITLE
Replace all deprecated sets.String with sets.Set

### DIFF
--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -545,11 +545,11 @@ func (n *NGINXController) getDefaultUpstream() *ingress.Backend {
 }
 
 // getConfiguration returns the configuration matching the standard kubernetes ingress
-func (n *NGINXController) getConfiguration(ingresses []*ingress.Ingress) (sets.String, []*ingress.Server, *ingress.Configuration) {
+func (n *NGINXController) getConfiguration(ingresses []*ingress.Ingress) (sets.Set[string], []*ingress.Server, *ingress.Configuration) {
 	upstreams, servers := n.getBackendServers(ingresses)
 	var passUpstreams []*ingress.SSLPassthroughBackend
 
-	hosts := sets.NewString()
+	hosts := sets.New[string]()
 
 	for _, server := range servers {
 		// If a location is defined by a prefix string that ends with the slash character, and requests are processed by one of

--- a/internal/ingress/controller/store/objectref.go
+++ b/internal/ingress/controller/store/objectref.go
@@ -37,13 +37,13 @@ type ObjectRefMap interface {
 
 type objectRefMap struct {
 	sync.Mutex
-	v map[string]sets.String
+	v map[string]sets.Set[string]
 }
 
 // NewObjectRefMap returns a new ObjectRefMap.
 func NewObjectRefMap() ObjectRefMap {
 	return &objectRefMap{
-		v: make(map[string]sets.String),
+		v: make(map[string]sets.Set[string]),
 	}
 }
 
@@ -54,7 +54,7 @@ func (o *objectRefMap) Insert(consumer string, ref ...string) {
 
 	for _, r := range ref {
 		if _, ok := o.v[r]; !ok {
-			o.v[r] = sets.NewString(consumer)
+			o.v[r] = sets.New[string](consumer)
 			continue
 		}
 		o.v[r].Insert(consumer)
@@ -112,7 +112,7 @@ func (o *objectRefMap) Reference(ref string) []string {
 	if !ok {
 		return make([]string, 0)
 	}
-	return consumers.List()
+	return consumers.UnsortedList()
 }
 
 // ReferencedBy returns all objects referenced by the given object.

--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -792,7 +792,7 @@ rewrite "(?i)%s" %s break;
 
 func filterRateLimits(input interface{}) []ratelimit.Config {
 	ratelimits := []ratelimit.Config{}
-	found := sets.String{}
+	found := sets.Set[string]{}
 
 	servers, ok := input.([]*ingress.Server)
 	if !ok {
@@ -815,12 +815,12 @@ func filterRateLimits(input interface{}) []ratelimit.Config {
 // for connection limit by IP address, one for limiting requests per minute, and
 // one for limiting requests per second.
 func buildRateLimitZones(input interface{}) []string {
-	zones := sets.String{}
+	zones := sets.Set[string]{}
 
 	servers, ok := input.([]*ingress.Server)
 	if !ok {
 		klog.Errorf("expected a '[]*ingress.Server' type but %T was returned", input)
-		return zones.List()
+		return zones.UnsortedList()
 	}
 
 	for _, server := range servers {
@@ -859,7 +859,7 @@ func buildRateLimitZones(input interface{}) []string {
 		}
 	}
 
-	return zones.List()
+	return zones.UnsortedList()
 }
 
 // buildRateLimit produces an array of limit_req to be used inside the Path of
@@ -1654,7 +1654,7 @@ func buildModSecurityForLocation(cfg config.Configuration, location *ingress.Loc
 func buildMirrorLocations(locs []*ingress.Location) string {
 	var buffer bytes.Buffer
 
-	mapped := sets.String{}
+	mapped := sets.Set[string]{}
 
 	for _, loc := range locs {
 		if loc.Mirror.Source == "" || loc.Mirror.Target == "" {

--- a/internal/ingress/metric/collectors/socket.go
+++ b/internal/ingress/metric/collectors/socket.go
@@ -80,7 +80,7 @@ type SocketCollector struct {
 
 	metricMapping map[string]interface{}
 
-	hosts sets.String
+	hosts sets.Set[string]
 
 	metricsPerHost      bool
 	reportStatusClasses bool
@@ -505,7 +505,7 @@ func (sc SocketCollector) Collect(ch chan<- prometheus.Metric) {
 
 // SetHosts sets the hostnames that are being served by the ingress controller
 // This set of hostnames is used to filter the metrics to be exposed
-func (sc *SocketCollector) SetHosts(hosts sets.String) {
+func (sc *SocketCollector) SetHosts(hosts sets.Set[string]) {
 	sc.hosts = hosts
 }
 

--- a/internal/ingress/metric/collectors/socket_test.go
+++ b/internal/ingress/metric/collectors/socket_test.go
@@ -485,7 +485,7 @@ func TestCollector(t *testing.T) {
 				t.Errorf("registering collector failed: %s", err)
 			}
 
-			sc.SetHosts(sets.NewString("testshop.com"))
+			sc.SetHosts(sets.New[string]("testshop.com"))
 
 			for _, d := range c.data {
 				sc.handleMessage([]byte(d))

--- a/internal/ingress/metric/dummy.go
+++ b/internal/ingress/metric/dummy.go
@@ -69,7 +69,7 @@ func (dc DummyCollector) SetSSLInfo([]*ingress.Server) {}
 func (dc DummyCollector) SetSSLExpireTime([]*ingress.Server) {}
 
 // SetHosts ...
-func (dc DummyCollector) SetHosts(hosts sets.String) {}
+func (dc DummyCollector) SetHosts(hosts sets.Set[string]) {}
 
 // OnStartedLeading indicates the pod is not the current leader
 func (dc DummyCollector) OnStartedLeading(electionID string) {}

--- a/internal/ingress/metric/main.go
+++ b/internal/ingress/metric/main.go
@@ -52,7 +52,7 @@ type Collector interface {
 	SetSSLInfo(servers []*ingress.Server)
 
 	// SetHosts sets the hostnames that are being served by the ingress controller
-	SetHosts(sets.String)
+	SetHosts(set sets.Set[string])
 
 	Start(string)
 	Stop(string)
@@ -191,7 +191,7 @@ func (c *collector) DecOrphanIngress(namespace string, name string, orphanityTyp
 	c.ingressController.DecOrphanIngress(namespace, name, orphanityType)
 }
 
-func (c *collector) SetHosts(hosts sets.String) {
+func (c *collector) SetHosts(hosts sets.Set[string]) {
 	c.socket.SetHosts(hosts)
 }
 

--- a/pkg/util/ingress/ingress.go
+++ b/pkg/util/ingress/ingress.go
@@ -191,7 +191,7 @@ type redirect struct {
 
 // BuildRedirects build the redirects of servers based on configurations and certificates
 func BuildRedirects(servers []*ingress.Server) []*redirect {
-	names := sets.String{}
+	names := sets.Set[string]{}
 	redirectServers := make([]*redirect, 0)
 
 	for _, srv := range servers {


### PR DESCRIPTION
Signed-off-by: Fish-pro <zechun.chen@daocloud.io>

<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

sets.String is deprecated, replace it with Set

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes

fixes #9590 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] Added Release Notes.
