### PR TITLE
Increase HSTS max-age to default to one year

### DIFF
--- a/docs/user-guide/nginx-configuration/configmap.md
+++ b/docs/user-guide/nginx-configuration/configmap.md
@@ -62,7 +62,7 @@ The following table shows a configuration option's name, type, and the default v
 |[http2-max-concurrent-streams](#http2-max-concurrent-streams)|int|128||
 |[hsts](#hsts)|bool|"true"||
 |[hsts-include-subdomains](#hsts-include-subdomains)|bool|"true"||
-|[hsts-max-age](#hsts-max-age)|string|"15724800"||
+|[hsts-max-age](#hsts-max-age)|string|"31536000"||
 |[hsts-preload](#hsts-preload)|bool|"false"||
 |[keep-alive](#keep-alive)|int|75||
 |[keep-alive-requests](#keep-alive-requests)|int|1000||

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -46,7 +46,7 @@ const (
 	// that tell browsers that it should only be communicated with using HTTPS, instead of using HTTP.
 	// https://developer.mozilla.org/en-US/docs/Web/Security/HTTP_strict_transport_security
 	// max-age is the time, in seconds, that the browser should remember that this site is only to be accessed using HTTPS.
-	hstsMaxAge = "15724800"
+	hstsMaxAge = "31536000"
 
 	gzipTypes = "application/atom+xml application/javascript application/x-javascript application/json application/rss+xml application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/svg+xml image/x-icon text/css text/javascript text/plain text/x-component"
 

--- a/test/data/cleanConf.expected.conf
+++ b/test/data/cleanConf.expected.conf
@@ -47,7 +47,7 @@ http {
 			listen_ports = { ssl_proxy = "442", https = "443" },
 			
 			hsts = true,
-			hsts_max_age = 15724800,
+			hsts_max_age = 31536000,
 			hsts_include_subdomains = true,
 			hsts_preload = false,
 		})

--- a/test/data/cleanConf.src.conf
+++ b/test/data/cleanConf.src.conf
@@ -65,7 +65,7 @@ lua_shared_dict ocsp_response_cache 5M;
 		listen_ports = { ssl_proxy = "442", https = "443" },
 
 		hsts = true,
-		hsts_max_age = 15724800,
+		hsts_max_age = 31536000,
 		hsts_include_subdomains = true,
 		hsts_preload = false,
 	})

--- a/test/data/config.json
+++ b/test/data/config.json
@@ -25,7 +25,7 @@
 		"gzipTypes": "application/atom+xml application/javascript application/x-javascript application/json application/rss+xml application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/svg+xml image/x-icon text/css text/javascript text/plain text/x-component",
 		"hsts": true,
 		"hstsIncludeSubdomains": true,
-		"hstsMaxAge": "15724800",
+		"hstsMaxAge": "31536000",
 		"keepAlive": 75,
 		"mapHashBucketSize": 64,
 		"maxWorkerConnections": 16384,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
<!--- Please make sure you title is descriptive, it is used in the Release notes to let others know what it does ---> 

## What this PR does / why we need it:
Increase hsts-max-age to secure default of 1 year, as this is the required minimum duration by several tools checking for header setup (like internet.nl). Currently people have to manually set `hsts-max-age` to one year, but I think this chart should come with a secure default.

It is also the minimum duration to activate `preload` (see https://hstspreload.org/).

It is also the recommended max-age on https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.html

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

Not sure if this qualifies as breaking change as it technically changes existing functionality but only the duration of the header.

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
Not tested, replaced all occurences of `15724800` in the repo.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [x] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.
