### PR TITLE
fix(helm): fallback on extraArgs update-status if not set 

### DIFF
--- a/charts/ingress-nginx/templates/controller-role.yaml
+++ b/charts/ingress-nginx/templates/controller-role.yaml
@@ -45,7 +45,7 @@ rules:
       - list
       - watch
   # Omit Ingress status permissions if `--update-status` is disabled.
-  {{- if ne (index .Values.controller.extraArgs "update-status") "false" }}
+  {{- if ne (index .Values.controller.extraArgs "update-status" | default "") "false" }}
   - apiGroups:
       - networking.k8s.io
     resources:


### PR DESCRIPTION
## What this PR does / why we need it:
`index` does not return an string, needed by `ne`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Which issue/s this PR fixes
fixes #10833


## How Has This Been Tested?
Yes

## Broken since
https://github.com/kubernetes/ingress-nginx/pull/10659
