### PR TITLE
Chart: Set `--enable-metrics` to `controller.metrics.enabled`.

### DIFF
--- a/charts/ingress-nginx/templates/_params.tpl
+++ b/charts/ingress-nginx/templates/_params.tpl
@@ -54,6 +54,7 @@
 {{- if .Values.controller.enableTopologyAwareRouting }}
 - --enable-topology-aware-routing=true
 {{- end }}
+- --enable-metrics={{ .Values.controller.metrics.enabled }}
 {{- range $key, $value := .Values.controller.extraArgs }}
 {{- /* Accept keys without values or with false as value */}}
 {{- if eq ($value | quote | len) 2 }}


### PR DESCRIPTION
## What this PR does / why we need it:

Metrics is not disabled even with the value `metrics.enabled` set to `false` because the chart templates only disable the metrics port.

This PR explicit set the flag `--enable-metrics`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested on Kubernetes v1.20.9 with `helm install test-nginx-ingress .` then the flag populated correctly and the metrics endpoint no longer return NGINX prometheus metrics

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
