### PR TITLE
perf: avoid unnecessary byte/string conversion

### DIFF
--- a/internal/ingress/annotations/auth/main.go
+++ b/internal/ingress/annotations/auth/main.go
@@ -197,7 +197,7 @@ func dumpSecretAuthMap(filename string, secret *api.Secret) error {
 	for user, pass := range secret.Data {
 		builder.WriteString(user)
 		builder.WriteString(":")
-		builder.WriteString(string(pass))
+		builder.Write(pass)
 		builder.WriteString("\n")
 	}
 

--- a/internal/ingress/annotations/authreq/main.go
+++ b/internal/ingress/annotations/authreq/main.go
@@ -143,7 +143,7 @@ func ValidMethod(method string) bool {
 
 // ValidHeader checks is the provided string satisfies the header's name regex
 func ValidHeader(header string) bool {
-	return headerRegexp.Match([]byte(header))
+	return headerRegexp.MatchString(header)
 }
 
 // ValidCacheDuration checks if the provided string is a valid cache duration
@@ -159,13 +159,13 @@ func ValidCacheDuration(duration string) bool {
 		if len(element) == 0 {
 			continue
 		}
-		if statusCodeRegex.Match([]byte(element)) {
+		if statusCodeRegex.MatchString(element) {
 			if seenDuration {
 				return false // code after duration
 			}
 			continue
 		}
-		if durationRegex.Match([]byte(element)) {
+		if durationRegex.MatchString(element) {
 			seenDuration = true
 		}
 	}

--- a/internal/net/ssl/ssl.go
+++ b/internal/net/ssl/ssl.go
@@ -81,7 +81,7 @@ func CreateSSLCert(cert, key []byte, uid string) (*ingress.SSLCert, error) {
 		}
 	}
 
-	pemCertBuffer.Write([]byte("\n"))
+	pemCertBuffer.WriteString("\n")
 	pemCertBuffer.Write(key)
 
 	pemBlock, _ := pem.Decode(pemCertBuffer.Bytes())
@@ -195,12 +195,12 @@ func StoreSSLCertOnDisk(name string, sslCert *ingress.SSLCert) (string, error) {
 func ConfigureCACertWithCertAndKey(name string, ca []byte, sslCert *ingress.SSLCert) error {
 	var buffer bytes.Buffer
 
-	_, err := buffer.Write([]byte(sslCert.PemCertKey))
+	_, err := buffer.WriteString(sslCert.PemCertKey)
 	if err != nil {
 		return fmt.Errorf("could not append newline to cert file %v: %v", sslCert.CAFileName, err)
 	}
 
-	_, err = buffer.Write([]byte("\n"))
+	_, err = buffer.WriteString("\n")
 	if err != nil {
 		return fmt.Errorf("could not append newline to cert file %v: %v", sslCert.CAFileName, err)
 	}

--- a/test/e2e/settings/ocsp/ocsp.go
+++ b/test/e2e/settings/ocsp/ocsp.go
@@ -68,7 +68,7 @@ var _ = framework.DescribeSetting("OCSP", func() {
 
 		var pemCertBuffer bytes.Buffer
 		pemCertBuffer.Write(leafCert)
-		pemCertBuffer.Write([]byte("\n"))
+		pemCertBuffer.WriteString("\n")
 		pemCertBuffer.Write(intermediateCa)
 
 		f.EnsureSecret(&corev1.Secret{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
<!--- Please make sure you title is descriptive, it is used in the Release notes to let others know what it does ---> 

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We can use alternative functions to avoid unnecessary byte/string conversion calls and reduce allocations.

1. `(*strings.Builder).Write` / `(*strings.Builder).WriteString`
2. `(*regexp.Regexp).Match` / `(*regexp.Regexp).MatchString`
3. `(*bytes.Buffer).Write` / `(*bytes.Buffer).WriteString`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

`make test`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.
