### PR TITLE
Add extra configMaps support to helm chart

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -163,6 +163,14 @@ jobs:
           go-version: '1.21.3'
           check-latest: true
 
+      - name: Install Helm Unit Test Plugin
+        run: |
+          helm plugin install https://github.com/quintush/helm-unittest
+
+      - name: Run Helm Unit Tests
+        run: |
+          helm unittest charts/ingress-nginx -d
+
       - name: cache
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ cmd/plugin/release/*.tar.gz
 cmd/plugin/release/LICENSE
 tmp/
 test/junitreports/
+tests/__snapshot__

--- a/charts/ingress-nginx/.helmignore
+++ b/charts/ingress-nginx/.helmignore
@@ -20,3 +20,4 @@
 .idea/
 *.tmproj
 .vscode/
+__snapshot__

--- a/charts/ingress-nginx/Chart.yaml
+++ b/charts/ingress-nginx/Chart.yaml
@@ -19,4 +19,4 @@ maintainers:
 name: ingress-nginx
 sources:
 - https://github.com/kubernetes/ingress-nginx
-version: 4.8.3
+version: 4.8.4

--- a/charts/ingress-nginx/README.md
+++ b/charts/ingress-nginx/README.md
@@ -2,7 +2,7 @@
 
 [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer
 
-![Version: 4.8.3](https://img.shields.io/badge/Version-4.8.3-informational?style=flat-square) ![AppVersion: 1.9.4](https://img.shields.io/badge/AppVersion-1.9.4-informational?style=flat-square)
+![Version: 4.8.4](https://img.shields.io/badge/Version-4.8.4-informational?style=flat-square) ![AppVersion: 1.9.4](https://img.shields.io/badge/AppVersion-1.9.4-informational?style=flat-square)
 
 To use, add `ingressClassName: nginx` spec field or the `kubernetes.io/ingress.class: nginx` annotation to your Ingress resources.
 
@@ -464,6 +464,7 @@ As of version `1.26.0` of this chart, by simply not providing any clusterIP valu
 | defaultBackend.enabled | bool | `false` |  |
 | defaultBackend.existingPsp | string | `""` | Use an existing PSP instead of creating one |
 | defaultBackend.extraArgs | object | `{}` |  |
+| defaultBackend.extraConfigMaps | list | `[]` |  |
 | defaultBackend.extraEnvs | list | `[]` | Additional environment variables to set for defaultBackend pods |
 | defaultBackend.extraVolumeMounts | list | `[]` |  |
 | defaultBackend.extraVolumes | list | `[]` |  |

--- a/charts/ingress-nginx/templates/default-backend-extra-configmaps.yaml
+++ b/charts/ingress-nginx/templates/default-backend-extra-configmaps.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.defaultBackend.enabled }}
+  {{- range .Values.defaultBackend.extraConfigMaps }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .name }}
+  namespace: {{ include "ingress-nginx.namespace" . }}
+  labels:
+    {{- include "ingress-nginx.labels" $ | nindent 4 }}
+    {{- with $.Values.defaultBackend.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+data:
+  {{- with .data }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
+{{- end }}
+

--- a/charts/ingress-nginx/templates/default-backend-extra-configmaps.yaml
+++ b/charts/ingress-nginx/templates/default-backend-extra-configmaps.yaml
@@ -1,10 +1,11 @@
 {{- if .Values.defaultBackend.enabled }}
   {{- range .Values.defaultBackend.extraConfigMaps }}
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .name }}
-  namespace: {{ include "ingress-nginx.namespace" . }}
+  namespace: {{ include "ingress-nginx.namespace" $ | quote }}
   labels:
     {{- include "ingress-nginx.labels" $ | nindent 4 }}
     {{- with $.Values.defaultBackend.labels }}

--- a/charts/ingress-nginx/tests/default-backend-extra-configmaps_test.yaml
+++ b/charts/ingress-nginx/tests/default-backend-extra-configmaps_test.yaml
@@ -1,0 +1,49 @@
+suite: test default backend extra ConfigMaps
+templates:
+  - default-backend-extra-configmaps.yaml
+
+tests:
+  - it: should not create any ConfigMap by default
+    set:
+      Release.Namespace: default
+      defaultBackend.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create one ConfigMap
+    set:
+      Release.Namespace: default
+      defaultBackend.enabled: true
+      defaultBackend.extraConfigMaps:
+        - name: my-configmap-1
+          data:
+            key1: value1
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: my-configmap-1
+
+  - it: should correctly render multiple ConfigMaps
+    set:
+      Release.Namespace: nginx
+      defaultBackend.enabled: true
+      defaultBackend.extraConfigMaps:
+        - name: my-configmap-1
+          data:
+            key1: value1
+        - name: my-configmap-2
+          data:
+            key2: value2
+    asserts:
+      - hasDocuments:
+          count: 2
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: metadata.name
+          pattern: "my-configmap-\\d+"

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -927,6 +927,21 @@ defaultBackend:
   ## Additional volumes to the default backend pod.
   #  - name: copy-portal-skins
   #    emptyDir: {}
+  extraConfigMaps: []
+    ## Additional configmaps to the default backend pod.
+    # Example ConfigMap, uncomment and configure as needed
+    # - name: my-extra-configmap-1
+    #   labels:
+    #     type: config-1
+    #   data:
+    #     extra_file_1.html: |
+    #       <!-- Extra HTML content for ConfigMap 1 -->
+    # - name: my-extra-configmap-2
+    #   labels:
+    #     type: config-2
+    #   data:
+    #     extra_file_2.html: |
+    #       <!-- Extra HTML content for ConfigMap 2 -->
 
   autoscaling:
     annotations: {}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
<!--- Please make sure you title is descriptive, it is used in the Release notes to let others know what it does ---> 

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
Reasoning behind this addition is that in our use case we didn't want to deploy externally the custom-error-pages configmap to use them in our default-backend but instead to be able to deploy them directly from the helm chart.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [x] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.
