### PR TITLE
add short sha to gcloud build and makefiles

### DIFF
--- a/images/cfssl/Makefile
+++ b/images/cfssl/Makefile
@@ -18,8 +18,12 @@ SHELL=/bin/bash -o pipefail -o errexit
 DIR:=$(strip $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST)))))
 INIT_BUILDX=$(DIR)/../../hack/init-buildx.sh
 
-TAG ?=v$(shell date +%Y%m%d)-$(shell git rev-parse --short HEAD)
+SHORT_SHA ?=$(shell git rev-parse --short HEAD)
+TAG ?=v$(shell date +%Y%m%d)-$(SHORT_SHA)
+
 REGISTRY ?= local
+
+
 
 IMAGE = $(REGISTRY)/e2e-test-cfssl
 

--- a/images/cfssl/cloudbuild.yaml
+++ b/images/cfssl/cloudbuild.yaml
@@ -6,6 +6,7 @@ steps:
     entrypoint: bash
     env:
       - DOCKER_CLI_EXPERIMENTAL=enabled
+      - SHORT_SHA=$SHORT_SHA
       - BASE_REF=$_PULL_BASE_REF
       - REGISTRY=gcr.io/k8s-staging-ingress-nginx
       # default cloudbuild has HOME=/builder/home and docker buildx is in /root/.docker/cli-plugins/docker-buildx

--- a/images/custom-error-pages/Makefile
+++ b/images/custom-error-pages/Makefile
@@ -20,7 +20,9 @@ SHELL=/bin/bash -o pipefail -o errexit
 DIR:=$(strip $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST)))))
 INIT_BUILDX=$(DIR)/../../hack/init-buildx.sh
 
-TAG ?=v$(shell date +%Y%m%d)-$(shell git rev-parse --short HEAD)
+SHORT_SHA ?=$(shell git rev-parse --short HEAD)
+TAG ?=v$(shell date +%Y%m%d)-$(SHORT_SHA)
+
 REGISTRY ?= local
 
 IMAGE = $(REGISTRY)/nginx-errors

--- a/images/custom-error-pages/cloudbuild.yaml
+++ b/images/custom-error-pages/cloudbuild.yaml
@@ -6,6 +6,7 @@ steps:
     entrypoint: bash
     env:
       - DOCKER_CLI_EXPERIMENTAL=enabled
+      - SHORT_SHA=$SHORT_SHA
       - BASE_REF=$_PULL_BASE_REF
       - REGISTRY=gcr.io/k8s-staging-ingress-nginx
       # default cloudbuild has HOME=/builder/home and docker buildx is in /root/.docker/cli-plugins/docker-buildx

--- a/images/echo/Makefile
+++ b/images/echo/Makefile
@@ -18,7 +18,9 @@ SHELL=/bin/bash -o pipefail -o errexit
 DIR:=$(strip $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST)))))
 INIT_BUILDX=$(DIR)/../../hack/init-buildx.sh
 
-TAG ?=v$(shell date +%Y%m%d)-$(shell git rev-parse --short HEAD)
+SHORT_SHA ?=$(shell git rev-parse --short HEAD)
+TAG ?=v$(shell date +%Y%m%d)-$(SHORT_SHA)
+
 REGISTRY ?= local
 
 IMAGE = $(REGISTRY)/e2e-test-echo

--- a/images/echo/cloudbuild.yaml
+++ b/images/echo/cloudbuild.yaml
@@ -6,6 +6,7 @@ steps:
     entrypoint: bash
     env:
       - DOCKER_CLI_EXPERIMENTAL=enabled
+      - SHORT_SHA=$SHORT_SHA
       - BASE_REF=$_PULL_BASE_REF
       - REGISTRY=gcr.io/k8s-staging-ingress-nginx
       # default cloudbuild has HOME=/builder/home and docker buildx is in /root/.docker/cli-plugins/docker-buildx

--- a/images/ext-auth-example-authsvc/cloudbuild.yaml
+++ b/images/ext-auth-example-authsvc/cloudbuild.yaml
@@ -8,6 +8,7 @@ steps:
     entrypoint: bash
     env:
       - DOCKER_CLI_EXPERIMENTAL=enabled
+      - SHORT_SHA=$SHORT_SHA
       - BASE_REF=$_PULL_BASE_REF
       - REGISTRY=gcr.io/k8s-staging-ingress-nginx
       # default cloudbuild has HOME=/builder/home and docker buildx is in /root/.docker/cli-plugins/docker-buildx

--- a/images/fastcgi-helloserver/Makefile
+++ b/images/fastcgi-helloserver/Makefile
@@ -20,7 +20,9 @@ SHELL=/bin/bash -o pipefail -o errexit
 DIR:=$(strip $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST)))))
 INIT_BUILDX=$(DIR)/../../hack/init-buildx.sh
 
-TAG ?=v$(shell date +%Y%m%d)-$(shell git rev-parse --short HEAD)
+SHORT_SHA ?=$(shell git rev-parse --short HEAD)
+TAG ?=v$(shell date +%Y%m%d)-$(SHORT_SHA)
+
 REGISTRY ?= local
 
 IMAGE = $(REGISTRY)/e2e-test-fastcgi-helloserver

--- a/images/fastcgi-helloserver/cloudbuild.yaml
+++ b/images/fastcgi-helloserver/cloudbuild.yaml
@@ -6,6 +6,7 @@ steps:
     entrypoint: bash
     env:
       - DOCKER_CLI_EXPERIMENTAL=enabled
+      - SHORT_SHA=$SHORT_SHA
       - BASE_REF=$_PULL_BASE_REF
       - REGISTRY=gcr.io/k8s-staging-ingress-nginx
       # default cloudbuild has HOME=/builder/home and docker buildx is in /root/.docker/cli-plugins/docker-buildx

--- a/images/go-grpc-greeter-server/Makefile
+++ b/images/go-grpc-greeter-server/Makefile
@@ -18,7 +18,9 @@ SHELL=/bin/bash -o pipefail -o errexit
 DIR:=$(strip $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST)))))
 INIT_BUILDX=$(DIR)/../../hack/init-buildx.sh
 
-TAG ?=v$(shell date +%Y%m%d)-$(shell git rev-parse --short HEAD)
+SHORT_SHA ?=$(shell git rev-parse --short HEAD)
+TAG ?=v$(shell date +%Y%m%d)-$(SHORT_SHA)
+
 REGISTRY ?= local
 
 IMAGE = $(REGISTRY)/go-grpc-greeter-server

--- a/images/go-grpc-greeter-server/cloudbuild.yaml
+++ b/images/go-grpc-greeter-server/cloudbuild.yaml
@@ -8,6 +8,7 @@ steps:
     entrypoint: bash
     env:
       - DOCKER_CLI_EXPERIMENTAL=enabled
+      - SHORT_SHA=$SHORT_SHA
       - BASE_REF=$_PULL_BASE_REF
       - REGISTRY=gcr.io/k8s-staging-ingress-nginx
       # default cloudbuild has HOME=/builder/home and docker buildx is in /root/.docker/cli-plugins/docker-buildx

--- a/images/httpbin/Makefile
+++ b/images/httpbin/Makefile
@@ -18,7 +18,9 @@ SHELL=/bin/bash -o pipefail -o errexit
 DIR:=$(strip $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST)))))
 INIT_BUILDX=$(DIR)/../../hack/init-buildx.sh
 
-TAG ?=v$(shell date +%Y%m%d)-$(shell git rev-parse --short HEAD)
+SHORT_SHA ?=$(shell git rev-parse --short HEAD)
+TAG ?=v$(shell date +%Y%m%d)-$(SHORT_SHA)
+
 REGISTRY ?= local
 
 IMAGE = $(REGISTRY)/e2e-test-httpbin

--- a/images/httpbin/cloudbuild.yaml
+++ b/images/httpbin/cloudbuild.yaml
@@ -8,6 +8,7 @@ steps:
     entrypoint: bash
     env:
       - DOCKER_CLI_EXPERIMENTAL=enabled
+      - SHORT_SHA=$SHORT_SHA
       - BASE_REF=$_PULL_BASE_REF
       - REGISTRY=gcr.io/k8s-staging-ingress-nginx
       # default cloudbuild has HOME=/builder/home and docker buildx is in /root/.docker/cli-plugins/docker-buildx

--- a/images/kube-webhook-certgen/Makefile
+++ b/images/kube-webhook-certgen/Makefile
@@ -19,7 +19,9 @@ SHELL=/bin/bash -o pipefail -o errexit
 DIR:=$(strip $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST)))))
 INIT_BUILDX=$(DIR)/../../hack/init-buildx.sh
 
-TAG ?=v$(shell date +%Y%m%d)-$(shell git rev-parse --short HEAD)
+SHORT_SHA ?=$(shell git rev-parse --short HEAD)
+TAG ?=v$(shell date +%Y%m%d)-$(SHORT_SHA)
+
 REGISTRY ?= local
 
 IMAGE = $(REGISTRY)/kube-webhook-certgen

--- a/images/kube-webhook-certgen/cloudbuild.yaml
+++ b/images/kube-webhook-certgen/cloudbuild.yaml
@@ -21,6 +21,7 @@ steps:
     entrypoint: bash
     env:
       - DOCKER_CLI_EXPERIMENTAL=enabled
+      - SHORT_SHA=$SHORT_SHA
       - BASE_REF=$_PULL_BASE_REF
       - REGISTRY=gcr.io/k8s-staging-ingress-nginx
       # default cloudbuild has HOME=/builder/home and docker buildx is in /root/.docker/cli-plugins/docker-buildx

--- a/images/nginx/Makefile
+++ b/images/nginx/Makefile
@@ -21,7 +21,9 @@ DIR:=$(strip $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST)))))
 INIT_BUILDX=$(DIR)/../../hack/init-buildx.sh
 
 # 0.0.0 shouldn't clobber any released builds
-TAG ?=v$(shell date +%Y%m%d)-$(shell git rev-parse --short HEAD)
+SHORT_SHA ?=$(shell git rev-parse --short HEAD)
+TAG ?=v$(shell date +%Y%m%d)-$(SHORT_SHA)
+
 REGISTRY ?= gcr.io/k8s-staging-ingress-nginx
 
 IMAGE = $(REGISTRY)/nginx

--- a/images/nginx/cloudbuild.yaml
+++ b/images/nginx/cloudbuild.yaml
@@ -8,6 +8,7 @@ steps:
     entrypoint: bash
     env:
       - DOCKER_CLI_EXPERIMENTAL=enabled
+      - SHORT_SHA=$SHORT_SHA
       - BASE_REF=$_PULL_BASE_REF
       - REGISTRY=gcr.io/k8s-staging-ingress-nginx
       - HOME=/root

--- a/images/opentelemetry/Makefile
+++ b/images/opentelemetry/Makefile
@@ -21,7 +21,9 @@ DIR:=$(strip $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST)))))
 INIT_BUILDX=$(DIR)/../../hack/init-buildx.sh
 
 # 0.0.0 shouldn't clobber any released builds
-TAG ?=v$(shell date +%Y%m%d)-$(shell git rev-parse --short HEAD)
+SHORT_SHA ?=$(shell git rev-parse --short HEAD)
+TAG ?=v$(shell date +%Y%m%d)-$(SHORT_SHA)
+
 REGISTRY ?= gcr.io/k8s-staging-ingress-nginx
 
 IMAGE = $(REGISTRY)/opentelemetry

--- a/images/opentelemetry/cloudbuild.yaml
+++ b/images/opentelemetry/cloudbuild.yaml
@@ -8,6 +8,7 @@ steps:
     entrypoint: bash
     env:
       - DOCKER_CLI_EXPERIMENTAL=enabled
+      - SHORT_SHA=$SHORT_SHA
       - BASE_REF=$_PULL_BASE_REF
       - REGISTRY=gcr.io/k8s-staging-ingress-nginx
       # default cloudbuild has HOME=/builder/home and docker buildx is in /root/.docker/cli-plugins/docker-buildx

--- a/images/test-runner/Makefile
+++ b/images/test-runner/Makefile
@@ -18,7 +18,9 @@ SHELL=/bin/bash -o pipefail -o errexit
 DIR:=$(strip $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST)))))
 INIT_BUILDX=$(DIR)/../../hack/init-buildx.sh
 
-TAG ?=v$(shell date +%Y%m%d)-$(shell git rev-parse --short HEAD)
+SHORT_SHA ?=$(shell git rev-parse --short HEAD)
+TAG ?=v$(shell date +%Y%m%d)-$(SHORT_SHA)
+
 REGISTRY ?= local
 
 IMAGE = $(REGISTRY)/e2e-test-runner

--- a/images/test-runner/cloudbuild.yaml
+++ b/images/test-runner/cloudbuild.yaml
@@ -6,6 +6,7 @@ steps:
     entrypoint: bash
     env:
       - DOCKER_CLI_EXPERIMENTAL=enabled
+      - SHORT_SHA=$SHORT_SHA
       - BASE_REF=$_PULL_BASE_REF
       - REGISTRY=gcr.io/k8s-staging-ingress-nginx
       # default cloudbuild has HOME=/builder/home and docker buildx is in /root/.docker/cli-plugins/docker-buildx


### PR DESCRIPTION
ensure all images have the same tag format. 

SHORT_SHA ?=$(shell git rev-parse --short HEAD)
TAG ?=v$(shell date +%Y%m%d)-$(SHORT_SHA)

Short sha will came from gcloud substitutions since our gcloud runner doesn't have git installed. 