### PR TITLE
allow exec into ingress-nginx-controll pod, when any type of sidecar is injected into the controller pod

### DIFF
--- a/cmd/plugin/commands/backends/backends.go
+++ b/cmd/plugin/commands/backends/backends.go
@@ -30,7 +30,7 @@ import (
 
 // CreateCommand creates and returns this cobra subcommand
 func CreateCommand(flags *genericclioptions.ConfigFlags) *cobra.Command {
-	var pod, deployment, selector *string
+	var pod, deployment, selector, container *string
 	cmd := &cobra.Command{
 		Use:   "backends",
 		Short: "Inspect the dynamic backend information of an ingress-nginx instance",
@@ -47,7 +47,7 @@ func CreateCommand(flags *genericclioptions.ConfigFlags) *cobra.Command {
 				return fmt.Errorf("--list and --backend cannot both be specified")
 			}
 
-			util.PrintError(backends(flags, *pod, *deployment, *selector, backend, onlyList))
+			util.PrintError(backends(flags, *pod, *deployment, *selector, *container, backend, onlyList))
 			return nil
 		},
 	}
@@ -55,6 +55,7 @@ func CreateCommand(flags *genericclioptions.ConfigFlags) *cobra.Command {
 	pod = util.AddPodFlag(cmd)
 	deployment = util.AddDeploymentFlag(cmd)
 	selector = util.AddSelectorFlag(cmd)
+	container = util.AddContainerFlag(cmd)
 
 	cmd.Flags().String("backend", "", "Output only the information for the given backend")
 	cmd.Flags().Bool("list", false, "Output a newline-separated list of backend names")
@@ -62,7 +63,7 @@ func CreateCommand(flags *genericclioptions.ConfigFlags) *cobra.Command {
 	return cmd
 }
 
-func backends(flags *genericclioptions.ConfigFlags, podName string, deployment string, selector string, backend string, onlyList bool) error {
+func backends(flags *genericclioptions.ConfigFlags, podName string, deployment string, selector string, container string, backend string, onlyList bool) error {
 	var command []string
 	if onlyList {
 		command = []string{"/dbg", "backends", "list"}
@@ -77,7 +78,7 @@ func backends(flags *genericclioptions.ConfigFlags, podName string, deployment s
 		return err
 	}
 
-	out, err := kubectl.PodExecString(flags, &pod, command)
+	out, err := kubectl.PodExecString(flags, &pod, container, command)
 	if err != nil {
 		return err
 	}

--- a/cmd/plugin/commands/certs/certs.go
+++ b/cmd/plugin/commands/certs/certs.go
@@ -30,7 +30,7 @@ import (
 
 // CreateCommand creates and returns this cobra subcommand
 func CreateCommand(flags *genericclioptions.ConfigFlags) *cobra.Command {
-	var pod, deployment, selector *string
+	var pod, deployment, selector, container *string
 	cmd := &cobra.Command{
 		Use:   "certs",
 		Short: "Output the certificate data stored in an ingress-nginx pod",
@@ -40,7 +40,7 @@ func CreateCommand(flags *genericclioptions.ConfigFlags) *cobra.Command {
 				return err
 			}
 
-			util.PrintError(certs(flags, *pod, *deployment, *selector, host))
+			util.PrintError(certs(flags, *pod, *deployment, *selector, *container, host))
 			return nil
 		},
 	}
@@ -50,11 +50,12 @@ func CreateCommand(flags *genericclioptions.ConfigFlags) *cobra.Command {
 	pod = util.AddPodFlag(cmd)
 	deployment = util.AddDeploymentFlag(cmd)
 	selector = util.AddSelectorFlag(cmd)
+	container = util.AddContainerFlag(cmd)
 
 	return cmd
 }
 
-func certs(flags *genericclioptions.ConfigFlags, podName string, deployment string, selector string, host string) error {
+func certs(flags *genericclioptions.ConfigFlags, podName string, deployment string, selector string, container string, host string) error {
 	command := []string{"/dbg", "certs", "get", host}
 
 	pod, err := request.ChoosePod(flags, podName, deployment, selector)
@@ -62,7 +63,7 @@ func certs(flags *genericclioptions.ConfigFlags, podName string, deployment stri
 		return err
 	}
 
-	out, err := kubectl.PodExecString(flags, &pod, command)
+	out, err := kubectl.PodExecString(flags, &pod, container, command)
 	if err != nil {
 		return err
 	}

--- a/cmd/plugin/commands/conf/conf.go
+++ b/cmd/plugin/commands/conf/conf.go
@@ -32,7 +32,7 @@ import (
 
 // CreateCommand creates and returns this cobra subcommand
 func CreateCommand(flags *genericclioptions.ConfigFlags) *cobra.Command {
-	var pod, deployment, selector *string
+	var pod, deployment, selector, container *string
 	cmd := &cobra.Command{
 		Use:   "conf",
 		Short: "Inspect the generated nginx.conf",
@@ -42,7 +42,7 @@ func CreateCommand(flags *genericclioptions.ConfigFlags) *cobra.Command {
 				return err
 			}
 
-			util.PrintError(conf(flags, host, *pod, *deployment, *selector))
+			util.PrintError(conf(flags, host, *pod, *deployment, *selector, *container))
 			return nil
 		},
 	}
@@ -50,17 +50,18 @@ func CreateCommand(flags *genericclioptions.ConfigFlags) *cobra.Command {
 	pod = util.AddPodFlag(cmd)
 	deployment = util.AddDeploymentFlag(cmd)
 	selector = util.AddSelectorFlag(cmd)
+	container = util.AddContainerFlag(cmd)
 
 	return cmd
 }
 
-func conf(flags *genericclioptions.ConfigFlags, host string, podName string, deployment string, selector string) error {
+func conf(flags *genericclioptions.ConfigFlags, host string, podName string, deployment string, selector string, container string) error {
 	pod, err := request.ChoosePod(flags, podName, deployment, selector)
 	if err != nil {
 		return err
 	}
 
-	nginxConf, err := kubectl.PodExecString(flags, &pod, []string{"/dbg", "conf"})
+	nginxConf, err := kubectl.PodExecString(flags, &pod, container, []string{"/dbg", "conf"})
 	if err != nil {
 		return err
 	}

--- a/cmd/plugin/commands/exec/exec.go
+++ b/cmd/plugin/commands/exec/exec.go
@@ -29,19 +29,21 @@ import (
 // CreateCommand creates and returns this cobra subcommand
 func CreateCommand(flags *genericclioptions.ConfigFlags) *cobra.Command {
 	opts := execFlags{}
-	var pod, deployment, selector *string
+	var pod, deployment, selector, container *string
 
 	cmd := &cobra.Command{
 		Use:   "exec",
 		Short: "Execute a command inside an ingress-nginx pod",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			util.PrintError(exec(flags, *pod, *deployment, *selector, args, opts))
+			util.PrintError(exec(flags, *pod, *deployment, *selector, *container, args, opts))
 			return nil
 		},
 	}
 	pod = util.AddPodFlag(cmd)
 	deployment = util.AddDeploymentFlag(cmd)
 	selector = util.AddSelectorFlag(cmd)
+	container = util.AddContainerFlag(cmd)
+
 	cmd.Flags().BoolVarP(&opts.TTY, "tty", "t", false, "Stdin is a TTY")
 	cmd.Flags().BoolVarP(&opts.Stdin, "stdin", "i", false, "Pass stdin to the container")
 
@@ -53,7 +55,7 @@ type execFlags struct {
 	Stdin bool
 }
 
-func exec(flags *genericclioptions.ConfigFlags, podName string, deployment string, selector string, cmd []string, opts execFlags) error {
+func exec(flags *genericclioptions.ConfigFlags, podName string, deployment string, selector string, container string, cmd []string, opts execFlags) error {
 	pod, err := request.ChoosePod(flags, podName, deployment, selector)
 	if err != nil {
 		return err
@@ -67,7 +69,7 @@ func exec(flags *genericclioptions.ConfigFlags, podName string, deployment strin
 		args = append(args, "-i")
 	}
 
-	args = append(args, []string{"-n", pod.Namespace, pod.Name, "--"}...)
+	args = append(args, []string{"-n", pod.Namespace, "-c", container, pod.Name, "--"}...)
 	args = append(args, cmd...)
 	return kubectl.Exec(flags, args)
 }

--- a/cmd/plugin/commands/general/general.go
+++ b/cmd/plugin/commands/general/general.go
@@ -30,29 +30,30 @@ import (
 
 // CreateCommand creates and returns this cobra subcommand
 func CreateCommand(flags *genericclioptions.ConfigFlags) *cobra.Command {
-	var pod, deployment, selector *string
+	var pod, deployment, selector, container *string
 	cmd := &cobra.Command{
 		Use:   "general",
 		Short: "Inspect the other dynamic ingress-nginx information",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			util.PrintError(general(flags, *pod, *deployment, *selector))
+			util.PrintError(general(flags, *pod, *deployment, *selector, *container))
 			return nil
 		},
 	}
 	pod = util.AddPodFlag(cmd)
 	deployment = util.AddDeploymentFlag(cmd)
 	selector = util.AddSelectorFlag(cmd)
+	container = util.AddContainerFlag(cmd)
 
 	return cmd
 }
 
-func general(flags *genericclioptions.ConfigFlags, podName string, deployment string, selector string) error {
+func general(flags *genericclioptions.ConfigFlags, podName string, deployment string, selector string, container string) error {
 	pod, err := request.ChoosePod(flags, podName, deployment, selector)
 	if err != nil {
 		return err
 	}
 
-	out, err := kubectl.PodExecString(flags, &pod, []string{"/dbg", "general"})
+	out, err := kubectl.PodExecString(flags, &pod, container, []string{"/dbg", "general"})
 	if err != nil {
 		return err
 	}

--- a/cmd/plugin/commands/logs/logs.go
+++ b/cmd/plugin/commands/logs/logs.go
@@ -31,19 +31,20 @@ import (
 // CreateCommand creates and returns this cobra subcommand
 func CreateCommand(flags *genericclioptions.ConfigFlags) *cobra.Command {
 	o := logsFlags{}
-	var pod, deployment, selector *string
+	var pod, deployment, selector, container *string
 
 	cmd := &cobra.Command{
 		Use:   "logs",
 		Short: "Get the kubernetes logs for an ingress-nginx pod",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			util.PrintError(logs(flags, *pod, *deployment, *selector, o))
+			util.PrintError(logs(flags, *pod, *deployment, *selector, *container, o))
 			return nil
 		},
 	}
 	pod = util.AddPodFlag(cmd)
 	deployment = util.AddDeploymentFlag(cmd)
 	selector = util.AddSelectorFlag(cmd)
+	container = util.AddContainerFlag(cmd)
 
 	cmd.Flags().BoolVarP(&o.Follow, "follow", "f", o.Follow, "Specify if the logs should be streamed.")
 	cmd.Flags().BoolVar(&o.Timestamps, "timestamps", o.Timestamps, "Include timestamps on each line in the log output")
@@ -94,13 +95,13 @@ func (o *logsFlags) toStrings() []string {
 	return r
 }
 
-func logs(flags *genericclioptions.ConfigFlags, podName string, deployment string, selector string, opts logsFlags) error {
+func logs(flags *genericclioptions.ConfigFlags, podName string, deployment string, selector string, container string, opts logsFlags) error {
 	pod, err := request.ChoosePod(flags, podName, deployment, selector)
 	if err != nil {
 		return err
 	}
 
-	cmd := []string{"logs", "-n", pod.Namespace, pod.Name}
+	cmd := []string{"logs", "-n", pod.Namespace, "-c", container, pod.Name}
 	cmd = append(cmd, opts.toStrings()...)
 	return kubectl.Exec(flags, cmd)
 }

--- a/cmd/plugin/commands/ssh/ssh.go
+++ b/cmd/plugin/commands/ssh/ssh.go
@@ -28,27 +28,28 @@ import (
 
 // CreateCommand creates and returns this cobra subcommand
 func CreateCommand(flags *genericclioptions.ConfigFlags) *cobra.Command {
-	var pod, deployment, selector *string
+	var pod, deployment, selector, container *string
 	cmd := &cobra.Command{
 		Use:   "ssh",
 		Short: "ssh into a running ingress-nginx pod",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			util.PrintError(ssh(flags, *pod, *deployment, *selector))
+			util.PrintError(ssh(flags, *pod, *deployment, *selector, *container))
 			return nil
 		},
 	}
 	pod = util.AddPodFlag(cmd)
 	deployment = util.AddDeploymentFlag(cmd)
 	selector = util.AddSelectorFlag(cmd)
+	container = util.AddContainerFlag(cmd)
 
 	return cmd
 }
 
-func ssh(flags *genericclioptions.ConfigFlags, podName string, deployment string, selector string) error {
+func ssh(flags *genericclioptions.ConfigFlags, podName string, deployment string, selector string, container string) error {
 	pod, err := request.ChoosePod(flags, podName, deployment, selector)
 	if err != nil {
 		return err
 	}
 
-	return kubectl.Exec(flags, []string{"exec", "-it", "-n", pod.Namespace, pod.Name, "--", "/bin/bash"})
+	return kubectl.Exec(flags, []string{"exec", "-it", "-n", pod.Namespace, "-c", container, pod.Name, "--", "/bin/bash"})
 }

--- a/cmd/plugin/kubectl/kubectl.go
+++ b/cmd/plugin/kubectl/kubectl.go
@@ -31,8 +31,8 @@ import (
 
 // PodExecString takes a pod and a command, uses kubectl exec to run the command in the pod
 // and returns stdout as a string
-func PodExecString(flags *genericclioptions.ConfigFlags, pod *apiv1.Pod, args []string) (string, error) {
-	args = append([]string{"exec", "-n", pod.Namespace, pod.Name}, args...)
+func PodExecString(flags *genericclioptions.ConfigFlags, pod *apiv1.Pod, container string, args []string) (string, error) {
+	args = append([]string{"exec", "-n", pod.Namespace, "-c", container, pod.Name}, args...)
 	return ExecToString(flags, args)
 }
 

--- a/cmd/plugin/util/util.go
+++ b/cmd/plugin/util/util.go
@@ -31,6 +31,7 @@ import (
 const (
 	DefaultIngressDeploymentName = "ingress-nginx-controller"
 	DefaultIngressServiceName    = "ingress-nginx-controller"
+	DefaultIngressContainerName  = "controller"
 )
 
 // IssuePrefix is the github url that we can append an issue number to to link to it
@@ -124,6 +125,13 @@ func AddDeploymentFlag(cmd *cobra.Command) *string {
 func AddSelectorFlag(cmd *cobra.Command) *string {
 	v := ""
 	cmd.Flags().StringVarP(&v, "selector", "l", "", "Selector (label query) of the ingress-nginx pod")
+	return &v
+}
+
+// AddContainerFlag adds a --container flag to a cobra command
+func AddContainerFlag(cmd *cobra.Command) *string {
+	v := ""
+	cmd.Flags().StringVar(&v, "container", DefaultIngressContainerName, "The name of the ingress-nginx controller container")
 	return &v
 }
 

--- a/docs/kubectl-plugin.md
+++ b/docs/kubectl-plugin.md
@@ -68,7 +68,7 @@ Use "ingress-nginx [command] --help" for more information about a command.
 ## Common Flags
 
 - Every subcommand supports the basic `kubectl` configuration flags like `--namespace`, `--context`, `--client-key` and so on.
-- Subcommands that act on a particular `ingress-nginx` pod (`backends`, `certs`, `conf`, `exec`, `general`, `logs`, `ssh`), support the `--deployment <deployment>` and `--pod <pod>` flags to select either a pod from a deployment with the given name, or a pod with the given name. The `--deployment` flag defaults to `ingress-nginx-controller`.
+- Subcommands that act on a particular `ingress-nginx` pod (`backends`, `certs`, `conf`, `exec`, `general`, `logs`, `ssh`), support the `--deployment <deployment>`, `--pod <pod>`, and `--container <container>` flags to select either a pod from a deployment with the given name, or a pod with the given name (and the given container name). The `--deployment` flag defaults to `ingress-nginx-controller`, and the `--container` flag defaults to `controller`.
 - Subcommands that inspect resources (`ingresses`, `lint`) support the `--all-namespaces` flag, which causes them to inspect resources in every namespace.
 
 ## Subcommands


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:

Add support for --container flag, which sets an explicit container name for exec operations. Defaults to `controller`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

Fixes #4361
Fixes #4362 
Fixes #9702 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested relevant commands against existing installation of the latest ingress-nginx, supplying valid and invalid `--container {container}` options, and omitting the flag entirely.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] Added Release Notes.

## Does my pull request need a release note?
Any user-visible or operator-visible change qualifies for a release note. This could be a:

- CLI change
- API change
- UI change
- configuration schema change
- behavioral change
- change in non-functional attributes such as efficiency or availability, availability of a new platform
- a warning about a deprecation
- fix of a previous Known Issue
- fix of a vulnerability (CVE)

No release notes are required for changes to the following:

- Tests
- Build infrastructure
- Fixes for unreleased bugs

For more tips on writing good release notes, check out the [Release Notes Handbook](https://github.com/kubernetes/sig-release/tree/master/release-team/role-handbooks/release-notes)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added support for the --container flag in the kubectl plugin, which can be supplied to override the default controller container name for commands that invoke `kubectl exec`. (@jacobhenner)
```
