### PR TITLE
Tests: Replace deprecated `grpc.Dial` by `grpc.NewClient`.

### DIFF
--- a/test/e2e/annotations/grpc.go
+++ b/test/e2e/annotations/grpc.go
@@ -107,7 +107,7 @@ var _ = framework.DescribeAnnotation("backend-protocol - GRPC", func() {
 			})
 
 		//nolint:goconst //string interpolation
-		conn, err := grpc.Dial(f.GetNginxIP()+":443",
+		conn, err := grpc.NewClient(f.GetNginxIP()+":443",
 			grpc.WithTransportCredentials(
 				credentials.NewTLS(&tls.Config{
 					ServerName:         echoHost,
@@ -168,7 +168,7 @@ var _ = framework.DescribeAnnotation("backend-protocol - GRPC", func() {
 				return strings.Contains(server, "grpc_pass grpc://upstream_balancer;")
 			})
 
-		conn, err := grpc.Dial(f.GetNginxIP()+":443",
+		conn, err := grpc.NewClient(f.GetNginxIP()+":443",
 			grpc.WithTransportCredentials(
 				credentials.NewTLS(&tls.Config{
 					ServerName:         echoHost,
@@ -242,7 +242,7 @@ var _ = framework.DescribeAnnotation("backend-protocol - GRPC", func() {
 				return strings.Contains(server, "grpc_pass grpcs://upstream_balancer;")
 			})
 
-		conn, err := grpc.Dial(f.GetNginxIP()+":443",
+		conn, err := grpc.NewClient(f.GetNginxIP()+":443",
 			grpc.WithTransportCredentials(
 				credentials.NewTLS(&tls.Config{
 					ServerName:         echoHost,
@@ -286,7 +286,7 @@ var _ = framework.DescribeAnnotation("backend-protocol - GRPC", func() {
 					strings.Contains(server, fmt.Sprintf("grpc_read_timeout %ss;", proxyTimeout))
 			})
 
-		conn, err := grpc.Dial(
+		conn, err := grpc.NewClient(
 			f.GetNginxIP()+":80",
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
 			grpc.WithAuthority(host),
@@ -329,7 +329,7 @@ var _ = framework.DescribeAnnotation("backend-protocol - GRPC", func() {
 					strings.Contains(server, fmt.Sprintf("grpc_read_timeout %ss;", proxyTimeout))
 			})
 
-		conn, err := grpc.Dial(
+		conn, err := grpc.NewClient(
 			f.GetNginxIP()+":80",
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
 			grpc.WithAuthority(host),

--- a/test/e2e/settings/grpc.go
+++ b/test/e2e/settings/grpc.go
@@ -86,7 +86,7 @@ var _ = framework.DescribeSetting("GRPC", func() {
 				return strings.Contains(server, "grpc_pass grpc://upstream_balancer;")
 			})
 
-		conn, err := grpc.Dial(f.GetNginxIP()+":443",
+		conn, err := grpc.NewClient(f.GetNginxIP()+":443",
 			grpc.WithTransportCredentials(
 				credentials.NewTLS(&tls.Config{
 					ServerName:         echoHost,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
<!--- Please make sure you title is descriptive, it is used in the Release notes to let others know what it does ---> 

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

`grpc.Dial` got deprecated in gRPC v1.64.0. We therefore need to replace it by `grpc.NewClient`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [x] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.
