### PR TITLE
Copy otel distroless flag to daemonset

### DIFF
--- a/charts/ingress-nginx/templates/controller-daemonset.yaml
+++ b/charts/ingress-nginx/templates/controller-daemonset.yaml
@@ -186,7 +186,7 @@ spec:
       {{- end }}
       {{- if .Values.controller.opentelemetry.enabled}}
           {{ $otelContainerSecurityContext := $.Values.controller.opentelemetry.containerSecurityContext | default $.Values.controller.containerSecurityContext }}
-          {{- include "extraModules" (dict "name" "opentelemetry" "image" .Values.controller.opentelemetry.image "containerSecurityContext" $otelContainerSecurityContext) | nindent 8}}
+          {{- include "extraModules" (dict "name" "opentelemetry" "image" .Values.controller.opentelemetry.image "containerSecurityContext" $otelContainerSecurityContext "distroless" true) | nindent 8}}
       {{- end}}
     {{- end }}
     {{- if .Values.controller.hostNetwork }}


### PR DESCRIPTION
## What this PR does / why we need it:
This flag was added to the controller deployment, but not the controller daemonset.

* Added to deployment in https://github.com/kubernetes/ingress-nginx/pull/10035
* Promoted to `true` in https://github.com/kubernetes/ingress-nginx/pull/10257

I'm applying both of these deployment changes to the daemonset in one go.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
Updating to `1.8.2` / `ingress-nginx-4.7.2` with opentelemetry enabled on a daemonset resulted in a broken installation, because the DaemonSet pod went into `Init:RunContainerError`.

I didn't file an issue first since the PR change was minimal.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I ran helm on my modified chart, and it produced a `DaemonSet` with the correct entrypoint for distroless.

Is there a better way to test this sort of difference between `DaemonSet` and `Deployment`? This is not the first time that the `Damonset` was neglected with the otel initcontainer.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
