### PR TITLE
Update main.go to make proxy-ssl-secret annotation optional

### DIFF
--- a/internal/ingress/annotations/proxyssl/main.go
+++ b/internal/ingress/annotations/proxyssl/main.go
@@ -190,27 +190,27 @@ func (p proxySSL) Parse(ing *networking.Ingress) (interface{}, error) {
 	config := &Config{}
 
 	proxysslsecret, err := parser.GetStringAnnotation(proxySSLSecretAnnotation, ing, p.annotationConfig.Annotations)
-	if err != nil {
+	if err != nil && err != ing_errors.ErrMissingAnnotations {
 		return &Config{}, err
-	}
+	} else {
+		ns, _, err := k8s.ParseNameNS(proxysslsecret)
+		if err != nil {
+			return &Config{}, ing_errors.NewLocationDenied(err.Error())
+		}
+	
+		secCfg := p.r.GetSecurityConfiguration()
+		// We don't accept different namespaces for secrets.
+		if !secCfg.AllowCrossNamespaceResources && ns != ing.Namespace {
+			return &Config{}, ing_errors.NewLocationDenied("cross namespace secrets are not supported")
+		}
 
-	ns, _, err := k8s.ParseNameNS(proxysslsecret)
-	if err != nil {
-		return &Config{}, ing_errors.NewLocationDenied(err.Error())
+		proxyCert, err := p.r.GetAuthCertificate(proxysslsecret)
+		if err != nil {
+			e := fmt.Errorf("error obtaining certificate: %w", err)
+			return &Config{}, ing_errors.LocationDeniedError{Reason: e}
+		}
+		config.AuthSSLCert = *proxyCert
 	}
-
-	secCfg := p.r.GetSecurityConfiguration()
-	// We don't accept different namespaces for secrets.
-	if !secCfg.AllowCrossNamespaceResources && ns != ing.Namespace {
-		return &Config{}, ing_errors.NewLocationDenied("cross namespace secrets are not supported")
-	}
-
-	proxyCert, err := p.r.GetAuthCertificate(proxysslsecret)
-	if err != nil {
-		e := fmt.Errorf("error obtaining certificate: %w", err)
-		return &Config{}, ing_errors.LocationDeniedError{Reason: e}
-	}
-	config.AuthSSLCert = *proxyCert
 
 	config.Ciphers, err = parser.GetStringAnnotation(proxySSLCiphersAnnotation, ing, p.annotationConfig.Annotations)
 	if err != nil {


### PR DESCRIPTION
Update main.go to make proxy-ssl-secret annotation optional usage of other proxy-ssl-* annotations.



<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
<!--- Please make sure you title is descriptive, it is used in the Release notes to let others know what it does ---> 

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently, if the annotation _proxy-ssl-secret_ is not provided, it is not possible to use other _proxy-ssl-*_ annotations. For example, it prevent to set only _proxy-ssl-protocols_ to specify the TLS protocol to connect to the upstream backend.
This change aim to make the annotation proxy-ssl-secret optional by preventing an exit from the method in case of it not being specified. I don't alter the current behavior in the regard that if that an invalid value if specified, no other _proxy-ssl-*_ annotations will be processed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->
fixes #10264

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in local dev cluster and also with tested regression with `FOCUS='proxyssl' make kind-e2e-test`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.
