### PR TITLE
Indent values.yaml using 2 instead of 4 spaces

### DIFF
--- a/magefiles/helm.go
+++ b/magefiles/helm.go
@@ -19,6 +19,7 @@ limitations under the License.
 package main
 
 import (
+	"bytes"
 	"fmt"
 	semver "github.com/blang/semver/v4"
 	"github.com/helm/helm/pkg/chartutil"
@@ -26,6 +27,7 @@ import (
 	"github.com/magefile/mage/sh"
 	yamlpath "github.com/vmware-labs/yaml-jsonpath/pkg/yamlpath"
 	"gopkg.in/yaml.v3"
+	"io/ioutil"
 	"os"
 	"strings"
 )
@@ -145,9 +147,13 @@ func updateChartValue(key, value string) {
 	}
 
 	//// write to file
-	newValueFile, err := yaml.Marshal(&n)
+	var b bytes.Buffer
+	yamlEncoder := yaml.NewEncoder(&b)
+	yamlEncoder.SetIndent(2)
+	yamlEncoder.Encode(&n)
+	err = yamlEncoder.Encode(&n)
 	CheckIfError(err, "HELM Could not Marshal new Values file")
-	err = os.WriteFile(HelmChartValues, newValueFile, 0644)
+	err = ioutil.WriteFile(HelmChartValues, b.Bytes(), 0644)
 	CheckIfError(err, "HELM Could not write new Values file to %s", HelmChartValues)
 
 	Info("HELM Ingress Nginx Helm Chart update %s %s", key, value)

--- a/magefiles/helm.go
+++ b/magefiles/helm.go
@@ -27,7 +27,6 @@ import (
 	"github.com/magefile/mage/sh"
 	yamlpath "github.com/vmware-labs/yaml-jsonpath/pkg/yamlpath"
 	"gopkg.in/yaml.v3"
-	"io/ioutil"
 	"os"
 	"strings"
 )
@@ -150,10 +149,9 @@ func updateChartValue(key, value string) {
 	var b bytes.Buffer
 	yamlEncoder := yaml.NewEncoder(&b)
 	yamlEncoder.SetIndent(2)
-	yamlEncoder.Encode(&n)
 	err = yamlEncoder.Encode(&n)
 	CheckIfError(err, "HELM Could not Marshal new Values file")
-	err = ioutil.WriteFile(HelmChartValues, b.Bytes(), 0644)
+	err = os.WriteFile(HelmChartValues, b.Bytes(), 0644)
 	CheckIfError(err, "HELM Could not write new Values file to %s", HelmChartValues)
 
 	Info("HELM Ingress Nginx Helm Chart update %s %s", key, value)


### PR DESCRIPTION
## What this PR does / why we need it:
This is much more conventional, and how it was here until commit 80fd69e641d5b730048fff61f3d58682e2494fd1 which didn't appear to intentionally change this. Fixes #9655 

## Types of changes
- [ x ] Bug fix (non-breaking change which fixes an issue)

Mostly just convention and standards

## Which issue/s this PR fixes
fixes #9655

## How Has This Been Tested?
The yaml is functionally identical.
See commentary for more testing - deployment is successful and resulting values.yaml is identical barring whitespace.

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Added Release Notes.
None required

## Does my pull request need a release note?
```release-note
Layout of values.yaml reverted to 2 spaces instead of 4
```
