### PR TITLE
Proposal: e2e tests for regex patterns

### DIFF
--- a/test/e2e/ingress/pathtype_prefix.go
+++ b/test/e2e/ingress/pathtype_prefix.go
@@ -111,7 +111,7 @@ var _ = framework.IngressNginxDescribe("[Ingress] [PathType] prefix checks", fun
 	})
 
 	ginkgo.It("should test prefix path using regex pattern for /id/{int} ignoring non-digits characters at end of string", func() {
-		host := "echo.com.br"
+		host := "echo.regex.br"
 
 		annotations := map[string]string{
 			"nginx.ingress.kubernetes.io/use-regex": `true`,
@@ -140,7 +140,7 @@ var _ = framework.IngressNginxDescribe("[Ingress] [PathType] prefix checks", fun
 	})
 
 	ginkgo.It("should test prefix path using fixed path size regex pattern /id/{int}{3}", func() {
-		host := "echo.com.br"
+		host := "echo.regex.size.br"
 
 		annotations := map[string]string{
 			"nginx.ingress.kubernetes.io/use-regex": `true`,
@@ -150,13 +150,7 @@ var _ = framework.IngressNginxDescribe("[Ingress] [PathType] prefix checks", fun
 		f.EnsureIngress(ing)
 
 		f.HTTPTestClient().
-			GET("/id/1").
-			WithHeader("Host", host).
-			Expect().
-			Status(http.StatusNotFound)
-
-		f.HTTPTestClient().
-			GET("/id/12").
+			GET("/id/99").
 			WithHeader("Host", host).
 			Expect().
 			Status(http.StatusNotFound)
@@ -168,7 +162,7 @@ var _ = framework.IngressNginxDescribe("[Ingress] [PathType] prefix checks", fun
 			Status(http.StatusOK)
 
 		f.HTTPTestClient().
-			GET("/id/1234").
+			GET("/id/9999").
 			WithHeader("Host", host).
 			Expect().
 			Status(http.StatusNotFound)
@@ -181,7 +175,7 @@ var _ = framework.IngressNginxDescribe("[Ingress] [PathType] prefix checks", fun
 	})
 
 	ginkgo.It("should correctly route multi-segment path patterns", func() {
-		host := "echo.com.br"
+		host := "echo.multi.segment.br"
 
 		annotations := map[string]string{
 			"nginx.ingress.kubernetes.io/use-regex": `true`,

--- a/test/e2e/ingress/pathtype_prefix.go
+++ b/test/e2e/ingress/pathtype_prefix.go
@@ -108,7 +108,6 @@ var _ = framework.IngressNginxDescribe("[Ingress] [PathType] prefix checks", fun
 			WithHeader("Host", host).
 			Expect().
 			Status(http.StatusOK)
-
 	})
 
 	ginkgo.It("should test prefix path using regex pattern for /id/{int} ignoring non-digits characters at end of string", func() {
@@ -138,7 +137,6 @@ var _ = framework.IngressNginxDescribe("[Ingress] [PathType] prefix checks", fun
 			WithHeader("Host", host).
 			Expect().
 			Status(http.StatusNotFound)
-
 	})
 
 	ginkgo.It("should test prefix path using fixed path size regex pattern /id/{int}{3}", func() {
@@ -180,7 +178,6 @@ var _ = framework.IngressNginxDescribe("[Ingress] [PathType] prefix checks", fun
 			WithHeader("Host", host).
 			Expect().
 			Status(http.StatusNotFound)
-
 	})
 
 	ginkgo.It("should correctly route multi-segment path patterns", func() {
@@ -210,7 +207,5 @@ var _ = framework.IngressNginxDescribe("[Ingress] [PathType] prefix checks", fun
 			WithHeader("Host", host).
 			Expect().
 			Status(http.StatusNotFound)
-
 	})
-
 })

--- a/test/e2e/ingress/pathtype_prefix.go
+++ b/test/e2e/ingress/pathtype_prefix.go
@@ -68,4 +68,149 @@ var _ = framework.IngressNginxDescribe("[Ingress] [PathType] prefix checks", fun
 			Expect().
 			Status(http.StatusOK)
 	})
+
+	ginkgo.It("should test prefix path using simple regex pattern for /id/{int}", func() {
+		host := "echo.com.br"
+
+		annotations := map[string]string{
+			"nginx.ingress.kubernetes.io/use-regex": `true`,
+		}
+
+		ing := framework.NewSingleIngress(host, "/id/[0-9]+", host, f.Namespace, framework.EchoService, 80, annotations)
+		f.EnsureIngress(ing)
+
+		f.HTTPTestClient().
+			GET("/id/1").
+			WithHeader("Host", host).
+			Expect().
+			Status(http.StatusOK)
+
+		f.HTTPTestClient().
+			GET("/id/12").
+			WithHeader("Host", host).
+			Expect().
+			Status(http.StatusOK)
+
+		f.HTTPTestClient().
+			GET("/id/123").
+			WithHeader("Host", host).
+			Expect().
+			Status(http.StatusOK)
+
+		f.HTTPTestClient().
+			GET("/id/aaa").
+			WithHeader("Host", host).
+			Expect().
+			Status(http.StatusNotFound)
+
+		f.HTTPTestClient().
+			GET("/id/123a").
+			WithHeader("Host", host).
+			Expect().
+			Status(http.StatusOK)
+
+	})
+
+	ginkgo.It("should test prefix path using regex pattern for /id/{int} ignoring non-digits characters at end of string", func() {
+		host := "echo.com.br"
+
+		annotations := map[string]string{
+			"nginx.ingress.kubernetes.io/use-regex": `true`,
+		}
+
+		ing := framework.NewSingleIngress(host, "/id/[0-9]+$", host, f.Namespace, framework.EchoService, 80, annotations)
+		f.EnsureIngress(ing)
+
+		f.HTTPTestClient().
+			GET("/id/1").
+			WithHeader("Host", host).
+			Expect().
+			Status(http.StatusOK)
+
+		f.HTTPTestClient().
+			GET("/id/aaa").
+			WithHeader("Host", host).
+			Expect().
+			Status(http.StatusNotFound)
+
+		f.HTTPTestClient().
+			GET("/id/123a").
+			WithHeader("Host", host).
+			Expect().
+			Status(http.StatusNotFound)
+
+	})
+
+	ginkgo.It("should test prefix path using fixed path size regex pattern /id/{int}{3}", func() {
+		host := "echo.com.br"
+
+		annotations := map[string]string{
+			"nginx.ingress.kubernetes.io/use-regex": `true`,
+		}
+
+		ing := framework.NewSingleIngress(host, "/id/[0-9]{3}$", host, f.Namespace, framework.EchoService, 80, annotations)
+		f.EnsureIngress(ing)
+
+		f.HTTPTestClient().
+			GET("/id/1").
+			WithHeader("Host", host).
+			Expect().
+			Status(http.StatusNotFound)
+
+		f.HTTPTestClient().
+			GET("/id/12").
+			WithHeader("Host", host).
+			Expect().
+			Status(http.StatusNotFound)
+
+		f.HTTPTestClient().
+			GET("/id/123").
+			WithHeader("Host", host).
+			Expect().
+			Status(http.StatusOK)
+
+		f.HTTPTestClient().
+			GET("/id/1234").
+			WithHeader("Host", host).
+			Expect().
+			Status(http.StatusNotFound)
+
+		f.HTTPTestClient().
+			GET("/id/123a").
+			WithHeader("Host", host).
+			Expect().
+			Status(http.StatusNotFound)
+
+	})
+
+	ginkgo.It("should correctly route multi-segment path patterns", func() {
+		host := "echo.com.br"
+
+		annotations := map[string]string{
+			"nginx.ingress.kubernetes.io/use-regex": `true`,
+		}
+
+		ing := framework.NewSingleIngress(host, "/id/[0-9]+/post/[a-zA-Z]+$", host, f.Namespace, framework.EchoService, 80, annotations)
+		f.EnsureIngress(ing)
+
+		f.HTTPTestClient().
+			GET("/id/123/post/abc").
+			WithHeader("Host", host).
+			Expect().
+			Status(http.StatusOK)
+
+		f.HTTPTestClient().
+			GET("/id/123/post/abc123").
+			WithHeader("Host", host).
+			Expect().
+			Status(http.StatusNotFound)
+
+		f.HTTPTestClient().
+			GET("/id/abc/post/abc").
+			WithHeader("Host", host).
+			Expect().
+			Status(http.StatusNotFound)
+
+	})
+
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
<!--- Please make sure you title is descriptive, it is used in the Release notes to let others know what it does ---> 

This proposal Introduces an expanded suite of tests for regex pattern handling in the Nginx Ingress Controller, aiming to cover an extra range of test scenarios of path routing regex feature.

Initial tests included: 

* Testing Simple Regex Patterns for Numeric Paths
* Ignoring Non-digit Characters at the End of Paths
* Fixed Path Size Regex Pattern
* Multi-segment Path Patterns

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only
- [x] Tests

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

fixes #9466

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [x] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.
