### PR TITLE
Ignore fake certificate for `NGINXCertificateExpiry` Prometheus alert in Helm chart

### DIFF
--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -732,7 +732,7 @@ controller:
       #     description: bad ingress config - nginx config test failed
       #     summary: uninstall the latest ingress changes to allow config reloads to resume
       # - alert: NGINXCertificateExpiry
-      #   expr: (avg(nginx_ingress_controller_ssl_expire_time_seconds) by (host) - time()) < 604800
+      #   expr: (avg(nginx_ingress_controller_ssl_expire_time_seconds{host!="_"}) by (host) - time()) < 604800
       #   for: 1s
       #   labels:
       #     severity: critical


### PR DESCRIPTION
The fake certificate is only a fallback and it is okay-ish if it expires.

Do not alert for its expiration.

## What this PR does / why we need it:

If the fake certificate expires it is fine and we should not receive a critical alert for it.

This was noticed already via the Grafana dashboard in #6365.

However, I have decided to not change/hide that in the Grafana dashboards (it can be interesting there viewing it, depending of the point-of-view... but it's not nice if a Prometheus critical alert wake up some poor folk in the middle of the night! :)).

If you think it should be also hidden in the Grafana dashboard please let me know and I will adjust that too!

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

N/A

## How Has This Been Tested?

I have double-checked that via PromQL on an `ingress-nginx` that was running for 359 days.

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.
