### PR TITLE
Release Helm Chart on branch update

### DIFF
--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -65,6 +65,7 @@ jobs:
     steps:
       - name: Checkout master
         uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
+        ref: ${{ github.ref_name }} 
         with:
           # Fetch entire history. Required for chart-releaser; see https://github.com/helm/chart-releaser-action/issues/13#issuecomment-602063896
           fetch-depth: 0


### PR DESCRIPTION
If we're going to release the helm chart from release branches then we need to check out that branch. 