### PR TITLE
fix 'permission denied' error on image build

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -76,11 +76,11 @@ RUN apk add --no-cache libcap \
   && apk del libcap \
   && ln -sf /usr/local/nginx/sbin/nginx /usr/bin/nginx
 
-USER www-data
-
 # Create symlinks to redirect nginx logs to stdout and stderr docker log collector
 RUN  ln -sf /dev/stdout /var/log/nginx/access.log \
   && ln -sf /dev/stderr /var/log/nginx/error.log
+
+USER www-data
 
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 


### PR DESCRIPTION
## What this PR does / why we need it:
make build && make image fails to build controller image due to Dockerfile error. This is because the USER directive is used too early and that user cannot create symbolic links later. It looks like the two commands are just swapped by accident.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes

## How Has This Been Tested?
make image successfully built after the fix