### PR TITLE
EWMA score adjusted by success rate when backend services fail fast

### DIFF
--- a/internal/ingress/controller/template/configmap.go
+++ b/internal/ingress/controller/template/configmap.go
@@ -78,6 +78,8 @@ var (
 		"balancer_ewma":                 10240,
 		"balancer_ewma_last_touched_at": 10240,
 		"balancer_ewma_locks":           1024,
+		"balancer_ewma_total":           10240,
+		"balancer_ewma_failed":          10240,
 		"certificate_servers":           5120,
 		"ocsp_response_cache":           5120, // keep this same as certificate_servers
 		"global_throttle_cache":         10240,

--- a/rootfs/etc/nginx/lua/balancer/ewma.lua
+++ b/rootfs/etc/nginx/lua/balancer/ewma.lua
@@ -25,6 +25,7 @@ local INFO = ngx.INFO
 local DECAY_TIME = 10 -- this value is in seconds
 local LOCK_KEY = ":ewma_key"
 local PICK_SET_SIZE = 2
+local MIN_SUCCESS_RATE = 0.1
 
 local ewma_lock, ewma_lock_err = resty_lock:new("balancer_ewma_locks", {timeout = 0, exptime = 0.1})
 if not ewma_lock then
@@ -62,7 +63,7 @@ local function decay_ewma(ewma, last_touched_at, rtt, now)
   return ewma
 end
 
-local function store_stats(upstream, ewma, now)
+local function store_stats(upstream, ewma, total_ewma, failed_ewma, now)
   local success, err, forcible = ngx.shared.balancer_ewma_last_touched_at:set(upstream, now)
   if not success then
     ngx.log(ngx.WARN, "balancer_ewma_last_touched_at:set failed " .. err)
@@ -78,31 +79,70 @@ local function store_stats(upstream, ewma, now)
   if forcible then
     ngx.log(ngx.WARN, "balancer_ewma:set valid items forcibly overwritten")
   end
+
+  success, err, forcible = ngx.shared.balancer_ewma_total:set(upstream, total_ewma)
+  if not success then
+    ngx.log(ngx.WARN, "balancer_ewma_total:set failed " .. err)
+  end
+  if forcible then
+    ngx.log(ngx.WARN, "balancer_ewma_total:set valid items forcibly overwritten")
+  end
+
+  success, err, forcible = ngx.shared.balancer_ewma_failed:set(upstream, failed_ewma)
+  if not success then
+    ngx.log(ngx.WARN, "balancer_ewma_failed:set failed " .. err)
+  end
+  if forcible then
+    ngx.log(ngx.WARN, "balancer_ewma_failed:set valid items forcibly overwritten")
+  end
 end
 
-local function get_or_update_ewma(upstream, rtt, update)
+local function get_or_update_ewma(upstream, rtt, failed, update)
   local lock_err = nil
   if update then
     lock_err = lock(upstream)
   end
+
   local ewma = ngx.shared.balancer_ewma:get(upstream) or 0
+  local total_ewma = ngx.shared.balancer_ewma_total:get(upstream) or 0
+  local failed_ewma = ngx.shared.balancer_ewma_failed:get(upstream) or 0
+
   if lock_err ~= nil then
     return ewma, lock_err
   end
 
   local now = ngx.now()
   local last_touched_at = ngx.shared.balancer_ewma_last_touched_at:get(upstream) or 0
+
   ewma = decay_ewma(ewma, last_touched_at, rtt, now)
+
+  if rtt > 0 then
+    total_ewma = decay_ewma(total_ewma, last_touched_at, 1, now)
+  end
+
+  if failed then
+    failed_ewma = decay_ewma(failed_ewma, last_touched_at, 1, now)
+  end
 
   if not update then
     return ewma, nil
   end
 
-  store_stats(upstream, ewma, now)
+  store_stats(upstream, ewma, total_ewma, failed_ewma, now)
 
   unlock()
 
-  return ewma, nil
+  if rtt == 0 then
+    return ewma, nil
+  else
+    local success_rate = 1 - failed_ewma / total_ewma
+
+    if success_rate < MIN_SUCCESS_RATE then
+      success_rate = MIN_SUCCESS_RATE
+    end
+
+    return ewma / success_rate, nil
+  end
 end
 
 
@@ -115,7 +155,7 @@ local function score(upstream)
   -- Original implementation used names
   -- Endpoints don't have names, so passing in IP:Port as key instead
   local upstream_name = get_upstream_name(upstream)
-  return get_or_update_ewma(upstream_name, 0, false)
+  return get_or_update_ewma(upstream_name, 0, false, false)
 end
 
 -- implementation similar to https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle
@@ -222,14 +262,17 @@ end
 function _M.after_balance(_)
   local response_time = tonumber(split.get_last_value(ngx.var.upstream_response_time)) or 0
   local connect_time = tonumber(split.get_last_value(ngx.var.upstream_connect_time)) or 0
+  local status = tonumber(split.get_last_value(ngx.var.status)) or 0
+
   local rtt = connect_time + response_time
   local upstream = split.get_last_value(ngx.var.upstream_addr)
+  local failed = status >= 400
 
   if util.is_blank(upstream) then
     return
   end
 
-  get_or_update_ewma(upstream, rtt, true)
+  return get_or_update_ewma(upstream, rtt, failed, true)
 end
 
 function _M.sync(self, backend)
@@ -250,6 +293,8 @@ function _M.sync(self, backend)
 
   for _, endpoint_string in ipairs(normalized_endpoints_removed) do
     ngx.shared.balancer_ewma:delete(endpoint_string)
+    ngx.shared.balancer_ewma_total:delete(endpoint_string)
+    ngx.shared.balancer_ewma_failed:delete(endpoint_string)
     ngx.shared.balancer_ewma_last_touched_at:delete(endpoint_string)
   end
 
@@ -257,7 +302,7 @@ function _M.sync(self, backend)
   if slow_start_ewma ~= nil then
     local now = ngx.now()
     for _, endpoint_string in ipairs(normalized_endpoints_added) do
-      store_stats(endpoint_string, slow_start_ewma, now)
+      store_stats(endpoint_string, slow_start_ewma, 0, 0, now)
     end
   end
 end

--- a/rootfs/etc/nginx/lua/test/balancer/ewma_test.lua
+++ b/rootfs/etc/nginx/lua/test/balancer/ewma_test.lua
@@ -16,8 +16,10 @@ local function flush_all_ewma_stats()
   ngx.shared.balancer_ewma_last_touched_at:flush_all()
 end
 
-local function store_ewma_stats(endpoint_string, ewma, touched_at)
+local function store_ewma_stats(endpoint_string, ewma, total_ewma, failed_ewma, touched_at)
   ngx.shared.balancer_ewma:set(endpoint_string, ewma)
+  ngx.shared.balancer_ewma_total:set(endpoint_string, total_ewma)
+  ngx.shared.balancer_ewma_failed:set(endpoint_string, failed_ewma)
   ngx.shared.balancer_ewma_last_touched_at:set(endpoint_string, touched_at)
 end
 
@@ -45,9 +47,9 @@ describe("Balancer ewma", function()
         { address = "10.10.10.3", port = "8080", maxFails = 0, failTimeout = 0 },
       }
     }
-    store_ewma_stats("10.10.10.1:8080", 0.2, ngx_now - 1)
-    store_ewma_stats("10.10.10.2:8080", 0.3, ngx_now - 5)
-    store_ewma_stats("10.10.10.3:8080", 1.2, ngx_now - 20)
+    store_ewma_stats("10.10.10.1:8080", 0.2, 0, 0, ngx_now - 1)
+    store_ewma_stats("10.10.10.2:8080", 0.3, 0, 0, ngx_now - 5)
+    store_ewma_stats("10.10.10.3:8080", 1.2, 0, 0, ngx_now - 20)
 
     instance = balancer_ewma:new(backend)
   end)
@@ -80,6 +82,39 @@ describe("Balancer ewma", function()
 
       assert.are.equals(expected_ewma, ngx.shared.balancer_ewma:get("10.10.10.2:8080"))
       assert.are.equals(ngx_now, ngx.shared.balancer_ewma_last_touched_at:get("10.10.10.2:8080"))
+    end)
+
+    it("updates EWMA stats with failed", function()
+      ngx.var = { upstream_addr = "10.10.10.2:8080", upstream_connect_time = "0.02", upstream_response_time = "0.1", status="400" }
+
+      local score = instance:after_balance()
+
+      local weight = math.exp(-5 / 10)
+      local expected_ewma = 0.3 * weight + 0.12 * (1.0 - weight)
+
+      assert.are.equals(expected_ewma, ngx.shared.balancer_ewma:get(ngx.var.upstream_addr))
+      assert.are.equals(ngx_now, ngx.shared.balancer_ewma_last_touched_at:get(ngx.var.upstream_addr))
+      assert.are.equals(score, expected_ewma / 0.1)
+    end)
+
+    it("updates EWMA stats with multi failed requests", function()
+      ngx.var = { upstream_addr = "10.10.10.2:8080", upstream_connect_time = "0.02", upstream_response_time = "0.1", status="400" }
+
+      store_ewma_stats("10.10.10.2:8080", 0.3, 1, 0, ngx_now - 5)
+
+      local score = instance:after_balance()
+
+      local weight = math.exp(-5 / 10)
+      local expected_ewma = 0.3 * weight + 0.12 * (1.0 - weight)
+
+      local total_ewma = ngx.shared.balancer_ewma_total:get(ngx.var.upstream_addr)
+      local failed_ewma = ngx.shared.balancer_ewma_failed:get(ngx.var.upstream_addr)
+      local success_rate = 1 - failed_ewma/total_ewma
+
+      assert.are.not_equals(0.1, success_rate)
+      assert.are.equals(expected_ewma, ngx.shared.balancer_ewma:get(ngx.var.upstream_addr))
+      assert.are.equals(ngx_now, ngx.shared.balancer_ewma_last_touched_at:get(ngx.var.upstream_addr))
+      assert.are.equals(score, expected_ewma / success_rate)
     end)
   end)
 

--- a/test/data/cleanConf.expected.conf
+++ b/test/data/cleanConf.expected.conf
@@ -21,6 +21,8 @@ http {
 	lua_package_path "/etc/nginx/lua/?.lua;;";
 	
 	lua_shared_dict balancer_ewma 10M;
+	lua_shared_dict balancer_ewma_total 10M;
+	lua_shared_dict balancer_ewma_failed 10M;
 	lua_shared_dict balancer_ewma_last_touched_at 10M;
 	lua_shared_dict balancer_ewma_locks 1M;
 	lua_shared_dict certificate_data 20M;

--- a/test/data/cleanConf.src.conf
+++ b/test/data/cleanConf.src.conf
@@ -38,6 +38,8 @@ http {
     lua_package_path "/etc/nginx/lua/?.lua;;";
 
     lua_shared_dict balancer_ewma 10M;
+lua_shared_dict balancer_ewma_total 10M;
+lua_shared_dict balancer_ewma_failed 10M;
 lua_shared_dict balancer_ewma_last_touched_at 10M;
 lua_shared_dict balancer_ewma_locks 1M;
 lua_shared_dict certificate_data 20M;

--- a/test/test-lua.sh
+++ b/test/test-lua.sh
@@ -32,6 +32,8 @@ SHDICT_ARGS=(
     "--shdict" "certificate_servers 1M"
     "--shdict" "ocsp_response_cache 1M"
     "--shdict" "balancer_ewma 1M"
+    "--shdict" "balancer_ewma_total 1M"
+    "--shdict" "balancer_ewma_failed 1M"
     "--shdict" "quota_tracker 1M"
     "--shdict" "high_throughput_tracker 1M"
     "--shdict" "balancer_ewma_last_touched_at 1M"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

PeakEWMA (or EWMA) is a latency-based load balancing algorithm. Latency-based load balancing algorithms are all based on the premise that the cost of processing requests is the same. But as we all know, user input is untrustworthy, and all backend services will verify user (or other service) input, and once the verification fails, the request will not be processed and the result will be returned quickly, which will lead to The load balancing algorithm gets a wrong view: this request is processed very quickly.

$$
\begin{align}
Avg  &= (\sum_{i=1}^{SuccessCount}SuccessDuration_i + \sum_{i=1}^{FailedCount}FailedDuration_i) / TotalCount \\
        &\approx \sum_{i=1}^{SuccessCount}SuccessDuration_i / TotalCount \\
        &\ll \sum_{i=1}^{SuccessCount}SuccessDuration_i / SuccessCount
\end{align}
$$

This problem is also described in *["The Site Reliability Workbook: Practical Ways to Implement SRE"](https://www.amazon.com/Site-Reliability-Workbook-Practical-Implement/dp/1492029505)*. When the resource-based load balancing algorithm encounters fail-fast, traffic will skew to the abnormal server.

We need a mathematical model to fix this wrong view. The easiest ways to do this is to fix all response times to the same value as the `SuccessDuration`

$$
\begin{align}
FixedAvg &= Avg / \alpha \\
SuccessCount &= \alpha TotalCount \\
\alpha &= SuccessCount / TotalCount
\end{align}
$$

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

All effects are limited to ewma load balancer, so I only added test cases for EWMA. I mocked the failed response and tested for changes in the EWMA value.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [x] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Added Release Notes.

## Does my pull request need a release note?
Any user-visible or operator-visible change qualifies for a release note. This could be a:

- CLI change
- API change
- UI change
- configuration schema change
- behavioral change
- change in non-functional attributes such as efficiency or availability, availability of a new platform
- a warning about a deprecation
- fix of a previous Known Issue
- fix of a vulnerability (CVE)

No release notes are required for changes to the following:

- Tests
- Build infrastructure
- Fixes for unreleased bugs

For more tips on writing good release notes, check out the [Release Notes Handbook](https://github.com/kubernetes/sig-release/tree/master/release-team/role-handbooks/release-notes)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
EWMA score adjusted by success rate when backend services fail fast (@jizhuozhi)
```
