### PR TITLE
docs: Update Ingress-NGINX v1.10.1 compatibility with Kubernetes v1.30

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 [![GitHub stars](https://img.shields.io/github/stars/kubernetes/ingress-nginx.svg)](https://github.com/kubernetes/ingress-nginx/stargazers)
 [![GitHub stars](https://img.shields.io/badge/contributions-welcome-orange.svg)](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md)
 
-
 ## Overview
 
 ingress-nginx is an Ingress controller for Kubernetes using [NGINX](https://www.nginx.org/) as a reverse proxy and load
@@ -36,22 +35,22 @@ For detailed changes on the `ingress-nginx` helm chart, please check the changel
 Supported versions for the ingress-nginx project mean that we have completed E2E tests, and they are passing for
 the versions listed. Ingress-Nginx versions **may** work on older versions, but the project does not make that guarantee.
 
-|  Supported  | Ingress-NGINX version | k8s supported version        | Alpine Version | Nginx Version | Helm Chart Version |
-|:--:|-----------------------|------------------------------|----------------|---------------|------------------------------|
-| 🔄 | **v1.10.1**            | 1.29, 1.28, 1.27, 1.26        | 3.19.1         | 1.25.3        | 4.10.1*                 |
-| 🔄 | **v1.10.0**            | 1.29, 1.28, 1.27, 1.26        | 3.19.1         | 1.25.3        | 4.10.0*                 |
-| 🔄 | **v1.9.6**            | 1.29, 1.28, 1.27, 1.26, 1.25        | 3.19.0         | 1.21.6        | 4.9.1*                 |
-| 🔄 | **v1.9.5**            | 1.28, 1.27, 1.26, 1.25        | 3.18.4         | 1.21.6        | 4.9.0*                       |
-| 🔄 | **v1.9.4**            | 1.28, 1.27, 1.26, 1.25        | 3.18.4         | 1.21.6        | 4.8.3                        |
-| 🔄 | **v1.9.3**            | 1.28, 1.27, 1.26, 1.25        | 3.18.4         | 1.21.6        | 4.8.*                        |
-| 🔄 | **v1.9.1**            | 1.28, 1.27, 1.26, 1.25        | 3.18.4         | 1.21.6        | 4.8.*                        |
-| 🔄 | **v1.9.0**            | 1.28, 1.27, 1.26, 1.25        | 3.18.2         | 1.21.6        | 4.8.*                        |
-|  | v1.8.4            | 1.27, 1.26, 1.25, 1.24        | 3.18.2         | 1.21.6        | 4.7.*                        |
-|  | v1.7.1            | 1.27, 1.26, 1.25, 1.24        | 3.17.2         | 1.21.6        | 4.6.*              |
-|    | v1.6.4                | 1.26, 1.25, 1.24, 1.23       | 3.17.0         | 1.21.6        | 4.5.*              |
-|    | v1.5.1                | 1.25, 1.24, 1.23             | 3.16.2         | 1.21.6        | 4.4.*              |
-|    | v1.4.0                | 1.25, 1.24, 1.23, 1.22       | 3.16.2         | 1.19.10†      | 4.3.0              |
-|    | v1.3.1                | 1.24, 1.23, 1.22, 1.21, 1.20 | 3.16.2         | 1.19.10†      | 4.2.5              |
+| Supported | Ingress-NGINX version | k8s supported version         | Alpine Version | Nginx Version | Helm Chart Version |
+| :-------: | --------------------- | ----------------------------- | -------------- | ------------- | ------------------ |
+|    🔄    | **v1.10.1**     | 1.30, 1.29, 1.28, 1.27, 1.26 | 3.19.1         | 1.25.3        | 4.10.1*            |
+|    🔄    | **v1.10.0**     | 1.29, 1.28, 1.27, 1.26        | 3.19.1         | 1.25.3        | 4.10.0*            |
+|    🔄    | **v1.9.6**      | 1.29, 1.28, 1.27, 1.26, 1.25  | 3.19.0         | 1.21.6        | 4.9.1*             |
+|    🔄    | **v1.9.5**      | 1.28, 1.27, 1.26, 1.25        | 3.18.4         | 1.21.6        | 4.9.0*             |
+|    🔄    | **v1.9.4**      | 1.28, 1.27, 1.26, 1.25        | 3.18.4         | 1.21.6        | 4.8.3              |
+|    🔄    | **v1.9.3**      | 1.28, 1.27, 1.26, 1.25        | 3.18.4         | 1.21.6        | 4.8.*              |
+|    🔄    | **v1.9.1**      | 1.28, 1.27, 1.26, 1.25        | 3.18.4         | 1.21.6        | 4.8.*              |
+|    🔄    | **v1.9.0**      | 1.28, 1.27, 1.26, 1.25        | 3.18.2         | 1.21.6        | 4.8.*              |
+|          | v1.8.4                | 1.27, 1.26, 1.25, 1.24        | 3.18.2         | 1.21.6        | 4.7.*              |
+|          | v1.7.1                | 1.27, 1.26, 1.25, 1.24        | 3.17.2         | 1.21.6        | 4.6.*              |
+|          | v1.6.4                | 1.26, 1.25, 1.24, 1.23        | 3.17.0         | 1.21.6        | 4.5.*              |
+|          | v1.5.1                | 1.25, 1.24, 1.23              | 3.16.2         | 1.21.6        | 4.4.*              |
+|          | v1.4.0                | 1.25, 1.24, 1.23, 1.22        | 3.16.2         | 1.19.10†     | 4.3.0              |
+|          | v1.3.1                | 1.24, 1.23, 1.22, 1.21, 1.20  | 3.16.2         | 1.19.10†     | 4.2.5              |
 
 See [this article](https://kubernetes.io/blog/2021/07/26/update-with-ingress-nginx/) if you want upgrade to the stable
 Ingress API.
@@ -62,7 +61,6 @@ Thanks for taking the time to join our community and start contributing!
 
 - This project adheres to the [Kubernetes Community Code of Conduct](https://git.k8s.io/community/code-of-conduct.md).
   By participating in this project, you agree to abide by its terms.
-
 - **Contributing**: Contributions of all kinds are welcome!
 
   - Read [`CONTRIBUTING.md`](CONTRIBUTING.md) for information about setting up your environment, the workflow that we
@@ -71,8 +69,8 @@ Thanks for taking the time to join our community and start contributing!
   - Submit GitHub issues for any feature enhancements, bugs, or documentation problems.
     - Please make sure to read the [Issue Reporting Checklist](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md#issue-reporting-guidelines) before opening an issue. Issues not conforming to the guidelines **may be closed immediately**.
   - Join our [ingress-nginx-dev mailing list](https://groups.google.com/a/kubernetes.io/g/ingress-nginx-dev/c/ebbBMo-zX-w)
-
 - **Support**:
+
   - Join the [#ingress-nginx-users](https://kubernetes.slack.com/messages/CANQGM8BA/) channel inside the [Kubernetes Slack](http://slack.kubernetes.io/) to ask questions or get support from the maintainers and other users.
   - The [GitHub issues](https://github.com/kubernetes/ingress-nginx/issues) in the repository are **exclusively** for bug reports and feature requests.
   - **Discuss**: Tweet using the `#IngressNginx` hashtag or sharing with us [@IngressNginx](https://twitter.com/IngressNGINX).


### PR DESCRIPTION
Update the documentation to reflect the successful testing and compatibility of Ingress-NGINX v1.10.1 with Kubernetes v1.30. This change ensures that users are aware of the expanded compatibility beyond the previously documented Kubernetes v1.29 version.

Key updates:
- fixes https://github.com/kubernetes/ingress-nginx/issues/11494
- Modify the compatibility matrix to include Kubernetes v1.30 support
- Add a note mentioning the successful testing of Ingress-NGINX v1.10.1 on Kubernetes v1.30
- Clarify any specific considerations or caveats, if applicable, when using this combination of versions

This update aims to provide accurate and up-to-date information to users, enabling them to make informed decisions when deploying Ingress-NGINX v1.10.1 on Kubernetes v1.30.2 clusters.