### PR TITLE
Fix: service targetPort error when ExternalName service targetPort not a number

### DIFF
--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -1766,7 +1766,7 @@ func externalNamePorts(name string, svc *apiv1.Service) *apiv1.ServicePort {
 		return &apiv1.ServicePort{
 			Protocol:   "TCP",
 			Port:       svcPort.Port,
-			TargetPort: svcPort.TargetPort,
+			TargetPort: tp,
 		}
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
<!--- Please make sure you title is descriptive, it is used in the Release notes to let others know what it does ---> 

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->
service ports targetPort is a string that not a number，nginx  will get endpoints that port is `0` 
for example
```
apiVersion: v1
kind: Service
metadata:
  labels:
    app: foo
  name: foo-svc
  namespace: test
spec:
  externalName: www.google.com
  ports:
  - name: http
    port: 8080
    protocol: TCP
    targetPort: http
  selector:
    foo: kms-server
  sessionAffinity: None
  type: ExternalName
```
nginx get endports port field is `0`
```
{
    "endpoints": [
        {
            "address": "www.google.com",
            "port": "0"
        }
    ],
    "service": {
        "metadata": {
            "creationTimestamp": null
        },
        "spec": {
            "sessionAffinity": "None",
            "selector": {
                "app": "foo"
            },
            "type": "ExternalName",
            "ports": [
                {
                    "targetPort": "http",
                    "protocol": "TCP",
                    "name": "http",
                    "port": 8080
                }
            ],
            "externalName": "www.google.com"
        },
        "status": {
            "loadBalancer": {}
        }
    },
    "noServer": false,
    "sslPassthrough": false,
    "trafficShapingPolicy": {
        "weight": 0,
        "header": "",
        "headerValue": "",
        "headerPattern": "",
        "cookie": ""
    },
    "sessionAffinityConfig": {
        "cookieSessionAffinity": {
            "name": ""
        },
        "name": "",
        "mode": ""
    },
    "name": "test-foo-svc-8080",
    "upstreamHashByConfig": {
        "upstream-hash-by-subset-size": 3
    },
    "port": 8080
}
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.
