### PR TITLE
[fix] fix nginx temp configs cleanup

### DIFF
--- a/internal/ingress/controller/nginx.go
+++ b/internal/ingress/controller/nginx.go
@@ -643,8 +643,7 @@ func (n *NGINXController) testTemplate(cfg []byte) error {
 	if len(cfg) == 0 {
 		return fmt.Errorf("invalid NGINX configuration (empty)")
 	}
-	tmpDir := os.TempDir() + "/nginx"
-	tmpfile, err := os.CreateTemp(tmpDir, tempNginxPattern)
+	tmpfile, err := os.CreateTemp(filepath.Join(os.TempDir(), "nginx"), tempNginxPattern)
 	if err != nil {
 		return err
 	}
@@ -1082,11 +1081,11 @@ func createOpentelemetryCfg(cfg *ngx_config.Configuration) error {
 func cleanTempNginxCfg() error {
 	var files []string
 
-	err := filepath.Walk(os.TempDir(), func(path string, info os.FileInfo, err error) error {
+	err := filepath.Walk(filepath.Join(os.TempDir(), "nginx"), func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
-		if info.IsDir() && os.TempDir() != path {
+		if info.IsDir() && path != filepath.Join(os.TempDir(), "nginx") {
 			return filepath.SkipDir
 		}
 
@@ -1105,7 +1104,7 @@ func cleanTempNginxCfg() error {
 	}
 
 	for _, file := range files {
-		err := os.Remove(file)
+		err = os.Remove(file)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
### Fix nginx temp config cleanup.
The problem was described in the issue.

## What this PR does / why we need it:
It fixes `cleanTempNginxCfg` function and its test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
fixes #11568

## How Has This Been Tested?
It has been tested by unit tests.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [x] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.
