### PR TITLE
revise Datadog trace sampling configuration

### DIFF
--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -87,11 +87,6 @@ const (
 	// Parameters for a shared memory zone that will keep states for various keys.
 	// http://nginx.org/en/docs/http/ngx_http_limit_conn_module.html#limit_conn_zone
 	defaultLimitConnZoneVariable = "$binary_remote_addr"
-
-	// Default sentinel value for Configuration.DatadogSampleRate, indicating
-	// that the Datadog tracer should consult the Datadog Agent for sampling
-	// rates rather than use a configured value.
-	DatadogDynamicSampleRate = -1.0
 )
 
 // Configuration represents the content of nginx.conf file
@@ -713,7 +708,7 @@ type Configuration struct {
 
 	// DatadogSampleRate specifies sample rate for any traces created.
 	// Default: use a dynamic rate instead
-	DatadogSampleRate float32 `json:"datadog-sample-rate"`
+	DatadogSampleRate *float32 `json:"datadog-sample-rate",omitempty`
 
 	// MainSnippet adds custom configuration to the main section of the nginx configuration
 	MainSnippet string `json:"main-snippet"`
@@ -999,7 +994,7 @@ func NewDefault() Configuration {
 		DatadogEnvironment:                     "prod",
 		DatadogCollectorPort:                   8126,
 		DatadogOperationNameOverride:           "nginx.handle",
-		DatadogSampleRate:                      DatadogDynamicSampleRate,
+		DatadogSampleRate:                      nil,
 		LimitReqStatusCode:                     503,
 		LimitConnStatusCode:                    503,
 		SyslogPort:                             514,

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -87,6 +87,11 @@ const (
 	// Parameters for a shared memory zone that will keep states for various keys.
 	// http://nginx.org/en/docs/http/ngx_http_limit_conn_module.html#limit_conn_zone
 	defaultLimitConnZoneVariable = "$binary_remote_addr"
+
+	// Default sentinel value for Configuration.DatadogSampleRate, indicating
+	// that the Datadog tracer should consult the Datadog Agent for sampling
+	// rates rather than use a configured value.
+	DatadogDynamicSampleRate = -1.0
 )
 
 // Configuration represents the content of nginx.conf file
@@ -706,15 +711,8 @@ type Configuration struct {
 	// Default: nginx.handle
 	DatadogOperationNameOverride string `json:"datadog-operation-name-override"`
 
-	// DatadogPrioritySampling specifies to use client-side sampling
-	// If true disables client-side sampling (thus ignoring sample_rate) and enables distributed
-	// priority sampling, where traces are sampled based on a combination of user-assigned
-	// Default: true
-	DatadogPrioritySampling bool `json:"datadog-priority-sampling"`
-
 	// DatadogSampleRate specifies sample rate for any traces created.
-	// This is effective only when datadog-priority-sampling is false
-	// Default: 1.0
+	// Default: use a dynamic rate instead
 	DatadogSampleRate float32 `json:"datadog-sample-rate"`
 
 	// MainSnippet adds custom configuration to the main section of the nginx configuration
@@ -1001,8 +999,7 @@ func NewDefault() Configuration {
 		DatadogEnvironment:                     "prod",
 		DatadogCollectorPort:                   8126,
 		DatadogOperationNameOverride:           "nginx.handle",
-		DatadogSampleRate:                      1.0,
-		DatadogPrioritySampling:                true,
+		DatadogSampleRate:                      DatadogDynamicSampleRate,
 		LimitReqStatusCode:                     503,
 		LimitConnStatusCode:                    503,
 		SyslogPort:                             514,

--- a/internal/ingress/controller/nginx.go
+++ b/internal/ingress/controller/nginx.go
@@ -1076,10 +1076,10 @@ parent_based = {{ .OtelSamplerParentBased }}
 
 func datadogOpentracingCfg(cfg ngx_config.Configuration) (string, error) {
 	m := map[string]interface{}{
-		"service": cfg.DatadogServiceName,
-		"agent_host": cfg.DatadogCollectorHost,
-		"agent_port": cfg.DatadogCollectorPort,
-		"environment": cfg.DatadogEnvironment,
+		"service":                 cfg.DatadogServiceName,
+		"agent_host":              cfg.DatadogCollectorHost,
+		"agent_port":              cfg.DatadogCollectorPort,
+		"environment":             cfg.DatadogEnvironment,
 		"operation_name_override": cfg.DatadogOperationNameOverride,
 	}
 

--- a/internal/ingress/controller/nginx.go
+++ b/internal/ingress/controller/nginx.go
@@ -1083,12 +1083,11 @@ func datadogOpentracingCfg(cfg ngx_config.Configuration) (string, error) {
 		"operation_name_override": cfg.DatadogOperationNameOverride,
 	}
 
-	// Omit "sample_rate" if the configuration's sample rate is set to the
-	// default sentinel value DatadogDynamicSampleRate (-1).
+	// Omit "sample_rate" if the configuration's sample rate is unset (nil).
 	// Omitting "sample_rate" from the plugin JSON indicates to the tracer that
 	// it should use dynamic rates instead of a configured rate.
-	if cfg.DatadogSampleRate != ngx_config.DatadogDynamicSampleRate {
-		jsn["sample_rate"] = cfg.DatadogSampleRate
+	if cfg.DatadogSampleRate != nil {
+		jsn["sample_rate"] = *cfg.DatadogSampleRate
 	}
 
 	jsnBytes, err := json.Marshal(jsn)


### PR DESCRIPTION
Datadog customers have begun to report that trace sampling is not behaving as expected when using ingress-nginx.

With other Datadog integrations, the default sampling behavior is to consult the Datadog Agent for a sample rate, which changes dynamically. This way, trace volume can be centrally controlled. A customer may optionally specify a fixed sampling rate; but if they don't, the default behavior is to let the Datadog Agent figure it out.

I made a change in Datadog's library [last March][1] that changed the meaning of `sample_rate` in the library's configuration. `sample_rate` corresponds to `DatadogSampleRate` in ingress-nginx. Previously, `sample_rate` was ignored by Datadog's library. This was a bug, but not a severe one, because the concept of "[sampling rules][3]" had since superceded what `sample_rate` used to configure. My change in March repurposed `sample_rate` to mean "append a sampling rule that [matches all traces][2]."

What I overlooked was the fact that ingress-nginx still uses `sample_rate`, and that it _always_ specifies a value for it in `/etc/nginx/opentracing.json`, defaulting to `1.0`.

This means that Datadog customers, since my change, have no way to say "use the rates calculated by the Datadog Agent." They can set `DatadogSampleRate`, and if they don't, they still get `1.0` instead of the desired default behavior.

The changes that I propose in this PR should have been proposed last March, but I didn't then notice this interaction.

These changes remove the `DatadogPrioritySampling` flag (which has not done anything for quite a long time), and change the type of `DatadogSampleRate` from `float32` to `*float32`. This way, the default value is `nil` rather than `1.0`, and we can detect this when constructing `/etc/nginx/opentracing.json`.

Conditionally including `"sample_rate"` in the generated JSON required me to rearrange the code that produces `/etc/nginx/opentracing.json`. Previously, the file content was chosen from one of multiple `text/template` templates. Such templates cannot, as far as I know, express conditionally included text based on the value of a pointer. Instead, I use `encoding/json` in a dedicated function to generate the Datadog JSON.

This will change the default sampling behavior of the Datadog integration, which is something that I'd like to mention in ingress-nginx's release notes should these changes be merged in their current form.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
The issue was not with ingress-nginx, but with behavior change in ingress-nginx brought on by a change in dd-opentracing-cpp.

The concern was raised in Datadog's support channels.

## How Has This Been Tested?
Manual integration testing involved a few Datadog-specific [files][4]:
- [agent.dockerfile][5]: Dockerfile for the mock Datadog Agent.
- [agent.js][6]: Node.js HTTP server used as a mock Datadog Agent.
- [agent.yaml][7]: Kubernetes `DaemonSet` resource that uses the image built by `agent.dockerfile`.
- [httpbin.yaml][8]: Example HTTP `Service` and a corresponding `Ingress`.

Run `make dev-env`.

Apply the files above (this involves `load`ing the built Docker image into the cluster, similarly to what is done in `make dev-env`).

Now requests made to the host's port 80 will flow through the NGINX ingress to httpbin.

Edit the ingress controller's `Deployment` to expose the node's IP address. That's where the mock Datadog Agent will be listening (because it's a `DaemonSet`, there's an instance on each node):
```yaml
# ...
        env:
        - name: HOST_IP
          valueFrom:
            fieldRef:
              fieldPath: status.hostIP
# ...
```

Edit the ingress controller's `ConfigMap` to enable Datadog tracing:
```yaml
apiVersion: v1
data:
  datadog-collector-host: $HOST_IP
  enable-opentracing: "true"
kind: ConfigMap
metadata:
  name: ingress-nginx-controller
  namespace: ingress-nginx
```

Verify that httpbin's `/headers` endpoint shows Datadog tracing propagation headers:
```console
ubuntu@dgoffredo-devbox:~$ curl 'http://localhost/headers'
{
  "headers": {
    "Accept": "*/*", 
    "Host": "localhost", 
    "User-Agent": "curl/7.81.0", 
    "X-Datadog-Parent-Id": "4176797220720185106", 
    "X-Datadog-Sampling-Priority": "1", 
    "X-Datadog-Tags": "_dd.p.dm=-0", 
    "X-Datadog-Trace-Id": "356006255528867060", 
    "X-Forwarded-Host": "localhost", 
    "X-Forwarded-Scheme": "http", 
    "X-Scheme": "http"
  }
}
```

Verify that the default `/etc/nginx/opentracing.json` omits `"sample_rate"`:
```console
ubuntu@dgoffredo-devbox:~$ kubectl -n ingress-nginx get pods
NAME                                       READY   STATUS      RESTARTS   AGE
ingress-nginx-admission-create-nk8q9       0/1     Completed   0          2d17h
ingress-nginx-admission-patch-p8qk7        0/1     Completed   0          2d17h
ingress-nginx-controller-56fc94fb8-zbkdg   1/1     Running     0          22h
ubuntu@dgoffredo-devbox:~$ kubectl -n ingress-nginx exec -it ingress-nginx-controller-56fc94fb8-zbkdg -- cat /etc/nginx/opentracing.json | jq
{
  "agent_host": "172.18.0.2",
  "agent_port": 8126,
  "environment": "prod",
  "operation_name_override": "nginx.handle",
  "service": "nginx"
}
```

Edit the ingress controller's `ConfigMap` to specify an explicit sampling rate:
```yaml
apiVersion: v1
kind: ConfigMap
data:
  datadog-collector-host: $HOST_IP
  datadog-sample-rate: "0.42"
  enable-opentracing: "true"
```

Send another request to httpbin, and check the log output of the mock Datadog Agent. Verify that the tagged sampling rate (`_dd.rule_psr`) is as configured.
```console
ubuntu@dgoffredo-devbox:~$ kubectl -n datadog logs --follow dd-trace-agent-tnsgj
[
  [
    {
      "name": "nginx.handle",
      "service": "nginx",
      "resource": "/",
      "type": "web",
      "start": 1688055351332243000,
      "duration": 2471860,
      "meta": {
        "http.url": "http://localhost/headers",
        "upstream.name": "upstream_balancer",
        "http.method": "GET",
        "http.status_code": "200",
        "http.host": "localhost",
        "peer.address": "172.18.0.1:50500",
        "nginx.worker_pid": "96",
        "http.status_line": "200 OK",
        "component": "nginx",
        "upstream.address": "10.244.0.8:80",
        "env": "prod",
        "operation": "/"
      },
      "metrics": {},
      "span_id": 1493341588522438100,
      "trace_id": 2107002113598878000,
      "parent_id": 2107002113598878000,
      "error": 0
    },
    {
      "name": "nginx.handle",
      "service": "nginx",
      "resource": "/",
      "type": "web",
      "start": 1688055351332218400,
      "duration": 2515420,
      "meta": {
        "http.url": "http://localhost/headers",
        "upstream.name": "upstream_balancer",
        "http.method": "GET",
        "nginx.worker_pid": "96",
        "_dd.p.dm": "-3",
        "component": "nginx",
        "http.status_line": "200 OK",
        "http.host": "localhost",
        "peer.address": "172.18.0.1:50500",
        "http.status_code": "200",
        "upstream.address": "10.244.0.8:80",
        "env": "prod",
        "operation": "/"
      },
      "metrics": {
        "_dd.rule_psr": 0.42,
        "_sampling_priority_v1": -1
      },
      "span_id": 2107002113598878000,
      "trace_id": 2107002113598878000,
      "parent_id": 0,
      "error": 0
    }
  ]
]
```
Note that it's `0.42`, as expected.

## Checklist:
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.

[1]: https://github.com/DataDog/dd-opentracing-cpp/commit/2b017b7e0c1ca24fcae7adc9d69505649b469e18
[2]: https://github.com/DataDog/dd-opentracing-cpp/blob/master/doc/sampling.md#dd_trace_sample_rate
[3]: https://github.com/DataDog/dd-opentracing-cpp/blob/master/doc/sampling.md#sampling-rules
[4]: https://github.com/dgoffredo/ingress-nginx/tree/david.goffredo/datadog-testing/datadog
[5]: https://github.com/dgoffredo/ingress-nginx/blob/david.goffredo/datadog-testing/datadog/agent.dockerfile
[6]: https://github.com/dgoffredo/ingress-nginx/blob/david.goffredo/datadog-testing/datadog/agent.js
[7]: https://github.com/dgoffredo/ingress-nginx/blob/david.goffredo/datadog-testing/datadog/agent.yaml
[8]: https://github.com/dgoffredo/ingress-nginx/blob/david.goffredo/datadog-testing/datadog/httpbin.yaml
