### PR TITLE
bump alpine version to 3.20 to custom-error-pages

### DIFF
--- a/images/custom-error-pages/rootfs/Dockerfile
+++ b/images/custom-error-pages/rootfs/Dockerfile
@@ -14,7 +14,7 @@
 
 ARG GOLANG_VERSION
 
-FROM golang:${GOLANG_VERSION}-alpine3.18 as builder
+FROM golang:${GOLANG_VERSION}-alpine3.20 as builder
 
 RUN apk update \
     && apk upgrade && apk add git


### PR DESCRIPTION


## What this PR does / why we need it:
With the recent Golang version change, the builder image cannot be pulled for custom-error-pages because golang doesn't have a 1.22.4-alpine3.18 tag, therefore I moved it to the latest Golang version.

I don't understand enough your dependency tracker to understand why it wasn't included in this commit https://github.com/kubernetes/ingress-nginx/pull/11438

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
```bash
export GOLANG_VERSION=1.22.4
docker build -t nginx-erros .

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
