### PR TITLE
Added maxmindMirror value to helm chart

### DIFF
--- a/charts/ingress-nginx/README.md
+++ b/charts/ingress-nginx/README.md
@@ -367,6 +367,7 @@ As of version `1.26.0` of this chart, by simply not providing any clusterIP valu
 | controller.livenessProbe.successThreshold | int | `1` |  |
 | controller.livenessProbe.timeoutSeconds | int | `1` |  |
 | controller.maxmindLicenseKey | string | `""` | Maxmind license key to download GeoLite2 Databases. # https://blog.maxmind.com/2019/12/18/significant-changes-to-accessing-and-using-geolite2-databases |
+| controller.maxmindMirror | string | `""` | Maxmind mirror to download GeoLite2 Databases. Example: https://maxmind.example.com |
 | controller.metrics.enabled | bool | `false` |  |
 | controller.metrics.port | int | `10254` |  |
 | controller.metrics.portName | string | `"metrics"` |  |

--- a/charts/ingress-nginx/templates/_params.tpl
+++ b/charts/ingress-nginx/templates/_params.tpl
@@ -42,6 +42,9 @@
 {{- if .Values.controller.maxmindLicenseKey }}
 - --maxmind-license-key={{ .Values.controller.maxmindLicenseKey }}
 {{- end }}
+{{- if .Values.controller.maxmindMirror }}
+- --maxmind-mirror={{ .Values.controller.maxmindMirror }}
+{{- end }}
 {{- if .Values.controller.healthCheckHost }}
 - --healthz-host={{ .Values.controller.healthCheckHost }}
 {{- end }}

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -196,6 +196,8 @@ controller:
   # -- Maxmind license key to download GeoLite2 Databases.
   ## https://blog.maxmind.com/2019/12/18/significant-changes-to-accessing-and-using-geolite2-databases
   maxmindLicenseKey: ""
+  # -- Maxmind mirror to download GeoLite2 Databases. Example: https://maxmind.example.com
+  maxmindMirror: ""
   # -- Additional command line arguments to pass to Ingress-Nginx Controller
   # E.g. to specify the default SSL certificate you can use
   extraArgs: {}


### PR DESCRIPTION
## What this PR does / why we need it:
The option to set a mirror for the maxmind geoip databases is already in the code, the option is only missing from the helm chart. This PR makes a maxmind mirror configurable from helm values.

## Types of changes
- [?] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## How Has This Been Tested?
Ran helm chart locally, it installed, and the controller tried to use the mirror I provided in the values properly

## Checklist:
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
