### PR TITLE
Revert "Remove curl from nginx base image (#10477)"

### DIFF
--- a/images/nginx/rootfs/Dockerfile
+++ b/images/nginx/rootfs/Dockerfile
@@ -65,10 +65,7 @@ RUN apk update \
   for dir in "${writeDirs[@]}"; do \
   mkdir -p ${dir}; \
   chown -R www-data.www-data ${dir}; \
-  done' \
-  # Why we do this? Because apk package of the library requests curl and we dont want curl
-  && mv /usr/lib/libmaxminddb.so.* /usr/local/lib/ \
-  && apk del --purge libmaxminddb curl
+  done'
 
 EXPOSE 80 443
 


### PR DESCRIPTION
This reverts commit 8bd33d29e742c2b26070a8362eb11dee5ad0a0d2.

modsecurity and other libraries relies on libcurl. We need to check how to get it working on the runtime image without the concerns of compilation time, and maybe check if there's an alternative for it