### PR TITLE
Build OTEL for the two nginx versions

### DIFF
--- a/.github/workflows/opentelemetry.yaml
+++ b/.github/workflows/opentelemetry.yaml
@@ -1,0 +1,88 @@
+name: Opentelemetry Images
+
+on:
+  pull_request:
+    branches:
+      - "*"
+    paths:
+      - 'images/opentelemetry/**'
+  push:
+    branches:
+    - main
+    paths:
+    - 'images/opentelemetry/**'
+
+permissions:
+  contents: write
+  packages: write
+
+env:
+  PLATFORMS: linux/amd64
+
+jobs:
+  changes:
+    permissions:
+      contents: read  # for dorny/paths-filter to fetch a list of changed files
+      pull-requests: read  # for dorny/paths-filter to read pull requests
+    runs-on: ubuntu-latest
+    outputs:
+      opentelemetry: ${{ steps.filter.outputs.opentelemetry }}
+      tag: ${{ steps.filter.outputs.opentelemetry }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
+        id: filter
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          filters: |
+            opentelemetry:
+              - 'images/opentelemetry/**'
+            tag:
+              - 'images/opentelemetry/TAG'
+
+  build:
+    runs-on: ubuntu-latest
+    needs: changes
+    if: |
+      (needs.changes.outputs.opentelemetry == 'true')
+    strategy:
+      matrix:
+        nginxversion: ["1.21.6", "1.25.3"]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    - name: Build
+      env:
+        PLATFORMS: linux/amd64
+      run: |
+        cd images/opentelemetry && make NAME=opentelemetry NGINX_VERSION=${{ matrix.nginxversion }} build
+  
+  push:
+    name: Push
+    needs: changes
+    if: |
+      (github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'kubernetes/ingress-nginx' && needs.changes.outputs.tag == 'true')
+    strategy:
+        matrix:
+          nginxversion: ["1.21.6", "1.25.3"]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    env:
+      PLATFORMS: linux/amd64,linux/arm,linux/arm64,linux/s390x
+    steps:
+    - name: Checkout
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1    
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}        
+    - name: Push
+      run: |
+        cd images/opentelemetry && make NAME=opentelemetry NGINX_VERSION=${{ matrix.nginxversion }} build
+        

--- a/images/opentelemetry/Makefile
+++ b/images/opentelemetry/Makefile
@@ -1,0 +1,71 @@
+# Copyright 2024 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+.DEFAULT_GOAL:=build
+
+# set default shell
+SHELL=/bin/bash -o pipefail -o errexit
+
+DIR:=$(strip $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST)))))
+INIT_BUILDX=$(DIR)/../../hack/init-buildx.sh
+
+
+REGISTRY ?= local
+NAME ?=
+NGINX_VERSION ?= 
+
+IMAGE = $(REGISTRY)/$(NAME)
+TAG ?= $(shell cat ./TAG)
+
+# required to enable buildx
+export DOCKER_CLI_EXPERIMENTAL=enabled
+
+# build with buildx
+PLATFORMS?=linux/amd64
+OUTPUT=
+PROGRESS=plain
+
+precheck:
+ifndef NAME
+	$(error NAME variable is required)
+endif
+ifndef NGINX_VERSION
+	$(error NGINX_VERSION is required)
+endif
+
+build: precheck ensure-buildx
+	docker buildx build \
+		--label=org.opencontainers.image.source=https://github.com/kubernetes/ingress-nginx \
+		--label=org.opencontainers.image.licenses=Apache-2.0 \
+		--label=org.opencontainers.image.description="Ingress NGINX $(NAME) image" \
+		--build-arg NGINX_VERSION=$(NGINX_VERSION) \
+		--platform=${PLATFORMS} $(OUTPUT) \
+		--progress=$(PROGRESS) \
+		-t $(IMAGE)-$(NGINX_VERSION):$(TAG) rootfs
+
+# push the cross built image
+push: OUTPUT=--push
+push: build
+
+# enable buildx
+ensure-buildx:
+# this is required for cloudbuild
+ifeq ("$(wildcard $(INIT_BUILDX))","")
+	@curl -sSL https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/hack/init-buildx.sh | bash
+else
+	@exec $(INIT_BUILDX)
+endif
+	@echo "done"
+
+.PHONY: build push ensure-buildx precheck

--- a/images/opentelemetry/cloudbuild.yaml
+++ b/images/opentelemetry/cloudbuild.yaml
@@ -16,4 +16,6 @@ steps:
     - -c
     - |
       gcloud auth configure-docker \
-      && cd images/ && make NAME=opentelemetry push
+      && cd images/opentelemetry \
+      && make NAME=opentelemetry NGINXVERSION=1.21.6 push \
+      && make NAME=opentelemetry NGINXVERSION=1.25.3 push

--- a/images/opentelemetry/rootfs/Dockerfile
+++ b/images/opentelemetry/rootfs/Dockerfile
@@ -42,9 +42,10 @@ RUN bash /opt/third_party/build.sh -o v1.11.0
 
 # install otel_ngx_module.so
 FROM base as nginx
+ARG NGINX_VERSION
 COPY --from=grpc /opt/third_party/install/ /usr
 COPY --from=otel-cpp /opt/third_party/install/ /usr
-RUN bash /opt/third_party/build.sh -n
+RUN bash /opt/third_party/build.sh -n ${NGINX_VERSION}
 
 FROM cgr.dev/chainguard/go:latest as build-init
 

--- a/images/opentelemetry/rootfs/build.sh
+++ b/images/opentelemetry/rootfs/build.sh
@@ -18,10 +18,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-export GRPC_GIT_TAG=${GRPC_GIT_TAG:="v1.43.2"}
+export GRPC_GIT_TAG=${GRPC_GIT_TAG:="v1.60.0"}
+export NGINX_VERSION=${NGINX_VERSION:="1.21.6"}
+
 # Check for recent changes: https://github.com/open-telemetry/opentelemetry-cpp/compare/v1.2.0...main
-export OPENTELEMETRY_CPP_VERSION=${OPENTELEMETRY_CPP_VERSION:="1.2.0"}
-export ABSL_CPP_VERSION=${ABSL_CPP_VERSION:="20230802.0"}
+export OPENTELEMETRY_CPP_VERSION=${OPENTELEMETRY_CPP_VERSION:="1.13.0"}
+export ABSL_CPP_VERSION=${ABSL_CPP_VERSION:="20230802.1"}
 export INSTAL_DIR=/opt/third_party/install
 # improve compilation times
 CORES=$(($(grep -c ^processor /proc/cpuinfo) - 1))
@@ -148,7 +150,6 @@ get_src()
 
 install_nginx()
 {
-  export NGINX_VERSION=1.21.6
 
   # Check for recent changes: https://github.com/open-telemetry/opentelemetry-cpp-contrib/compare/2656a4...main
   export OPENTELEMETRY_CONTRIB_COMMIT=aaa51e2297bcb34297f3c7aa44fa790497d2f7f3
@@ -197,6 +198,7 @@ while getopts ":pha:g:o:n" option; do
         prepare
         exit;;
     n) # install nginx
+        NGINX_VERSION=${OPTARG}
         install_nginx
         exit;;
     a) # install abseil


### PR DESCRIPTION
## What this PR does / why we need it:
With the upcoming NGINX v1.25.3 build, we need OTEL to be published for both versions, v1.21.6 and v1.25.3

Part of #10390 