### PR TITLE
bumped ginkgo to v2.9.0

### DIFF
--- a/build/run-in-docker.sh
+++ b/build/run-in-docker.sh
@@ -87,7 +87,7 @@ if [[ "$DOCKER_IN_DOCKER_ENABLED" == "true" ]]; then
   echo "..reached DIND check TRUE block, inside run-in-docker.sh"
   echo "FLAGS=$FLAGS"
   #go env
-  go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo@v2.6.1
+  go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo@v2.9.0
   find / -type f -name ginkgo 2>/dev/null
   which ginkgo
   /bin/bash -c "${FLAGS}"

--- a/images/test-runner/rootfs/Dockerfile
+++ b/images/test-runner/rootfs/Dockerfile
@@ -55,7 +55,7 @@ ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
 
-RUN go install github.com/onsi/ginkgo/v2/ginkgo@v2.6.1  && go install golang.org/x/lint/golint@latest
+RUN go install github.com/onsi/ginkgo/v2/ginkgo@v2.9.0  && go install golang.org/x/lint/golint@latest
 
 ARG RESTY_CLI_VERSION
 ARG RESTY_CLI_SHA

--- a/test/e2e/run-chart-test.sh
+++ b/test/e2e/run-chart-test.sh
@@ -78,7 +78,7 @@ fi
 
 if [ "${SKIP_IMAGE_CREATION:-false}" = "false" ]; then
   if ! command -v ginkgo &> /dev/null; then
-    go install github.com/onsi/ginkgo/v2/ginkgo@v2.6.1
+    go install github.com/onsi/ginkgo/v2/ginkgo@v2.9.0
   fi
   echo "[dev-env] building image"
   make -C ${DIR}/../../ clean-image build image

--- a/test/e2e/run-kind-e2e.sh
+++ b/test/e2e/run-kind-e2e.sh
@@ -95,7 +95,7 @@ fi
 
 if [ "${SKIP_E2E_IMAGE_CREATION}" = "false" ]; then
   if ! command -v ginkgo &> /dev/null; then
-    go install github.com/onsi/ginkgo/v2/ginkgo@v2.6.1
+    go install github.com/onsi/ginkgo/v2/ginkgo@v2.9.0
   fi
 
   echo "[dev-env] .. done building controller images"


### PR DESCRIPTION
## What this PR does / why we need it:
- Dependabot PR #9695  bumped ginkgo from v2.6.1 to v2.9.0
- The project has some pinned/hardcoded bits for ginkgo version that dependabot does not change
- This PR manually bumps the pinned bits for ginkgo to v2.9.0 as continuation to #9695 
- This PR will also fire cloudbuild for creating new test-runner-image with ginkgo@v2.9.0
- So after this merges, the new-test-runner image has to be promoted or else tests will continue to run with inappropriate version 2.6.1 of ginkgo cli
 
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
- No issue was created as this is a continuation of a internal process related PR by dependabot

## How Has This Been Tested?
- Test by running `FOCUS="no-auth-locations" make kind-e2e-test` locally

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Added Release Notes.

## Does my pull request need a release note?
Any user-visible or operator-visible change qualifies for a release note. This could be a:

- CLI change
- API change
- UI change
- configuration schema change
- behavioral change
- change in non-functional attributes such as efficiency or availability, availability of a new platform
- a warning about a deprecation
- fix of a previous Known Issue
- fix of a vulnerability (CVE)

No release notes are required for changes to the following:

- Tests
- Build infrastructure
- Fixes for unreleased bugs

For more tips on writing good release notes, check out the [Release Notes Handbook](https://github.com/kubernetes/sig-release/tree/master/release-team/role-handbooks/release-notes)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Bumped pinned ginkgo version to v2.9.0 as continuation of PR #9695
```
