### PR TITLE
fix: validation check for session-cookie-samesite annotation

### DIFF
--- a/internal/ingress/annotations/sessionaffinity/main.go
+++ b/internal/ingress/annotations/sessionaffinity/main.go
@@ -129,7 +129,7 @@ var sessionAffinityAnnotations = parser.Annotation{
 			Documentation: `This annotation defines the Domain attribute of the sticky cookie.`,
 		},
 		annotationAffinityCookieSameSite: {
-			Validator: parser.ValidateOptions([]string{"None", "Lax", "Strict"}, false, true),
+			Validator: parser.ValidateOptions([]string{"none", "lax", "strict"}, false, true),
 			Scope:     parser.AnnotationScopeIngress,
 			Risk:      parser.AnnotationRiskLow,
 			Documentation: `This annotation is used to apply a SameSite attribute to the sticky cookie. 

--- a/internal/ingress/annotations/sessionaffinity/main_test.go
+++ b/internal/ingress/annotations/sessionaffinity/main_test.go
@@ -79,6 +79,7 @@ func TestIngressAffinityCookieConfig(t *testing.T) {
 	data[parser.GetAnnotationWithPrefix(annotationAffinityCookieMaxAge)] = "3000"
 	data[parser.GetAnnotationWithPrefix(annotationAffinityCookiePath)] = "/foo"
 	data[parser.GetAnnotationWithPrefix(annotationAffinityCookieDomain)] = "foo.bar"
+	data[parser.GetAnnotationWithPrefix(annotationAffinityCookieSameSite)] = "Strict"
 	data[parser.GetAnnotationWithPrefix(annotationAffinityCookieChangeOnFailure)] = "true"
 	data[parser.GetAnnotationWithPrefix(annotationAffinityCookieSecure)] = "true"
 	ing.SetAnnotations(data)
@@ -119,6 +120,10 @@ func TestIngressAffinityCookieConfig(t *testing.T) {
 
 	if nginxAffinity.Cookie.Domain != "foo.bar" {
 		t.Errorf("expected foo.bar as session-cookie-domain but returned %v", nginxAffinity.Cookie.Domain)
+	}
+
+	if nginxAffinity.Cookie.SameSite != "Strict" {
+		t.Errorf("expected Strict as session-cookie-same-site but returned %v", nginxAffinity.Cookie.SameSite)
 	}
 
 	if !nginxAffinity.Cookie.ChangeOnFailure {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
<!--- Please make sure you title is descriptive, it is used in the Release notes to let others know what it does ---> 

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The validation check for `annotationAffinityCookieSameSite` is marked as case insensitive. For this reason the validator [forces the user-defined string to be lower case](https://github.com/kubernetes/ingress-nginx/blob/main/internal/ingress/annotations/parser/validators.go#L126) before [comparing](https://github.com/kubernetes/ingress-nginx/blob/main/internal/ingress/annotations/parser/validators.go#L129) it to the options defined in the source code. However the options in the source code [are in capital case](https://github.com/kubernetes/ingress-nginx/blob/main/internal/ingress/annotations/sessionaffinity/main.go#L132) and therefore the check can never be true.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Test Case Ingress:

```yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  annotations:
    nginx.ingress.kubernetes.io/affinity: cookie
    nginx.ingress.kubernetes.io/session-cookie-samesite: Strict
  name: validation-test-case
spec:
  ingressClassName: nginx
  defaultBackend:
    service:
      name: test
      port:
        number: 80
```

Result before patch:
```yaml
W1101 17:32:59.524132       7 validators.go:221] validation error on ingress default/validation-test-case: annotation session-cookie-samesite contains invalid value Strict
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [x] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
