### PR TITLE
Use luarocks to manage Lua dependencies

### DIFF
--- a/images/nginx/rootfs/build.sh
+++ b/images/nginx/rootfs/build.sh
@@ -99,9 +99,6 @@ export LUA_RESTY_CACHE=0.11
 # Check for recent changes: https://github.com/openresty/lua-resty-core/compare/v0.1.23...master
 export LUA_RESTY_CORE=0.1.23
 
-# Check for recent changes: https://github.com/cloudflare/lua-resty-cookie/compare/v0.1.0...master
-export LUA_RESTY_COOKIE_VERSION=303e32e512defced053a6484bc0745cf9dc0d39e
-
 # Check for recent changes: https://github.com/openresty/lua-resty-dns/compare/v0.22...master
 export LUA_RESTY_DNS=0.22
 
@@ -289,9 +286,6 @@ fi
 
 get_src 0c551d6898f89f876e48730f9b55790d0ba07d5bc0aa6c76153277f63c19489f \
         "https://github.com/openresty/lua-cjson/archive/$LUA_CJSON_VERSION.tar.gz"
-
-get_src 5ed48c36231e2622b001308622d46a0077525ac2f751e8cc0c9905914254baa4 \
-        "https://github.com/cloudflare/lua-resty-cookie/archive/$LUA_RESTY_COOKIE_VERSION.tar.gz"
 
 get_src e810ed124fe788b8e4aac2c8960dda1b9a6f8d0ca94ce162f28d3f4d877df8af \
         "https://github.com/openresty/lua-resty-lrucache/archive/v$LUA_RESTY_CACHE.tar.gz"
@@ -668,10 +662,6 @@ export LUA_INCLUDE_DIR=/usr/local/include/luajit-2.1
 ln -s $LUA_INCLUDE_DIR /usr/include/lua5.1
 
 cd "$BUILD_PATH/lua-cjson-$LUA_CJSON_VERSION"
-make all
-make install
-
-cd "$BUILD_PATH/lua-resty-cookie-$LUA_RESTY_COOKIE_VERSION"
 make all
 make install
 

--- a/images/nginx/rootfs/build.sh
+++ b/images/nginx/rootfs/build.sh
@@ -105,9 +105,6 @@ export LUA_RESTY_COOKIE_VERSION=303e32e512defced053a6484bc0745cf9dc0d39e
 # Check for recent changes: https://github.com/openresty/lua-resty-dns/compare/v0.22...master
 export LUA_RESTY_DNS=0.22
 
-# Check for recent changes: https://github.com/ledgetech/lua-resty-http/compare/v0.16.1...master
-export LUA_RESTY_HTTP=0ce55d6d15da140ecc5966fa848204c6fd9074e8
-
 # Check for recent changes: https://github.com/openresty/lua-resty-lock/compare/v0.08...master
 export LUA_RESTY_LOCK=0.08
 
@@ -304,9 +301,6 @@ get_src 2b4683f9abe73e18ca00345c65010c9056777970907a311d6e1699f753141de2 \
 
 get_src 70e9a01eb32ccade0d5116a25bcffde0445b94ad35035ce06b94ccd260ad1bf0 \
         "https://github.com/openresty/lua-resty-dns/archive/v$LUA_RESTY_DNS.tar.gz"
-
-get_src 9fcb6db95bc37b6fce77d3b3dc740d593f9d90dce0369b405eb04844d56ac43f \
-        "https://github.com/ledgetech/lua-resty-http/archive/$LUA_RESTY_HTTP.tar.gz"
 
 get_src 42893da0e3de4ec180c9bf02f82608d78787290a70c5644b538f29d243147396 \
         "https://github.com/openresty/lua-resty-memcached/archive/v$LUA_RESTY_MEMCACHED_VERSION.tar.gz"
@@ -688,10 +682,6 @@ cd "$BUILD_PATH/lua-resty-dns-$LUA_RESTY_DNS"
 make install
 
 cd "$BUILD_PATH/lua-resty-lock-$LUA_RESTY_LOCK"
-make install
-
-# required for OCSP verification
-cd "$BUILD_PATH/lua-resty-http-$LUA_RESTY_HTTP"
 make install
 
 cd "$BUILD_PATH/lua-resty-upload-$LUA_RESTY_UPLOAD_VERSION"

--- a/images/nginx/rootfs/build.sh
+++ b/images/nginx/rootfs/build.sh
@@ -126,9 +126,6 @@ export LUA_RESTY_REDIS_VERSION=0.30
 # Check for recent changes: https://github.com/api7/lua-resty-ipmatcher/compare/v0.6.1...master
 export LUA_RESTY_IPMATCHER_VERSION=0.6.1
 
-# Check for recent changes: https://github.com/ElvinEfendi/lua-resty-global-throttle/compare/v0.2.0...main
-export LUA_RESTY_GLOBAL_THROTTLE_VERSION=0.2.0
-
 # Check for recent changes:  https://github.com/microsoft/mimalloc/compare/v1.7.6...master
 export MIMALOC_VERSION=1.7.6
 
@@ -322,9 +319,6 @@ get_src c15aed1a01c88a3a6387d9af67a957dff670357f5fdb4ee182beb44635eef3f1 \
 
 get_src efb767487ea3f6031577b9b224467ddbda2ad51a41c5867a47582d4ad85d609e \
         "https://github.com/api7/lua-resty-ipmatcher/archive/v$LUA_RESTY_IPMATCHER_VERSION.tar.gz"
-
-get_src 0fb790e394510e73fdba1492e576aaec0b8ee9ef08e3e821ce253a07719cf7ea \
-        "https://github.com/ElvinEfendi/lua-resty-global-throttle/archive/v$LUA_RESTY_GLOBAL_THROTTLE_VERSION.tar.gz"
 
 get_src d74f86ada2329016068bc5a243268f1f555edd620b6a7d6ce89295e7d6cf18da \
         "https://github.com/microsoft/mimalloc/archive/refs/tags/v${MIMALOC_VERSION}.tar.gz"
@@ -720,9 +714,6 @@ make install
 
 cd "$BUILD_PATH/lua-resty-ipmatcher-$LUA_RESTY_IPMATCHER_VERSION"
 INST_LUADIR=/usr/local/lib/lua make install
-
-cd "$BUILD_PATH/lua-resty-global-throttle-$LUA_RESTY_GLOBAL_THROTTLE_VERSION"
-make install
 
 cd "$BUILD_PATH/mimalloc-$MIMALOC_VERSION"
 mkdir -p out/release

--- a/images/nginx/rootfs/build.sh
+++ b/images/nginx/rootfs/build.sh
@@ -123,9 +123,6 @@ export LUA_RESTY_MEMCACHED_VERSION=0.16
 # Check for recent changes: https://github.com/openresty/lua-resty-redis/compare/v0.30...master
 export LUA_RESTY_REDIS_VERSION=0.30
 
-# Check for recent changes: https://github.com/api7/lua-resty-ipmatcher/compare/v0.6.1...master
-export LUA_RESTY_IPMATCHER_VERSION=0.6.1
-
 # Check for recent changes:  https://github.com/microsoft/mimalloc/compare/v1.7.6...master
 export MIMALOC_VERSION=1.7.6
 
@@ -316,9 +313,6 @@ get_src 42893da0e3de4ec180c9bf02f82608d78787290a70c5644b538f29d243147396 \
 
 get_src c15aed1a01c88a3a6387d9af67a957dff670357f5fdb4ee182beb44635eef3f1 \
         "https://github.com/openresty/lua-resty-redis/archive/v$LUA_RESTY_REDIS_VERSION.tar.gz"
-
-get_src efb767487ea3f6031577b9b224467ddbda2ad51a41c5867a47582d4ad85d609e \
-        "https://github.com/api7/lua-resty-ipmatcher/archive/v$LUA_RESTY_IPMATCHER_VERSION.tar.gz"
 
 get_src d74f86ada2329016068bc5a243268f1f555edd620b6a7d6ce89295e7d6cf18da \
         "https://github.com/microsoft/mimalloc/archive/refs/tags/v${MIMALOC_VERSION}.tar.gz"
@@ -711,9 +705,6 @@ make install
 
 cd "$BUILD_PATH/lua-resty-redis-$LUA_RESTY_REDIS_VERSION"
 make install
-
-cd "$BUILD_PATH/lua-resty-ipmatcher-$LUA_RESTY_IPMATCHER_VERSION"
-INST_LUADIR=/usr/local/lib/lua make install
 
 cd "$BUILD_PATH/mimalloc-$MIMALOC_VERSION"
 mkdir -p out/release

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -14,6 +14,25 @@
 
 ARG BASE_IMAGE
 
+# Prepare Lua files and their dependencies.
+FROM ${BASE_IMAGE} as lua_builder
+RUN apk add \
+  make \
+  wget \
+  git
+RUN curl -sSL -o /tmp/luarocks.tar.gz https://github.com/luarocks/luarocks/archive/refs/tags/v3.9.2.tar.gz \
+  && echo "a0b36cd68586cd79966d0106bb2e5a4f5523327867995fd66bee4237062b3e3b */tmp/luarocks.tar.gz" | sha256sum -c - \
+  && tar -C /tmp -xzf /tmp/luarocks.tar.gz \
+  && cd /tmp/luarocks* \
+  && ./configure \
+  && make \
+  && make install
+COPY etc/nginx/lua /lua
+WORKDIR /lua
+RUN luarocks make --local --tree /luarocks ingress-nginx-lua-main-1.rockspec
+
+
+# Build the final image.
 FROM ${BASE_IMAGE}
 
 ARG TARGETARCH
@@ -39,7 +58,11 @@ RUN apk update \
     diffutils \
   && rm -rf /var/cache/apk/*
 
-COPY --chown=www-data:www-data etc /etc
+COPY --chown=www-data:www-data etc/nginx/template /etc/nginx/template
+COPY --chown=www-data:www-data etc/nginx/nginx.conf /etc/nginx
+COPY --chown=www-data:www-data etc/nginx/opentracing.json /etc/nginx
+COPY --from=lua_builder --chown=www-data:www-data /luarocks/lib/luarocks/rocks-5.1/ingress-nginx-lua/main-1/ingress-nginx-lua /etc/nginx/lua 
+COPY --from=lua_builder --chown=www-data:www-data /luarocks/share/lua/5.1 /usr/local/lib/lua
 
 COPY --chown=www-data:www-data bin/${TARGETARCH}/dbg /
 COPY --chown=www-data:www-data bin/${TARGETARCH}/nginx-ingress-controller /

--- a/rootfs/etc/nginx/lua/Makefile
+++ b/rootfs/etc/nginx/lua/Makefile
@@ -1,0 +1,17 @@
+ all:
+	@echo --- build
+	@echo CFLAGS: $(CFLAGS)
+	@echo LIBFLAG: $(LIBFLAG)
+	@echo LUA_LIBDIR: $(LUA_LIBDIR)
+	@echo LUA_BINDIR: $(LUA_BINDIR)
+	@echo LUA_INCDIR: $(LUA_INCDIR)
+
+.PHONY: install
+install:
+	@echo $(INST_PREFIX)
+	@echo $(INST_CONFDIR)
+	@echo INST_LIBDIR: $(INST_LIBDIR)
+	@echo INST_LUADIR: $(INST_LUADIR)
+	mkdir $(INST_PREFIX)/ingress-nginx-lua
+	cp -r . $(INST_PREFIX)/ingress-nginx-lua
+	rm -rf $(INST_PREFIX)/ingress-nginx-lua/test $(INST_PREFIX)/ingress-nginx-lua/Makefile $(INST_PREFIX)/ingress-nginx-lua/*.rockspec

--- a/rootfs/etc/nginx/lua/ingress-nginx-lua-main-1.rockspec
+++ b/rootfs/etc/nginx/lua/ingress-nginx-lua-main-1.rockspec
@@ -1,0 +1,32 @@
+package = "ingress-nginx-lua"
+version = "main-1"
+supported_platforms = {"linux", "macosx"}
+source = {
+   url = "git+https://github.com/kubernetes/ingress-nginx.git"
+}
+description = {
+   summary = "Lua modules for ingress-nginx.",
+   homepage = "https://github.com/kubernetes/ingress-nginx",
+   license = "Apache License 2.0"
+}
+dependencies = {
+   "lua-resty-global-throttle >= 0.2"
+}
+build = {
+   type = "make",
+   build_variables = {
+      CFLAGS="$(CFLAGS)",
+      LIBFLAG="$(LIBFLAG)",
+      LUA_LIBDIR="$(LUA_LIBDIR)",
+      LUA_BINDIR="$(LUA_BINDIR)",
+      LUA_INCDIR="$(LUA_INCDIR)",
+      LUA="$(LUA)",
+   },
+   install_variables = {
+      INST_PREFIX="$(PREFIX)",
+      INST_BINDIR="$(BINDIR)",
+      INST_LIBDIR="$(LIBDIR)",
+      INST_LUADIR="$(LUADIR)",
+      INST_CONFDIR="$(CONFDIR)",
+   },
+}

--- a/rootfs/etc/nginx/lua/ingress-nginx-lua-main-1.rockspec
+++ b/rootfs/etc/nginx/lua/ingress-nginx-lua-main-1.rockspec
@@ -12,7 +12,8 @@ description = {
 dependencies = {
    "lua-resty-global-throttle >= 0.2",
    "lua-resty-ipmatcher >= 0.6.1",
-   "lua-resty-http >= 0.16.1"
+   "lua-resty-http >= 0.16.1",
+   "lua-resty-cookie >= 0.1.0"
 }
 build = {
    type = "make",

--- a/rootfs/etc/nginx/lua/ingress-nginx-lua-main-1.rockspec
+++ b/rootfs/etc/nginx/lua/ingress-nginx-lua-main-1.rockspec
@@ -10,7 +10,8 @@ description = {
    license = "Apache License 2.0"
 }
 dependencies = {
-   "lua-resty-global-throttle >= 0.2"
+   "lua-resty-global-throttle >= 0.2",
+   "lua-resty-ipmatcher >= 0.6.1"
 }
 build = {
    type = "make",

--- a/rootfs/etc/nginx/lua/ingress-nginx-lua-main-1.rockspec
+++ b/rootfs/etc/nginx/lua/ingress-nginx-lua-main-1.rockspec
@@ -11,7 +11,8 @@ description = {
 }
 dependencies = {
    "lua-resty-global-throttle >= 0.2",
-   "lua-resty-ipmatcher >= 0.6.1"
+   "lua-resty-ipmatcher >= 0.6.1",
+   "lua-resty-http >= 0.16.1"
 }
 build = {
    type = "make",


### PR DESCRIPTION
Introducing a rock file to manage Lua dependencies. Managing some of the Lua dependencies using https://github.com/kubernetes/ingress-nginx/blob/6f713b76a15f4ed6488b9969cedaa176f3cbeb9d/images/nginx/rootfs/build.sh#L146 can get painful, particularly the ones with many second-level dependencies (i.e lua-resty-openidc). But at the same time, some Lua dependencies we need are either not available through Luarocks or not up to date in Luarocks. So I'm also keeping the old way of doing things.