### PR TITLE
[helm] Support custom port configuration for internal service

### DIFF
--- a/charts/ingress-nginx/README.md
+++ b/charts/ingress-nginx/README.md
@@ -406,6 +406,8 @@ As of version `1.26.0` of this chart, by simply not providing any clusterIP valu
 | controller.service.internal.annotations | object | `{}` | Annotations are mandatory for the load balancer to come up. Varies with the cloud service. |
 | controller.service.internal.enabled | bool | `false` | Enables an additional internal load balancer (besides the external one). |
 | controller.service.internal.loadBalancerSourceRanges | list | `[]` | Restrict access For LoadBalancer service. Defaults to 0.0.0.0/0. |
+| controller.service.internal.ports | object | `{}` | Custom port mapping for internal service |
+| controller.service.internal.targetPorts | object | `{}` | Custom target port mapping for internal service |
 | controller.service.ipFamilies | list | `["IPv4"]` | List of IP families (e.g. IPv4, IPv6) assigned to the service. This field is usually assigned automatically based on cluster configuration and the ipFamilyPolicy field. # Ref: https://kubernetes.io/docs/concepts/services-networking/dual-stack/ |
 | controller.service.ipFamilyPolicy | string | `"SingleStack"` | Represents the dual-stack-ness requested or required by this Service. Possible values are SingleStack, PreferDualStack or RequireDualStack. The ipFamilies and clusterIPs fields depend on the value of this field. # Ref: https://kubernetes.io/docs/concepts/services-networking/dual-stack/ |
 | controller.service.labels | object | `{}` |  |

--- a/charts/ingress-nginx/ci/deployment-internal-lb-values.yaml
+++ b/charts/ingress-nginx/ci/deployment-internal-lb-values.yaml
@@ -11,3 +11,9 @@ controller:
       enabled: true
       annotations:
         service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+      ports:
+        http: 443
+        https: 80
+      targetPorts:
+        http: 443
+        https: 80

--- a/charts/ingress-nginx/templates/controller-service-internal.yaml
+++ b/charts/ingress-nginx/templates/controller-service-internal.yaml
@@ -29,9 +29,9 @@ spec:
   {{- $setNodePorts := (or (eq .Values.controller.service.type "NodePort") (eq .Values.controller.service.type "LoadBalancer")) }}
   {{- if .Values.controller.service.enableHttp }}
     - name: http
-      port: {{ .Values.controller.service.ports.http }}
+      port: {{ .Values.controller.service.internal.ports.http | default .Values.controller.service.ports.http }}
       protocol: TCP
-      targetPort: {{ .Values.controller.service.targetPorts.http }}
+      targetPort: {{ .Values.controller.service.internal.targetPorts.http | default .Values.controller.service.targetPorts.http }}
     {{- if semverCompare ">=1.20" .Capabilities.KubeVersion.Version }}
       appProtocol: http
     {{- end }}
@@ -41,9 +41,9 @@ spec:
   {{- end }}
   {{- if .Values.controller.service.enableHttps }}
     - name: https
-      port: {{ .Values.controller.service.ports.https }}
+      port: {{ .Values.controller.service.internal.ports.https | default .Values.controller.service.ports.https }}
       protocol: TCP
-      targetPort: {{ .Values.controller.service.targetPorts.https }}
+      targetPort: {{ .Values.controller.service.internal.targetPorts.https | default .Values.controller.service.targetPorts.https }}
     {{- if semverCompare ">=1.20" .Capabilities.KubeVersion.Version }}
       appProtocol: https
     {{- end }}

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -482,6 +482,17 @@ controller:
       ## providers supporting it
       ## Ref: https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typeloadbalancer
       # externalTrafficPolicy: ""
+
+      # -- Custom port mapping for internal service
+      ports: {}
+      #  http: 80
+      #  https: 443
+
+      # -- Custom target port mapping for internal service
+      targetPorts: {}
+      #  http: http
+      #  https: https
+
   # shareProcessNamespace enables process namespace sharing within the pod.
   # This can be used for example to signal log rotation using `kill -USR1` from a sidecar.
   shareProcessNamespace: false


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
I have to implement [Azure Private Link service](https://learn.microsoft.com/en-us/azure/private-link/private-link-service-overview) on my setup. I have to support proxy_protocol in additional to the normal listeners to gain the client ip addresses from the Private Link Services. All my ingress services should be exposed through the public and the internal loadbalancer (which will be exposed to customers through Private Link Services). Setup a 2nd ingress controller and duplicate all ingress objects feel like unnecessary overhead. I'm currently trying to handle both if one ingress-nginx installation.

At least I could archive a working configuration:

```yaml
defaultBackend:
  enabled: true

controller:
  containerPort:
    http: 80
    https: 443
    http-proxy: 5080
    https-proxy: 5443
  config:
    use-proxy-protocol: false
    http-snippet: |
      server {
        server_name _ ;

        listen 5080 default_server reuseport backlog=4096;
        listen 5443 default_server reuseport backlog=4096 ssl http2;
      
        deny all;
      }
    server-snippet: |
      listen 5080;
      listen 5443 ssl http2;
      real_ip_header proxy_protocol;
  service:
    type: ClusterIP
    external:
      enabled: true
    internal:
      enabled: true
      annotations:
        service.beta.kubernetes.io/azure-load-balancer-internal: "true"
        service.beta.kubernetes.io/azure-pls-create: "true"
        service.beta.kubernetes.io/azure-pls-proxy-protocol: "true"
      # needs to be implemented
      targetPorts:
        http: http-proxy
        https: https-proxy
```

At the moment, the internal and external service maps the the same port. In my use case, I would like to remap the http port of the internal service to 5080.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
Minikube, lokal developement and curl

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Added Release Notes.

## Does my pull request need a release note?
Any user-visible or operator-visible change qualifies for a release note. This could be a:

- CLI change
- API change
- UI change
- configuration schema change
- behavioral change
- change in non-functional attributes such as efficiency or availability, availability of a new platform
- a warning about a deprecation
- fix of a previous Known Issue
- fix of a vulnerability (CVE)

No release notes are required for changes to the following:

- Tests
- Build infrastructure
- Fixes for unreleased bugs

For more tips on writing good release notes, check out the [Release Notes Handbook](https://github.com/kubernetes/sig-release/tree/master/release-team/role-handbooks/release-notes)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[helm] Support custom port configuration for internal service
```
