### PR TITLE
Fix indent in YAML for example pod

### DIFF
--- a/docs/user-guide/fcgi-services.md
+++ b/docs/user-guide/fcgi-services.md
@@ -21,8 +21,8 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: example-app
-labels:
-  app: example-app
+  labels:
+    app: example-app
 spec:
   containers:
   - name: example-app


### PR DESCRIPTION
- This is documentation only change.
- Previous example of k8s Pod definition in YAML contains minor indentation error making it invalid.