### PR TITLE
Making auth access logs optional

### DIFF
--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -131,6 +131,10 @@ type Configuration struct {
 	// By default this is disabled
 	EnableAccessLogForDefaultBackend bool `json:"enable-access-log-for-default-backend"`
 
+	// EnableAuthAccessLog enable auth access log
+	// By default this is disabled
+	EnableAuthAccessLog bool `json:"enable-auth-access-log"`
+
 	// AccessLogPath sets the path of the access logs for both http and stream contexts if enabled
 	// http://nginx.org/en/docs/http/ngx_http_log_module.html#access_log
 	// http://nginx.org/en/docs/stream/ngx_stream_log_module.html#access_log
@@ -871,6 +875,7 @@ func NewDefault() Configuration {
 		AccessLogPath:                    "/var/log/nginx/access.log",
 		AccessLogParams:                  "",
 		EnableAccessLogForDefaultBackend: false,
+		EnableAuthAccessLog:              false,
 		WorkerCPUAffinity:                "",
 		ErrorLogPath:                     "/var/log/nginx/error.log",
 		BlockCIDRs:                       defBlockEntity,

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -1102,7 +1102,9 @@ stream {
             opentelemetry_propagate;
             {{ end }}
 
+            {{ if not $all.Cfg.EnableAuthAccessLog }}
             access_log off;
+            {{ end }}
 
             # Ensure that modsecurity will not run on an internal location as this is not accessible from outside
             {{ if $all.Cfg.EnableModsecurity }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
<!--- Please make sure you title is descriptive, it is used in the Release notes to let others know what it does ---> 

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Since the introduction of [controller-v1.6.4](https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.6.4), authentication access logs have been disabled (#9049). Before this version, requests to endpoints requiring authentication generated two log entries: one for the authentication endpoint and another for the user's intended target. In versions post v1.6.4, only the user's intended target is logged. However, some customers still rely on these authentication logs.

To ensure we don't hinder their upgrade path or inadvertently disrupt existing features, this PR introduces an option to enable these logs (again).

The default behavior remains unchanged; **auth access logs are still disabled**.

To enable the authentication logs using Helm values, refer to the example below:
```yaml
controller:
  config:
    enable-auth-access-log: "true"
```
### Logging Output Examples:


1. **Successful Requests to Endpoints Requiring Authentication**:

   - **Prior to controller-v1.6.4** (or after this PR with `enable-auth-access-log: "true"`):
     ```log
     127.0.0.1 - - [25/Aug/2023:17:42:53 +0000] "GET / HTTP/1.1" 200 0 "-" "curl/8.2.1" 0 0.007 [apps-app-01-80] [] 10.96.122.125:80 0 0.006 200 20b35799e6d62a9166d1907fcc9b9da7
     127.0.0.1 - - [25/Aug/2023:17:42:53 +0000] "GET / HTTP/1.1" 200 138 "-" "curl/8.2.1" 90 0.020 [apps-app-01-80] [] 10.244.0.5:80 138 0.013 200 20b35799e6d62a9166d1907fcc9b9da7
     ```

   - **After controller-v1.6.4** (or after this PR with `enable-auth-access-log: "false"`):
     ```log
     127.0.0.1 - - [25/Aug/2023:17:43:32 +0000] "GET / HTTP/1.1" 200 138 "-" "curl/8.2.1" 90 0.018 [apps-app-01-80] [] 10.244.0.5:80 138 0.009 200 320ea8cc4cbd9cdb69b33f98628eae77
     ```

2. **Denied Requests to Endpoints Requiring Authentication**:

   - **Prior to controller-v1.6.4** (or after this PR with `enable-auth-access-log: "true"`):
     ```log
     127.0.0.1 - - [25/Aug/2023:17:35:08 +0000] "GET / HTTP/1.1" 401 0 "-" "curl/8.2.1" 0 0.003 [apps-app-01-80] [] 10.96.122.125:80 0 0.002 401 96e51371ea8785dc25b4290ebfafa280
     127.0.0.1 - - [25/Aug/2023:17:35:08 +0000] "GET / HTTP/1.1" 401 172 "-" "curl/8.2.1" 73 0.003 [apps-app-01-80] [] - - - - 96e51371ea8785dc25b4290ebfafa280
     ```

   - **After controller-v1.6.4** (or after this PR with `enable-auth-access-log: "false"`):
     ```log
     127.0.0.1 - - [25/Aug/2023:17:31:36 +0000] "GET / HTTP/1.1" 401 172 "-" "curl/8.2.1" 73 1.362 [apps-app-01-80] [] - - - - 5b931cd1a13a5e19bab314589c377f92
     ```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [X] All new and existing tests passed.
