### PR TITLE
fixes brotli build issues

### DIFF
--- a/images/nginx/rootfs/build.sh
+++ b/images/nginx/rootfs/build.sh
@@ -466,8 +466,10 @@ make install
 
 # Get Brotli source and deps
 cd "$BUILD_PATH"
-git clone --depth=1 https://github.com/google/ngx_brotli.git
+git clone --depth=100 https://github.com/google/ngx_brotli.git
 cd ngx_brotli
+# https://github.com/google/ngx_brotli/issues/156
+git reset --hard 63ca02abdcf79c9e788d2eedcc388d2335902e52
 git submodule init
 git submodule update
 


### PR DESCRIPTION
Fixes #10457

brotli changed the build upstream and caused build failures on the older version of nginx it seems. 

https://github.com/google/ngx_brotli/issues/156

