### PR TITLE
HPA: bump apiVersion to v2 for defaultBackend

### DIFF
--- a/charts/ingress-nginx/README.md
+++ b/charts/ingress-nginx/README.md
@@ -456,6 +456,7 @@ Kubernetes: `>=1.20.0-0`
 | controller.watchIngressWithoutClass | bool | `false` | Process Ingress objects without ingressClass annotation/ingressClassName field Overrides value for --watch-ingress-without-class flag of the controller binary Defaults to false |
 | defaultBackend.affinity | object | `{}` |  |
 | defaultBackend.autoscaling.annotations | object | `{}` |  |
+| defaultBackend.autoscaling.apiVersion | string | `"autoscaling/v2"` |  |
 | defaultBackend.autoscaling.enabled | bool | `false` |  |
 | defaultBackend.autoscaling.maxReplicas | int | `2` |  |
 | defaultBackend.autoscaling.minReplicas | int | `1` |  |

--- a/charts/ingress-nginx/templates/default-backend-hpa.yaml
+++ b/charts/ingress-nginx/templates/default-backend-hpa.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.defaultBackend.enabled .Values.defaultBackend.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: {{ .Values.defaultBackend.autoscaling.apiVersion }}
 kind: HorizontalPodAutoscaler
 metadata:
   labels:

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -827,6 +827,7 @@ defaultBackend:
     #    emptyDir: {}
 
     autoscaling:
+        apiVersion: autoscaling/v2
         annotations: {}
         enabled: false
         minReplicas: 1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
```autoscaling/v2beta2 HorizontalPodAutoscaler is deprecated in v1.23+, unavailable in v1.26+; use autoscaling/v2 HorizontalPodAutoscaler```
We had a hardcode `apiVersion: autoscaling/v2beta1`  in [default-backend-hpa.yaml](https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/templates/default-backend-hpa.yaml#L2)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->
fixes #9728
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```
$ helm template --set defaultBackend.enabled=true  --set defaultBackend.autoscaling.enabled=true . | grep -A2 -B2 HorizontalPodAutoscaler
# Source: ingress-nginx/templates/default-backend-hpa.yaml
apiVersion: autoscaling/v2
kind: HorizontalPodAutoscaler
metadata:
  labels:
  
$ helm template --set defaultBackend.enabled=true  --set defaultBackend.autoscaling.enabled=true --set defaultBackend.autoscaling.apiVersion=autoscaling/v2beta2 . | grep -A2 -B2 HorizontalPodAutoscaler
# Source: ingress-nginx/templates/default-backend-hpa.yaml
apiVersion: autoscaling/v2beta2
kind: HorizontalPodAutoscaler
metadata:
  labels:
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Added Release Notes.
