### PR TITLE
fix run command in dockerfile of test-runner-image

### DIFF
--- a/images/test-runner/rootfs/Dockerfile
+++ b/images/test-runner/rootfs/Dockerfile
@@ -123,7 +123,8 @@ RUN wget -qO /tmp/helm.tgz \
 # Pip not working. Check PR https://github.com/kubernetes/ingress-nginx/pull/10874
 # RUN pip install --user "yamllint==$YAML_LINT_VERSION"
 RUN apk update -U \
-    apk add yamllint
+    && apk add yamllint \
+    && yamllint --version
 
 # Install Yamale YAML schema validator
 # Commenting pip install yamale because broken cloudbuild https://github.com/kubernetes/ingress-nginx/pull/10885


### PR DESCRIPTION
## What this PR does / why we need it:
- yamllint executable is missing in new build of test-runner image and breaking CI https://github.com/kubernetes/ingress-nginx/actions/runs/7670256851/job/20906393041?pr=10919#step:7:124

```
% docker run -ti gcr.io/k8s-staging-ingress-nginx/e2e-test-runner:v20240122-aac5d228a sh                                                                                                                                                
Unable to find image 'gcr.io/k8s-staging-ingress-nginx/e2e-test-runner:v20240122-aac5d228a' locally                                                                                                                                     
v20240122-aac5d228a: Pulling from k8s-staging-ingress-nginx/e2e-test-runner                                                                                                                                                             
661ff4d9561e: Pull complete                                                                                                                                                                                                             
b230074f81ad: Pull complete                                                                                                                                                                                                             
7e0499c37319: Pull complete                                                                                                                                                                                                             
ac1a909a4ac9: Pull complete                                                                                                                                                                                                             
6aeac9761fc5: Pull complete                                                                                                                                                                                                             
4f4fb700ef54: Pull complete                                                                                                                                                                                                             
c586a2b8cfba: Pull complete                                                                                                                                                                                                             
16079dc275d8: Pull complete                                                                                                                                                                                                             
72524a03e583: Pull complete                                                                                                                                                                                                             
b454528ecbb9: Pull complete                                                                                                                                                                                                             
a68804291eb8: Pull complete                                                                                                                                                                                                             
72dbab57ae1e: Pull complete                                                                                                                                                                                                             
ae5d9a986eef: Pull complete                                                                                                                                                                                                             
f286b1cecad7: Pull complete                                                                                                                                                                                                             
f6a71d7c0b1d: Pull complete                                                                                                                                                                                                             
fcaa155c6c7e: Pull complete                                                                                                                                                                                                             
7de9a0bac272: Pull complete                                                                                                                                                                                                             
40f5e495ff8d: Pull complete                                                                                                                                                                                                             
55dc27680730: Pull complete                                                                                                                                                                                                             
2870fc7c3093: Pull complete                                                                                                                                                                                                             
52863b095bd0: Pull complete                                                                                                                                                                                                             
8b06bdb56838: Pull complete                                                                                                                                                                                                             
Digest: sha256:3f18286471d0d1a8a8b11c98b5477c43a747c9c9a1f08978c5b07955f1ef6474                                                                                                                                                         
Status: Downloaded newer image for gcr.io/k8s-staging-ingress-nginx/e2e-test-runner:v20240122-aac5d228a                                                                                                                                 
/go # which yamllint                                                                                                                                                                                                                    
/go # apk list | grep -i yamllint                                                                                                                                                                                                       
yamllint-1.33.0-r0 x86_64 {yamllint} (GPL-3.0-or-later)                                                                                                                                                                                 
yamllint-pyc-1.33.0-r0 x86_64 {yamllint} (GPL-3.0-or-later)                                                                                                                                                                             
/go # which yamllint                                                                                                                                                                                                                    
/go # ls -l /usr/bin/yamllint                                                                                                                                                                                                           
ls: /usr/bin/yamllint: No such file or directory                              
```
- This PR is trying to fix yamllint install on the tes-runner image

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
- Internal to project and discovered in CI and discussed on slack dev channel so no issue created

## How Has This Been Tested?
- Can only be tested after merger and can only be tested on GCP cloudbuild

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.


cc @strongjz  @tao12345666333 

James, the dockerfle RUN command for yamllint install may not be running to completion so added wait 

/triage accepted
/kind bug
/triage urgent-soon