### PR TITLE
CI: Replace `chart-testing` image by `e2e-test-runner`.

### DIFF
--- a/hack/verify-chart-lint.sh
+++ b/hack/verify-chart-lint.sh
@@ -19,6 +19,4 @@ set -o nounset
 set -o pipefail
 
 KUBE_ROOT="$( cd "$(dirname "$0")../" >/dev/null 2>&1 ; pwd -P )"
-# TODO: This is a temporary workaround while we don't update Helm Chart test
-curl https://raw.githubusercontent.com/helm/chart-testing/v3.8.0/etc/chart_schema.yaml -o /tmp/chart_schema.yaml
-ct lint --charts ${KUBE_ROOT}/charts/ingress-nginx --validate-maintainers=false --chart-yaml-schema=/tmp/chart_schema.yaml
+ct lint --charts ${KUBE_ROOT}/charts/ingress-nginx --validate-maintainers=false

--- a/test/e2e/run-chart-test.sh
+++ b/test/e2e/run-chart-test.sh
@@ -104,13 +104,12 @@ if [ "${SKIP_CERT_MANAGER_CREATION:-false}" = "false" ]; then
 fi
 
 echo "[dev-env] running helm chart e2e tests..."
-# Uses a custom chart-testing image to avoid timeouts waiting for namespace deletion.
-# The changes can be found here: https://github.com/aledbf/chart-testing/commit/41fe0ae0733d0c9a538099fb3cec522e888e3d82
 docker run --rm --interactive --network host \
     --name ct \
     --volume $KUBECONFIG:/root/.kube/config \
     --volume "${DIR}/../../":/workdir \
     --workdir /workdir \
-    aledbf/chart-testing:v3.3.1-next ct install \
+    registry.k8s.io/ingress-nginx/e2e-test-runner:v20231208-4c39e6acc@sha256:0607184ca9c53c9c24a47b6f52347dd96137b05c6f276efa67051929a39e8f7a \
+        ct install \
         --charts charts/ingress-nginx \
         --helm-extra-args "--timeout 60s"


### PR DESCRIPTION
## What this PR does / why we need it:

This PR replaces the `chart-testing` image by `e2e-test-runner` which also contains `ct` and a newer Helm version. The old image contained Helm v3.5.1 which becomes 3 years old in January 2024 and lacks some required features.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes

https://github.com/kubernetes/ingress-nginx/pull/10659#issuecomment-1856639926

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [x] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.
