### PR TITLE
Metrics: Fix namespace in `nginx_ingress_controller_ssl_expire_time_seconds`.

### DIFF
--- a/internal/ingress/metric/collectors/controller.go
+++ b/internal/ingress/metric/collectors/controller.go
@@ -305,6 +305,7 @@ func (cm *Controller) SetSSLExpireTime(servers []*ingress.Server) {
 		}
 		labels["host"] = s.Hostname
 		labels["secret_name"] = s.SSLCert.Name
+		labels["namespace"] = s.SSLCert.Namespace
 		labels["identifier"] = s.SSLCert.Identifier()
 
 		cm.sslExpireTime.With(labels).Set(float64(s.SSLCert.ExpireTime.Unix()))

--- a/internal/ingress/metric/collectors/controller_test.go
+++ b/internal/ingress/metric/collectors/controller_test.go
@@ -88,6 +88,8 @@ func TestControllerCounters(t *testing.T) {
 						Hostname: "demo",
 						SSLCert: &ingress.SSLCert{
 							ExpireTime: t1,
+							Name:       "secret-name",
+							Namespace:  "secret-namespace",
 							Certificate: &x509.Certificate{
 								PublicKeyAlgorithm: x509.ECDSA,
 								Issuer: pkix.Name{
@@ -111,7 +113,7 @@ func TestControllerCounters(t *testing.T) {
 			want: `
 				# HELP nginx_ingress_controller_ssl_expire_time_seconds Number of seconds since 1970 to the SSL Certificate expire.\n			An example to check if this certificate will expire in 10 days is: "nginx_ingress_controller_ssl_expire_time_seconds < (time() + (10 * 24 * 3600))"
 				# TYPE nginx_ingress_controller_ssl_expire_time_seconds gauge
-				nginx_ingress_controller_ssl_expire_time_seconds{class="nginx",host="demo",identifier="abcd1234-100",namespace="default",secret_name=""} 1.351807721e+09
+				nginx_ingress_controller_ssl_expire_time_seconds{class="nginx",host="demo",identifier="abcd1234-100",namespace="secret-namespace",secret_name="secret-name"} 1.351807721e+09
 			`,
 			metrics: []string{"nginx_ingress_controller_ssl_expire_time_seconds"},
 		},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
<!--- Please make sure you title is descriptive, it is used in the Release notes to let others know what it does ---> 

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

now the metric in the namespace label gives the value of where the controller is located but not the ingress itself, which is misleading for an engineer who studies the NGINXCertificateExpiry alert created on the basis of the nginx_ingress_controller_ssl_expire_time_seconds metric. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
The hotfix will improve the NGINXCertificateExpiry alert. After the fix, it will contain information about the space where the ingress was created and the name of the secret, instead of where the ingress controller is, which is more convenient for understanding where to look for a faulty secret with a certificate.
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
build and manually check the values of labels that are passed to Prometheus.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [x] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.
