### PR TITLE
Cleanup errcheck code in test/e2e pkg

### DIFF
--- a/test/e2e/endpointslices/topology.go
+++ b/test/e2e/endpointslices/topology.go
@@ -76,9 +76,8 @@ var _ = framework.IngressNginxDescribeSerial("[TopologyHints] topology aware rou
 		status, err := f.ExecIngressPod(curlCmd)
 		assert.Nil(ginkgo.GinkgoT(), err)
 		var backends []map[string]interface{}
-		if err := json.Unmarshal([]byte(status), &backends); err != nil {
-			assert.Nil(ginkgo.GinkgoT(), err)
-		}
+		err = json.Unmarshal([]byte(status), &backends)
+		assert.Nil(ginkgo.GinkgoT(), err, "unexpected error unmarshalling backends")
 		gotBackends := 0
 		for _, bck := range backends {
 			if strings.Contains(bck["name"].(string), "topology") {

--- a/test/e2e/settings/proxy_protocol.go
+++ b/test/e2e/settings/proxy_protocol.go
@@ -63,12 +63,11 @@ var _ = framework.DescribeSetting("use-proxy-protocol", func() {
 		defer conn.Close()
 
 		header := "PROXY TCP4 192.168.0.1 192.168.0.11 56324 1234\r\n"
-		if _, err := conn.Write([]byte(header)); err != nil {
-			assert.Nil(ginkgo.GinkgoT(), err, "unexpected error writing header")
-		}
-		if _, err := conn.Write([]byte("GET / HTTP/1.1\r\nHost: proxy-protocol\r\n\r\n")); err != nil {
-			assert.Nil(ginkgo.GinkgoT(), err, "unexpected error writing request")
-		}
+		_, err = conn.Write([]byte(header))
+		assert.Nil(ginkgo.GinkgoT(), err, "unexpected error writing header")
+
+		_, err = conn.Write([]byte("GET / HTTP/1.1\r\nHost: proxy-protocol\r\n\r\n"))
+		assert.Nil(ginkgo.GinkgoT(), err, "unexpected error writing request")
 
 		data, err := io.ReadAll(conn)
 		assert.Nil(ginkgo.GinkgoT(), err, "unexpected error reading connection data")
@@ -100,12 +99,11 @@ var _ = framework.DescribeSetting("use-proxy-protocol", func() {
 		defer conn.Close()
 
 		header := "PROXY TCP4 192.168.0.1 192.168.0.11 56324 443\r\n"
-		if _, err := conn.Write([]byte(header)); err != nil {
-			assert.Nil(ginkgo.GinkgoT(), err, "unexpected error writing header")
-		}
-		if _, err := conn.Write([]byte("GET / HTTP/1.1\r\nHost: proxy-protocol\r\n\r\n")); err != nil {
-			assert.Nil(ginkgo.GinkgoT(), err, "unexpected error writing request")
-		}
+		_, err = conn.Write([]byte(header))
+		assert.Nil(ginkgo.GinkgoT(), err, "unexpected error writing header")
+
+		_, err = conn.Write([]byte("GET / HTTP/1.1\r\nHost: proxy-protocol\r\n\r\n"))
+		assert.Nil(ginkgo.GinkgoT(), err, "unexpected error writing request")
 
 		data, err := io.ReadAll(conn)
 		assert.Nil(ginkgo.GinkgoT(), err, "unexpected error reading connection data")
@@ -213,12 +211,12 @@ var _ = framework.DescribeSetting("use-proxy-protocol", func() {
 		defer conn.Close()
 
 		header := "PROXY TCP4 192.168.0.1 192.168.0.11 56324 8080\r\n"
-		if _, err := conn.Write([]byte(header)); err != nil {
-			assert.Nil(ginkgo.GinkgoT(), err, "unexpected error writing header")
-		}
-		if _, err := conn.Write([]byte("GET / HTTP/1.1\r\nHost: proxy-protocol\r\n\r\n")); err != nil {
-			assert.Nil(ginkgo.GinkgoT(), err, "unexpected error writing request")
-		}
+		_, err = conn.Write([]byte(header))
+		assert.Nil(ginkgo.GinkgoT(), err, "unexpected error writing header")
+
+		_, err = conn.Write([]byte("GET / HTTP/1.1\r\nHost: proxy-protocol\r\n\r\n"))
+		assert.Nil(ginkgo.GinkgoT(), err, "unexpected error writing request")
+
 		_, err = io.ReadAll(conn)
 		assert.Nil(ginkgo.GinkgoT(), err, "unexpected error reading connection data")
 

--- a/test/e2e/ssl/secret_update.go
+++ b/test/e2e/ssl/secret_update.go
@@ -73,9 +73,8 @@ var _ = framework.IngressNginxDescribe("[SSL] secret update", func() {
 
 		dummySecret.Data["some-key"] = []byte("some value")
 
-		if _, err := f.KubeClientSet.CoreV1().Secrets(f.Namespace).Update(context.TODO(), dummySecret, metav1.UpdateOptions{}); err != nil {
-			assert.Nil(ginkgo.GinkgoT(), err, "updating secret")
-		}
+		_, err = f.KubeClientSet.CoreV1().Secrets(f.Namespace).Update(context.TODO(), dummySecret, metav1.UpdateOptions{})
+		assert.Nil(ginkgo.GinkgoT(), err, "updating secret")
 
 		assert.NotContains(ginkgo.GinkgoT(), log, fmt.Sprintf("starting syncing of secret %v/dummy", f.Namespace))
 		assert.NotContains(ginkgo.GinkgoT(), log, fmt.Sprintf("error obtaining PEM from secret %v/dummy", f.Namespace))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
<!--- Please make sure you title is descriptive, it is used in the Release notes to let others know what it does ---> 

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

Fixes the comment: https://github.com/kubernetes/ingress-nginx/pull/10128/files#r1250836940. 
I'm using `assert.Nil` instead of `assert.NoError` to keep the code style consistent, like:
https://github.com/kubernetes/ingress-nginx/blob/main/test/e2e/settings/proxy_protocol.go#L110C1-L111C80

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
