### PR TITLE
Fix ACME when mTLS with client CN check is enabled

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -985,8 +985,10 @@ stream {
 
         {{ if not ( empty $server.CertificateAuth.MatchCN ) }}
         {{ if gt (len $server.CertificateAuth.MatchCN) 0 }}
-        if ( $ssl_client_s_dn !~ {{ $server.CertificateAuth.MatchCN }} ) {
-            return 403 "client certificate unauthorized";
+        location ~ ^/(?!(\.well-known/acme-challenge)) {
+            if ( $ssl_client_s_dn !~ {{ $server.CertificateAuth.MatchCN }} ) {
+                return 403 "client certificate unauthorized";
+            }
         }
         {{ end }}
         {{ end }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
<!--- Please make sure you title is descriptive, it is used in the Release notes to let others know what it does ---> 

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Described in #10185 
CertManager will fail to create a certificate If we enable mTLS on an ingress with client CN match enabled:

```yaml
    cert-manager.io/cluster-issuer: my-issuer
    nginx.ingress.kubernetes.io/auth-tls-secret: ns/secret
    nginx.ingress.kubernetes.io/auth-tls-verify-client: "on"
    nginx.ingress.kubernetes.io/auth-tls-match-cn: "CN=some-cn"
```

If the annotation `nginx.ingress.kubernetes.io/auth-tls-match-cn: "CN=some-cn"` is removed it does not fail.
The issue is that the client CN match is implemented too early (which makes sense - fail fast). The PR fixes this case
by only checking the client certificate for its CN if the location is not `.well-known/acme-challenge/...`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):
-->
fixes #10185 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

The following configuration was mounted into a local `nginx` container (`docker run --rm -v $PWD/default.conf:/etc/nginx/conf.d/default.conf -p 8080:80 nginx`:

```
server {
    listen       80;
    server_name  localhost;

    ssl_verify_client on;

    if ( $ssl_client_s_dn !~ some-cn ) { 
        return 403 "client certificate unauthorized"; 
    }

    location / {
        root   /usr/share/nginx/html;
        index  index.html index.htm;
    }
}
```

When running curl against this config we get `403`:
```bash
curl http://localhost:8080/.well-known/acme-challenge/redacted
client certificate unauthorized
```

The same command against this config:

```
server {
    listen       80;
    server_name  localhost;

    ssl_verify_client on;

    location ~ ^/(?!(\.well-known/acme-challenge)) {
        if ( $ssl_client_s_dn !~ some-cn ) { 
            return 403 "client certificate unauthorized"; 
        }
    }

    location / {
        root   /usr/share/nginx/html;
        index  index.html index.htm;
    }
}
```

returns `404`, which is expected since there is nothing on this url:

```bash
curl http://localhost:8080/.well-known/acme-challenge/redacted
<html>
<head><title>404 Not Found</title></head>
<body>
<center><h1>404 Not Found</h1></center>
<hr><center>nginx/1.25.4</center>
</body>
</html>
```

While other urls still return `403`:

```bash
curl http://localhost:8080/test                               
client certificate unauthorized
```

This test should be sufficient as acme works on http. Similar is shown in #10185 when removing the `match-ch` annotation.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
