### PR TITLE
Added template function for ingress class resource name 

### DIFF
--- a/charts/ingress-nginx/templates/controller-ingressclass.yaml
+++ b/charts/ingress-nginx/templates/controller-ingressclass.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- with .Values.controller.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  name: {{ tpl (toYaml .Values.controller.ingressClassResource.name) . | nindent 2 }}
+  name: {{ tpl (toYaml .Values.controller.ingressClassResource.name) . }}
 {{- if .Values.controller.ingressClassResource.default }}
   annotations:
     ingressclass.kubernetes.io/is-default-class: "true"

--- a/charts/ingress-nginx/templates/controller-ingressclass.yaml
+++ b/charts/ingress-nginx/templates/controller-ingressclass.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- with .Values.controller.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  name: {{ .Values.controller.ingressClassResource.name }}
+  name: {{ tpl (toYaml .Values.controller.ingressClassResource.name) . | nindent 2 }}
 {{- if .Values.controller.ingressClassResource.default }}
   annotations:
     ingressclass.kubernetes.io/is-default-class: "true"


### PR DESCRIPTION
As a child charts needs to able to pass class resource as variable including release namespace as template variable.
Example: 
`    ingressClassResource:
      name: "{{ .Release.Namespace }}-flow-ingress"
`

## What this PR does / why we need it:
Added ability to pass class resource name templating helm variables like release namespace, release name
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
Installed chart passing values file as below in parent chart values file.
```
ingress-nginx:
  enabled: true
  controller:
    service:
      externalTrafficPolicy: Local
    ingressClassResource:
      name: "{{ .Release.Namespace }}-flow-ingress"
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.
