### PR TITLE
Rename variable to fix typo

### DIFF
--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -744,9 +744,9 @@ type Configuration struct {
 	// simultaneous connections.
 	GlobalRateLimitMemcachedPoolSize int `json:"global-rate-limit-memcached-pool-size"`
 
-	// GlobalRateLimitStatucCode determines the HTTP status code to return
+	// GlobalRateLimitStatusCode determines the HTTP status code to return
 	// when limit is exceeding during global rate limiting.
-	GlobalRateLimitStatucCode int `json:"global-rate-limit-status-code"`
+	GlobalRateLimitStatusCode int `json:"global-rate-limit-status-code"`
 
 	// DebugConnections Enables debugging log for selected client connections
 	// http://nginx.org/en/docs/ngx_core_module.html#debug_connection
@@ -927,7 +927,7 @@ func NewDefault() Configuration {
 		GlobalRateLimitMemcachedConnectTimeout: 50,
 		GlobalRateLimitMemcachedMaxIdleTimeout: 10000,
 		GlobalRateLimitMemcachedPoolSize:       50,
-		GlobalRateLimitStatucCode:              429,
+		GlobalRateLimitStatusCode:              429,
 		DebugConnections:                       []string{},
 		StrictValidatePathType:                 false, // TODO: This will be true in future releases
 		GRPCBufferSizeKb:                       0,

--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -413,7 +413,7 @@ func configForLua(input interface{}) string {
 		all.Cfg.GlobalRateLimitMemcachedConnectTimeout,
 		all.Cfg.GlobalRateLimitMemcachedMaxIdleTimeout,
 		all.Cfg.GlobalRateLimitMemcachedPoolSize,
-		all.Cfg.GlobalRateLimitStatucCode,
+		all.Cfg.GlobalRateLimitStatusCode,
 	)
 }
 


### PR DESCRIPTION
I was looking at the code and spot a typo in the `GlobalRateLimitStatusCode` variable. It should be an internal variable, so I think that's safe to rename.

## What this PR does / why we need it:

Nitpick.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes

## How Has This Been Tested?

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.
