### PR TITLE
Fix golang makefile var name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,10 @@ SHELL=/bin/bash -o pipefail -o errexit
 # Use the 0.0 tag for testing, it shouldn't clobber any release builds
 TAG ?= $(shell cat TAG)
 
-GOLANG_VERSION ?= $(shell cat GOLANG_VERSION)
+# The env below is called GO_VERSION and not GOLANG_VERSION because 
+# the gcb image we use to build already defines GOLANG_VERSION and is a 
+# really old version
+GO_VERSION ?= $(shell cat GOLANG_VERSION)
 
 # e2e settings
 # Allow limiting the scope of the e2e tests. By default run everything
@@ -107,7 +110,7 @@ clean-chroot-image: ## Removes local image
 
 .PHONY: build
 build:  ## Build ingress controller, debug tool and pre-stop hook.
-	E2E_IMAGE=golang:$(GOLANG_VERSION)-alpine3.19 USE_SHELL=/bin/sh build/run-in-docker.sh \
+	E2E_IMAGE=golang:$(GO_VERSION)-alpine3.19 USE_SHELL=/bin/sh build/run-in-docker.sh \
 		MAC_OS=$(MAC_OS) \
 		PKG=$(PKG) \
 		ARCH=$(ARCH) \

--- a/images/Makefile
+++ b/images/Makefile
@@ -23,7 +23,10 @@ INIT_BUILDX=$(DIR)/../hack/init-buildx.sh
 
 BASE_IMAGE = $(shell cat $(DIR)/../NGINX_BASE)
 
-GOLANG_VERSION = $(shell cat $(DIR)/../GOLANG_VERSION)
+# The env below is called GO_VERSION and not GOLANG_VERSION because 
+# the gcb image we use to build already defines GOLANG_VERSION and is a 
+# really old version
+GO_VERSION = $(shell cat $(DIR)/../GOLANG_VERSION)
 
 REGISTRY ?= local
 NAME ?=
@@ -54,7 +57,7 @@ build: precheck ensure-buildx
 		--label=org.opencontainers.image.licenses=Apache-2.0 \
 		--label=org.opencontainers.image.description="Ingress NGINX $(NAME) image" \
 		--build-arg BASE_IMAGE=$(BASE_IMAGE) \
-		--build-arg GOLANG_VERSION=$(GOLANG_VERSION) \
+		--build-arg GOLANG_VERSION=$(GO_VERSION) \
 		--platform=${PLATFORMS} $(OUTPUT) \
 		--progress=$(PROGRESS) \
 		--pull $(EXTRAARGS) \

--- a/images/test-runner/Makefile
+++ b/images/test-runner/Makefile
@@ -27,7 +27,10 @@ IMAGE = $(REGISTRY)/e2e-test-runner
 
 NGINX_BASE_IMAGE ?= $(shell cat $(DIR)/../../NGINX_BASE)
 
-GOLANG_VERSION ?= $(shell cat $(DIR)/../../GOLANG_VERSION)
+# The env below is called GO_VERSION and not GOLANG_VERSION because 
+# the gcb image we use to build already defines GOLANG_VERSION and is a 
+# really old version
+GO_VERSION ?= $(shell cat $(DIR)/../../GOLANG_VERSION)
 
 # required to enable buildx
 export DOCKER_CLI_EXPERIMENTAL=enabled
@@ -45,7 +48,7 @@ image:
 		--pull \
 		--push \
 		--build-arg BASE_IMAGE=${NGINX_BASE_IMAGE} \
-		--build-arg GOLANG_VERSION=${GOLANG_VERSION} \
+		--build-arg GOLANG_VERSION=${GO_VERSION} \
 		--build-arg ETCD_VERSION=3.4.3-0 \
 		--build-arg K8S_RELEASE=v1.26.0 \
 		--build-arg RESTY_CLI_VERSION=0.27 \
@@ -66,7 +69,7 @@ build: ensure-buildx
 		--progress=${PROGRESS} \
 		--pull \
 		--build-arg BASE_IMAGE=${NGINX_BASE_IMAGE} \
-		--build-arg GOLANG_VERSION=${GOLANG_VERSION} \
+		--build-arg GOLANG_VERSION=${GO_VERSION} \
 		--build-arg ETCD_VERSION=3.4.3-0 \
 		--build-arg K8S_RELEASE=v1.26.0 \
 		--build-arg RESTY_CLI_VERSION=0.27 \


### PR DESCRIPTION
We use image-builder from k8s on some cases, and it uses a very old version of go. We should actually bump this image, but right now we need at least to not rely on the GOLANG_VERSION name from those images and instead use ours