### PR TITLE
Add default-server-config to the configuration ConfigMap

### DIFF
--- a/docs/user-guide/nginx-configuration/configmap.md
+++ b/docs/user-guide/nginx-configuration/configmap.md
@@ -174,6 +174,7 @@ The following table shows a configuration option's name, type, and the default v
 |[otel-sampler-ratio](#otel-sampler-ratio)|float|0.01||
 |[main-snippet](#main-snippet)|string|""||
 |[http-snippet](#http-snippet)|string|""||
+|[default-server-snippet](#default-server-snippet)|string|""||
 |[server-snippet](#server-snippet)|string|""||
 |[stream-snippet](#stream-snippet)|string|""||
 |[location-snippet](#location-snippet)|string|""||
@@ -735,7 +736,7 @@ _**default:**_ false
 ## enable-brotli
 
 Enables or disables compression of HTTP responses using the ["brotli" module](https://github.com/google/ngx_brotli).
-The default mime type list to compress is: `application/xml+rss application/atom+xml application/javascript application/x-javascript application/json application/rss+xml application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/svg+xml image/x-icon text/css text/plain text/x-component`. 
+The default mime type list to compress is: `application/xml+rss application/atom+xml application/javascript application/x-javascript application/json application/rss+xml application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/svg+xml image/x-icon text/css text/plain text/x-component`.
 _**default:**_ false
 
 > __Note:__ Brotli does not works in Safari < 11. For more information see [https://caniuse.com/#feat=brotli](https://caniuse.com/#feat=brotli)
@@ -1097,6 +1098,10 @@ Adds custom configuration to the main section of the nginx configuration.
 
 Adds custom configuration to the http section of the nginx configuration.
 
+## default-server-snippet
+
+Adds custom configuration to the default server in the nginx configuration.
+
 ## server-snippet
 
 Adds custom configuration to all the servers in the nginx configuration.
@@ -1418,5 +1423,5 @@ and containing invalid characters to be denied.
 
 This means that Ingress objects that rely on paths containing regex characters should use `ImplementationSpecific` pathType.
 
-The cluster admin should establish validation rules using mechanisms like [Open Policy Agent](https://www.openpolicyagent.org/) to 
+The cluster admin should establish validation rules using mechanisms like [Open Policy Agent](https://www.openpolicyagent.org/) to
 validate that only authorized users can use `ImplementationSpecific` pathType and that only the authorized characters can be used.

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -727,6 +727,9 @@ type Configuration struct {
 	// HTTPSnippet adds custom configuration to the http section of the nginx configuration
 	HTTPSnippet string `json:"http-snippet"`
 
+	// DefaultServerSnippet adds custom configuration to the default server in the nginx configuration
+	DefaultServerSnippet string `json:"default-server-snippet"`
+
 	// ServerSnippet adds custom configuration to all the servers in the nginx configuration
 	ServerSnippet string `json:"server-snippet"`
 

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -729,6 +729,11 @@ http {
         {{ if $cfg.EnableOpentelemetry }}
         opentelemetry off;
         {{ end }}
+        
+        {{ if not (empty $cfg.DefaultServerSnippet) }}
+        # Custom code snippet configured for default server
+        {{ $cfg.DefaultServerSnippet }}
+        {{ end }}
         location {{ $healthzURI }} {
             return 200;
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
<!--- Please make sure you title is descriptive, it is used in the Release notes to let others know what it does ---> 

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Currently it is not possible to add custom directive in the default server used for NGINX healthcheck and access to nginx stats. There are already some special cases here, e.g. for ModSecurity, OpenTracing and Opentelemetry, but nothing more general that can be used to add completely custom options.

I'm using ingress-nginx with a custom module ([libnginx-mod-redirectionio](https://github.com/redirectionio/libnginx-mod-redirectionio)) and would like to prevent it from processing this server. This requires us to add a custom configuration directive, which is not possible with the current options:

```
redirectionio off;
```

This PR resolves this issue, by adding a new `default-server-snippet` option to the configuration ConfigMap. This is in line with similar options such as the `main-snippet`, `http-snippet`, etc.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I've run the ingress in a local cluster (kind) according to the developer guide. To test the new option I've modified the configuration ConfigMap and compared the before/after to ensure correct behavior.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.