### PR TITLE
bump pinned golang to 1.20.5

### DIFF
--- a/images/custom-error-pages/rootfs/Dockerfile
+++ b/images/custom-error-pages/rootfs/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.20.4-alpine3.18 as builder
+FROM golang:1.20.5-alpine3.18 as builder
 
 RUN apk update \
     && apk upgrade && apk add git

--- a/images/ext-auth-example-authsvc/rootfs/Dockerfile
+++ b/images/ext-auth-example-authsvc/rootfs/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.4-alpine3.18 as builder
+FROM golang:1.20.5-alpine3.18 as builder
 RUN mkdir /authsvc
 WORKDIR /authsvc
 COPY . ./

--- a/images/fastcgi-helloserver/rootfs/Dockerfile
+++ b/images/fastcgi-helloserver/rootfs/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.20.4-alpine3.18 as builder
+FROM golang:1.20.5-alpine3.18 as builder
 
 WORKDIR /go/src/k8s.io/ingress-nginx/images/fastcgi
 

--- a/images/go-grpc-greeter-server/rootfs/Dockerfile
+++ b/images/go-grpc-greeter-server/rootfs/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.4-alpine3.18 as build
+FROM golang:1.20.5-alpine3.18 as build
 
 WORKDIR /go/src/greeter-server
 

--- a/images/httpbun/rootfs/Dockerfile
+++ b/images/httpbun/rootfs/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.20 AS builder
+FROM golang:1.20.5 AS builder
 
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8

--- a/images/kube-webhook-certgen/rootfs/Dockerfile
+++ b/images/kube-webhook-certgen/rootfs/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=$BUILDPLATFORM golang:1.20.1 as builder
+FROM --platform=$BUILDPLATFORM golang:1.20.5 as builder
 ARG BUILDPLATFORM
 ARG TARGETARCH
 


### PR DESCRIPTION
## What this PR does / why we need it:
- Go was bumped to v1.20.5 
- This PR bumps go to 1.20.5 in pinned locations
- This will trigger build of new images including webhook certgen
- 2 Follow up PRs will be needed.  One to promote new images and another to change tag+sha in project to use new images

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
- No issues was created

## How Has This Been Tested?
- Will be tested only after new images are built, promoted and e2e-tests use new images

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.

/triage accepted
/priority important-soon

@tao12345666333  @strongjz @rikatz @cpanato  Please review lgtm approve before releasing controller v1.8.1 as values.yaml will need new webhook certgen image