### PR TITLE
Chart: Set `--enable-metrics` depending on `controller.metrics.enabled`.

### DIFF
--- a/charts/ingress-nginx/templates/_params.tpl
+++ b/charts/ingress-nginx/templates/_params.tpl
@@ -54,6 +54,9 @@
 {{- if .Values.controller.watchIngressWithoutClass }}
 - --watch-ingress-without-class=true
 {{- end }}
+{{- if not .Values.controller.metrics.enabled }}
+- --enable-metrics={{ .Values.controller.metrics.enabled }}
+{{- end }}
 {{- if .Values.controller.enableTopologyAwareRouting }}
 - --enable-topology-aware-routing=true
 {{- end }}

--- a/charts/ingress-nginx/tests/controller-daemonset_test.yaml
+++ b/charts/ingress-nginx/tests/controller-daemonset_test.yaml
@@ -14,3 +14,34 @@ tests:
       - equal:
           path: metadata.name
           value: RELEASE-NAME-ingress-nginx-controller
+
+  - it: should create a DaemonSet with argument `--enable-metrics=false` if `controller.metrics.enabled` is false
+    set:
+      controller.kind: DaemonSet
+      controller.metrics.enabled: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --enable-metrics=false
+
+  - it: should create a DaemonSet without argument `--enable-metrics=false` if `controller.metrics.enabled` is true
+    set:
+      controller.kind: DaemonSet
+      controller.metrics.enabled: true
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --enable-metrics=false
+
+  - it: should create a DaemonSet with resource limits if `controller.resources.limits` is set
+    set:
+      controller.kind: DaemonSet
+      controller.resources.limits.cpu: 500m
+      controller.resources.limits.memory: 512Mi
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: 500m
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 512Mi

--- a/charts/ingress-nginx/tests/controller-deployment_test.yaml
+++ b/charts/ingress-nginx/tests/controller-deployment_test.yaml
@@ -21,6 +21,22 @@ tests:
           path: spec.replicas
           value: 3
 
+  - it: should create a Deployment with argument `--enable-metrics=false` if `controller.metrics.enabled` is false
+    set:
+      controller.metrics.enabled: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --enable-metrics=false
+
+  - it: should create a Deployment without argument `--enable-metrics=false` if `controller.metrics.enabled` is true
+    set:
+      controller.metrics.enabled: true
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --enable-metrics=false
+
   - it: should create a Deployment with resource limits if `controller.resources.limits` is set
     set:
       controller.resources.limits.cpu: 500m


### PR DESCRIPTION
Credits to @pmint93 (#10070)!

<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
<!--- Please make sure you title is descriptive, it is used in the Release notes to let others know what it does ---> 

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The chart has a value `controller.metrics.enabled` which gives the impression of enabling or disabling the metrics collection of the controller. Actually it only controls the exposition of the metrics port to the cluster and some other resources around metrics collection, but does not enable or disable the metrics collection inside the controller.

This PR sets the `--enable-metrics` argument to `false` if `controller.metrics.enabled` is `false`, which is the default.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [x] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.
