### PR TITLE
Validate path types

### DIFF
--- a/docs/user-guide/nginx-configuration/configmap.md
+++ b/docs/user-guide/nginx-configuration/configmap.md
@@ -229,6 +229,7 @@ The following table shows a configuration option's name, type, and the default v
 |[service-upstream](#service-upstream)|bool|"false"|
 |[ssl-reject-handshake](#ssl-reject-handshake)|bool|"false"|
 |[debug-connections](#debug-connections)|[]string|"127.0.0.1,1.1.1.1/24"|
+|[strict-validate-path-type](#strict-validate-path-type)|bool|"false" (v1.7.x)|
 
 ## add-headers
 
@@ -1379,3 +1380,17 @@ _**default:**_ ""
 
 _References:_
 [http://nginx.org/en/docs/ngx_core_module.html#debug_connection](http://nginx.org/en/docs/ngx_core_module.html#debug_connection)
+
+## strict-validate-path-type
+Ingress objects contains a field called pathType that defines the proxy behavior. It can be `Exact`, `Prefix` and `ImplementationSpecific`.
+
+When pathType is configured as `Exact` or `Prefix`, there should be a more strict validation, allowing only paths starting with "/" and
+containing only alphanumeric characters and "-", "_" and additional "/".
+
+When this option is enabled, the validation will happen on the Admission Webhook, making any Ingress not using pathType `ImplementationSpecific`
+and containing invalid characters to be denied.
+
+This means that Ingress objects that rely on paths containing regex characters should use `ImplementationSpecific` pathType.
+
+The cluster admin should establish validation rules using mechanisms like [Open Policy Agent](https://www.openpolicyagent.org/) to 
+validate that only authorized users can use `ImplementationSpecific` pathType and that only the authorized characters can be used.

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -830,6 +830,12 @@ type Configuration struct {
 	// http://nginx.org/en/docs/ngx_core_module.html#debug_connection
 	// Default: ""
 	DebugConnections []string `json:"debug-connections"`
+
+	// StrictValidatePathType enable the strict validation of Ingress Paths
+	// It enforces that pathType of type Exact or Prefix contains only
+	// alphanumeric chars, "-", "_", "/".In case of additional characters,
+	// like used on Rewrite configurations the user should use pathType as ImplementationSpecific
+	StrictValidatePathType bool `json:"strict-validate-path-type"`
 }
 
 // NewDefault returns the default nginx configuration
@@ -1002,6 +1008,7 @@ func NewDefault() Configuration {
 		GlobalRateLimitMemcachedPoolSize:       50,
 		GlobalRateLimitStatucCode:              429,
 		DebugConnections:                       []string{},
+		StrictValidatePathType:                 false, // TODO: This will be true in future releases
 	}
 
 	if klog.V(5).Enabled() {

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -832,7 +832,7 @@ type Configuration struct {
 	DebugConnections []string `json:"debug-connections"`
 
 	// StrictValidatePathType enable the strict validation of Ingress Paths
-	// It enforces that pathType of type Exact or Prefix contains only
+	// It enforces that pathType of type Exact or Prefix should start with / and contain only
 	// alphanumeric chars, "-", "_", "/".In case of additional characters,
 	// like used on Rewrite configurations the user should use pathType as ImplementationSpecific
 	StrictValidatePathType bool `json:"strict-validate-path-type"`

--- a/internal/ingress/inspector/inspector_test.go
+++ b/internal/ingress/inspector/inspector_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/internal/ingress/inspector/inspector_test.go
+++ b/internal/ingress/inspector/inspector_test.go
@@ -1,0 +1,191 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inspector
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	networking "k8s.io/api/networking/v1"
+)
+
+var (
+	exact  = networking.PathTypeExact
+	prefix = networking.PathTypePrefix
+)
+
+var (
+	validIngress = &networking.Ingress{
+		Spec: networking.IngressSpec{
+			Rules: []networking.IngressRule{
+				{
+					IngressRuleValue: networking.IngressRuleValue{
+						HTTP: &networking.HTTPIngressRuleValue{
+							Paths: []networking.HTTPIngressPath{
+								{
+									Path: "/test",
+								},
+								{
+									PathType: &prefix,
+									Path:     "/xpto/ab0/x_ss-9",
+								},
+								{
+									PathType: &exact,
+									Path:     "/bla/",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	emptyIngress = &networking.Ingress{
+		Spec: networking.IngressSpec{
+			Rules: []networking.IngressRule{
+				{
+					IngressRuleValue: networking.IngressRuleValue{
+						HTTP: &networking.HTTPIngressRuleValue{
+							Paths: []networking.HTTPIngressPath{
+								{
+									PathType: &exact,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	invalidIngress = &networking.Ingress{
+		Spec: networking.IngressSpec{
+			Rules: []networking.IngressRule{
+				{
+					IngressRuleValue: networking.IngressRuleValue{
+						HTTP: &networking.HTTPIngressRuleValue{
+							Paths: []networking.HTTPIngressPath{
+								{
+									PathType: &exact,
+									Path:     "/foo.+",
+								},
+								{
+									PathType: &exact,
+									Path:     "xpto/lala",
+								},
+								{
+									PathType: &exact,
+									Path:     "/xpto/lala",
+								},
+								{
+									PathType: &prefix,
+									Path:     "/foo/bar/[a-z]{3}",
+								},
+								{
+									PathType: &prefix,
+									Path:     "/lala/xp\ntest",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	validImplSpecific = &networking.Ingress{
+		Spec: networking.IngressSpec{
+			Rules: []networking.IngressRule{
+				{
+					IngressRuleValue: networking.IngressRuleValue{
+						HTTP: &networking.HTTPIngressRuleValue{
+							Paths: []networking.HTTPIngressPath{
+								{
+									PathType: &implSpecific,
+									Path:     "/foo.+",
+								},
+								{
+									PathType: &implSpecific,
+									Path:     "xpto/lala",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+)
+
+var aErr = func(s, pathType string) error {
+	return fmt.Errorf("path %s cannot be used with pathType %s", s, pathType)
+}
+
+func TestValidatePathType(t *testing.T) {
+	tests := []struct {
+		name    string
+		ing     *networking.Ingress
+		wantErr bool
+		err     error
+	}{
+		{
+			name:    "nil should return an error",
+			ing:     nil,
+			wantErr: true,
+			err:     fmt.Errorf("received null ingress"),
+		},
+		{
+			name:    "valid should not return an error",
+			ing:     validIngress,
+			wantErr: false,
+		},
+		{
+			name:    "empty should not return an error",
+			ing:     emptyIngress,
+			wantErr: false,
+		},
+		{
+			name:    "empty should not return an error",
+			ing:     validImplSpecific,
+			wantErr: false,
+		},
+		{
+			name:    "invalid should return multiple errors",
+			ing:     invalidIngress,
+			wantErr: true,
+			err: errors.Join(
+				aErr("/foo.+", "Exact"),
+				aErr("xpto/lala", "Exact"),
+				aErr("/foo/bar/[a-z]{3}", "Prefix"),
+				aErr("/lala/xp\ntest", "Prefix"),
+			),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidatePathType(tt.ing)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidatePathType() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if (err != nil && tt.err != nil) && tt.err.Error() != err.Error() {
+				t.Errorf("received invalid error: want = %v, expected %v", tt.err, err)
+			}
+		})
+	}
+}

--- a/internal/ingress/inspector/rules.go
+++ b/internal/ingress/inspector/rules.go
@@ -28,6 +28,14 @@ var (
 	invalidSecretsDir     = regexp.MustCompile(`/var/run/secrets`)
 	invalidByLuaDirective = regexp.MustCompile(`.*_by_lua.*`)
 
+	// validPathType enforces alphanumeric, -, _ and / characters.
+	// The field (?i) turns this regex case insensitive
+	// The remaining regex says that the string must start with a "/" (^/)
+	// the group [[:alnum:]\_\-\/]* says that any amount of characters (A-Za-z0-9), _, - and /
+	// are accepted until the end of the line
+	// Nothing else is accepted.
+	validPathType = regexp.MustCompile(`(?i)^/[[:alnum:]\_\-\/]*$`)
+
 	invalidRegex = []regexp.Regexp{}
 )
 


### PR DESCRIPTION
## What this PR does / why we need it:
Adds validation on the path vs pathType used.
This is a new config on Ingress configmap that is disabled by default (but should be enabled on the next minor version, like v1.8).

When this option is enabled, the path will be validated and the only allowed characters will be "A-Za-z0-9/_-" when the pathType is not ImplementationSpecific.

Cluster admins should validate when users can use ImplementationSpecific, and if there is some dangerous character being used.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes


## How Has This Been Tested?
Added unit tests on validator, added e2e tests containing valid and invalid scenarios


