### PR TITLE
updated certgen image sha & README

### DIFF
--- a/charts/ingress-nginx/README.md
+++ b/charts/ingress-nginx/README.md
@@ -253,7 +253,7 @@ As of version `1.26.0` of this chart, by simply not providing any clusterIP valu
 | controller.admissionWebhooks.namespaceSelector | object | `{}` |  |
 | controller.admissionWebhooks.objectSelector | object | `{}` |  |
 | controller.admissionWebhooks.patch.enabled | bool | `true` |  |
-| controller.admissionWebhooks.patch.image.digest | string | `"sha256:44d1d0e9f19c63f58b380c5fddaca7cf22c7cee564adeff365225a5df5ef3334"` |  |
+| controller.admissionWebhooks.patch.image.digest | string | `"sha256:d8af609b5136aa653de2ecdb119b156e5f166b3cfa642e5973cfa480fb8c6e71"` |  |
 | controller.admissionWebhooks.patch.image.image | string | `"ingress-nginx/kube-webhook-certgen"` |  |
 | controller.admissionWebhooks.patch.image.pullPolicy | string | `"IfNotPresent"` |  |
 | controller.admissionWebhooks.patch.image.registry | string | `"registry.k8s.io"` |  |

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -803,7 +803,7 @@ controller:
         ## use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail
         ## repository:
         tag: v1.4.0
-        digest: sha256:44d1d0e9f19c63f58b380c5fddaca7cf22c7cee564adeff365225a5df5ef3334
+        digest: sha256:d8af609b5136aa653de2ecdb119b156e5f166b3cfa642e5973cfa480fb8c6e71
         pullPolicy: IfNotPresent
       # -- Provide a priority class name to the webhook patching job
       ##


### PR DESCRIPTION
## What this PR does / why we need it:
- A new kube-webhook-certgen image was built due to golang and other updates
- This PR changes the project's chart values file to use the new certgen image
- Also ran helm-docs to autogenerate the updated README for the chart

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
- No issue created as task from internal process

## How Has This Been Tested?
- Will be tested in CI after the new image is used in installs

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.

/triage accepted
/priority backlog

cc @strongjz @rikatz @cpanato @tao12345666333 