### PR TITLE
Update tls.md

### DIFF
--- a/docs/user-guide/tls.md
+++ b/docs/user-guide/tls.md
@@ -33,13 +33,13 @@ for requests that do not match any of the configured server names.
 This configuration works out-of-the-box for HTTP traffic.
 For HTTPS, a certificate is naturally required.
 
-For this reason the Ingress controller provides the flag `--default-ssl-certificate`.
+For this reason the Ingress controller provides the flag `--default-ssl-certificate-secret`.
 The secret referred to by this flag contains the default certificate to be used when
 accessing the catch-all server.
 If this flag is not provided NGINX will use a self-signed certificate.
 
 For instance, if you have a TLS secret `foo-tls` in the `default` namespace,
-add `--default-ssl-certificate=default/foo-tls` in the `nginx-controller` deployment.
+add `--default-server-tls-secret=default/foo-tls` in the `nginx-controller` deployment.
 
 The default certificate will also be used for ingress `tls:` sections that do not
 have a `secretName` option.


### PR DESCRIPTION
Nginx runtime flag was updated to `default-server-tls-secret` it appears 'default-server-tls-certificate` has been deprecated

<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
<!--- Please make sure you title is descriptive, it is used in the Release notes to let others know what it does ---> 

## What this PR does / why we need it:
Updated documentation for Nginx Ingress Tls configurations

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation only

## Which issue/s this PR fixes
N/A

## How Has This Been Tested?
```bash
helm install nginx-ingress nginx-stable/nginx-ingress --set controller.extraArgs.default-server-tls-secret=<namespace>/secret-tls
```

- Kubernetes Deployment: Ingress-Nginx to containers:  -args:
-  Reference Supporting Docs: [Nginx Ingress Official Docs - Command-line Args](https://docs.nginx.com/nginx-ingress-controller/configuration/global-configuration/command-line-arguments/)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
