### PR TITLE
Chart: Creating extraManifests on Helm Chart

### DIFF
--- a/charts/ingress-nginx/README.md
+++ b/charts/ingress-nginx/README.md
@@ -538,6 +538,7 @@ As of version `1.26.0` of this chart, by simply not providing any clusterIP valu
 | defaultBackend.topologySpreadConstraints | list | `[]` | Topology spread constraints rely on node labels to identify the topology domain(s) that each Node is in. Ref.: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/ |
 | defaultBackend.updateStrategy | object | `{}` | The update strategy to apply to the Deployment or DaemonSet # |
 | dhParam | string | `""` | A base64-encoded Diffie-Hellman parameter. This can be generated with: `openssl dhparam 4096 2> /dev/null | base64` # Ref: https://github.com/kubernetes/ingress-nginx/tree/main/docs/examples/customization/ssl-dh-param |
+| extraManifests | list | `[]` |  |
 | imagePullSecrets | list | `[]` | Optional array of imagePullSecrets containing private registry credentials # Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ |
 | namespaceOverride | string | `""` | Override the deployment namespace; defaults to .Release.Namespace |
 | podSecurityPolicy.enabled | bool | `false` |  |

--- a/charts/ingress-nginx/templates/extra-manifests.yaml
+++ b/charts/ingress-nginx/templates/extra-manifests.yaml
@@ -1,0 +1,5 @@
+{{- range .Values.extraManifests }}
+{{- $manifest := tpl . $ }}
+{{ $manifest | nindent 0 }}
+---
+{{- end }}

--- a/charts/ingress-nginx/tests/extra-manifests_test.yaml
+++ b/charts/ingress-nginx/tests/extra-manifests_test.yaml
@@ -1,0 +1,28 @@
+suite: extraManifests
+templates:
+  - extra-manifests.yaml
+
+tests:
+  - it: should create a TargetGroupBinding if `extraManifests` contains TargetGroupBinding configuration
+    set:
+      extraManifests:
+          - |
+            apiVersion: elbv2.k8s.aws/v1beta1
+            kind: TargetGroupBinding
+            metadata:
+              name: nginx-tgb
+            spec:
+              serviceRef:
+                name: ingress-nginx-controller
+              targetGroupARN: arn:aws:elasticloadbalancing:region:123123123:targetgroup/foo
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: TargetGroupBinding
+      - equal:
+          path: metadata.name
+          value: nginx-tgb
+      - equal:
+          path: spec.serviceRef.name
+          value: ingress-nginx-controller

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -1134,3 +1134,35 @@ portNamePrefix: ""
 # This can be generated with: `openssl dhparam 4096 2> /dev/null | base64`
 ## Ref: https://github.com/kubernetes/ingress-nginx/tree/main/docs/examples/customization/ssl-dh-param
 dhParam: ""
+
+# Optional array to generate extra manifests.
+extraManifests: []
+  # - |
+  #   apiVersion: cert-manager.io/v1
+  #   kind: ClusterIssuer
+  #   metadata:
+  #     name: letsencrypt-example
+  #   spec:
+  #     acme:
+  #       server: https://acme-v02.api.letsencrypt.org/directory
+  #       email: your-email@example.com
+  #       privateKeySecretRef:
+  #         name: letsencrypt-prod
+  #       solvers:
+  #       - http01:
+  #           ingress:
+  #             class: nginx
+  # - |
+  #   apiVersion: cert-manager.io/v1
+  #   kind: Certificate
+  #   metadata:
+  #     name: foo-cert
+  #     namespace: default
+  #   spec:
+  #     secretName: foo-tls-secret
+  #     issuerRef:
+  #       name: letsencrypt-example
+  #       kind: ClusterIssuer
+  #     commonName: foo.bar.com
+  #     dnsNames:
+  #     - foo.bar.com


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
<!--- Please make sure you title is descriptive, it is used in the Release notes to let others know what it does ---> 

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I'm sending this Pull Request to address the Issue that mentions the helm chart's ability to create extra manifests on demand. I think the issue may require a bit more screening, but I'm putting the work in progress to discuss.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

fixes #11351

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [x] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.
