### PR TITLE
Add HSTS headers to www redirects

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -629,6 +629,11 @@ http {
             {{ end }}
         }
 
+        header_filter_by_lua_block {
+            lua_ingress.header()
+            plugins.run()
+        }
+
         return {{ $all.Cfg.HTTPRedirectCode }} $redirect_to;
     }
     ## end server {{ $redirect.From }}

--- a/test/e2e/annotations/fromtowwwredirect.go
+++ b/test/e2e/annotations/fromtowwwredirect.go
@@ -120,5 +120,16 @@ var _ = framework.DescribeAnnotation("from-to-www-redirect", func() {
 			Expect().
 			Status(http.StatusOK).
 			Header("ExpectedHost").Equal(fromHost)
+
+		ginkgo.By("responding with an HSTS header")
+		f.HTTPTestClientWithTLSConfig(&tls.Config{
+			InsecureSkipVerify: true, //nolint:gosec // Ignore the gosec error in testing
+			ServerName:         fromHost,
+		}).
+			GET("/").
+			WithURL(f.GetURL(framework.HTTPS)).
+			WithHeader("Host", fromHost).
+			Expect().
+			Headers().ContainsKey("Strict-Transport-Security")
 	})
 })


### PR DESCRIPTION
## What this PR does / why we need it:

If from-to-www-redirects and the TLS redirect are enabled requests using HTTP will first be redirected to HTTPS and only then will they be redirected to the correct domain (either with or without www). These redirects use a server template which does not respect ingress-nginx' HSTS setting.

Example:

http://example.org --> https://example.org (no HSTS) --> https://www.example.org (HSTS)

If a client always accesses http://example.org it will not automatically upgrade to HTTPS on subsequent connections opening up a vulnerability for an attacker to exploit.

Note: For this reason it is *not* advisable to implement a mechanic to perform a redirect from/to www and upgrading to HTTPS in one go.

This PR simply extends the template with the same mechanic used for adding an HSTS header elsewhere in the template.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes

## How Has This Been Tested?
An E2E test has been added for the kind based testing environment.

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [x] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
