### PR TITLE
Remove curl dependencies in e2e tests #9716

### DIFF
--- a/test/e2e/annotations/serviceupstream.go
+++ b/test/e2e/annotations/serviceupstream.go
@@ -25,8 +25,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"k8s.io/ingress-nginx/test/e2e/framework"
-
-	"k8s.io/ingress-nginx/internal/nginx"
 )
 
 var _ = framework.DescribeAnnotation("service-upstream", func() {
@@ -59,10 +57,10 @@ var _ = framework.DescribeAnnotation("service-upstream", func() {
 
 			ginkgo.By("checking if the Service Cluster IP and Port are used")
 			s := f.GetService(f.Namespace, framework.EchoService)
-			curlCmd := fmt.Sprintf("curl --fail --silent http://localhost:%v/configuration/backends", nginx.StatusPort)
-			output, err := f.ExecIngressPod(curlCmd)
+			dbgCmd := "/dbg backends all"
+			output, err := f.ExecIngressPod(dbgCmd)
 			assert.Nil(ginkgo.GinkgoT(), err)
-			assert.Contains(ginkgo.GinkgoT(), output, fmt.Sprintf(`{"address":"%s"`, s.Spec.ClusterIP))
+			assert.Contains(ginkgo.GinkgoT(), output, fmt.Sprintf(`"address": "%s"`, s.Spec.ClusterIP))
 		})
 	})
 
@@ -88,10 +86,10 @@ var _ = framework.DescribeAnnotation("service-upstream", func() {
 
 			ginkgo.By("checking if the Service Cluster IP and Port are used")
 			s := f.GetService(f.Namespace, framework.EchoService)
-			curlCmd := fmt.Sprintf("curl --fail --silent http://localhost:%v/configuration/backends", nginx.StatusPort)
-			output, err := f.ExecIngressPod(curlCmd)
+			dbgCmd := "/dbg backends all"
+			output, err := f.ExecIngressPod(dbgCmd)
 			assert.Nil(ginkgo.GinkgoT(), err)
-			assert.Contains(ginkgo.GinkgoT(), output, fmt.Sprintf(`{"address":"%s"`, s.Spec.ClusterIP))
+			assert.Contains(ginkgo.GinkgoT(), output, fmt.Sprintf(`"address": "%s"`, s.Spec.ClusterIP))
 		})
 	})
 
@@ -119,10 +117,10 @@ var _ = framework.DescribeAnnotation("service-upstream", func() {
 
 			ginkgo.By("checking if the Service Cluster IP and Port are not used")
 			s := f.GetService(f.Namespace, framework.EchoService)
-			curlCmd := fmt.Sprintf("curl --fail --silent http://localhost:%v/configuration/backends", nginx.StatusPort)
-			output, err := f.ExecIngressPod(curlCmd)
+			dbgCmd := "/dbg backends all"
+			output, err := f.ExecIngressPod(dbgCmd)
 			assert.Nil(ginkgo.GinkgoT(), err)
-			assert.NotContains(ginkgo.GinkgoT(), output, fmt.Sprintf(`{"address":"%s"`, s.Spec.ClusterIP))
+			assert.NotContains(ginkgo.GinkgoT(), output, fmt.Sprintf(`"address": "%s"`, s.Spec.ClusterIP))
 		})
 	})
 })

--- a/test/e2e/endpointslices/topology.go
+++ b/test/e2e/endpointslices/topology.go
@@ -28,7 +28,6 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/stretchr/testify/assert"
 
-	"k8s.io/ingress-nginx/internal/nginx"
 	"k8s.io/ingress-nginx/test/e2e/framework"
 )
 
@@ -72,8 +71,8 @@ var _ = framework.IngressNginxDescribeSerial("[TopologyHints] topology aware rou
 			}
 		}
 
-		curlCmd := fmt.Sprintf("curl --fail --silent http://localhost:%v/configuration/backends", nginx.StatusPort)
-		status, err := f.ExecIngressPod(curlCmd)
+		dbgCmd := "/dbg backends all"
+		status, err := f.ExecIngressPod(dbgCmd)
 		assert.Nil(ginkgo.GinkgoT(), err)
 		var backends []map[string]interface{}
 		err = json.Unmarshal([]byte(status), &backends)

--- a/test/e2e/servicebackend/service_externalname.go
+++ b/test/e2e/servicebackend/service_externalname.go
@@ -30,7 +30,6 @@ import (
 	networking "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"k8s.io/ingress-nginx/internal/nginx"
 	"k8s.io/ingress-nginx/test/e2e/framework"
 )
 
@@ -330,17 +329,13 @@ var _ = framework.IngressNginxDescribe("[Service] Type ExternalName", func() {
 		assert.Contains(ginkgo.GinkgoT(), body, `"X-Forwarded-Host": "echo"`)
 
 		ginkgo.By("checking the service is updated to use new host")
-		curlCmd := fmt.Sprintf(
-			"curl --fail --silent http://localhost:%v/configuration/backends",
-			nginx.StatusPort,
-		)
-
-		output, err := f.ExecIngressPod(curlCmd)
+		dbgCmd := "/dbg backends all"
+		output, err := f.ExecIngressPod(dbgCmd)
 		assert.Nil(ginkgo.GinkgoT(), err)
 		assert.Contains(
 			ginkgo.GinkgoT(),
 			output,
-			fmt.Sprintf("{\"address\":\"%s\"", framework.BuildNIPHost(ip)),
+			fmt.Sprintf(`"address": "%s"`, framework.BuildNIPHost(ip)),
 		)
 	})
 

--- a/test/e2e/settings/tls.go
+++ b/test/e2e/settings/tls.go
@@ -170,15 +170,17 @@ var _ = framework.DescribeSetting("[SSL] TLS protocols, ciphers and headers)", f
 				hstsIncludeSubdomains: "false",
 			})
 
-			// we can not use gorequest here because it flattens the duplicate headers
-			// and specifically in case of Strict-Transport-Security it ignore extra headers
-			// intead of concatenating, rightfully. And I don't know of any API it provides for getting raw headers.
-			curlCmd := fmt.Sprintf("curl -I -k --fail --silent --resolve settings-tls:443:127.0.0.1 https://settings-tls%v", "?hsts=true")
-			output, err := f.ExecIngressPod(curlCmd)
-			assert.Nil(ginkgo.GinkgoT(), err)
-			assert.Contains(ginkgo.GinkgoT(), output, "strict-transport-security: max-age=86400; preload")
-			// this is what the upstream sets
-			assert.NotContains(ginkgo.GinkgoT(), output, "strict-transport-security: max-age=3600; preload")
+			expectResponse := f.HTTPTestClientWithTLSConfig(tlsConfig).
+				GET("/").
+				WithURL(f.GetURL(framework.HTTPS)).
+				WithHeader("Host", host).
+				WithQuery("hsts", "true").
+				Expect()
+
+			expectResponse.Header("Strict-Transport-Security").Equal("max-age=86400; preload")
+			header := expectResponse.Raw().Header
+			got := header["Strict-Transport-Security"]
+			assert.Equal(ginkgo.GinkgoT(), 1, len(got))
 		})
 
 	})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
<!--- Please make sure you title is descriptive, it is used in the Release notes to let others know what it does ---> 

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->
fixes #9716
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```
ginkgo  --trace --focus "should return 200 when service has topology hints" ./e2e.test
ginkgo  --trace --focus "should update the external name after a service update" ./e2e.test
ginkgo  --trace --focus "should use the Service Cluster IP and Port" ./e2e.test
ginkgo  --trace --focus "should not use the Service Cluster IP and Port" ./e2e.test
ginkgo  --trace --focus "overriding what's set from the upstream" ./e2e.test
```
