### PR TITLE
changed yamale install from pip to manual download & install

### DIFF
--- a/images/test-runner/rootfs/Dockerfile
+++ b/images/test-runner/rootfs/Dockerfile
@@ -126,7 +126,13 @@ RUN apk update -U \
     apk add yamllint
 
 # Install Yamale YAML schema validator
-RUN pip install --user "yamale==$YAMALE_VERSION"
+# Commenting pip install yamale because broken cloudbuild https://github.com/kubernetes/ingress-nginx/pull/10885
+# RUN pip install --user "yamale==$YAMALE_VERSION"
+RUN wget https://github.com/23andMe/Yamale/archive/master.zip \
+    && unzip -d /tmp master.zip \
+    && cd /tmp/Yamale-master \
+    && python setup.py install \
+    && yamale -V
 
 LABEL org.opencontainers.image.source=https://github.com/kubernetes/ingress-nginx
 


### PR DESCRIPTION
## What this PR does / why we need it:
- History in https://github.com/kubernetes/ingress-nginx/pull/10874 https://github.com/kubernetes/ingress-nginx/pull/10875 https://github.com/kubernetes/ingress-nginx/pull/10885
- test-runner image cloudbuild,  goes past the` pip install yamllint` error.. .  but still broken because of `pip install yamale`.

![image](https://github.com/kubernetes/ingress-nginx/assets/5085914/8c77d18f-c1ad-436d-8de6-425f0bfd9407)

- There is no apk available for yamale
-  Since this PR implements a manual download + install of yamale  (yamale's pypi page https://pypi.org/project/yamale/ shows the steps)


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
- No issue created since bug in cloudbuild discovered internally

## How Has This Been Tested?
- The manual install of yamale was tested locally

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.

cc @strongjz  @tao12345666333 

/triage accepted
/kind bug
/priority critical-urgent