### PR TITLE
Remove `_ssl_expire_time_seconds` metric by identifier

### DIFF
--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -253,9 +253,8 @@ func (n *NGINXController) syncIngress(interface{}) error {
 	}
 
 	ri := utilingress.GetRemovedIngresses(n.runningConfig, pcfg)
-	re := utilingress.GetRemovedHosts(n.runningConfig, pcfg)
 	rc := utilingress.GetRemovedCertificateSerialNumbers(n.runningConfig, pcfg)
-	n.metricCollector.RemoveMetrics(ri, re, rc)
+	n.metricCollector.RemoveMetrics(ri, rc)
 
 	n.runningConfig = pcfg
 

--- a/internal/ingress/metric/dummy.go
+++ b/internal/ingress/metric/dummy.go
@@ -54,7 +54,7 @@ func (dc DummyCollector) IncCheckCount(string, string) {}
 func (dc DummyCollector) IncCheckErrorCount(string, string) {}
 
 // RemoveMetrics dummy implementation
-func (dc DummyCollector) RemoveMetrics(_, _, _ []string) {}
+func (dc DummyCollector) RemoveMetrics(_, _ []string) {}
 
 // Start dummy implementation
 func (dc DummyCollector) Start(_ string) {}

--- a/internal/ingress/metric/main.go
+++ b/internal/ingress/metric/main.go
@@ -46,7 +46,7 @@ type Collector interface {
 	IncOrphanIngress(string, string, string)
 	DecOrphanIngress(string, string, string)
 
-	RemoveMetrics(ingresses, endpoints, certificates []string)
+	RemoveMetrics(ingresses, certificates []string)
 
 	SetSSLExpireTime([]*ingress.Server)
 	SetSSLInfo(servers []*ingress.Server)
@@ -131,9 +131,9 @@ func (c *collector) IncReloadErrorCount() {
 	c.ingressController.IncReloadErrorCount()
 }
 
-func (c *collector) RemoveMetrics(ingresses, hosts, certificates []string) {
+func (c *collector) RemoveMetrics(ingresses, certificates []string) {
 	c.socket.RemoveMetrics(ingresses, c.registry)
-	c.ingressController.RemoveMetrics(hosts, certificates, c.registry)
+	c.ingressController.RemoveMetrics(certificates, c.registry)
 }
 
 func (c *collector) Start(admissionStatus string) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR added a new label `identifier` for `_ssl_expire_time_seconds` metric, which has the same meaning as the label in `_ssl_certificate_info`. 
When your TLS configuration changed, it will try to remove `_ssl_expire_time_seconds` by `identifier`, instead of `host`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #9705
-->

## How Has This Been Tested?
Follow the instructions in #9705.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] Added Release Notes.

## Does my pull request need a release note?
Any user-visible or operator-visible change qualifies for a release note. This could be a:

- CLI change
- API change
- UI change
- configuration schema change
- behavioral change
- change in non-functional attributes such as efficiency or availability, availability of a new platform
- a warning about a deprecation
- fix of a previous Known Issue
- fix of a vulnerability (CVE)

No release notes are required for changes to the following:

- Tests
- Build infrastructure
- Fixes for unreleased bugs

For more tips on writing good release notes, check out the [Release Notes Handbook](https://github.com/kubernetes/sig-release/tree/master/release-team/role-handbooks/release-notes)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
PLACE RELEASE NOTES HERE
```
