### PR TITLE
helm: Add loadBalancerClass to internal service

### DIFF
--- a/charts/ingress-nginx/README.md
+++ b/charts/ingress-nginx/README.md
@@ -137,6 +137,22 @@ If one of them is missing the internal load balancer will not be deployed. Examp
 
 Example for AWS:
 
+* using [AWS Load Balancer Controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller/), which is recommanded by AWS, but you will have to install and configure this additional controller:
+
+```yaml
+controller:
+  service:
+    # Create internal NLB
+    loadBalancerClass: "service.k8s.aws/nlb"
+    internal:
+      enabled: true
+      annotations:
+        service.beta.kubernetes.io/aws-load-balancer-scheme: "internal"
+        # Any other annotation can be declared here.
+```
+
+* using the default inside kubernetes controller-manager (not up to date and will be mark as deprecated in futur release of kubernetes):
+
 ```yaml
 controller:
   service:
@@ -144,9 +160,8 @@ controller:
       enabled: true
       annotations:
         # Create internal NLB
+        service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
         service.beta.kubernetes.io/aws-load-balancer-scheme: "internal"
-        # Create internal ELB(Deprecated)
-        # service.beta.kubernetes.io/aws-load-balancer-internal: "true"
         # Any other annotation can be declared here.
 ```
 

--- a/charts/ingress-nginx/README.md.gotmpl
+++ b/charts/ingress-nginx/README.md.gotmpl
@@ -134,6 +134,22 @@ If one of them is missing the internal load balancer will not be deployed. Examp
 
 Example for AWS:
 
+* using [AWS Load Balancer Controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller/), which is recommanded by AWS, but you will have to install and configure this additional controller:
+
+```yaml
+controller:
+  service:
+    # Create internal NLB
+    loadBalancerClass: "service.k8s.aws/nlb"
+    internal:
+      enabled: true
+      annotations:
+        service.beta.kubernetes.io/aws-load-balancer-scheme: "internal"
+        # Any other annotation can be declared here.
+```
+
+* using the default inside kubernetes controller-manager (not up to date and will be mark as deprecated in futur release of kubernetes):
+
 ```yaml
 controller:
   service:
@@ -141,9 +157,8 @@ controller:
       enabled: true
       annotations:
         # Create internal NLB
+        service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
         service.beta.kubernetes.io/aws-load-balancer-scheme: "internal"
-        # Create internal ELB(Deprecated)
-        # service.beta.kubernetes.io/aws-load-balancer-internal: "true"
         # Any other annotation can be declared here.
 ```
 

--- a/charts/ingress-nginx/templates/controller-service-internal.yaml
+++ b/charts/ingress-nginx/templates/controller-service-internal.yaml
@@ -22,6 +22,9 @@ spec:
 {{- if .Values.controller.service.internal.loadBalancerSourceRanges }}
   loadBalancerSourceRanges: {{ toYaml .Values.controller.service.internal.loadBalancerSourceRanges | nindent 4 }}
 {{- end }}
+{{- if .Values.controller.service.loadBalancerClass }}
+  loadBalancerClass: {{ .Values.controller.service.loadBalancerClass }}
+{{- end }}
 {{- if .Values.controller.service.internal.externalTrafficPolicy }}
   externalTrafficPolicy: {{ .Values.controller.service.internal.externalTrafficPolicy }}
 {{- end }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
<!--- Please make sure you title is descriptive, it is used in the Release notes to let others know what it does ---> 

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When setting controller→service→loadBalancerClass , both internal and external services should be updated.
It's not currently the case, this PR fix this issue.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

fix https://github.com/kubernetes/ingress-nginx/issues/10504

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.