### PR TITLE
images: upgrade to Alpine 3.18.4

### DIFF
--- a/images/cfssl/rootfs/Dockerfile
+++ b/images/cfssl/rootfs/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.18.2
+FROM alpine:3.18.4
 
 
 RUN echo "@testing http://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories

--- a/images/nginx/rootfs/Dockerfile
+++ b/images/nginx/rootfs/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM alpine:3.18.2 as builder
+FROM alpine:3.18.4 as builder
 
 COPY . /
 
@@ -21,7 +21,7 @@ RUN apk update \
   && /build.sh
 
 # Use a multi-stage build
-FROM alpine:3.18.2
+FROM alpine:3.18.4
 
 ENV PATH=$PATH:/usr/local/luajit/bin:/usr/local/nginx/sbin:/usr/local/nginx/bin
 

--- a/images/opentelemetry/rootfs/Dockerfile
+++ b/images/opentelemetry/rootfs/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-FROM alpine:3.18.2 as base
+FROM alpine:3.18.4 as base
 
 RUN mkdir -p /opt/third_party/install
 COPY . /opt/third_party/

--- a/rootfs/Dockerfile-chroot
+++ b/rootfs/Dockerfile-chroot
@@ -23,7 +23,7 @@ RUN apk update \
   && apk upgrade \
   && /chroot.sh
 
-FROM alpine:3.18.2
+FROM alpine:3.18.4
 
 ARG TARGETARCH
 ARG VERSION

--- a/test/e2e-image/Dockerfile
+++ b/test/e2e-image/Dockerfile
@@ -1,7 +1,7 @@
 ARG E2E_BASE_IMAGE
 FROM ${E2E_BASE_IMAGE} AS BASE
 
-FROM alpine:3.18.2
+FROM alpine:3.18.4
 
 RUN apk update \
 	&& apk upgrade && apk add -U --no-cache \


### PR DESCRIPTION
## What this PR does / why we need it:
This PR resolves vulnerability CVE-2023-38039 mentioned in this issue: https://github.com/kubernetes/ingress-nginx/issues/10445

Alpine 3.18.2 is using the vulnerable curl version 8.2.1. The curl version got updated to 8.3.0 in Alpine 3.18.4 recently: https://git.alpinelinux.org/aports/commit/?h=v3.18.4&id=1af4e3f61a44fb1028399c7433fe7e47b9efcb1e

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes

fixes #10445 

## How Has This Been Tested?

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.
