### PR TITLE
refactor helm ci tests part I

### DIFF
--- a/.ct.yaml
+++ b/.ct.yaml
@@ -11,12 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+---
 remote: origin
-validate-maintainers: false
 target-branch: main
+
+validate-maintainers: false
+check-version-increment: false
+
 chart-repos:
   - ingress-nginx=https://kubernetes.github.io/ingress-nginx
 helm-extra-args: --timeout 800s
+
 chart-dirs:
   - charts

--- a/.ct.yaml
+++ b/.ct.yaml
@@ -1,6 +1,4 @@
-#!/bin/bash
-
-# Copyright 2020 The Kubernetes Authors.
+# Copyright 2024 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -o errexit
-set -o nounset
-set -o pipefail
-
-KUBE_ROOT="$( cd "$(dirname "$0")../" >/dev/null 2>&1 ; pwd -P )"
-ct lint --charts ${KUBE_ROOT}/charts/ingress-nginx --validate-maintainers=false
+remote: origin
+validate-maintainers: false
+target-branch: main
+chart-repos:
+  - ingress-nginx=https://kubernetes.github.io/ingress-nginx
+helm-extra-args: --timeout 800s
+chart-dirs:
+  - charts

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -213,7 +213,7 @@ jobs:
           helm unittest charts/ingress-nginx -d
 
       - name: Run chart-testing (lint)
-        run: ct lint --config ct.yaml
+        run: ct lint --config ./.ct.yaml
 
       - name: Run helm-docs
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -168,6 +168,7 @@ jobs:
           name: docker.tar.gz
           path: docker.tar.gz
           retention-days: 5
+
   helm:
     name: Helm chart
     runs-on: ubuntu-latest
@@ -191,6 +192,18 @@ jobs:
           go-version: ${{ needs.build.outputs.golangversion }}
           check-latest: true
 
+      - name: Set up Helm
+        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5
+        with:
+          version: '3.14.3'
+
+      - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
+        with:
+          python-version: '3.x'
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@e6669bcd63d7cb57cb4380c33043eebe5d111992 # v2.6.1
+
       - name: Install Helm Unit Test Plugin
         run: |
           helm plugin install https://github.com/helm-unittest/helm-unittest
@@ -199,14 +212,8 @@ jobs:
         run: |
           helm unittest charts/ingress-nginx -d
 
-      - name: cache
-        uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
-        with:
-          name: docker.tar.gz
-
-      - name: Lint
-        run: |
-          ./build/run-in-docker.sh ./hack/verify-chart-lint.sh
+      - name: Run chart-testing (lint)
+        run: ct lint --config ct.yaml
 
       - name: Run helm-docs
         run: |
@@ -226,6 +233,11 @@ jobs:
           tar -xzvf ah_1.5.0_linux_amd64.tar.gz ah
           ./ah lint -p charts/ingress-nginx || exit 1
           rm -f ./ah ./ah_1.5.0_linux_amd64.tar.gz
+
+      - name: cache
+        uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
+        with:
+          name: docker.tar.gz
 
       - name: fix permissions
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -194,8 +194,6 @@ jobs:
 
       - name: Set up Helm
         uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5
-        with:
-          version: '3.14.3'
 
       - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -169,28 +169,19 @@ jobs:
           path: docker.tar.gz
           retention-days: 5
 
-  helm:
-    name: Helm chart
+  helm-lint:
+    name: Helm chart lint
     runs-on: ubuntu-latest
     needs:
       - changes
-      - build
     if: |
       (needs.changes.outputs.charts == 'true') || (needs.changes.outputs.baseimage == 'true')
-
-    strategy:
-      matrix:
-        k8s: [v1.26.6, v1.27.3, v1.28.0, v1.29.0]
 
     steps:
       - name: Checkout
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
-
-      - name: Setup Go
-        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version: ${{ needs.build.outputs.golangversion }}
-          check-latest: true
+          fetch-depth: 0
 
       - name: Set up Helm
         uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5
@@ -231,6 +222,30 @@ jobs:
           tar -xzvf ah_1.5.0_linux_amd64.tar.gz ah
           ./ah lint -p charts/ingress-nginx || exit 1
           rm -f ./ah ./ah_1.5.0_linux_amd64.tar.gz
+
+  helm-test:
+    name: Helm chart testing
+    runs-on: ubuntu-latest
+    needs:
+      - changes
+      - build
+      - helm-lint
+    if: |
+      (needs.changes.outputs.charts == 'true') || (needs.changes.outputs.baseimage == 'true')
+
+    strategy:
+      matrix:
+        k8s: [v1.26.6, v1.27.3, v1.28.0, v1.29.0]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+
+      - name: Setup Go
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+        with:
+          go-version: ${{ needs.build.outputs.golangversion }}
+          check-latest: true
 
       - name: cache
         uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4

--- a/charts/ingress-nginx/Chart.yaml
+++ b/charts/ingress-nginx/Chart.yaml
@@ -9,15 +9,15 @@ description: Ingress controller for Kubernetes using NGINX as a reverse proxy an
 home: https://github.com/kubernetes/ingress-nginx
 icon: https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Nginx_logo.svg/500px-Nginx_logo.svg.png
 keywords:
-- ingress
-- nginx
+  - ingress
+  - nginx
 kubeVersion: '>=1.20.0-0'
 maintainers:
-- name: Gacko
-- name: rikatz
-- name: strongjz
-- name: tao12345666333
+  - name: Gacko
+  - name: rikatz
+  - name: strongjz
+  - name: tao12345666333
 name: ingress-nginx
 sources:
-- https://github.com/kubernetes/ingress-nginx
+  - https://github.com/kubernetes/ingress-nginx
 version: 4.10.0


### PR DESCRIPTION

## What this PR does / why we need it:

Working to remove legacy and make easier to do maintenance for the helm ci tests (for now)

this pr uses the ct testing for lint and remove the script, more to come

- refactor helm ci tests part I
/assign @rikatz @Gacko @strongjz  
