### PR TITLE
Mage: Stop mutating release notes.

### DIFF
--- a/magefiles/steps/helm.go
+++ b/magefiles/steps/helm.go
@@ -18,9 +18,7 @@ package steps
 
 import (
 	"bytes"
-	"fmt"
 	"os"
-	"strings"
 
 	semver "github.com/blang/semver/v4"
 	"github.com/helm/helm/pkg/chartutil"
@@ -104,18 +102,21 @@ func updateVersion(version string) {
 	utils.CheckIfError(err, "HELM Saving new Chart")
 }
 
-func updateChartReleaseNotes(releasesNotes []string) {
-	utils.Info("HELM Updating the Chart Release notes")
+func updateChartReleaseNotes(releaseNotes []string) {
+	utils.Info("HELM Updating chart release notes")
 	chart, err := chartutil.LoadChartfile(HelmChartPath)
-	utils.CheckIfError(err, "HELM Could not Load Chart to update release notes %s", HelmChartPath)
-	for i := range releasesNotes {
-		releasesNotes[i] = fmt.Sprintf("- %q", releasesNotes[i])
-	}
-	releaseNoteString := strings.Join(releasesNotes, "\n")
-	utils.Info("HELM Release note string %s", releaseNoteString)
-	chart.Annotations["artifacthub.io/changes"] = releaseNoteString
+	utils.CheckIfError(err, "HELM Failed to load chart manifest: %s", HelmChartPath)
+
+	releaseNotesBytes, err := yaml.Marshal(releaseNotes)
+	utils.CheckIfError(err, "HELM Failed to marshal release notes")
+
+	releaseNotesString := string(releaseNotesBytes)
+	utils.Info("HELM Chart release notes:\n%s", releaseNotesString)
+	chart.Annotations["artifacthub.io/changes"] = releaseNotesString
+
+	utils.Info("HELM Saving chart release notes")
 	err = chartutil.SaveChartfile(HelmChartPath, chart)
-	utils.CheckIfError(err, "HELM Saving updated release notes for Chart")
+	utils.CheckIfError(err, "HELM Failed to save chart manifest: %s", HelmChartPath)
 }
 
 // UpdateChartValue Updates the Helm ChartValue

--- a/magefiles/steps/release.go
+++ b/magefiles/steps/release.go
@@ -74,7 +74,7 @@ func (Release) NewReleaseFromOld(version, oldversion string) {
 func (Release) E2EDocs() {
 	e2edocs, err := utils.GenerateE2EDocs()
 	utils.CheckIfError(err, "error on template")
-	err = os.WriteFile("docs/e2e-tests.md", []byte(e2edocs), 644)
+	err = os.WriteFile("docs/e2e-tests.md", []byte(e2edocs), 0644)
 	utils.CheckIfError(err, "Could not write new e2e test file ")
 }
 
@@ -158,7 +158,7 @@ func updateIndexMD(old, new string) error {
 	utils.CheckIfError(err, "Could not read INDEX_DOCS file %s", INDEX_DOCS)
 	datString := string(data)
 	datString = strings.Replace(datString, old, new, -1)
-	err = os.WriteFile(INDEX_DOCS, []byte(datString), 644)
+	err = os.WriteFile(INDEX_DOCS, []byte(datString), 0644)
 	if err != nil {
 		utils.ErrorF("Could not write new %s %s", INDEX_DOCS, err)
 		return err
@@ -255,7 +255,7 @@ func makeReleaseNotes(newVersion, oldVersion string) (*utils.ReleaseNote, error)
 
 	// the newControllerVersion should match the latest tag
 	if newControllerVersion != allControllerTags[0] {
-		return nil, errors.New(fmt.Sprintf("Generating release new version %s didnt match the current latest tag %s", newControllerVersion, allControllerTags[0]))
+		return nil, fmt.Errorf("generating release new version %s didnt match the current latest tag %s", newControllerVersion, allControllerTags[0])
 	}
 	// previous version
 	newReleaseNotes.PreviousControllerVersion = allControllerTags[1]
@@ -272,8 +272,8 @@ func makeReleaseNotes(newVersion, oldVersion string) (*utils.ReleaseNote, error)
 	var allUpdates []string
 	var depUpdates []string
 	var helmUpdates []string
-	prRegex := regexp.MustCompile("\\(#\\d+\\)")
-	depBot := regexp.MustCompile("^(\\w){1,10} Bump ")
+	prRegex := regexp.MustCompile(`\(#\d+\)`)
+	depBot := regexp.MustCompile(`^(\w){1,10} Bump `)
 	helmRegex := regexp.MustCompile("helm|chart")
 	for i, s := range commits {
 		// matches on PR
@@ -322,13 +322,13 @@ func makeReleaseNotes(newVersion, oldVersion string) (*utils.ReleaseNote, error)
 	controllerDigest := utils.FindImageDigest(data, "controller", newVersion)
 	if len(controllerDigest) == 0 {
 		utils.ErrorF("Controller Digest could not be found")
-		return nil, errors.New("Controller digest could not be found")
+		return nil, errors.New("controller digest could not be found")
 	}
 
 	controllerChrootDigest := utils.FindImageDigest(data, "controller-chroot", newVersion)
 	if len(controllerChrootDigest) == 0 {
 		utils.ErrorF("Controller Chroot Digest could not be found")
-		return nil, errors.New("Controller Chroot digest could not be found")
+		return nil, errors.New("controller chroot digest could not be found")
 	}
 
 	utils.Debug("Latest Controller Digest %v", controllerDigest)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
<!--- Please make sure you title is descriptive, it is used in the Release notes to let others know what it does ---> 

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Without that PR, the release notes being put into the chart change log template got mutated by adding quotes around and a dash in front of them, since that operation was executed directly on the array, so replaced the elements in the array handed into the method.

With that PR, the value of the `artifacthub.io/changes` annotation for the `Chart.yaml` is being generated without mutating the original release notes by directly marshaling them into a YAML list.

Also this PR implements some static check recommendations.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```
go run magefiles/exec.go release:newRelease 1.10.2
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.
