### PR TITLE
ensured hpa mem spec before cpu spec

### DIFF
--- a/charts/ingress-nginx/templates/controller-hpa.yaml
+++ b/charts/ingress-nginx/templates/controller-hpa.yaml
@@ -21,18 +21,18 @@ spec:
   minReplicas: {{ .Values.controller.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.controller.autoscaling.maxReplicas }}
   metrics:
-  {{- with .Values.controller.autoscaling.targetCPUUtilizationPercentage }}
-  - type: Resource
-    resource:
-      name: cpu
-      target:
-        type: Utilization
-        averageUtilization: {{ . }}
-  {{- end }}
   {{- with .Values.controller.autoscaling.targetMemoryUtilizationPercentage }}
   - type: Resource
     resource:
       name: memory
+      target:
+        type: Utilization
+        averageUtilization: {{ . }}
+  {{- end }}
+  {{- with .Values.controller.autoscaling.targetCPUUtilizationPercentage }}
+  - type: Resource
+    resource:
+      name: cpu
       target:
         type: Utilization
         averageUtilization: {{ . }}


### PR DESCRIPTION
## What this PR does / why we need it:
- The reason for this PR is detailed clearly in https://github.com/kubernetes/ingress-nginx/issues/10038
- Basically, having the hpa template spec of mem before cpu helps integrate with ArgoCD

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
fixes #10038

## How Has This Been Tested?
- Can be tested after merge for integration with ArgoCD by reporting user

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.

/triage accepted

cc @tao12345666333 @strongjz @rikatz @cpanato 