### PR TITLE
fix: Validate x-forwarded-prefix annotation with RegexPathWithCapture

### DIFF
--- a/internal/ingress/annotations/parser/validators.go
+++ b/internal/ingress/annotations/parser/validators.go
@@ -71,7 +71,7 @@ var (
 	NGINXVariable = regexp.MustCompile(`^[A-Za-z0-9\-\_\$\{\}]*$`)
 	// RegexPathWithCapture allows entries that SHOULD start with "/" and may contain alphanumeric + capture
 	// character for regex based paths, like /something/$1/anything/$2
-	RegexPathWithCapture = regexp.MustCompile(`^/[` + alphaNumericChars + `\/\$]*$`)
+	RegexPathWithCapture = regexp.MustCompile(`^/?[` + alphaNumericChars + `\/\$]*$`)
 	// HeadersVariable defines a regex that allows headers separated by comma
 	HeadersVariable = regexp.MustCompile(`^[A-Za-z0-9-_, ]*$`)
 	// URLWithNginxVariableRegex defines a url that can contain nginx variables.

--- a/internal/ingress/annotations/xforwardedprefix/main.go
+++ b/internal/ingress/annotations/xforwardedprefix/main.go
@@ -31,10 +31,11 @@ var xForwardedForAnnotations = parser.Annotation{
 	Group: "backend",
 	Annotations: parser.AnnotationFields{
 		xForwardedForPrefixAnnotation: {
-			Validator:     parser.ValidateRegex(parser.BasicCharsRegex, true),
-			Scope:         parser.AnnotationScopeLocation,
-			Risk:          parser.AnnotationRiskLow, // Low, as it allows regexes but on a very limited set
-			Documentation: `This annotation can be used to add the non-standard X-Forwarded-Prefix header to the upstream request with a string value`,
+			Validator: parser.ValidateRegex(parser.RegexPathWithCapture, true),
+			Scope:     parser.AnnotationScopeLocation,
+			Risk:      parser.AnnotationRiskMedium,
+			Documentation: `This annotation can be used to add the non-standard X-Forwarded-Prefix header to the upstream request with a string value. It can 
+			contain regular characters and captured groups specified as '$1', '$2', etc.`,
 		},
 	},
 }

--- a/internal/ingress/annotations/xforwardedprefix/main_test.go
+++ b/internal/ingress/annotations/xforwardedprefix/main_test.go
@@ -40,6 +40,7 @@ func TestParse(t *testing.T) {
 		{map[string]string{annotation: "true"}, "true"},
 		{map[string]string{annotation: "1"}, "1"},
 		{map[string]string{annotation: ""}, ""},
+		{map[string]string{annotation: "/$1"}, "/$1"},
 		{map[string]string{}, ""},
 		{nil, ""},
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
<!--- Please make sure you title is descriptive, it is used in the Release notes to let others know what it does ---> 

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This fixes the issue where annotation validation fails for an annotation similar to this:
```yaml
nginx.ingress.kubernetes.io/x-forwarded-prefix: /$1
```

I changed the x-forwarded-prefix validator to use the same one as rewrite-target however the tests then failed for the existing test cases. Relaxing the regex to make the leading `/` optional, (the comment says SHOULD not MUST) then passes all tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

-->

fixes #10597

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```
$ go test ./internal/ingress/annotations/{parser,rewrite,xforwardedprefix}/
ok      k8s.io/ingress-nginx/internal/ingress/annotations/parser        0.005s
ok      k8s.io/ingress-nginx/internal/ingress/annotations/rewrite       0.005s
ok      k8s.io/ingress-nginx/internal/ingress/annotations/xforwardedprefix      0.004s
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [x] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.
