### PR TITLE
Expose continent data as geoip2 variables in the case of Maxmind city files

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -224,6 +224,8 @@ http {
         $geoip2_subregion_code source=$remote_addr subdivisions 1 iso_code;
         $geoip2_subregion_name source=$remote_addr subdivisions 1 names en;
         $geoip2_subregion_geoname_id source=$remote_addr subdivisions 1 geoname_id;
+        $geoip2_city_continent_code source=$remote_addr continent code;
+        $geoip2_city_continent_name source=$remote_addr continent names en;
     }
     {{ end }}
 
@@ -245,6 +247,8 @@ http {
         $geoip2_subregion_code source=$remote_addr subdivisions 1 iso_code;
         $geoip2_subregion_name source=$remote_addr subdivisions 1 names en;
         $geoip2_subregion_geoname_id source=$remote_addr subdivisions 1 geoname_id;
+        $geoip2_city_continent_code source=$remote_addr continent code;
+        $geoip2_city_continent_name source=$remote_addr continent names en;
     }
     {{ end }}
 


### PR DESCRIPTION
## What this PR does / why we need it:
Maxmind does offer continent data in their City files, which is currently not exposed, thus inaccessible. This PR exposes them as $geoip2 variables, like every other parameter.

## Types of changes
- [?] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## How Has This Been Tested?
In a general nginx docker environment
I did not actually test it running the ingress controller in a kubernetes cluster, but the changes are so small, they shouldn't work any differently there

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
