### PR TITLE
Docs: Specify `ingressClass` for multi-controller setup.

### DIFF
--- a/docs/user-guide/multiple-ingress.md
+++ b/docs/user-guide/multiple-ingress.md
@@ -57,6 +57,7 @@ or if installing with Helm:
 ```yaml
 controller:
   electionID: ingress-controller-leader
+  ingressClass: internal-nginx  # default: nginx
   ingressClassResource:
     name: internal-nginx  # default: nginx
     enabled: true


### PR DESCRIPTION
## What this PR does / why we need it:

For correct handling, `ingressClass` needs to be mentioned as well. Because https://github.com/kubernetes/ingress-nginx/blob/5784be2784210534c460e8118bde47ec8b865ed0/charts/ingress-nginx/templates/_params.tpl#L19 is set based on `.Values.controller.ingressClass`, not based on `.Values.controller.ingressClassResource.name`

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation only

## Which issue/s this PR fixes

Not mentioned in any issue

## How Has This Been Tested?

Only documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.
