### PR TITLE
fix: live-docs script for previewing documentation locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,8 +210,9 @@ live-docs: ## Build and launch a local copy of the documentation website in http
 	@docker run ${PLATFORM_FLAG} ${PLATFORM} --rm -it \
 		-p 8000:8000 \
 		-v ${PWD}:/docs \
-		--entrypoint mkdocs \
-		ingress-nginx-docs serve --dev-addr=0.0.0.0:8000
+		--entrypoint /bin/bash   \
+		ingress-nginx-docs \
+		-c "pip install -r /docs/docs/requirements.txt && mkdocs serve --dev-addr=0.0.0.0:8000"
 
 .PHONY: misspell
 misspell:  ## Check for spelling errors.


### PR DESCRIPTION
## What this PR does / why we need it:

Fixes #10927

This commit updates the live-docs script in the Makefile to install the necessary dependencies for running mkdocs, before starting it.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes

Fixes #10927

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
