### PR TITLE
Adds option to turn off automount service account token for deployments

### DIFF
--- a/charts/ingress-nginx/Chart.yaml
+++ b/charts/ingress-nginx/Chart.yaml
@@ -1,6 +1,6 @@
 annotations:
   artifacthub.io/changes: |-
-    - "Adds option to turn off automount of service account token"
+    - "Update Ingress-Nginx version controller-v1.10.0"
   artifacthub.io/prerelease: "false"
 apiVersion: v2
 appVersion: 1.10.0
@@ -19,4 +19,4 @@ maintainers:
 name: ingress-nginx
 sources:
 - https://github.com/kubernetes/ingress-nginx
-version: 4.10.1
+version: 4.10.0

--- a/charts/ingress-nginx/Chart.yaml
+++ b/charts/ingress-nginx/Chart.yaml
@@ -1,6 +1,6 @@
 annotations:
   artifacthub.io/changes: |-
-    - "Update Ingress-Nginx version controller-v1.10.0"
+    - "Adds option to turn off automount of service account token"
   artifacthub.io/prerelease: "false"
 apiVersion: v2
 appVersion: 1.10.0
@@ -19,4 +19,4 @@ maintainers:
 name: ingress-nginx
 sources:
 - https://github.com/kubernetes/ingress-nginx
-version: 4.10.0
+version: 4.10.1

--- a/charts/ingress-nginx/README.md
+++ b/charts/ingress-nginx/README.md
@@ -2,7 +2,7 @@
 
 [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer
 
-![Version: 4.10.0](https://img.shields.io/badge/Version-4.10.0-informational?style=flat-square) ![AppVersion: 1.10.0](https://img.shields.io/badge/AppVersion-1.10.0-informational?style=flat-square)
+![Version: 4.10.1](https://img.shields.io/badge/Version-4.10.1-informational?style=flat-square) ![AppVersion: 1.10.0](https://img.shields.io/badge/AppVersion-1.10.0-informational?style=flat-square)
 
 To use, add `ingressClassName: nginx` spec field or the `kubernetes.io/ingress.class: nginx` annotation to your Ingress resources.
 
@@ -277,6 +277,7 @@ As of version `1.26.0` of this chart, by simply not providing any clusterIP valu
 | controller.affinity | object | `{}` | Affinity and anti-affinity rules for server scheduling to nodes # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity # |
 | controller.allowSnippetAnnotations | bool | `false` | This configuration defines if Ingress Controller should allow users to set their own *-snippet annotations, otherwise this is forbidden / dropped when users add those annotations. Global snippets in ConfigMap are still respected |
 | controller.annotations | object | `{}` | Annotations to be added to the controller Deployment or DaemonSet # |
+| controller.automountServiceAccountToken | bool | `true` | Automount service account token on controller deployment # Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/ |
 | controller.autoscaling.annotations | object | `{}` |  |
 | controller.autoscaling.behavior | object | `{}` |  |
 | controller.autoscaling.enabled | bool | `false` |  |
@@ -475,6 +476,7 @@ As of version `1.26.0` of this chart, by simply not providing any clusterIP valu
 | controller.updateStrategy | object | `{}` | The update strategy to apply to the Deployment or DaemonSet # |
 | controller.watchIngressWithoutClass | bool | `false` | Process Ingress objects without ingressClass annotation/ingressClassName field Overrides value for --watch-ingress-without-class flag of the controller binary Defaults to false |
 | defaultBackend.affinity | object | `{}` |  |
+| defaultBackend.automountServiceAccountToken | bool | `true` | Automount service account token on controller deployment # Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/ |
 | defaultBackend.autoscaling.annotations | object | `{}` |  |
 | defaultBackend.autoscaling.enabled | bool | `false` |  |
 | defaultBackend.autoscaling.maxReplicas | int | `2` |  |

--- a/charts/ingress-nginx/changelog/helm-chart-4.10.1.md
+++ b/charts/ingress-nginx/changelog/helm-chart-4.10.1.md
@@ -1,0 +1,9 @@
+# Changelog
+
+This file documents all notable changes to [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
+
+### 4.10.1
+
+* - "Adds option to turn off automount of service account token on deployments"
+
+**Full Changelog**: https://github.com/kubernetes/ingress-nginx/compare/helm-chart-4.10.0...helm-chart-4.10.1

--- a/charts/ingress-nginx/templates/controller-deployment.yaml
+++ b/charts/ingress-nginx/templates/controller-deployment.yaml
@@ -45,7 +45,7 @@ spec:
         {{- toYaml .Values.controller.podLabels | nindent 8 }}
       {{- end }}
     spec:
-      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
+      automountServiceAccountToken: {{ .Values.controller.automountServiceAccountToken }}
     {{- if .Values.controller.dnsConfig }}
       dnsConfig: {{ toYaml .Values.controller.dnsConfig | nindent 8 }}
     {{- end }}

--- a/charts/ingress-nginx/templates/controller-deployment.yaml
+++ b/charts/ingress-nginx/templates/controller-deployment.yaml
@@ -45,6 +45,7 @@ spec:
         {{- toYaml .Values.controller.podLabels | nindent 8 }}
       {{- end }}
     spec:
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
     {{- if .Values.controller.dnsConfig }}
       dnsConfig: {{ toYaml .Values.controller.dnsConfig | nindent 8 }}
     {{- end }}

--- a/charts/ingress-nginx/templates/default-backend-deployment.yaml
+++ b/charts/ingress-nginx/templates/default-backend-deployment.yaml
@@ -39,6 +39,7 @@ spec:
         {{- toYaml .Values.defaultBackend.podLabels | nindent 8 }}
       {{- end }}
     spec:
+      automountServiceAccountToken: {{ .Values.defaultBackend.automountServiceAccountToken }}
     {{- if .Values.imagePullSecrets }}
       imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 8 }}
     {{- end }}

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -45,6 +45,9 @@ controller:
   containerPort:
     http: 80
     https: 443
+  # -- Automount service account token on controller deployment
+  ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+  automountServiceAccountToken: true
   # -- Will add custom configuration options to Nginx https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/
   config: {}
   # -- Annotations to be added to the controller config configuration configmap.
@@ -1071,9 +1074,6 @@ serviceAccount:
   automountServiceAccountToken: true
   # -- Annotations for the controller service account
   annotations: {}
-# -- Automount service account token on controller deployment
-## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
-automountServiceAccountToken: true
 # -- Optional array of imagePullSecrets containing private registry credentials
 ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 imagePullSecrets: []

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -939,6 +939,9 @@ defaultBackend:
     create: true
     name: ""
     automountServiceAccountToken: true
+  # -- Automount service account token on controller deployment
+  ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+  automountServiceAccountToken: true
   # -- Additional environment variables to set for defaultBackend pods
   extraEnvs: []
   port: 8080
@@ -1068,6 +1071,9 @@ serviceAccount:
   automountServiceAccountToken: true
   # -- Annotations for the controller service account
   annotations: {}
+# -- Automount service account token on controller deployment
+## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+automountServiceAccountToken: true
 # -- Optional array of imagePullSecrets containing private registry credentials
 ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 imagePullSecrets: []


### PR DESCRIPTION
## What this PR does / why we need it:
This PR adds option to set automount of service account token to false.

This is because Azure Microsoft Defender for Cloud recommends doing so and shows up as a warning.

To make the warning disappear, it is not sufficient to set it on the service account level, but has to be on the pod level.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes

## How Has This Been Tested?

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
