### PR TITLE
Fix several Helm YAML issues with extraModules and extraInitContainers

### DIFF
--- a/charts/ingress-nginx/templates/controller-daemonset.yaml
+++ b/charts/ingress-nginx/templates/controller-daemonset.yaml
@@ -178,15 +178,15 @@ spec:
       {{- end }}
       {{- if .Values.controller.extraModules }}
         {{- range .Values.controller.extraModules }}
-          - name: {{ .Name }}
-            image: {{ .Image }}
-            command: ['sh', '-c', '/usr/local/bin/init_module.sh']
-            {{- if (or $.Values.controller.containerSecurityContext .containerSecurityContext) }}
-            securityContext: {{ .containerSecurityContext | default $.Values.controller.containerSecurityContext | toYaml | nindent 14 }}
-            {{- end }}
-            volumeMounts:
-              - name: modules
-                mountPath: /modules_mount
+        - name: {{ .name }}
+          image: {{ .image }}
+          command: ['sh', '-c', '/usr/local/bin/init_module.sh']
+          {{- if (or $.Values.controller.containerSecurityContext .containerSecurityContext) }}
+          securityContext: {{ .containerSecurityContext | default $.Values.controller.containerSecurityContext | toYaml | nindent 14 }}
+          {{- end }}
+          volumeMounts:
+            - name: modules
+              mountPath: /modules_mount
         {{- end }}
       {{- end }}
     {{- end }}

--- a/charts/ingress-nginx/templates/controller-daemonset.yaml
+++ b/charts/ingress-nginx/templates/controller-daemonset.yaml
@@ -182,6 +182,10 @@ spec:
 {{ include "extraModules" (dict "name" .name "image" .image "containerSecurityContext" $containerSecurityContext) | indent 8 }}
         {{- end }}
       {{- end }}
+      {{- if .Values.controller.opentelemetry.enabled}}
+          {{ $otelContainerSecurityContext := $.Values.controller.opentelemetry.containerSecurityContext | default $.Values.controller.containerSecurityContext }}
+          {{- include "extraModules" (dict "name" "opentelemetry" "image" .Values.controller.opentelemetry.image "containerSecurityContext" $otelContainerSecurityContext) | nindent 8}}
+      {{- end}}
     {{- end }}
     {{- if .Values.controller.hostNetwork }}
       hostNetwork: {{ .Values.controller.hostNetwork }}
@@ -200,9 +204,9 @@ spec:
     {{- end }}
       serviceAccountName: {{ template "ingress-nginx.serviceAccountName" . }}
       terminationGracePeriodSeconds: {{ .Values.controller.terminationGracePeriodSeconds }}
-    {{- if (or .Values.controller.customTemplate.configMapName .Values.controller.extraVolumeMounts .Values.controller.admissionWebhooks.enabled .Values.controller.extraVolumes .Values.controller.extraModules) }}
+    {{- if (or .Values.controller.customTemplate.configMapName .Values.controller.extraVolumeMounts .Values.controller.admissionWebhooks.enabled .Values.controller.extraVolumes .Values.controller.extraModules .Values.controller.opentelemetry.enabled) }}
       volumes:
-      {{- if .Values.controller.extraModules }}
+      {{- if (or .Values.controller.extraModules .Values.controller.opentelemetry.enabled)}}
         - name: modules
           emptyDir: {}
       {{- end }}

--- a/charts/ingress-nginx/templates/controller-daemonset.yaml
+++ b/charts/ingress-nginx/templates/controller-daemonset.yaml
@@ -178,15 +178,8 @@ spec:
       {{- end }}
       {{- if .Values.controller.extraModules }}
         {{- range .Values.controller.extraModules }}
-        - name: {{ .name }}
-          image: {{ .image }}
-          command: ['sh', '-c', '/usr/local/bin/init_module.sh']
-          {{- if (or $.Values.controller.containerSecurityContext .containerSecurityContext) }}
-          securityContext: {{ .containerSecurityContext | default $.Values.controller.containerSecurityContext | toYaml | nindent 14 }}
-          {{- end }}
-          volumeMounts:
-            - name: modules
-              mountPath: /modules_mount
+          {{ $containerSecurityContext := .containerSecurityContext | default $.Values.controller.containerSecurityContext }}
+{{ include "extraModules" (dict "name" .name "image" .image "containerSecurityContext" $containerSecurityContext) | indent 8 }}
         {{- end }}
       {{- end }}
     {{- end }}

--- a/charts/ingress-nginx/templates/controller-deployment.yaml
+++ b/charts/ingress-nginx/templates/controller-deployment.yaml
@@ -185,7 +185,7 @@ spec:
       {{- if .Values.controller.extraModules }}
         {{- range .Values.controller.extraModules }}
           {{ $containerSecurityContext := .containerSecurityContext | default $.Values.controller.containerSecurityContext }}
-          {{- include "extraModules" (dict "name" .name "image" .image "containerSecurityContext" $containerSecurityContext | nindent 8) }}
+{{ include "extraModules" (dict "name" .name "image" .image "containerSecurityContext" $containerSecurityContext) | indent 8 }}
         {{- end }}
       {{- end }}
       {{- if .Values.controller.opentelemetry.enabled}}

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -527,6 +527,8 @@ controller:
 
     # -- Modules, which are mounted into the core nginx image. See values.yaml for a sample to add opentelemetry module
     extraModules: []
+    # - name: mytestmodule
+    #   image: registry.k8s.io/ingress-nginx/mytestmodule
     #   containerSecurityContext:
     #     allowPrivilegeEscalation: false
     #


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
Prior to this fix, users are unable to specify both values for both extraInitContainers and extraModules. The resulting template will be rejected because it's semantically invalid due to a YAML indention issue. In addition, there's a casing issue. The Deployment refers to `image` and `name`, but DaemonSet uses `Image` and `Name`. 

Given the following `values.yaml`:
```yaml
controller:
  extraInitContainers:
    - command:
        - /bin/chown
        - '101'
        - /mycache
      image: busybox:latest
      name: chmod
      volumeMounts:
        - mountPath: /mycache
          name: cache
  extraVolumeMounts:
    - mountPath: /var/cache/nginx
      name: cache
  extraVolumes:
    - hostPath:
        path: /var/cache/nginx-k8s
        type: ''
      name: cache
  kind: DaemonSet
  extraModules:
    - name: opentelemetry
      image: registry.k8s.io/ingress-nginx/opentelemetry:v20230107-helm-chart-4.4.2-2-g96b3d2165@sha256:331b9bebd6acfcd2d3048abbdd86555f5be76b7e3d0b5af4300b04235c6056c9
```
Prior to this change, the DaemonSet gets generated like this:
```yaml
      initContainers:
        
        - command:
          - /bin/chown
          - "101"
          - /mycache
          image: busybox:latest
          name: chmod
          volumeMounts:
          - mountPath: /mycache
            name: cache
          - name:   # <--- Notice that this is aligned under the volumeMounts, not under initContainers
            image:   # <-- Also note the empty image and names
            command: ['sh', '-c', '/usr/local/bin/init_module.sh']
            volumeMounts:
              - name: modules
                mountPath: /modules_mount
```

After this change, it generates a correct YAML:

```yaml
      initContainers:
        
        - command:
          - /bin/chown
          - "101"
          - /mycache
          image: busybox:latest
          name: chmod
          volumeMounts:
          - mountPath: /mycache
            name: cache
        - name: opentelemetry
          image: registry.k8s.io/ingress-nginx/opentelemetry:v20230107-helm-chart-4.4.2-2-g96b3d2165@sha256:331b9bebd6acfcd2d3048abbdd86555f5be76b7e3d0b5af4300b04235c6056c9
          command: ['sh', '-c', '/usr/local/bin/init_module.sh']
          volumeMounts:
            - name: modules
              mountPath: /modules_mount
``` 

Honestly, I'm not sure if extraModules even works in the Deployment case. I wasn't able to do Helm template if I generated a Deployment or DaemonSet. Trying to generate a Deployment gave me:

```
error: template: ingress-nginx/templates/controller-deployment.yaml:188:134: executing "ingress-nginx/templates/controller-deployment.yaml" at <8>: wrong type for value; expected string; got map[string]interface {}
helm.go:84: [debug] template: ingress-nginx/templates/controller-deployment.yaml:188:134: executing "ingress-nginx/templates/controller-deployment.yaml" at <8>: wrong type for value; expected string; got map[string]interface {}
```

 I only discovered this issue because the DaemonSet didn't support specifying `controller.opentelemetry.enabled=true`

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
I manually reviewed the generated template (see above) and deployed this commit to my cluster and verified the DaemonSet looks correct.

Are there any Helm tests that actually assert anything? I see the files in `charts/ingress-nginx/ci`, but I didn't see any expected values to make sure that's correct.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] Added Release Notes.

## Does my pull request need a release note?
Any user-visible or operator-visible change qualifies for a release note. This could be a:


- fix of a previous Known Issue

No release notes are required for changes to the following:

- Tests
- Build infrastructure
- Fixes for unreleased bugs

For more tips on writing good release notes, check out the [Release Notes Handbook](https://github.com/kubernetes/sig-release/tree/master/release-team/role-handbooks/release-notes)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed Helm template issue when specifying extraModules and allow OpenTelemetry to be enabled on DaemonSets
```
