### PR TITLE
Scanning port 10247 lead to tcp connection 502 error

### DIFF
--- a/rootfs/etc/nginx/lua/tcp_udp_configuration.lua
+++ b/rootfs/etc/nginx/lua/tcp_udp_configuration.lua
@@ -1,5 +1,6 @@
 local ngx = ngx
 local tostring = tostring
+local cjson = require("cjson.safe")
 -- this is the Lua representation of TCP/UDP Configuration
 local tcp_udp_configuration_data = ngx.shared.tcp_udp_configuration_data
 
@@ -36,6 +37,14 @@ function _M.call()
   if backends == nil or backends == "" then
     return
   end
+
+   _, err = cjson.decode(backends)
+
+  if err then
+    ngx.log(ngx.ERR, "could not parse backends data: ", err)
+    return
+  end
+
 
   local success, err_conf = tcp_udp_configuration_data:set("backends", backends)
   if not success then

--- a/rootfs/etc/nginx/lua/tcp_udp_configuration.lua
+++ b/rootfs/etc/nginx/lua/tcp_udp_configuration.lua
@@ -38,10 +38,10 @@ function _M.call()
     return
   end
 
-   local _, err = cjson.decode(backends)
+  local _, backends_err = cjson.decode(backends)
 
-  if err then
-    ngx.log(ngx.ERR, "could not parse backends data: ", err)
+  if backends_err then
+    ngx.log(ngx.ERR, "could not parse backends data: ", backends_err)
     return
   end
 

--- a/rootfs/etc/nginx/lua/tcp_udp_configuration.lua
+++ b/rootfs/etc/nginx/lua/tcp_udp_configuration.lua
@@ -38,7 +38,7 @@ function _M.call()
     return
   end
 
-   _, err = cjson.decode(backends)
+   local _, err = cjson.decode(backends)
 
   if err then
     ngx.log(ngx.ERR, "could not parse backends data: ", err)


### PR DESCRIPTION
If you have a safe process to scan local port 10247, Ingress nginx will clean up your backend endpoints. At this time, While you change your http project, Ingress nginx will be reloaded and your tcp connection will have a 502 error.