### PR TITLE
change to go1205 & alpine3182 images

### DIFF
--- a/build/run-in-docker.sh
+++ b/build/run-in-docker.sh
@@ -44,7 +44,7 @@ function cleanup {
 }
 trap cleanup EXIT
 
-E2E_IMAGE=${E2E_IMAGE:-registry.k8s.io/ingress-nginx/e2e-test-runner:v20230623-d50c7193b@sha256:e5c68dc56934c273850bfb75c0348a2819756669baf59fcdce9e16771537b247}
+E2E_IMAGE=${E2E_IMAGE:-registry.k8s.io/ingress-nginx/e2e-test-runner:v20230627-1ddecfc0@9ha256:2cc681d0d20911946e6b9c2048397f5c9e9b17e8f5c2007f6a3814bfb22f1816"}
 
 if [[ "$RUNTIME" == podman ]]; then
   # Podman does not support both tag and digest

--- a/charts/ingress-nginx/README.md
+++ b/charts/ingress-nginx/README.md
@@ -252,11 +252,11 @@ As of version `1.26.0` of this chart, by simply not providing any clusterIP valu
 | controller.admissionWebhooks.networkPolicyEnabled | bool | `false` |  |
 | controller.admissionWebhooks.objectSelector | object | `{}` |  |
 | controller.admissionWebhooks.patch.enabled | bool | `true` |  |
-| controller.admissionWebhooks.patch.image.digest | string | `"sha256:543c40fd093964bc9ab509d3e791f9989963021f1e9e4c9c7b6700b02bfb227b"` |  |
+| controller.admissionWebhooks.patch.image.digest | string | `"sha256:1b6b18750eab3b5ebc00f1a6d96a34bf21138c875f3be6122103669a024fe63f"` |  |
 | controller.admissionWebhooks.patch.image.image | string | `"ingress-nginx/kube-webhook-certgen"` |  |
 | controller.admissionWebhooks.patch.image.pullPolicy | string | `"IfNotPresent"` |  |
 | controller.admissionWebhooks.patch.image.registry | string | `"registry.k8s.io"` |  |
-| controller.admissionWebhooks.patch.image.tag | string | `"v20230407"` |  |
+| controller.admissionWebhooks.patch.image.tag | string | `"v20230626"` |  |
 | controller.admissionWebhooks.patch.labels | object | `{}` | Labels to be added to patch job resources |
 | controller.admissionWebhooks.patch.nodeSelector."kubernetes.io/os" | string | `"linux"` |  |
 | controller.admissionWebhooks.patch.podAnnotations | object | `{}` |  |
@@ -375,7 +375,7 @@ As of version `1.26.0` of this chart, by simply not providing any clusterIP valu
 | controller.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for controller pod assignment # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/ # |
 | controller.opentelemetry.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
 | controller.opentelemetry.enabled | bool | `false` |  |
-| controller.opentelemetry.image | string | `"registry.k8s.io/ingress-nginx/opentelemetry:v20230527@sha256:fd7ec835f31b7b37187238eb4fdad4438806e69f413a203796263131f4f02ed0"` |  |
+| controller.opentelemetry.image | string | `"registry.k8s.io/ingress-nginx/opentelemetry:v20230612@sha256:1c8fa555f66d016b27e230f0b9b8c2fd7c8fe86fef342bdf5be609b392bf121f"` |  |
 | controller.podAnnotations | object | `{}` | Annotations to be added to controller pods # |
 | controller.podLabels | object | `{}` | Labels to add to the pod container metadata |
 | controller.podSecurityContext | object | `{}` | Security Context policies for controller pods |

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -554,7 +554,7 @@ controller:
 
   opentelemetry:
     enabled: false
-    image: registry.k8s.io/ingress-nginx/opentelemetry:v20230527@sha256:fd7ec835f31b7b37187238eb4fdad4438806e69f413a203796263131f4f02ed0
+    image: registry.k8s.io/ingress-nginx/opentelemetry:v20230612@sha256:1c8fa555f66d016b27e230f0b9b8c2fd7c8fe86fef342bdf5be609b392bf121f
     containerSecurityContext:
       allowPrivilegeEscalation: false
   admissionWebhooks:
@@ -616,8 +616,8 @@ controller:
         ## for backwards compatibility consider setting the full image url via the repository value below
         ## use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail
         ## repository:
-        tag: v20230407
-        digest: sha256:543c40fd093964bc9ab509d3e791f9989963021f1e9e4c9c7b6700b02bfb227b
+        tag: v20230626
+        digest: sha256:1b6b18750eab3b5ebc00f1a6d96a34bf21138c875f3be6122103669a024fe63f
         pullPolicy: IfNotPresent
       # -- Provide a priority class name to the webhook patching job
       ##

--- a/docs/examples/canary/README.md
+++ b/docs/examples/canary/README.md
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
       - name: production
-        image: registry.k8s.io/ingress-nginx/e2e-test-echo@sha256:6fc5aa2994c86575975bb20a5203651207029a0d28e3f491d8a127d08baadab4
+        image: registry.k8s.io/ingress-nginx/e2e-test-echo@sha256:d9c4240efb797beeaa7d4a28314a6c982469da1de0a62645c4c72d4f3fa338ee
         ports:
         - containerPort: 80
         env:
@@ -97,7 +97,7 @@ spec:
     spec:
       containers:
       - name: canary
-        image: registry.k8s.io/ingress-nginx/e2e-test-echo@sha256:6fc5aa2994c86575975bb20a5203651207029a0d28e3f491d8a127d08baadab4
+        image: registry.k8s.io/ingress-nginx/e2e-test-echo@sha256:d9c4240efb797beeaa7d4a28314a6c982469da1de0a62645c4c72d4f3fa338ee
         ports:
         - containerPort: 80
         env:

--- a/docs/examples/customization/custom-errors/custom-default-backend.helm.values.yaml
+++ b/docs/examples/customization/custom-errors/custom-default-backend.helm.values.yaml
@@ -6,7 +6,7 @@ defaultBackend:
   image:
     registry: registry.k8s.io
     image: ingress-nginx/nginx-errors
-    tag: "v20230505@sha256:3600dcd1bbd0d05959bb01af4b272714e94d22d24a64e91838e7183c80e53f7f"
+    tag: "v20230626@sha256:59bd93fede2559c2b61d3baa5e9066e5b3ba71fa4faa06e368629ed287469b1d"
   extraVolumes:
   - name: custom-error-pages
     configMap:

--- a/docs/examples/customization/external-auth-headers/echo-service.yaml
+++ b/docs/examples/customization/external-auth-headers/echo-service.yaml
@@ -18,7 +18,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
       - name: echo-service
-        image: registry.k8s.io/ingress-nginx/e2e-test-echo:v20230527@sha256:6fc5aa2994c86575975bb20a5203651207029a0d28e3f491d8a127d08baadab4
+        image: registry.k8s.io/ingress-nginx/e2e-test-echo:sha256:d9c4240efb797beeaa7d4a28314a6c982469da1de0a62645c4c72d4f3fa338ee
         ports:
         - containerPort: 8080
         resources:

--- a/test/e2e-image/Makefile
+++ b/test/e2e-image/Makefile
@@ -1,6 +1,6 @@
 
 DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
-E2E_BASE_IMAGE ?= "registry.k8s.io/ingress-nginx/e2e-test-runner:v20230623-d50c7193b@sha256:e5c68dc56934c273850bfb75c0348a2819756669baf59fcdce9e16771537b247"
+E2E_BASE_IMAGE ?= "registry.k8s.io/ingress-nginx/e2e-test-runner:v20230627-1ddecfc0@9ha256:2cc681d0d20911946e6b9c2048397f5c9e9b17e8f5c2007f6a3814bfb22f1816"
 
 image:
 	echo "..entered Makefile in /test/e2e-image"

--- a/test/e2e/HTTPBUN_IMAGE
+++ b/test/e2e/HTTPBUN_IMAGE
@@ -1,1 +1,1 @@
-registry.k8s.io/ingress-nginx/e2e-test-httpbun:v20230505-v0.0.1
+registry.k8s.io/ingress-nginx/e2e-test-httpbun:v20230626@sha256:bd6728b770de8425dbbd7937bcadf27373a1ad3c103e4b00801f60d48059e39f

--- a/test/e2e/framework/deployment.go
+++ b/test/e2e/framework/deployment.go
@@ -47,7 +47,7 @@ const NIPService = "external-nip"
 var HTTPBunImage = os.Getenv("HTTPBUN_IMAGE")
 
 // EchoImage is the default image to be used by the echo service
-const EchoImage = "registry.k8s.io/ingress-nginx/e2e-test-echo@sha256:4938d1d91a2b7d19454460a8c1b010b89f6ff92d2987fd889ac3e8fc3b70d91a"
+const EchoImage = "registry.k8s.io/ingress-nginx/e2e-test-echo@sha256:d9c4240efb797beeaa7d4a28314a6c982469da1de0a62645c4c72d4f3fa338ee"
 
 // TODO: change all Deployment functions to use these options
 // in order to reduce complexity and have a unified API accross the
@@ -220,7 +220,7 @@ func (f *Framework) NewHttpbunDeployment(opts ...func(*deploymentOptions)) strin
 		80,
 		int32(options.replicas),
 		nil, nil,
-		//Required to get hostname information
+		// Required to get hostname information
 		[]corev1.EnvVar{
 			{
 				Name:  "HTTPBUN_INFO_ENABLED",
@@ -494,7 +494,8 @@ func (f *Framework) NewGRPCBinDeployment() {
 }
 
 func newDeployment(name, namespace, image string, port int32, replicas int32, command []string, args []string, env []corev1.EnvVar,
-	volumeMounts []corev1.VolumeMount, volumes []corev1.Volume, setProbe bool) *appsv1.Deployment {
+	volumeMounts []corev1.VolumeMount, volumes []corev1.Volume, setProbe bool,
+) *appsv1.Deployment {
 	probe := &corev1.Probe{
 		InitialDelaySeconds: 2,
 		PeriodSeconds:       1,

--- a/test/e2e/framework/fastcgi_helloserver.go
+++ b/test/e2e/framework/fastcgi_helloserver.go
@@ -58,7 +58,7 @@ func (f *Framework) NewNewFastCGIHelloServerDeploymentWithReplicas(replicas int3
 					Containers: []corev1.Container{
 						{
 							Name:  "fastcgi-helloserver",
-							Image: "registry.k8s.io/ingress-nginx/e2e-test-fastcgi-helloserver@sha256:0e08c836cc58f1ea862578de99b13bc4264fe071e816f96dc1d79857bfba7473",
+							Image: "registry.k8s.io/ingress-nginx/e2e-test-fastcgi-helloserver@sha256:5470f0ddcfdaadcb7ccaf3db1b9fd7ac692e86eae2d59d272cd09d20a6a45c53",
 							Env:   []corev1.EnvVar{},
 							Ports: []corev1.ContainerPort{
 								{


### PR DESCRIPTION
## What this PR does / why we need it:
- For CVE fixes, many images got rebuilt for bumping go to v1.20.5 and updating alpine to v3.18.2
- This PR updates the sha & tag for 7 of these updated images
- This also needs to be cherry-picked to the v1.8 branch so that static yaml manifests and values file for chart gets updated

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
- Multiple CVE reported issues exist so will need to close them one by one after this merges
- 
## How Has This Been Tested?
- Will be tested n CI when testrunner and httpbun etc gets used

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.

/triage accepted
/priority important-soon

cc @strongjz @rikatz @cpanato @tao12345666333  Please review/lgtm/approve