### PR TITLE
added --user flag to pip install

### DIFF
--- a/images/test-runner/rootfs/Dockerfile
+++ b/images/test-runner/rootfs/Dockerfile
@@ -120,10 +120,10 @@ RUN wget -qO /tmp/helm.tgz \
   && rm -rf /tmp/*
 
 # Install a YAML Linter
-RUN pip install "yamllint==$YAML_LINT_VERSION"
+RUN pip install --user "yamllint==$YAML_LINT_VERSION"
 
 # Install Yamale YAML schema validator
-RUN pip install "yamale==$YAMALE_VERSION"
+RUN pip install --user "yamale==$YAMALE_VERSION"
 
 LABEL org.opencontainers.image.source=https://github.com/kubernetes/ingress-nginx
 


### PR DESCRIPTION
## What this PR does / why we need it:
- Mysteriously cloud-build for test-runner image failed with error on `pip install` stating PEP 668
- Mysterious because if it is genuinely about PEP 668, then it should have appeared in multiple cloudbuilds in the past weeks 

![image](https://github.com/kubernetes/ingress-nginx/assets/5085914/3608c648-be98-4b43-a2a6-0f9c1fe82267)

- Also discovered that we have pinned v1.27.1 of yamllinter in Makefile of the test-runner image https://github.com/kubernetes/ingress-nginx/blob/24d0c355259f176e24f0bf8ce55d5a02dbea8b6e/images/test-runner/Makefile#L54

 but pip auto-installs v1.33.0
```
/ # pip install yamllint
Collecting yamllint
  Downloading yamllint-1.33.0-py3-none-any.whl (65 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 65.4/65.4 kB 748.5 kB/s eta 0:00:00
Collecting pathspec>=0.5.3 (from yamllint)
  Downloading pathspec-0.12.1-py3-none-any.whl (31 kB)
Collecting pyyaml (from yamllint)
  Downloading PyYAML-6.0.1-cp311-cp311-musllinux_1_1_x86_64.whl (748 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 748.5/748.5 kB 5.6 MB/s eta 0:00:00
Installing collected packages: pyyaml, pathspec, yamllint
Successfully installed pathspec-0.12.1 pyyaml-6.0.1 yamllint-1.33.0
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
/ # cat /etc/os-release 
NAME="Alpine Linux"
ID=alpine
VERSION_ID=3.18.5
PRETTY_NAME="Alpine Linux v3.18"
HOME_URL="https://alpinelinux.org/"
BUG_REPORT_URL="https://gitlab.alpinelinux.org/alpine/aports/-/issues"
``` 
- Talked to @tao12345666333  https://kubernetes.slack.com/archives/C021E147ZA4/p1705629799015849
-  Added --user flag to pip install

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
- No issue opened a failure in CI and talking internally

## How Has This Been Tested?
- Can only be tested on cloudbuild after merge

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.

cc @tao12345666333 @strongjz 