### PR TITLE
tracing: upgrade to dd-opentracing-cpp v1.3.7

### DIFF
--- a/images/nginx/rootfs/build.sh
+++ b/images/nginx/rootfs/build.sh
@@ -53,8 +53,8 @@ export JAEGER_VERSION=0.7.0
 # Check for recent changes: https://github.com/msgpack/msgpack-c/compare/cpp-3.3.0...master
 export MSGPACK_VERSION=3.3.0
 
-# Check for recent changes: https://github.com/DataDog/dd-opentracing-cpp/compare/v1.3.2...master
-export DATADOG_CPP_VERSION=1.3.2
+# Check for recent changes: https://github.com/DataDog/dd-opentracing-cpp/compare/v1.3.7...master
+export DATADOG_CPP_VERSION=1.3.7
 
 # Check for recent changes: https://github.com/SpiderLabs/ModSecurity-nginx/compare/v1.0.3...master
 export MODSECURITY_VERSION=1.0.3
@@ -265,7 +265,7 @@ get_src d3f2c870f8f88477b01726b32accab30f6e5d57ae59c5ec87374ff73d0794316 \
         "https://github.com/openresty/luajit2/archive/v$LUAJIT_VERSION.tar.gz"
 fi
 
-get_src 586f92166018cc27080d34e17c59d68219b85af745edf3cc9fe41403fc9b4ac6 \
+get_src 8d39c6b23f941a2d11571daaccc04e69539a3fcbcc50a631837560d5861a7b96 \
         "https://github.com/DataDog/dd-opentracing-cpp/archive/v$DATADOG_CPP_VERSION.tar.gz"
 
 get_src 4c1933434572226942c65b2f2b26c8a536ab76aa771a3c7f6c2629faa764976b \


### PR DESCRIPTION
## What this PR does / why we need it:
Upgrades the Datadog tracing plugin to new release v1.3.7: https://github.com/DataDog/dd-opentracing-cpp/releases/tag/v1.3.7

This most recent release adds logging for uncommon error scenarios that can occur between nginx and the Datadog Agent.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only
- [x] Upgrade tracing plugin

## How Has This Been Tested?
The nginx base image builds and runs and produces traces using the Datadog tracing plugin.

`docker build --tag ingress-nginx-nginx .` in `images/nginx/rootfs`.

Use the following configuration files:

`/tmp/nginx.conf`
```nginx
load_module /etc/nginx/modules/ngx_http_opentracing_module.so;

events {
    worker_connections  1024;
}

http {
    opentracing_load_tracer /usr/local/lib/libdd_opentracing.so /etc/nginx/dd-config.json;

    opentracing on;
    opentracing_tag http_user_agent $http_user_agent;
    opentracing_trace_locations off;
    opentracing_operation_name "$request_method $uri";

    log_format with_trace_id '$remote_addr - $http_x_forwarded_user [$time_local] "$request" '
        '$status $body_bytes_sent "$http_referer" '
        '"$http_user_agent" "$http_x_forwarded_for" '
        '"$opentracing_context_x_datadog_trace_id" "$opentracing_context_x_datadog_parent_id"';

    access_log /dev/stderr with_trace_id;

    server {
        listen       80;

        location / {
            opentracing_tag "custom-tag" "special value";
            opentracing_propagate_context;
            proxy_pass http://localhost/upstream;
        }

        location /upstream {
            return 200;
        }
    }
}
```

`/tmp/dd-config.json`
```json
{
  "service": "nginx-test"
}
```

Run nginx.
```console
$ docker run -it --mount type=bind,source=/tmp/nginx.conf,target=/etc/nginx/nginx.conf,readonly --mount type=bind,source=/tmp/dd-config.json,target=/etc/nginx/dd-config.json,readonly --publish 127.0.0.1:8000:80 ingress-nginx-nginx
```

Send a request.
```console
$ curl '127.0.0.1:8000'
```

Note the tracing in the nginx log:
```text
info: DATADOG TRACER CONFIGURATION - {"agent_url":"http://localhost:8126","analytics_enabled":false,"analytics_sample_rate":null,"date":"2023-06-02T19:20:36+0000","enabled":true,"env":"","lang":"cpp","lang_version":"201402","report_hostname":false,"sampling_rules":"[]","service":"nginx-test","version":"v1.3.7"}
127.0.0.1 - - [02/Jun/2023:19:20:44 +0000] "GET /upstream HTTP/1.0" 200 0 "-" "curl/7.81.0" "-" "3293968931881126918" "8622360542771705867"
172.17.0.1 - - [02/Jun/2023:19:20:44 +0000] "GET / HTTP/1.1" 200 0 "-" "curl/7.81.0" "-" "3293968931881126918" "3293968931881126918"
```

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
