### PR TITLE
chore: move httpbun to be part of E2E framework

### DIFF
--- a/test/e2e/HTTPBUN_IMAGE
+++ b/test/e2e/HTTPBUN_IMAGE
@@ -1,0 +1,1 @@
+registry.k8s.io/ingress-nginx/e2e-test-httpbun:v20230505-v0.0.1

--- a/test/e2e/framework/deployment.go
+++ b/test/e2e/framework/deployment.go
@@ -43,12 +43,28 @@ const HTTPBunService = "httpbun"
 // NipService name of external service using nip.io
 const NIPService = "external-nip"
 
+// HTTPBunImage is the default image that is used to deploy HTTPBun with the framwork
+var HTTPBunImage = os.Getenv("HTTPBUN_IMAGE")
+
+// EchoImage is the default image to be used by the echo service
+const EchoImage = "registry.k8s.io/ingress-nginx/e2e-test-echo@sha256:4938d1d91a2b7d19454460a8c1b010b89f6ff92d2987fd889ac3e8fc3b70d91a"
+
+// TODO: change all Deployment functions to use these options
+// in order to reduce complexity and have a unified API accross the
+// framework
 type deploymentOptions struct {
-	namespace      string
 	name           string
-	replicas       int
-	svcAnnotations map[string]string
+	namespace      string
 	image          string
+	port           int32
+	replicas       int
+	command        []string
+	args           []string
+	env            []corev1.EnvVar
+	volumeMounts   []corev1.VolumeMount
+	volumes        []corev1.Volume
+	svcAnnotations map[string]string
+	setProbe       bool
 }
 
 // WithDeploymentNamespace allows configuring the deployment's namespace
@@ -100,22 +116,25 @@ func (f *Framework) NewEchoDeployment(opts ...func(*deploymentOptions)) {
 		namespace: f.Namespace,
 		name:      EchoService,
 		replicas:  1,
-		image:     "registry.k8s.io/ingress-nginx/e2e-test-echo@sha256:6fc5aa2994c86575975bb20a5203651207029a0d28e3f491d8a127d08baadab4",
+		image:     EchoImage,
 	}
 	for _, o := range opts {
 		o(options)
 	}
 
-	deployment := newDeployment(options.name, options.namespace, options.image, 80, int32(options.replicas),
+	f.EnsureDeployment(newDeployment(
+		options.name,
+		options.namespace,
+		options.image,
+		80,
+		int32(options.replicas),
 		nil, nil, nil,
 		[]corev1.VolumeMount{},
 		[]corev1.Volume{},
 		true,
-	)
+	))
 
-	f.EnsureDeployment(deployment)
-
-	service := &corev1.Service{
+	f.EnsureService(&corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        options.name,
 			Namespace:   options.namespace,
@@ -134,17 +153,27 @@ func (f *Framework) NewEchoDeployment(opts ...func(*deploymentOptions)) {
 				"app": options.name,
 			},
 		},
-	}
+	})
 
-	f.EnsureService(service)
-
-	err := WaitForEndpoints(f.KubeClientSet, DefaultTimeout, options.name, options.namespace, options.replicas)
+	err := WaitForEndpoints(
+		f.KubeClientSet,
+		DefaultTimeout,
+		options.name,
+		options.namespace,
+		options.replicas,
+	)
 	assert.Nil(ginkgo.GinkgoT(), err, "waiting for endpoints to become ready")
 }
 
 // BuildNipHost used to generate a nip host for DNS resolving
 func BuildNIPHost(ip string) string {
 	return fmt.Sprintf("%s.nip.io", ip)
+}
+
+// GetNipHost used to generate a nip host for external DNS resolving
+// for the instance deployed by the framework
+func (f *Framework) GetNIPHost() string {
+	return BuildNIPHost(f.HTTPBunIP)
 }
 
 // BuildNIPExternalNameService used to generate a service pointing to nip.io to
@@ -177,22 +206,27 @@ func (f *Framework) NewHttpbunDeployment(opts ...func(*deploymentOptions)) strin
 		namespace: f.Namespace,
 		name:      HTTPBunService,
 		replicas:  1,
-		image:     "registry.k8s.io/ingress-nginx/e2e-test-httpbun:v20230505-v0.0.1",
+		image:     HTTPBunImage,
 	}
 	for _, o := range opts {
 		o(options)
 	}
 
-	deployment := newDeployment(options.name, options.namespace, options.image, 80, int32(options.replicas),
+	// Create the HTTPBun Deployment
+	f.EnsureDeployment(newDeployment(
+		options.name,
+		options.namespace,
+		options.image,
+		80,
+		int32(options.replicas),
 		nil, nil, nil,
 		[]corev1.VolumeMount{},
 		[]corev1.Volume{},
 		true,
-	)
+	))
 
-	f.EnsureDeployment(deployment)
-
-	service := &corev1.Service{
+	// Create a service pointing to deployment
+	f.EnsureService(&corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        options.name,
 			Namespace:   options.namespace,
@@ -211,14 +245,26 @@ func (f *Framework) NewHttpbunDeployment(opts ...func(*deploymentOptions)) strin
 				"app": options.name,
 			},
 		},
-	}
+	})
 
-	s := f.EnsureService(service)
-
-	err := WaitForEndpoints(f.KubeClientSet, DefaultTimeout, options.name, options.namespace, options.replicas)
+	// Wait for deployment to become available
+	err := WaitForEndpoints(
+		f.KubeClientSet,
+		DefaultTimeout,
+		options.name,
+		options.namespace,
+		options.replicas,
+	)
 	assert.Nil(ginkgo.GinkgoT(), err, "waiting for endpoints to become ready")
 
-	return s.Spec.ClusterIPs[0]
+	// Get cluster ip for HTTPBun to be used in tests
+	e, err := f.KubeClientSet.
+		CoreV1().
+		Endpoints(f.Namespace).
+		Get(context.TODO(), HTTPBunService, metav1.GetOptions{})
+	assert.Nil(ginkgo.GinkgoT(), err, "failed to get httpbun endpoint")
+
+	return e.Subsets[0].Addresses[0].IP
 }
 
 // NewSlowEchoDeployment creates a new deployment of the slow echo server image in a particular namespace.
@@ -276,13 +322,16 @@ func (f *Framework) NGINXDeployment(name string, cfg string, waitendpoint bool) 
 		"nginx.conf": cfg,
 	}
 
-	_, err := f.KubeClientSet.CoreV1().ConfigMaps(f.Namespace).Create(context.TODO(), &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: f.Namespace,
-		},
-		Data: cfgMap,
-	}, metav1.CreateOptions{})
+	_, err := f.KubeClientSet.
+		CoreV1().
+		ConfigMaps(f.Namespace).
+		Create(context.TODO(), &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: f.Namespace,
+			},
+			Data: cfgMap,
+		}, metav1.CreateOptions{})
 	assert.Nil(ginkgo.GinkgoT(), err, "creating configmap")
 
 	deployment := newDeployment(name, f.Namespace, f.GetNginxBaseImage(), 80, 1,

--- a/test/e2e/run-e2e-suite.sh
+++ b/test/e2e/run-e2e-suite.sh
@@ -51,6 +51,7 @@ fi
 
 BASEDIR=$(dirname "$0")
 NGINX_BASE_IMAGE=$(cat $BASEDIR/../../NGINX_BASE)
+HTTPBUN_IMAGE=$(cat $BASEDIR/HTTPBUN_IMAGE)
 
 echo -e "${BGREEN}Granting permissions to ingress-nginx e2e service account...${NC}"
 kubectl create serviceaccount ingress-nginx-e2e || true
@@ -79,6 +80,7 @@ kubectl run --rm \
   --env="IS_CHROOT=${IS_CHROOT:-false}"\
   --env="E2E_CHECK_LEAKS=${E2E_CHECK_LEAKS}" \
   --env="NGINX_BASE_IMAGE=${NGINX_BASE_IMAGE}" \
+  --env="HTTPBUN_IMAGE=${HTTPBUN_IMAGE}" \
   --overrides='{ "apiVersion": "v1", "spec":{"serviceAccountName": "ingress-nginx-e2e"}}' \
   e2e --image=nginx-ingress-controller:e2e
 

--- a/test/e2e/servicebackend/service_externalname.go
+++ b/test/e2e/servicebackend/service_externalname.go
@@ -35,7 +35,7 @@ import (
 )
 
 var _ = framework.IngressNginxDescribe("[Service] Type ExternalName", func() {
-	f := framework.NewDefaultFramework("type-externalname")
+	f := framework.NewDefaultFramework("type-externalname", framework.WithHTTPBunEnabled())
 
 	ginkgo.It("works with external name set to incomplete fqdn", func() {
 		f.NewEchoDeployment()
@@ -43,7 +43,7 @@ var _ = framework.IngressNginxDescribe("[Service] Type ExternalName", func() {
 
 		svc := &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      framework.HTTPBunService,
+				Name:      framework.NIPService,
 				Namespace: f.Namespace,
 			},
 			Spec: corev1.ServiceSpec{
@@ -51,10 +51,15 @@ var _ = framework.IngressNginxDescribe("[Service] Type ExternalName", func() {
 				Type:         corev1.ServiceTypeExternalName,
 			},
 		}
-
 		f.EnsureService(svc)
 
-		ing := framework.NewSingleIngress(host, "/", host, f.Namespace, framework.HTTPBunService, 80, nil)
+		ing := framework.NewSingleIngress(host,
+			"/",
+			host,
+			f.Namespace,
+			framework.NIPService,
+			80,
+			nil)
 		f.EnsureIngress(ing)
 
 		f.WaitForNginxServer(host,
@@ -70,10 +75,6 @@ var _ = framework.IngressNginxDescribe("[Service] Type ExternalName", func() {
 	})
 
 	ginkgo.It("should return 200 for service type=ExternalName without a port defined", func() {
-		// This is a workaround so we only depend on a self hosted instance of
-		// httpbun
-		ip := f.NewHttpbunDeployment()
-
 		host := "echo"
 
 		svc := &corev1.Service{
@@ -82,17 +83,23 @@ var _ = framework.IngressNginxDescribe("[Service] Type ExternalName", func() {
 				Namespace: f.Namespace,
 			},
 			Spec: corev1.ServiceSpec{
-				ExternalName: framework.BuildNIPHost(ip),
+				ExternalName: f.GetNIPHost(),
 				Type:         corev1.ServiceTypeExternalName,
 			},
 		}
-
 		f.EnsureService(svc)
 
 		annotations := map[string]string{
-			"nginx.ingress.kubernetes.io/upstream-vhost": framework.BuildNIPHost(ip),
+			"nginx.ingress.kubernetes.io/upstream-vhost": f.GetNIPHost(),
 		}
-		ing := framework.NewSingleIngress(host, "/", host, f.Namespace, framework.HTTPBunService, 80, annotations)
+
+		ing := framework.NewSingleIngress(host,
+			"/",
+			host,
+			f.Namespace,
+			framework.HTTPBunService,
+			80,
+			annotations)
 		f.EnsureIngress(ing)
 
 		f.WaitForNginxServer(host,
@@ -108,19 +115,21 @@ var _ = framework.IngressNginxDescribe("[Service] Type ExternalName", func() {
 	})
 
 	ginkgo.It("should return 200 for service type=ExternalName with a port defined", func() {
-		// This is a workaround so we only depend on a self hosted instance of
-		// httpbun
-		ip := f.NewHttpbunDeployment()
-
 		host := "echo"
 
-		svc := framework.BuildNIPExternalNameService(f, ip, host)
+		svc := framework.BuildNIPExternalNameService(f, f.HTTPBunIP, host)
 		f.EnsureService(svc)
 
 		annotations := map[string]string{
-			"nginx.ingress.kubernetes.io/upstream-vhost": framework.BuildNIPHost(ip),
+			"nginx.ingress.kubernetes.io/upstream-vhost": f.GetNIPHost(),
 		}
-		ing := framework.NewSingleIngress(host, "/", host, f.Namespace, framework.HTTPBunService, 80, annotations)
+		ing := framework.NewSingleIngress(host,
+			"/",
+			host,
+			f.Namespace,
+			framework.HTTPBunService,
+			80,
+			annotations)
 		f.EnsureIngress(ing)
 
 		f.WaitForNginxServer(host,
@@ -140,7 +149,7 @@ var _ = framework.IngressNginxDescribe("[Service] Type ExternalName", func() {
 
 		svc := &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      framework.HTTPBunService,
+				Name:      framework.NIPService,
 				Namespace: f.Namespace,
 			},
 			Spec: corev1.ServiceSpec{
@@ -148,10 +157,15 @@ var _ = framework.IngressNginxDescribe("[Service] Type ExternalName", func() {
 				Type:         corev1.ServiceTypeExternalName,
 			},
 		}
-
 		f.EnsureService(svc)
 
-		ing := framework.NewSingleIngress(host, "/", host, f.Namespace, framework.HTTPBunService, 80, nil)
+		ing := framework.NewSingleIngress(host,
+			"/",
+			host,
+			f.Namespace,
+			framework.NIPService,
+			80,
+			nil)
 		f.EnsureIngress(ing)
 
 		f.WaitForNginxServer(host,
@@ -167,19 +181,22 @@ var _ = framework.IngressNginxDescribe("[Service] Type ExternalName", func() {
 	})
 
 	ginkgo.It("should return 200 for service type=ExternalName using a port name", func() {
-		// This is a workaround so we only depend on a self hosted instance of
-		// httpbun
-		ip := f.NewHttpbunDeployment()
-
 		host := "echo"
 
-		svc := framework.BuildNIPExternalNameService(f, ip, host)
+		svc := framework.BuildNIPExternalNameService(f, f.HTTPBunIP, host)
 		f.EnsureService(svc)
 
 		annotations := map[string]string{
-			"nginx.ingress.kubernetes.io/upstream-vhost": framework.BuildNIPHost(ip),
+			"nginx.ingress.kubernetes.io/upstream-vhost": f.GetNIPHost(),
 		}
-		ing := framework.NewSingleIngress(host, "/", host, f.Namespace, framework.HTTPBunService, 80, annotations)
+		ing := framework.NewSingleIngress(host,
+			"/",
+			host,
+			f.Namespace,
+			framework.HTTPBunService,
+			80,
+			annotations)
+
 		namedBackend := networking.IngressBackend{
 			Service: &networking.IngressServiceBackend{
 				Name: framework.NIPService,
@@ -188,6 +205,7 @@ var _ = framework.IngressNginxDescribe("[Service] Type ExternalName", func() {
 				},
 			},
 		}
+
 		ing.Spec.Rules[0].HTTP.Paths[0].Backend = namedBackend
 		f.EnsureIngress(ing)
 
@@ -204,10 +222,6 @@ var _ = framework.IngressNginxDescribe("[Service] Type ExternalName", func() {
 	})
 
 	ginkgo.It("should return 200 for service type=ExternalName using FQDN with trailing dot", func() {
-		// This is a workaround so we only depend on a self hosted instance of
-		// httpbun
-		ip := f.NewHttpbunDeployment()
-
 		host := "echo"
 
 		svc := &corev1.Service{
@@ -216,14 +230,19 @@ var _ = framework.IngressNginxDescribe("[Service] Type ExternalName", func() {
 				Namespace: f.Namespace,
 			},
 			Spec: corev1.ServiceSpec{
-				ExternalName: framework.BuildNIPHost(ip),
+				ExternalName: f.GetNIPHost(),
 				Type:         corev1.ServiceTypeExternalName,
 			},
 		}
-
 		f.EnsureService(svc)
 
-		ing := framework.NewSingleIngress(host, "/", host, f.Namespace, framework.HTTPBunService, 80, nil)
+		ing := framework.NewSingleIngress(host,
+			"/",
+			host,
+			f.Namespace,
+			framework.HTTPBunService,
+			80,
+			nil)
 		f.EnsureIngress(ing)
 
 		f.WaitForNginxServer(host,
@@ -239,20 +258,23 @@ var _ = framework.IngressNginxDescribe("[Service] Type ExternalName", func() {
 	})
 
 	ginkgo.It("should update the external name after a service update", func() {
-		// This is a workaround so we only depend on a self hosted instance of
-		// httpbun
-		ip := f.NewHttpbunDeployment()
-
 		host := "echo"
 
-		svc := framework.BuildNIPExternalNameService(f, ip, host)
+		svc := framework.BuildNIPExternalNameService(f, f.HTTPBunIP, host)
 		f.EnsureService(svc)
 
 		annotations := map[string]string{
-			"nginx.ingress.kubernetes.io/upstream-vhost": framework.BuildNIPHost(ip),
+			"nginx.ingress.kubernetes.io/upstream-vhost": f.GetNIPHost(),
 		}
 
-		ing := framework.NewSingleIngress(host, "/", host, f.Namespace, framework.HTTPBunService, 80, annotations)
+		ing := framework.NewSingleIngress(host,
+			"/",
+			host,
+			f.Namespace,
+			framework.HTTPBunService,
+			80,
+			annotations)
+
 		namedBackend := networking.IngressBackend{
 			Service: &networking.IngressServiceBackend{
 				Name: framework.NIPService,
@@ -279,14 +301,20 @@ var _ = framework.IngressNginxDescribe("[Service] Type ExternalName", func() {
 
 		assert.Contains(ginkgo.GinkgoT(), body, `"X-Forwarded-Host": "echo"`)
 
-		svc, err := f.KubeClientSet.CoreV1().Services(f.Namespace).Get(context.TODO(), framework.NIPService, metav1.GetOptions{})
+		svc, err := f.KubeClientSet.
+			CoreV1().
+			Services(f.Namespace).
+			Get(context.TODO(), framework.NIPService, metav1.GetOptions{})
 		assert.Nil(ginkgo.GinkgoT(), err, "unexpected error obtaining external service")
 
-		ip = f.NewHttpbunDeployment(framework.WithDeploymentName("eu-server"))
-
+		//Deploy a new instance to switch routing to
+		ip := f.NewHttpbunDeployment(framework.WithDeploymentName("eu-server"))
 		svc.Spec.ExternalName = framework.BuildNIPHost(ip)
 
-		_, err = f.KubeClientSet.CoreV1().Services(f.Namespace).Update(context.Background(), svc, metav1.UpdateOptions{})
+		_, err = f.KubeClientSet.
+			CoreV1().
+			Services(f.Namespace).
+			Update(context.Background(), svc, metav1.UpdateOptions{})
 		assert.Nil(ginkgo.GinkgoT(), err, "unexpected error updating external service")
 
 		framework.Sleep()
@@ -302,21 +330,31 @@ var _ = framework.IngressNginxDescribe("[Service] Type ExternalName", func() {
 		assert.Contains(ginkgo.GinkgoT(), body, `"X-Forwarded-Host": "echo"`)
 
 		ginkgo.By("checking the service is updated to use new host")
-		curlCmd := fmt.Sprintf("curl --fail --silent http://localhost:%v/configuration/backends", nginx.StatusPort)
+		curlCmd := fmt.Sprintf(
+			"curl --fail --silent http://localhost:%v/configuration/backends",
+			nginx.StatusPort,
+		)
+
 		output, err := f.ExecIngressPod(curlCmd)
 		assert.Nil(ginkgo.GinkgoT(), err)
-		assert.Contains(ginkgo.GinkgoT(), output, fmt.Sprintf("{\"address\":\"%s\"", framework.BuildNIPHost(ip)))
+		assert.Contains(
+			ginkgo.GinkgoT(),
+			output,
+			fmt.Sprintf("{\"address\":\"%s\"", framework.BuildNIPHost(ip)),
+		)
 	})
 
 	ginkgo.It("should sync ingress on external name service addition/deletion", func() {
-		// This is a workaround so we only depend on a self hosted instance of
-		// httpbun
-		ip := f.NewHttpbunDeployment()
-
 		host := "echo"
 
 		// Create the Ingress first
-		ing := framework.NewSingleIngress(host, "/", host, f.Namespace, framework.NIPService, 80, nil)
+		ing := framework.NewSingleIngress(host,
+			"/",
+			host,
+			f.Namespace,
+			framework.NIPService,
+			80,
+			nil)
 		f.EnsureIngress(ing)
 
 		f.WaitForNginxServer(host,
@@ -332,7 +370,7 @@ var _ = framework.IngressNginxDescribe("[Service] Type ExternalName", func() {
 			Status(http.StatusServiceUnavailable)
 
 		// Now create the service
-		svc := framework.BuildNIPExternalNameService(f, ip, host)
+		svc := framework.BuildNIPExternalNameService(f, f.HTTPBunIP, host)
 		f.EnsureService(svc)
 
 		framework.Sleep()
@@ -345,7 +383,10 @@ var _ = framework.IngressNginxDescribe("[Service] Type ExternalName", func() {
 			Status(http.StatusOK)
 
 		// And back to 503 after deleting the service
-		err := f.KubeClientSet.CoreV1().Services(f.Namespace).Delete(context.TODO(), framework.NIPService, metav1.DeleteOptions{})
+		err := f.KubeClientSet.
+			CoreV1().
+			Services(f.Namespace).
+			Delete(context.TODO(), framework.NIPService, metav1.DeleteOptions{})
 		assert.Nil(ginkgo.GinkgoT(), err, "unexpected error deleting external service")
 
 		framework.Sleep()

--- a/test/e2e/settings/brotli.go
+++ b/test/e2e/settings/brotli.go
@@ -28,13 +28,12 @@ import (
 )
 
 var _ = framework.IngressNginxDescribe("brotli", func() {
-	f := framework.NewDefaultFramework("brotli")
+	f := framework.NewDefaultFramework(
+		"brotli",
+		framework.WithHTTPBunEnabled(),
+	)
 
 	host := "brotli"
-
-	ginkgo.BeforeEach(func() {
-		f.NewHttpbunDeployment()
-	})
 
 	ginkgo.It("should only compress responses that meet the `brotli-min-length` condition", func() {
 		brotliMinLength := 24

--- a/test/e2e/settings/global_external_auth.go
+++ b/test/e2e/settings/global_external_auth.go
@@ -32,7 +32,10 @@ import (
 )
 
 var _ = framework.DescribeSetting("[Security] global-auth-url", func() {
-	f := framework.NewDefaultFramework("global-external-auth")
+	f := framework.NewDefaultFramework(
+		"global-external-auth",
+		framework.WithHTTPBunEnabled(),
+	)
 
 	host := "global-external-auth"
 
@@ -50,7 +53,6 @@ var _ = framework.DescribeSetting("[Security] global-auth-url", func() {
 
 	ginkgo.BeforeEach(func() {
 		f.NewEchoDeployment()
-		f.NewHttpbunDeployment()
 	})
 
 	ginkgo.Context("when global external authentication is configured", func() {
@@ -307,9 +309,9 @@ http {
 			assert.GreaterOrEqual(ginkgo.GinkgoT(), len(e.Subsets), 1, "expected at least one endpoint")
 			assert.GreaterOrEqual(ginkgo.GinkgoT(), len(e.Subsets[0].Addresses), 1, "expected at least one address ready in the endpoint")
 
-			httpbunIP := e.Subsets[0].Addresses[0].IP
+			nginxIP := e.Subsets[0].Addresses[0].IP
 
-			f.UpdateNginxConfigMapData(globalExternalAuthURLSetting, fmt.Sprintf("http://%s/cookies/set/alma/armud", httpbunIP))
+			f.UpdateNginxConfigMapData(globalExternalAuthURLSetting, fmt.Sprintf("http://%s/cookies/set/alma/armud", nginxIP))
 
 			ing1 = framework.NewSingleIngress(host, "/", host, f.Namespace, "http-cookie-with-error", 80, nil)
 			f.EnsureIngress(ing1)

--- a/test/e2e/settings/listen_nondefault_ports.go
+++ b/test/e2e/settings/listen_nondefault_ports.go
@@ -17,14 +17,12 @@ limitations under the License.
 package settings
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"strings"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/stretchr/testify/assert"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"k8s.io/ingress-nginx/test/e2e/framework"
 )
@@ -33,7 +31,7 @@ var _ = framework.IngressNginxDescribe("[Flag] custom HTTP and HTTPS ports", fun
 
 	host := "forwarded-headers"
 
-	f := framework.NewDefaultFramework("forwarded-port-headers")
+	f := framework.NewDefaultFramework("forwarded-port-headers", framework.WithHTTPBunEnabled())
 
 	ginkgo.BeforeEach(func() {
 		f.NewEchoDeployment()
@@ -98,21 +96,8 @@ var _ = framework.IngressNginxDescribe("[Flag] custom HTTP and HTTPS ports", fun
 		ginkgo.Context("when external authentication is configured", func() {
 
 			ginkgo.It("should set the X-Forwarded-Port header to 443", func() {
-				f.NewHttpbunDeployment()
-
-				err := framework.WaitForEndpoints(f.KubeClientSet, framework.DefaultTimeout, framework.HTTPBunService, f.Namespace, 1)
-				assert.Nil(ginkgo.GinkgoT(), err)
-
-				e, err := f.KubeClientSet.CoreV1().Endpoints(f.Namespace).Get(context.TODO(), framework.HTTPBunService, metav1.GetOptions{})
-				assert.Nil(ginkgo.GinkgoT(), err)
-
-				assert.GreaterOrEqual(ginkgo.GinkgoT(), len(e.Subsets), 1, "expected at least one endpoint")
-				assert.GreaterOrEqual(ginkgo.GinkgoT(), len(e.Subsets[0].Addresses), 1, "expected at least one address ready in the endpoint")
-
-				httpbunIP := e.Subsets[0].Addresses[0].IP
-
 				annotations := map[string]string{
-					"nginx.ingress.kubernetes.io/auth-url":    fmt.Sprintf("http://%s/basic-auth/user/password", httpbunIP),
+					"nginx.ingress.kubernetes.io/auth-url":    fmt.Sprintf("http://%s/basic-auth/user/password", f.HTTPBunIP),
 					"nginx.ingress.kubernetes.io/auth-signin": "http://$host/auth/start",
 				}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
<!--- Please make sure you title is descriptive, it is used in the Release notes to let others know what it does ---> 

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Moving the HttpBun deployment to be part of the E2E testing framework so that we can reduce complexity of the tests


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->
fixes: https://github.com/kubernetes/ingress-nginx/issues/9947

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested by running the E2E tests and validating that they all pass as expected

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.
