### PR TITLE
update docs to explicitly state TLS termination location

### DIFF
--- a/docs/examples/grpc/README.md
+++ b/docs/examples/grpc/README.md
@@ -9,6 +9,7 @@ This example demonstrates how to route traffic to a gRPC service through the Ing
 3. You have the ingress-nginx-controller installed as per docs.
 4. You have a backend application running a gRPC server listening for TCP traffic.  If you want, you can use <https://github.com/grpc/grpc-go/blob/91e0aeb192456225adf27966d04ada4cf8599915/examples/features/reflection/server/main.go> as an example.
 5. You're also responsible for provisioning an SSL certificate for the ingress. So you need to have a valid SSL certificate, deployed as a Kubernetes secret of type `tls`, in the same namespace as the gRPC application.
+   - Note: To use gRPC with ingress-nginx, TLS _must_ be terminated by the ingress or gRPC server (using the `backend-protocol: "GRPCS"` annotation described below). 
 
 ### Step 1: Create a Kubernetes `Deployment` for gRPC app
 


### PR DESCRIPTION
## What this PR does / why we need it:
Adds explicit note to the docs about TLS termination compatibility. I've seen some other questions about this (I had the question myself), so I figured it might be good to callout explicitly.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation only


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
