### PR TITLE
Chart: Fix `IngressClass` annotations.

### DIFF
--- a/charts/ingress-nginx/templates/controller-ingressclass-aliases.yaml
+++ b/charts/ingress-nginx/templates/controller-ingressclass-aliases.yaml
@@ -11,6 +11,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
   name: {{ . }}
+  {{- if $.Values.controller.ingressClassResource.annotations }}
+  annotations: {{ toYaml $.Values.controller.ingressClassResource.annotations | nindent 4 }}
+  {{- end }}
 spec:
   controller: {{ $.Values.controller.ingressClassResource.controllerValue }}
   {{- with $.Values.controller.ingressClassResource.parameters }}

--- a/charts/ingress-nginx/templates/controller-ingressclass.yaml
+++ b/charts/ingress-nginx/templates/controller-ingressclass.yaml
@@ -9,13 +9,15 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
   name: {{ .Values.controller.ingressClassResource.name }}
+  {{- if or .Values.controller.ingressClassResource.default .Values.controller.ingressClassResource.annotations }}
   annotations:
     {{- if .Values.controller.ingressClassResource.default }}
     ingressclass.kubernetes.io/is-default-class: "true"
     {{- end }}
     {{- if .Values.controller.ingressClassResource.annotations }}
-      {{- toYaml .Values.controller.ingressClassResource.annotations | nindent 4 }}
+    {{- toYaml .Values.controller.ingressClassResource.annotations | nindent 4 }}
     {{- end }}
+  {{- end }}
 spec:
   controller: {{ .Values.controller.ingressClassResource.controllerValue }}
   {{- with .Values.controller.ingressClassResource.parameters }}

--- a/charts/ingress-nginx/tests/controller-ingressclass-aliases_test.yaml
+++ b/charts/ingress-nginx/tests/controller-ingressclass-aliases_test.yaml
@@ -37,6 +37,24 @@ tests:
       - notExists:
           path: metadata.annotations["ingressclass.kubernetes.io/is-default-class"]
 
+  - it: should create an IngressClass alias with annotations if `controller.ingressClassResource.annotations` is set
+    set:
+      controller.ingressClassResource.aliases:
+        - nginx-alias
+      controller.ingressClassResource.annotations:
+        my-fancy-annotation: has-a-value
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: IngressClass
+      - equal:
+          path: metadata.name
+          value: nginx-alias
+      - equal:
+          path: metadata.annotations.my-fancy-annotation
+          value: has-a-value
+
   - it: should create an IngressClass alias with controller "k8s.io/ingress-nginx-internal" if `controller.ingressClassResource.controllerValue` is "k8s.io/ingress-nginx-internal"
     set:
       controller.ingressClassResource.aliases:

--- a/charts/ingress-nginx/tests/controller-ingressclass_test.yaml
+++ b/charts/ingress-nginx/tests/controller-ingressclass_test.yaml
@@ -40,6 +40,22 @@ tests:
           path: metadata.annotations["ingressclass.kubernetes.io/is-default-class"]
           value: "true"
 
+  - it: should create an IngressClass with annotations if `controller.ingressClassResource.annotations` is set
+    set:
+      controller.ingressClassResource.annotations:
+        my-fancy-annotation: has-a-value
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: IngressClass
+      - equal:
+          path: metadata.name
+          value: nginx
+      - equal:
+          path: metadata.annotations.my-fancy-annotation
+          value: has-a-value
+
   - it: should create an IngressClass with controller "k8s.io/ingress-nginx-internal" if `controller.ingressClassResource.controllerValue` is "k8s.io/ingress-nginx-internal"
     set:
       controller.ingressClassResource.controllerValue: k8s.io/ingress-nginx-internal


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
<!--- Please make sure you title is descriptive, it is used in the Release notes to let others know what it does ---> 

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR improves the way we recently implemented annotations for IngressClasses in the Helm chart in https://github.com/kubernetes/ingress-nginx/pull/11362. There's a high chance to not have the IngressClass be the default IngressClass in the cluster AND not having set additional annotations, so right now the rendering would end up with an empty `annotations` key, which might be a bit confusing.

Also I added tests and synchronized the new feature to the IngressClass aliases.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Helm Unit Tests

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [x] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.
