### PR TITLE
Tests: Replace deprecated `grpc.Dial` by `grpc.NewClient`.

### DIFF
--- a/test/e2e/annotations/grpc.go
+++ b/test/e2e/annotations/grpc.go
@@ -104,7 +104,7 @@ var _ = framework.DescribeAnnotation("backend-protocol - GRPC", func() {
 			})
 
 		//nolint:goconst //string interpolation
-		conn, err := grpc.Dial(f.GetNginxIP()+":443",
+		conn, err := grpc.NewClient(f.GetNginxIP()+":443",
 			grpc.WithTransportCredentials(
 				credentials.NewTLS(&tls.Config{
 					ServerName:         echoHost,
@@ -165,7 +165,7 @@ var _ = framework.DescribeAnnotation("backend-protocol - GRPC", func() {
 				return strings.Contains(server, "grpc_pass grpc://upstream_balancer;")
 			})
 
-		conn, err := grpc.Dial(f.GetNginxIP()+":443",
+		conn, err := grpc.NewClient(f.GetNginxIP()+":443",
 			grpc.WithTransportCredentials(
 				credentials.NewTLS(&tls.Config{
 					ServerName:         echoHost,
@@ -239,7 +239,7 @@ var _ = framework.DescribeAnnotation("backend-protocol - GRPC", func() {
 				return strings.Contains(server, "grpc_pass grpcs://upstream_balancer;")
 			})
 
-		conn, err := grpc.Dial(f.GetNginxIP()+":443",
+		conn, err := grpc.NewClient(f.GetNginxIP()+":443",
 			grpc.WithTransportCredentials(
 				credentials.NewTLS(&tls.Config{
 					ServerName:         echoHost,


### PR DESCRIPTION
This is a manual cherry-pick of [this PR](https://github.com/kubernetes/ingress-nginx/pull/11462), since `test/e2e/settings/grpc.go` does not exist on `release-1.10`, yet.