### PR TITLE
change to alpine318 baseimage

### DIFF
--- a/NGINX_BASE
+++ b/NGINX_BASE
@@ -1,1 +1,1 @@
-registry.k8s.io/ingress-nginx/nginx:v20230526@sha256:b05566e432d85a7681feb7ef93fda8385d53712478737b39e617c993c86c5e65
+registry.k8s.io/ingress-nginx/nginx:v20230527@sha256:cf77c71aa6e4284925ca2233ddf871b5823eaa3ee000347ae25096b07fb52c57


### PR DESCRIPTION
## What this PR does / why we need it:
- New images based on alpine v3.18 were built and promoted from https://github.com/kubernetes/ingress-nginx/pull/9997 and https://github.com/kubernetes/k8s.io/pull/5329
- This PR changes the tag+sha of baseimage to use the above mentioned new baseimage built on alpine v3.18
- This is expected to trigger other builds automagically but we will see. If images using baseimage are not rebuilt on this PR merging, then will need to trigger manual builds of other images to use alpine v3.18

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
- Many issues are related but none created specifically for this change as it is internal an part of a multi PR process

## How Has This Been Tested?
- Can be test in CI or after merge only

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.


cc @tao12345666333 @strongjz @rikatz 

/triage accepted
/kind bug
/priority important-soon