### PR TITLE
support 2 tier control over sticky_persistent sessions

### DIFF
--- a/rootfs/etc/nginx/lua/balancer/sticky_persistent.lua
+++ b/rootfs/etc/nginx/lua/balancer/sticky_persistent.lua
@@ -4,18 +4,35 @@
 -- be rebalanced.
 --
 local balancer_sticky = require("balancer.sticky")
+local balancer_round_robin = require("balancer.round_robin")
+local balancer_chash = require("balancer.chash")
+local balancer_chashsubset = require("balancer.chashsubset")
+local balancer_ewma = require("balancer.ewma")
 local util_get_nodes = require("util").get_nodes
 local util_nodemap = require("util.nodemap")
 local setmetatable = setmetatable
+
+local function get_secondary_balancer(backend)
+  local name = backend["load-balance"]
+
+  if not name then return nil
+  elseif name == "chash" then return balancer_chash:new(backend)
+  elseif name == "chashsubset" then return balancer_chashsubset:new(backend)
+  elseif name == "round_robin" then return balancer_round_robin:new(backend)
+  elseif name == "ewma" then return balancer_ewma:new(backend)
+  end
+end
 
 local _M = balancer_sticky:new()
 
 function _M.new(self, backend)
   local nodes = util_get_nodes(backend.endpoints)
   local hash_salt = backend["name"]
+  local secondary_balancer = get_secondary_balancer(backend)
 
   local o = {
     name = "sticky_persistent",
+    secondary_balancer = secondary_balancer,
     instance = util_nodemap:new(nodes, hash_salt)
   }
 
@@ -28,7 +45,19 @@ function _M.new(self, backend)
 end
 
 function _M.pick_new_upstream(self, failed_upstreams)
+  if self.secondary_balancer then
+    local endpoint = self.secondary_balancer:balance()
+    local key = self.instance:key_from_endpoint(endpoint)
+    if endpoint and key then
+      return endpoint, key
+    end
+  end
+
   return self.instance:random_except(failed_upstreams)
+end
+
+function _M.sync(self, backend)
+  self.secondary_balancer = get_secondary_balancer(backend)
 end
 
 return _M

--- a/rootfs/etc/nginx/lua/util/nodemap.lua
+++ b/rootfs/etc/nginx/lua/util/nodemap.lua
@@ -122,4 +122,13 @@ function _M.random_except(self, ignore_nodes)
   return get_random_node(valid_nodes)
 end
 
+--- find the key of a given endpoint
+-- @tparam string endpoint The endpoint.
+-- @treturn string The key for endpoint or nil.
+function _M.key_from_endpoint(self, endpoint)
+  for k, v in pairs(self.map) do
+    if v==endpoint then return k end
+  end
+end
+
 return _M


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
<!--- Please make sure you title is descriptive, it is used in the Release notes to let others know what it does ---> 

## What this PR does / why we need it:

Better control over the balancing logic of `sticky_persistent` when clients do not have a valid cookie value (or don't support cookies for whatever reason)  by replacing the currently random selection. I've implemented the ability to control the *2nd tier* of balancing by using the `load-balance` annotation to select any of the existing balancers (excluding the `sticky_*` balancers to prevent infinite loops).

If `load-balance` annotation is not present in an otherwise `sticky_persistent` configuration the new features are entirely ignored and will simply fallback to the existing `return self.instance:random_except(failed_upstreams)`.

Our particular use-case is to replace an existing F5 config using k8s+ingress-nginx which selects the 2nd tier by client IP. This PR solves that use-case generically by effectively allowing *any* of the existing balancers to be leveraged as the 2nd tier.

Some examples:

```
# using consistent hashing based on client IP
nginx.ingress.kubernetes.io/affinity: cookie
nginx.ingress.kubernetes.io/affinity-mode: persistent
nginx.ingress.kubernetes.io/load-balance: chash
nginx.ingress.kubernetes.io/upstream-hash-by: $remote_addr

# ewma
nginx.ingress.kubernetes.io/affinity: cookie
nginx.ingress.kubernetes.io/affinity-mode: persistent
nginx.ingress.kubernetes.io/load-balance: ewma

# round_robin
nginx.ingress.kubernetes.io/affinity: cookie
nginx.ingress.kubernetes.io/affinity-mode: persistent
nginx.ingress.kubernetes.io/load-balance: round_robin
```

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested with an on-prem cluster using metallb with `externalTrafficPolicy` set to `Local` to ensure consistent client IP (`$remote_addr`). I have removed various debugging statements but had them spread everywhere to test the various logic flows. Beyond testing the pin-by-IP logic I also tested `round_robin` and `ewma` as secondary balancers as well. On the surface all seems sane at this point.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
