### PR TITLE
bump yamllinter to v1330

### DIFF
--- a/images/test-runner/Makefile
+++ b/images/test-runner/Makefile
@@ -51,7 +51,7 @@ image:
 		--build-arg LUAROCKS_VERSION=3.8.0 \
 		--build-arg LUAROCKS_SHA=ab6612ca9ab87c6984871d2712d05525775e8b50172701a0a1cabddf76de2be7 \
 		--build-arg CHART_TESTING_VERSION=3.8.0 \
-		--build-arg YAML_LINT_VERSION=1.27.1 \
+		--build-arg YAML_LINT_VERSION=1.33.0 \
 		--build-arg YAMALE_VERSION=4.0.4 \
 		--build-arg HELM_VERSION=3.11.2 \
 		--build-arg GINKGO_VERSION=2.14.0 \
@@ -72,7 +72,7 @@ build: ensure-buildx
 		--build-arg LUAROCKS_VERSION=3.8.0 \
 		--build-arg LUAROCKS_SHA=ab6612ca9ab87c6984871d2712d05525775e8b50172701a0a1cabddf76de2be7 \
 		--build-arg CHART_TESTING_VERSION=3.8.0 \
-		--build-arg YAML_LINT_VERSION=1.27.1 \
+		--build-arg YAML_LINT_VERSION=1.33.0 \
 		--build-arg YAMALE_VERSION=4.0.4 \
 		--build-arg HELM_VERSION=3.11.2 \
 		--build-arg GINKGO_VERSION=2.14.0 \


### PR DESCRIPTION
## What this PR does / why we need it:
- Critical  because cloud-build is broken for test-runner image and without new-build of test-runner image, ginkgo can not be bumped + release of v1.9.6 of controller is blocked
- History is https://github.com/kubernetes/ingress-nginx/pull/10874  (python pip error = **_This environment is externally managed_**)
- But cloud-build failed even after `"--user"` flag added in the pip install command, and reported with the same error, on the same pip install line

![image](https://github.com/kubernetes/ingress-nginx/assets/5085914/b0e2a4e1-ccd4-41aa-a5cd-6b1c695bf7ab)

- So now, this PR is bumping yamllinter version to be installed,  to v1.33.0. This is because the pinned version in Makefile is v1.27.1 but pip  auto-pulls v1.33.0 on latest alpine being used, for the test-runner image

- If this also does not fix cloudbuild, then have to replace `pip install` with `apk add` maybe , to install yamllinter, if possible

```
/ # pip install yamllint
Collecting yamllint
  Downloading yamllint-1.33.0-py3-none-any.whl (65 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 65.4/65.4 kB 748.5 kB/s eta 0:00:00
Collecting pathspec>=0.5.3 (from yamllint)
  Downloading pathspec-0.12.1-py3-none-any.whl (31 kB)
Collecting pyyaml (from yamllint)
  Downloading PyYAML-6.0.1-cp311-cp311-musllinux_1_1_x86_64.whl (748 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 748.5/748.5 kB 5.6 MB/s eta 0:00:00
Installing collected packages: pyyaml, pathspec, yamllint
Successfully installed pathspec-0.12.1 pyyaml-6.0.1 yamllint-1.33.0
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
/ # cat /etc/os-release 
NAME="Alpine Linux"
ID=alpine
VERSION_ID=3.18.5
PRETTY_NAME="Alpine Linux v3.18"
HOME_URL="https://alpinelinux.org/"
BUG_REPORT_URL="https://gitlab.alpinelinux.org/alpine/aports/-/issues"
``` 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
- No issue created as broken post-CI-step of cloudbuild,  being discussed internally

## How Has This Been Tested?
- Can only be tested after merging this

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.

cc @tao12345666333 

/triage accepted
/kind bug
/priority critical-urgent