### PR TITLE
fix(labels): use complete labels variable on default-backend deployment

### DIFF
--- a/charts/ingress-nginx/templates/default-backend-deployment.yaml
+++ b/charts/ingress-nginx/templates/default-backend-deployment.yaml
@@ -30,7 +30,7 @@ spec:
       annotations: {{ toYaml .Values.defaultBackend.podAnnotations | nindent 8 }}
     {{- end }}
       labels:
-        {{- include "ingress-nginx.selectorLabels" . | nindent 8 }}
+        {{- include "ingress-nginx.labels" . | nindent 8 }}
         app.kubernetes.io/component: default-backend
         {{- with .Values.defaultBackend.labels }}
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
<!--- Please make sure you title is descriptive, it is used in the Release notes to let others know what it does ---> 

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This simply swaps a usage of `ingress-nginx.selectorLabels` for `ingress-nginx.labels`, which itself contains `selectorLabels` so there's no loss of metadata.

Essentially every templated resource in the chart uses `ingress-nginx.labels` within `metadata.labels` to include custom labels supplied via `.Values.commonLabels`.
For reasons I can't determine from perusing blame history this was the exception and it just so happens to be something I noticed at runtime~

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

N/A

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

locally validated with `helm template`, verifying that labels supplied to `commonLabels` appear in the default backend `spec.template.metadata.labels` where they don't in the current release

```
~/repos/ingress-nginx/charts/ingress-nginx$ helm template ingress-nginx . \
    --set='commonLabels.test=foobar,commonLabels.another=one' \
    --set='defaultBackend.enabled=true'
```
```yaml
# <snipped for brevity>
---
# Source: ingress-nginx/templates/default-backend-deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    helm.sh/chart: ingress-nginx-4.7.1
    app.kubernetes.io/name: ingress-nginx
    app.kubernetes.io/instance: ingress-nginx
    app.kubernetes.io/version: "1.8.1"
    app.kubernetes.io/part-of: ingress-nginx
    app.kubernetes.io/managed-by: Helm
    another: one
    test: foobar
    app.kubernetes.io/component: default-backend
  name: ingress-nginx-defaultbackend
  namespace: default
spec:
  selector:
    matchLabels:
      app.kubernetes.io/name: ingress-nginx
      app.kubernetes.io/instance: ingress-nginx
      app.kubernetes.io/component: default-backend
  replicas: 1
  revisionHistoryLimit: 10
  minReadySeconds: 0
  template:
    metadata:
      labels:
        helm.sh/chart: ingress-nginx-4.7.1
        app.kubernetes.io/name: ingress-nginx
        app.kubernetes.io/instance: ingress-nginx
        app.kubernetes.io/version: "1.8.1"
        app.kubernetes.io/part-of: ingress-nginx
        app.kubernetes.io/managed-by: Helm
        another: one
        test: foobar
        app.kubernetes.io/component: default-backend
# <snipped for brevity>
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
