### PR TITLE
Fix mirror-target values without path separator and port

### DIFF
--- a/docs/user-guide/nginx-configuration/annotations.md
+++ b/docs/user-guide/nginx-configuration/annotations.md
@@ -945,9 +945,6 @@ The mirror backend can be set by applying:
 nginx.ingress.kubernetes.io/mirror-target: https://test.env.com/$request_uri
 ```
 
-!!! attention
-    When `nginx.ingress.kubernetes.io/mirror-host` is not defined, the `Host` header value is extracted from `nginx.ingress.kubernetes.io/mirror-target`, which is processed using [`url.Parse`](https://pkg.go.dev/net/url#Parse). However, if there is no `/` separator, `url.Parse` is unable to distinguish between additional path variables and the port number in the `mirror-target` value.
-
 By default the request-body is sent to the mirror backend, but can be turned off by applying:
 
 ```yaml

--- a/docs/user-guide/nginx-configuration/annotations.md
+++ b/docs/user-guide/nginx-configuration/annotations.md
@@ -945,6 +945,9 @@ The mirror backend can be set by applying:
 nginx.ingress.kubernetes.io/mirror-target: https://test.env.com/$request_uri
 ```
 
+!!! attention
+    When `nginx.ingress.kubernetes.io/mirror-host` is not defined, the `Host` header value is extracted from `nginx.ingress.kubernetes.io/mirror-target`, which is processed using [`url.Parse`](https://pkg.go.dev/net/url#Parse). However, if there is no `/` separator, `url.Parse` is unable to distinguish between additional path variables and the port number in the `mirror-target` value.
+
 By default the request-body is sent to the mirror backend, but can be turned off by applying:
 
 ```yaml

--- a/internal/ingress/annotations/mirror/main.go
+++ b/internal/ingress/annotations/mirror/main.go
@@ -93,12 +93,13 @@ func (a mirror) Parse(ing *networking.Ingress) (interface{}, error) {
 	config.Host, err = parser.GetStringAnnotation("mirror-host", ing)
 	if err != nil {
 		if config.Target != "" {
-			url, err := parser.StringToURL(config.Target)
+			target := strings.Split(config.Target, "$")
+
+			url, err := parser.StringToURL(target[0])
 			if err != nil {
 				config.Host = ""
 			} else {
-				hostname := strings.Split(url.Hostname(), "$")
-				config.Host = hostname[0]
+				config.Host = url.Hostname()
 			}
 		}
 	}

--- a/internal/ingress/annotations/mirror/main_test.go
+++ b/internal/ingress/annotations/mirror/main_test.go
@@ -48,6 +48,24 @@ func TestParse(t *testing.T) {
 			Target:      "https://test.env.com/$request_uri",
 			Host:        "test.env.com",
 		}},
+		{map[string]string{backendURL: "https://test.env.com$request_uri"}, &Config{
+			Source:      ngxURI,
+			RequestBody: "on",
+			Target:      "https://test.env.com$request_uri",
+			Host:        "test.env.com",
+		}},
+		{map[string]string{backendURL: "https://test.env.com:8080$request_uri"}, &Config{
+			Source:      ngxURI,
+			RequestBody: "on",
+			Target:      "https://test.env.com:8080$request_uri",
+			Host:        "test.env.com",
+		}},
+		{map[string]string{backendURL: "https://test.env.com:8080/$request_uri"}, &Config{
+			Source:      ngxURI,
+			RequestBody: "on",
+			Target:      "https://test.env.com:8080/$request_uri",
+			Host:        "test.env.com",
+		}},
 		{map[string]string{requestBody: "off"}, &Config{
 			Source:      "",
 			RequestBody: "off",

--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -1727,7 +1727,7 @@ func buildMirrorLocations(locs []*ingress.Location) string {
 	mapped := sets.Set[string]{}
 
 	for _, loc := range locs {
-		if loc.Mirror.Source == "" || loc.Mirror.Target == "" {
+		if loc.Mirror.Source == "" || loc.Mirror.Target == "" || loc.Mirror.Host == "" {
 			continue
 		}
 
@@ -1738,8 +1738,8 @@ func buildMirrorLocations(locs []*ingress.Location) string {
 		mapped.Insert(loc.Mirror.Source)
 		buffer.WriteString(fmt.Sprintf(`location = %v {
 internal;
-proxy_set_header Host %v;
-proxy_pass %v;
+proxy_set_header Host "%v";
+proxy_pass "%v";
 }
 
 `, loc.Mirror.Source, loc.Mirror.Host, loc.Mirror.Target))

--- a/test/e2e/annotations/mirror.go
+++ b/test/e2e/annotations/mirror.go
@@ -60,7 +60,7 @@ var _ = framework.DescribeAnnotation("mirror-*", func() {
 			func(server string) bool {
 				return strings.Contains(server, fmt.Sprintf("mirror /_mirror-%v;", ing.UID)) &&
 					strings.Contains(server, "mirror_request_body on;") &&
-					strings.Contains(server, "proxy_pass https://test.env.com/$request_uri;")
+					strings.Contains(server, `proxy_pass "https://test.env.com/$request_uri";`)
 			})
 	})
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Bug report in https://github.com/kubernetes/ingress-nginx/issues/9898

Ingress resources with annotation `nginx.ingress.kubernetes.io/mirror-target` and a value like `http://my-host.org:8080$request_uri` (note there is no `/` between the port and the $) cause ingress-nginx pods to crash (Tested with `v1.3.1` but relevant code portions did not change since then).

Parsing the url using golangs `url.Parse` would fail because of a missing `/` separator. This caused the `Host` portion of the mirror config to be set to an empty string which then would make the internal nginx instance unhappy. (emergency exit).

This PR changes
- How the host header is extracted from the annotation value
- How the extracted values are being rendered into the nginx template

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tests have been added.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [x] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] Added Release Notes.

## Does my pull request need a release note?
Any user-visible or operator-visible change qualifies for a release note. This could be a:

- CLI change
- API change
- UI change
- configuration schema change
- behavioral change
- change in non-functional attributes such as efficiency or availability, availability of a new platform
- a warning about a deprecation
- fix of a previous Known Issue
- fix of a vulnerability (CVE)

No release notes are required for changes to the following:

- Tests
- Build infrastructure
- Fixes for unreleased bugs

For more tips on writing good release notes, check out the [Release Notes Handbook](https://github.com/kubernetes/sig-release/tree/master/release-team/role-handbooks/release-notes)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Prevent rendering invalid ngx_http_mirror_module templates
```
