### PR TITLE
fix: Ensure changes in MatchCN annotation are detected

### DIFF
--- a/internal/ingress/annotations/authtls/main.go
+++ b/internal/ingress/annotations/authtls/main.go
@@ -122,6 +122,9 @@ func (assl1 *Config) Equal(assl2 *Config) bool {
 	if assl1.PassCertToUpstream != assl2.PassCertToUpstream {
 		return false
 	}
+	if assl1.MatchCN != assl2.MatchCN {
+		return false
+	}
 
 	return true
 }

--- a/internal/ingress/annotations/authtls/main_test.go
+++ b/internal/ingress/annotations/authtls/main_test.go
@@ -333,6 +333,15 @@ func TestEquals(t *testing.T) {
 	}
 	cfg2.PassCertToUpstream = true
 
+	// Different MatchCN
+	cfg1.MatchCN = "CN=(hello-app|goodbye)"
+	cfg2.MatchCN = "CN=(hello-app)"
+	result = cfg1.Equal(cfg2)
+	if result != false {
+		t.Errorf("Expected false")
+	}
+	cfg2.MatchCN = "CN=(hello-app|goodbye)"
+
 	// Equal Configs
 	result = cfg1.Equal(cfg2)
 	if result != true {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
<!--- Please make sure you title is descriptive, it is used in the Release notes to let others know what it does ---> 

## What this PR does / why we need it:
Ensure the AuthTLS config correctly detects changes in MatchCN.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->
Fixes #10915 

## How Has This Been Tested?
I have built the docker image and deployed it into our kubernetes cluster that was exhibiting the bug.
When this version is running the `nginx.conf` file is correctly updated when the `nginx.ingress.kubernetes.io/auth-tls-match-cn` is updated.

I could not immediately find an end-to-end test that covers this scenario, but if you point me in the right direction, I'll happily add one.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [x] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.
