### PR TITLE
Fix incorrect service name being set in the nginx template

### DIFF
--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -37,6 +37,7 @@ import (
 	text_template "text/template"
 
 	networkingv1 "k8s.io/api/networking/v1"
+	v1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 
@@ -1060,7 +1061,7 @@ func (info *ingressInformation) Equal(other *ingressInformation) bool {
 	return true
 }
 
-func getIngressInformation(i, h, p interface{}) *ingressInformation {
+func getIngressInformation(i, h, p, t interface{}) *ingressInformation {
 	ing, ok := i.(*ingress.Ingress)
 	if !ok {
 		klog.Errorf("expected an '*ingress.Ingress' type but %T was returned", i)
@@ -1077,6 +1078,11 @@ func getIngressInformation(i, h, p interface{}) *ingressInformation {
 	if !ok {
 		klog.Errorf("expected a 'string' type but %T was returned", p)
 		return &ingressInformation{}
+	}
+
+	ingressPathType, ok := t.(*v1.PathType)
+	if !ok {
+		klog.Errorf("expected a '*v1.PathType' type but %T was returned", t)
 	}
 
 	if ing == nil {
@@ -1124,6 +1130,10 @@ func getIngressInformation(i, h, p interface{}) *ingressInformation {
 
 		for _, rPath := range rule.HTTP.Paths {
 			if ingressPath != rPath.Path {
+				continue
+			}
+
+			if *ingressPathType != *rPath.PathType {
 				continue
 			}
 

--- a/internal/ingress/controller/template/template_test.go
+++ b/internal/ingress/controller/template/template_test.go
@@ -55,6 +55,7 @@ func init() {
 
 var (
 	pathPrefix networking.PathType = networking.PathTypePrefix
+	pathExact  networking.PathType = networking.PathTypeExact
 
 	// TODO: add tests for SSLPassthrough
 	tmplFuncTestcases = map[string]struct {
@@ -1157,18 +1158,21 @@ func TestGetIngressInformation(t *testing.T) {
 		Ingress  interface{}
 		Host     string
 		Path     interface{}
+		PathType interface{}
 		Expected *ingressInformation
 	}{
 		"wrong ingress type": {
 			"wrongtype",
 			"host1",
 			"/ok",
+			"",
 			&ingressInformation{},
 		},
 		"wrong path type": {
 			&ingress.Ingress{},
 			"host1",
 			10,
+			"",
 			&ingressInformation{},
 		},
 		"valid ingress definition with name validIng in namespace default  using a service with name a-svc port number 8080": {
@@ -1194,6 +1198,7 @@ func TestGetIngressInformation(t *testing.T) {
 				},
 			},
 			"host1",
+			"",
 			"",
 			&ingressInformation{
 				Namespace: "default",
@@ -1230,6 +1235,7 @@ func TestGetIngressInformation(t *testing.T) {
 			},
 			"host1",
 			"",
+			"",
 			&ingressInformation{
 				Namespace: "default",
 				Rule:      "validIng",
@@ -1261,6 +1267,7 @@ func TestGetIngressInformation(t *testing.T) {
 				},
 			},
 			"host1",
+			"",
 			"",
 			&ingressInformation{
 				Namespace: "default",
@@ -1312,6 +1319,7 @@ func TestGetIngressInformation(t *testing.T) {
 			},
 			"foo.bar",
 			"/ok",
+			&pathPrefix,
 			&ingressInformation{
 				Namespace: "something",
 				Rule:      "demo",
@@ -1362,6 +1370,7 @@ func TestGetIngressInformation(t *testing.T) {
 			},
 			"foo.bar",
 			"/ok",
+			&pathPrefix,
 			&ingressInformation{
 				Namespace: "something",
 				Rule:      "demo",
@@ -1407,6 +1416,7 @@ func TestGetIngressInformation(t *testing.T) {
 			},
 			"foo.bar",
 			"/ok",
+			&pathPrefix,
 			&ingressInformation{
 				Namespace: "something",
 				Rule:      "demo",
@@ -1462,6 +1472,7 @@ func TestGetIngressInformation(t *testing.T) {
 			},
 			"foo.bar",
 			"/oksvc",
+			&pathPrefix,
 			&ingressInformation{
 				Namespace: "something",
 				Rule:      "demo",
@@ -1472,10 +1483,66 @@ func TestGetIngressInformation(t *testing.T) {
 				ServicePort: "b-svc-80",
 			},
 		},
+		"valid ingress definition with name demo in namespace something and two path / with Prefix and Exact": {
+			&ingress.Ingress{
+				Ingress: networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "demo",
+						Namespace: "something",
+						Annotations: map[string]string{
+							"ingress.annotation": "ok",
+						},
+					},
+					Spec: networking.IngressSpec{
+						Rules: []networking.IngressRule{
+							{
+								Host: "foo.bar",
+								IngressRuleValue: networking.IngressRuleValue{
+									HTTP: &networking.HTTPIngressRuleValue{
+										Paths: []networking.HTTPIngressPath{
+											{
+												Path:     "/",
+												PathType: &pathPrefix,
+												Backend: networking.IngressBackend{
+													Service: &networking.IngressServiceBackend{
+														Name: "a-svc",
+													},
+												},
+											},
+											{
+												Path:     "/",
+												PathType: &pathExact,
+												Backend: networking.IngressBackend{
+													Service: &networking.IngressServiceBackend{
+														Name: "b-svc",
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"foo.bar",
+			"/",
+			&pathExact,
+			&ingressInformation{
+				Path:      "/",
+				Namespace: "something",
+				Rule:      "demo",
+				Annotations: map[string]string{
+					"ingress.annotation": "ok",
+				},
+				Service: "b-svc",
+			},
+		},
 	}
 
 	for title, testCase := range testcases {
-		info := getIngressInformation(testCase.Ingress, testCase.Host, testCase.Path)
+		info := getIngressInformation(testCase.Ingress, testCase.Host, testCase.Path, testCase.PathType)
 
 		if !info.Equal(testCase.Expected) {
 			t.Fatalf("%s: expected '%v' but returned %v", title, testCase.Expected, info)

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -1247,7 +1247,7 @@ stream {
         {{ end }}
 
         location {{ $path }} {
-            {{ $ing := (getIngressInformation $location.Ingress $server.Hostname $location.IngressPath) }}
+            {{ $ing := (getIngressInformation $location.Ingress $server.Hostname $location.IngressPath $location.PathType) }}
             set $namespace      {{ $ing.Namespace | quote}};
             set $ingress_name   {{ $ing.Rule | quote }};
             set $service_name   {{ $ing.Service | quote }};


### PR DESCRIPTION

This handles the case where multiple rules have identical paths, but differing types.
This should populate the $service_name variable with the correct service name.

## What this PR does / why we need it:
Fixes: https://github.com/kubernetes/ingress-nginx/issues/10210

At the moment if multiple rules contain the same path, sometimes the incorrect service name may be set in the $service_name variable

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
fixes #10210

## How Has This Been Tested?
Test case added in PR.
Manual testing locally and checking the outputted `nginx.conf` file

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [x] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
