### PR TITLE
Disable Modsecurity from internal processing which affects large ingresses 

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -710,7 +710,7 @@ http {
     # default server, used for NGINX healthcheck and access to nginx stats
     server {
         # Ensure that modsecurity will not run on an internal location as this is not accessible from outside
-        {{ if $modsecurityEnabled }}
+        {{ if $all.Cfg.EnableModsecurity }}
         modsecurity off;
         {{ end }}
 

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -709,6 +709,11 @@ http {
 
     # default server, used for NGINX healthcheck and access to nginx stats
     server {
+        # Ensure that modsecurity will not run on an internal location as this is not accessible from outside
+        {{ if $modsecurityEnabled }}
+        modsecurity off;
+        {{ end }}
+
         listen 127.0.0.1:{{ .StatusPort }};
         set $proxy_upstream_name "internal";
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
<!--- Please make sure you title is descriptive, it is used in the Release notes to let others know what it does ---> 

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
We ran into situation where our large number on ingresses would not work when Modsecurity was enabled. It was determined that Modsecurity was turned on by default for internal processing and this was impacting ingress operations. We tested disabling Modsecurity for internal processing and issue was resolved
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):
fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
We tested in our production environment with large number of ingresses overriding file /etc/nginx/template/nginx.tmpl with necessary change to disable Modsecurity from internal processing. It worked in full production environment 
<!--- Include details of your testing environment, and the tests you ran to -->
We tested all ingress URLs after change and Modsecurity was blocking WAF violations, but not hindering internal processing
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
