### PR TITLE
Clarify TCP/UDP service docs

### DIFF
--- a/docs/user-guide/exposing-tcp-udp-services.md
+++ b/docs/user-guide/exposing-tcp-udp-services.md
@@ -1,6 +1,8 @@
 # Exposing TCP and UDP services
 
-Ingress does not support TCP or UDP services. For this reason this Ingress controller uses the flags `--tcp-services-configmap` and `--udp-services-configmap` to point to an existing config map where the key is the external port to use and the value indicates the service to expose using the format:
+While the Kubernetes Ingress resource only officially supports routing external HTTP(s) traffic to services, ingress-nginx can be configured to receive external TCP/UDP traffic from non-HTTP protocols and route them to internal services using TCP/UDP port mappings that are specified within a ConfigMap.
+
+To support this, the `--tcp-services-configmap` and `--udp-services-configmap` flags can be used to point to an existing config map where the key is the external port to use and the value indicates the service to expose using the format:
 `<namespace/service name>:<service port>:[PROXY]:[PROXY]`
 
 It is also possible to use a number or the name of the port. The two last fields are optional.


### PR DESCRIPTION
In the current state, the docs on TCP/UDP aren't really clear on exactly whether/how TCP/UDP traffic is supported. This is an attempt to clarify the limitations inherent to k8s Ingress resources vs what can be accomplished with this controller.
