### PR TITLE
Properly support a TLS-wrapped OCSP responder

### DIFF
--- a/rootfs/etc/nginx/lua/certificate.lua
+++ b/rootfs/etc/nginx/lua/certificate.lua
@@ -103,6 +103,7 @@ local function do_ocsp_request(url, ocsp_request)
       ["Host"] = parsed_url[2],
     },
     body = ocsp_request,
+    ssl_server_name = parsed_url[2],
   })
   if not http_response then
     return nil, err


### PR DESCRIPTION
## What this PR does / why we need it:

Current implementation of OCSP stapling makes use of the DNS caching machinery[^1], which results in resty.http not seeing the actual host name of the OCSP responder. On HTTP level, this is already mitigated via overriding the Host header, but if a given responder operates on a HTTPS endpoint (a setup which, admittedly, isn't very popular due to its chicken-and-egg caveats involved but is nonetheless legal[^2]) the connection will fail to be established. A relevant (and a bit redacted) excerpt from logs:

```
2023/07/02 18:13:23 [info] 112#112: *29039 [lua] dns.lua:32: cache_set(): cache set for 'my.ocsp.responder' with value of [10.1.2.3, 10.4.5.6, 10.7.8.9] and ttl of 30., context: ngx.timer, client: 127.0.0.1, server: 0.0.0.0:442
2023/07/02 18:13:23 [error] 112#112: *29039 lua ssl certificate does not match host "10.1.2.3", context: ngx.timer, client: 127.0.0.1, server: 0.0.0.0:442
2023/07/02 18:13:23 [error] 112#112: *29039 [lua] certificate.lua:143: fetch_and_cache_ocsp_response(): could not get OCSP response: certificate host mismatch, context: ngx.timer, client: 127.0.0.1, server: 0.0.0.0:442
```

[^1]: https://github.com/kubernetes/ingress-nginx/blob/ebb6314/rootfs/etc/nginx/lua/certificate.lua#L81
[^2]: https://datatracker.ietf.org/doc/html/rfc2560#appendix-A.1.1

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes

Haven't seen any that'd touch this problem.

## How Has This Been Tested?

I've test-drive deployed this patch to an instance serving certs from an in-house CA having its OCSP responder operating on HTTPS (and putting a `https://` OCSP URLs in the certs themselves) and apparently this change suffices for the stapling process to properly work.

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.
