### PR TITLE
chore(deps): upgrade headers-more module to 0.37

### DIFF
--- a/images/nginx-1.25/rootfs/build.sh
+++ b/images/nginx-1.25/rootfs/build.sh
@@ -26,7 +26,7 @@ export NDK_VERSION=v0.3.3
 # Check for recent changes: https://github.com/openresty/set-misc-nginx-module/compare/v0.33...master
 export SETMISC_VERSION=796f5a3e518748eb29a93bd450324e0ad45b704e
 
-# Check for recent changes: https://github.com/openresty/headers-more-nginx-module/compare/v0.34...master
+# Check for recent changes: https://github.com/openresty/headers-more-nginx-module/compare/v0.37...master
 export MORE_HEADERS_VERSION=v0.37
 
 # Check for recent changes: https://github.com/atomx/nginx-http-auth-digest/compare/v1.0.0...atomx:master

--- a/images/nginx/rootfs/build.sh
+++ b/images/nginx/rootfs/build.sh
@@ -26,8 +26,8 @@ export NDK_VERSION=0.3.2
 # Check for recent changes: https://github.com/openresty/set-misc-nginx-module/compare/v0.33...master
 export SETMISC_VERSION=0.33
 
-# Check for recent changes: https://github.com/openresty/headers-more-nginx-module/compare/v0.34...master
-export MORE_HEADERS_VERSION=0.34
+# Check for recent changes: https://github.com/openresty/headers-more-nginx-module/compare/v0.37...master
+export MORE_HEADERS_VERSION=0.37
 
 # Check for recent changes: https://github.com/atomx/nginx-http-auth-digest/compare/v1.0.0...atomx:master
 export NGINX_DIGEST_AUTH=1.0.0
@@ -204,7 +204,7 @@ get_src aa961eafb8317e0eb8da37eb6e2c9ff42267edd18b56947384e719b85188f58b \
 get_src cd5e2cc834bcfa30149e7511f2b5a2183baf0b70dc091af717a89a64e44a2985 \
         "https://github.com/openresty/set-misc-nginx-module/archive/v$SETMISC_VERSION.tar.gz"
 
-get_src 0c0d2ced2ce895b3f45eb2b230cd90508ab2a773299f153de14a43e44c1209b3 \
+get_src cf6e169d6b350c06d0c730b0eaf4973394026ad40094cddd3b3a5b346577019d \
         "https://github.com/openresty/headers-more-nginx-module/archive/v$MORE_HEADERS_VERSION.tar.gz"
 
 get_src f09851e6309560a8ff3e901548405066c83f1f6ff88aa7171e0763bd9514762b \


### PR DESCRIPTION
## What this PR does / why we need it:
Upgrade to v0.37 of the `headers-more` module.

Changelog: https://github.com/openresty/headers-more-nginx-module/compare/v0.34...v0.37

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
n/a

## How Has This Been Tested?
I'm currently unable to test this locally as I cannot successfully build a fully functioning controller image right now. (I'm getting unknown directive `http2`?)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.
