### PR TITLE
Update Lua resty.balancer module to 0.05

### DIFF
--- a/images/nginx/rootfs/build.sh
+++ b/images/nginx/rootfs/build.sh
@@ -84,7 +84,7 @@ export GEOIP2_VERSION=a607a41a8115fecfc05b5c283c81532a3d605425
 export LUAJIT_VERSION=2.1-20230410
 
 # Check for recent changes: https://github.com/openresty/lua-resty-balancer/compare/v0.04...master
-export LUA_RESTY_BALANCER=0.04
+export LUA_RESTY_BALANCER=0.05
 
 # Check for recent changes: https://github.com/openresty/lua-resty-lrucache/compare/v0.13...master
 export LUA_RESTY_CACHE=0.13

--- a/images/nginx/rootfs/build.sh
+++ b/images/nginx/rootfs/build.sh
@@ -83,7 +83,7 @@ export GEOIP2_VERSION=a607a41a8115fecfc05b5c283c81532a3d605425
 # Check for recent changes: https://github.com/openresty/luajit2/compare/v2.1-20230410...v2.1-agentzh
 export LUAJIT_VERSION=2.1-20230410
 
-# Check for recent changes: https://github.com/openresty/lua-resty-balancer/compare/v0.04...master
+# Check for recent changes: https://github.com/openresty/lua-resty-balancer/compare/v0.05...master
 export LUA_RESTY_BALANCER=0.05
 
 # Check for recent changes: https://github.com/openresty/lua-resty-lrucache/compare/v0.13...master


### PR DESCRIPTION
Lua resty.balancer module version 0.04  have a known risk that insufficient memory can lead to a crash.

We have encountered this issue in our production environment. (https://github.com/kubernetes/ingress-nginx/issues/11125)

ref  PR：https://github.com/openresty/lua-resty-balancer/commit/a7a8b625c6d79d203702709983b736137be2a9bd