### PR TITLE
drop k8s 1.23 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -204,7 +204,7 @@ jobs:
 
     strategy:
       matrix:
-        k8s: [v1.23.13, v1.24.7, v1.25.3, v1.26.0]
+        k8s: [v1.24.7, v1.25.3, v1.26.0]
 
     steps:
       - name: Checkout
@@ -284,7 +284,7 @@ jobs:
 
     strategy:
       matrix:
-        k8s: [v1.23.13, v1.24.7, v1.25.3, v1.26.0]
+        k8s: [v1.24.7, v1.25.3, v1.26.0]
 
     steps:
       - name: Checkout
@@ -337,7 +337,7 @@ jobs:
 
     strategy:
       matrix:
-        k8s: [v1.23.13, v1.24.7, v1.25.3, v1.26.0]
+        k8s: [v1.24.7, v1.25.3, v1.26.0]
 
     steps:
 
@@ -460,7 +460,7 @@ jobs:
 
     strategy:
       matrix:
-        k8s: [v1.23.13, v1.24.7, v1.25.3, v1.26.0]
+        k8s: [v1.24.7, v1.25.3, v1.26.0]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Drop Kubernetes 1.23 support and remove it from the test matrix