### PR TITLE
bump pinned ginkgo to v2.9.5

### DIFF
--- a/build/run-in-docker.sh
+++ b/build/run-in-docker.sh
@@ -87,7 +87,7 @@ if [[ "$DOCKER_IN_DOCKER_ENABLED" == "true" ]]; then
   echo "..reached DIND check TRUE block, inside run-in-docker.sh"
   echo "FLAGS=$FLAGS"
   #go env
-  go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo@v2.9.0
+  go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo@v2.9.5
   find / -type f -name ginkgo 2>/dev/null
   which ginkgo
   /bin/bash -c "${FLAGS}"

--- a/images/test-runner/Makefile
+++ b/images/test-runner/Makefile
@@ -54,7 +54,7 @@ image:
 		--build-arg YAML_LINT_VERSION=1.27.1 \
 		--build-arg YAMALE_VERSION=4.0.4 \
 		--build-arg HELM_VERSION=3.11.2 \
-		--build-arg GINKGO_VERSION=2.9.0 \
+		--build-arg GINKGO_VERSION=2.9.5 \
 		--build-arg GOLINT_VERSION=latest \
 		-t ${IMAGE}:${TAG} rootfs
 
@@ -75,7 +75,7 @@ build: ensure-buildx
 		--build-arg YAML_LINT_VERSION=1.27.1 \
 		--build-arg YAMALE_VERSION=4.0.4 \
 		--build-arg HELM_VERSION=3.11.2 \
-		--build-arg GINKGO_VERSION=2.9.0 \
+		--build-arg GINKGO_VERSION=2.9.5 \
 		--build-arg GOLINT_VERSION=latest \
 		-t ${IMAGE}:${TAG} rootfs
 

--- a/test/e2e/run-chart-test.sh
+++ b/test/e2e/run-chart-test.sh
@@ -78,7 +78,7 @@ fi
 
 if [ "${SKIP_IMAGE_CREATION:-false}" = "false" ]; then
   if ! command -v ginkgo &> /dev/null; then
-    go install github.com/onsi/ginkgo/v2/ginkgo@v2.9.0
+    go install github.com/onsi/ginkgo/v2/ginkgo@v2.9.5
   fi
   echo "[dev-env] building image"
   make -C ${DIR}/../../ clean-image build image

--- a/test/e2e/run-kind-e2e.sh
+++ b/test/e2e/run-kind-e2e.sh
@@ -95,7 +95,7 @@ fi
 
 if [ "${SKIP_E2E_IMAGE_CREATION}" = "false" ]; then
   if ! command -v ginkgo &> /dev/null; then
-    go install github.com/onsi/ginkgo/v2/ginkgo@v2.9.0
+    go install github.com/onsi/ginkgo/v2/ginkgo@v2.9.5
   fi
 
   echo "[dev-env] .. done building controller images"


### PR DESCRIPTION
## What this PR does / why we need it:
- There are 4 places in the code where ginkgo version is pinned
- Dependabot bumped ginkgo from v2.9.0 to v2.9.5 in https://github.com/kubernetes/ingress-nginx/pull/9980
- Dependabot can/does not change the pinned version of ginkgo
- This PR is yet another one in a series of PRs that bumps pinned ginkgo version, whenever dependabot bumps ginkgo
- This PR will re-generate the test-runner docker image so follow up PRs should/will be created to promote the new test-runner image to prod registry, in addition to updating project code to use the newly promoted test-runner image tag and sha

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
- No issue was created as this is a follow up version upgrade

## How Has This Been Tested?
- Can be tested in CI only after merging this and promoting the resulting new test-runner image

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.

/triage accepted
/priority important-soon
/kind bug

cc @rikatz @cpanato @strongjz @tao12345666333  seeking review/lgtm/approve. thanks