### PR TITLE
changed pip to apk in test-runner dockerfile

### DIFF
--- a/images/test-runner/rootfs/Dockerfile
+++ b/images/test-runner/rootfs/Dockerfile
@@ -120,7 +120,10 @@ RUN wget -qO /tmp/helm.tgz \
   && rm -rf /tmp/*
 
 # Install a YAML Linter
-RUN pip install --user "yamllint==$YAML_LINT_VERSION"
+# Pip not working. Check PR https://github.com/kubernetes/ingress-nginx/pull/10874
+# RUN pip install --user "yamllint==$YAML_LINT_VERSION"
+RUN apk update -U \
+    apk add yamllint
 
 # Install Yamale YAML schema validator
 RUN pip install --user "yamale==$YAMALE_VERSION"


### PR DESCRIPTION
## What this PR does / why we need it:
- History is https://github.com/kubernetes/ingress-nginx/pull/10875
- And earliest history is https://github.com/kubernetes/ingress-nginx/pull/10874
- test-runner build fails in cloudbuild (works locally) with python related error **_This environment is externally managed_**) for command _**pip install yamllint**_
![image](https://github.com/kubernetes/ingress-nginx/assets/5085914/b0e2a4e1-ccd4-41aa-a5cd-6b1c695bf7ab)
- Since adding the _**--user**_ flag to pip fails (& bump of yamllint also does not fix the broken build), this PR changes yamllint install from `pip install ` to `apk add yamllint`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
- No issues created but 2 related PRs exist and are mentioned above

## How Has This Been Tested?
- This is for cloudbuild so can only be tested after merge

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.

cc @tao12345666333 @strongjz 

/triage accepted
/kind bug
/priority critical-urgent