### PR TITLE
docs(tls): add warning for not supporting TLSv1, TLSv1.1

### DIFF
--- a/docs/user-guide/tls.md
+++ b/docs/user-guide/tls.md
@@ -127,6 +127,9 @@ ingress-nginx defaults to using TLS 1.2 and 1.3 only, with a [secure set of TLS 
 
 ### Legacy TLS
 
+!!! warning
+    TLSv1, TLSv1.1 are not supported in ingress-nginx v1.6.0 and above.
+
 The default configuration, though secure, does not support some older browsers and operating systems.
 
 For instance, TLS 1.1+ is only enabled by default from Android 5.0 on. At the time of writing,


### PR DESCRIPTION
## What this PR does / why we need it:

Add warning in doc for deprecating of TLSv1, and TLSv1.1 so that user who want to use legacy TLS can know which version shall be used.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation only

## Which issue/s this PR fixes

fixes #10215

## How Has This Been Tested?

N/A. This is only document update.

## Checklist:

- [] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
