### PR TITLE
Helm - Fix Chart.yaml - add license annotations, add type keyword, remove gotpl

### DIFF
--- a/charts/ingress-nginx/Chart.yaml
+++ b/charts/ingress-nginx/Chart.yaml
@@ -5,12 +5,12 @@ annotations:
      - "[helm] configure allow to configure hostAliases (#10180)"
      - "[helm] pass service annotations through helm tpl engine (#10084)"
      - "Update Ingress-Nginx version controller-v1.9.0-beta.0"
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/prerelease: "true"
 apiVersion: v2
 appVersion: 1.9.0-beta.0
 description: Ingress controller for Kubernetes using NGINX as a reverse proxy and
   load balancer
-engine: gotpl
 home: https://github.com/kubernetes/ingress-nginx
 icon: https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Nginx_logo.svg/500px-Nginx_logo.svg.png
 keywords:
@@ -24,4 +24,5 @@ maintainers:
 name: ingress-nginx
 sources:
 - https://github.com/kubernetes/ingress-nginx
+type: application
 version: 4.8.0-beta.0

--- a/charts/ingress-nginx/README.md
+++ b/charts/ingress-nginx/README.md
@@ -2,7 +2,7 @@
 
 [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer
 
-![Version: 4.8.0-beta.0](https://img.shields.io/badge/Version-4.8.0--beta.0-informational?style=flat-square) ![AppVersion: 1.9.0-beta.0](https://img.shields.io/badge/AppVersion-1.9.0--beta.0-informational?style=flat-square)
+![Version: 4.8.0-beta.0](https://img.shields.io/badge/Version-4.8.0--beta.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.9.0-beta.0](https://img.shields.io/badge/AppVersion-1.9.0--beta.0-informational?style=flat-square)
 
 To use, add `ingressClassName: nginx` spec field or the `kubernetes.io/ingress.class: nginx` annotation to your Ingress resources.
 


### PR DESCRIPTION
## What this PR does / why we need it:

- Chart.yaml refinement
  - add license annotations
    - Licenses will displayed on artifacthub
    - License search will available
  - add type keyword
  - remove gotpl
    - No longer supported in [apiVersionV2 syntax](https://helm.sh/docs/topics/charts/#the-chartyaml-file)

![image](https://github.com/kubernetes/ingress-nginx/assets/10738333/be2059de-444c-4b22-8191-1506dac9bbe9)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation only

## Which issue/s this PR fixes

- none.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- There is no test.
  - But, these keywords are already in use in many of ArtifactHub's repositories
  - VSCode IntelliSense does not cause errors.
  - I have read read the docs
    - https://helm.sh/docs/topics/charts/#the-chartyaml-file
    - https://artifacthub.io/docs/topics/annotations/helm/

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
