### PR TITLE
bump ginkgo to 2-17-1 in testrunner

### DIFF
--- a/images/test-runner/Makefile
+++ b/images/test-runner/Makefile
@@ -59,7 +59,7 @@ image:
 		--build-arg YAML_LINT_VERSION=1.33.0 \
 		--build-arg YAMALE_VERSION=4.0.4 \
 		--build-arg HELM_VERSION=3.11.2 \
-		--build-arg GINKGO_VERSION=2.15.0 \
+		--build-arg GINKGO_VERSION=2.17.1 \
 		--build-arg GOLINT_VERSION=latest \
 		-t ${IMAGE}:${TAG} rootfs
 
@@ -80,7 +80,7 @@ build: ensure-buildx
 		--build-arg YAML_LINT_VERSION=1.33.0 \
 		--build-arg YAMALE_VERSION=4.0.4 \
 		--build-arg HELM_VERSION=3.11.2 \
-		--build-arg GINKGO_VERSION=2.15.0 \
+		--build-arg GINKGO_VERSION=2.17.1 \
 		--build-arg GOLINT_VERSION=latest \
 		-t ${IMAGE}:${TAG} rootfs
 


### PR DESCRIPTION
## What this PR does / why we need it:
- ginkgo bump to v2.17.1 was missed in the test-runner image's Makefile
- This PR bumps ginkgo in that Makefile as everywhere else is using ginkgo v2.17.1

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
- No issues created as this is internal tracking of a missed but required change

## How Has This Been Tested?
- Can only be tested after merging and then promoting the new test-runner image to change the code to use new test-runner image sha

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.

/triage accepted
/priority important

cc @strongjz 