### PR TITLE
Fix “dev-env” Makefile target to work with kubectl 1.28+

### DIFF
--- a/build/dev-env.sh
+++ b/build/dev-env.sh
@@ -52,7 +52,7 @@ if [[ ${HELM_VERSION} -lt 3.10.0 ]]; then
   exit 1
 fi
 
-KUBE_CLIENT_VERSION=$(kubectl version --client --short 2>/dev/null | grep Client | awk '{print $3}' | cut -d. -f2) || true
+KUBE_CLIENT_VERSION=$(kubectl version --client -oyaml 2>/dev/null | grep "minor:" | awk '{print $2}' | tr -d '"') || true
 if [[ ${KUBE_CLIENT_VERSION} -lt 24 ]]; then
   echo "Please update kubectl to 1.24.2 or higher"
   exit 1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
<!--- Please make sure you title is descriptive, it is used in the Release notes to let others know what it does ---> 

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With the introduction of PR [#116720](https://github.com/kubernetes/kubernetes/pull/116720), the `--short` flag was set to be the default behavior of the `kubectl version` and later removed as an explicit option. This led to errors when executing the `kubectl version --client --short`. This PR amends the "dev-env" Makefile target to make it compatible with both the new and the older variants of the `kubectl version`.

Related: https://github.com/kubernetes/kubernetes/pull/116720

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):
fixes #
-->
Issue (when using `kubectl` >= 1.28.0):
```sh
~ kubectl version --client --short
error: unknown flag: --short
See 'kubectl version --help' for usage.
```
Usage on [build/dev-env.sh](https://github.com/kubernetes/ingress-nginx/blob/ac3ff59ea42a8c7defd84f5b5bf0e2c6e71ac133/build/dev-env.sh#L55): 
```sh
KUBE_CLIENT_VERSION=$(kubectl version --client --short 2>/dev/null | grep Client | awk '{print $3}' | cut -d. -f2) || true
if [[ ${KUBE_CLIENT_VERSION} -lt 24 ]]; then
  echo "Please update kubectl to 1.24.2 or higher"
  exit 1
fi
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [X] All new and existing tests passed.
