### PR TITLE
Add http3 support

### DIFF
--- a/images/nginx-1.25/rootfs/build.sh
+++ b/images/nginx-1.25/rootfs/build.sh
@@ -447,6 +447,7 @@ WITH_FLAGS="--with-debug \
   --with-http_gzip_static_module \
   --with-http_sub_module \
   --with-http_v2_module \
+  --with-http_v3_module \
   --with-stream \
   --with-stream_ssl_module \
   --with-stream_realip_module \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
<!--- Please make sure you title is descriptive, it is used in the Release notes to let others know what it does ---> 

## What this PR does / why we need it:
This update enables HTTP/3 support in Ingress-Nginx by incorporating the necessary flag, --with-http_v3_module, for OpenResty into the build configuration. Now, users can leverage the advantages of HTTP/3 protocol within their Kubernetes clusters, enhancing performance, security, and efficiency for web traffic management. This enhancement underscores our commitment to staying at the forefront of modern web technologies and providing users with cutting-edge solutions for their ingress needs.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
```
server {
    listen 443 ssl http2 http3;
    ...
}
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
