### PR TITLE
Accept wildcard in nginx.ingress.kubernetes.io/cors-allow-headers annotation

### DIFF
--- a/internal/ingress/annotations/cors/main.go
+++ b/internal/ingress/annotations/cors/main.go
@@ -49,9 +49,9 @@ var (
 	// Method must contain valid methods list (PUT, GET, POST, BLA)
 	// May contain or not spaces between each verb
 	corsMethodsRegex = regexp.MustCompile(`^([A-Za-z]+,?\s?)+$`)
-	// Expose Headers must contain valid values only (*, X-HEADER12, X-ABC)
+	// CORS Headers must contain valid values only (*, X-HEADER12, X-ABC)
 	// May contain or not spaces between each Header
-	corsExposeHeadersRegex = regexp.MustCompile(`^(([A-Za-z0-9\-\_]+|\*),?\s?)+$`)
+	corsHeadersRegex = regexp.MustCompile(`^(([A-Za-z0-9\-\_]+|\*),?\s?)+$`)
 )
 
 const (
@@ -82,11 +82,11 @@ var corsAnnotation = parser.Annotation{
 			It also supports single level wildcard subdomains and follows this format: http(s)://*.foo.bar, http(s)://*.bar.foo:8080 or http(s)://*.abc.bar.foo:9000`,
 		},
 		corsAllowHeadersAnnotation: {
-			Validator: parser.ValidateRegex(parser.HeadersVariable, true),
+			Validator: parser.ValidateRegex(corsHeadersRegex, true),
 			Scope:     parser.AnnotationScopeIngress,
 			Risk:      parser.AnnotationRiskMedium,
 			Documentation: `This annotation controls which headers are accepted.
-			This is a multi-valued field, separated by ',' and accepts letters, numbers, _ and -`,
+			This is a multi-valued field, separated by ',' and accepts letters, numbers, _, - and *.`,
 		},
 		corsAllowMethodsAnnotation: {
 			Validator: parser.ValidateRegex(corsMethodsRegex, true),
@@ -102,7 +102,7 @@ var corsAnnotation = parser.Annotation{
 			Documentation: `This annotation controls if credentials can be passed during CORS operations.`,
 		},
 		corsExposeHeadersAnnotation: {
-			Validator: parser.ValidateRegex(corsExposeHeadersRegex, true),
+			Validator: parser.ValidateRegex(corsHeadersRegex, true),
 			Scope:     parser.AnnotationScopeIngress,
 			Risk:      parser.AnnotationRiskMedium,
 			Documentation: `This annotation controls which headers are exposed to response.
@@ -225,7 +225,7 @@ func (c cors) Parse(ing *networking.Ingress) (interface{}, error) {
 	}
 
 	config.CorsAllowHeaders, err = parser.GetStringAnnotation(corsAllowHeadersAnnotation, ing, c.annotationConfig.Annotations)
-	if err != nil || !parser.HeadersVariable.MatchString(config.CorsAllowHeaders) {
+	if err != nil || !corsHeadersRegex.MatchString(config.CorsAllowHeaders) {
 		config.CorsAllowHeaders = defaultCorsHeaders
 	}
 
@@ -245,7 +245,7 @@ func (c cors) Parse(ing *networking.Ingress) (interface{}, error) {
 	}
 
 	config.CorsExposeHeaders, err = parser.GetStringAnnotation(corsExposeHeadersAnnotation, ing, c.annotationConfig.Annotations)
-	if err != nil || !corsExposeHeadersRegex.MatchString(config.CorsExposeHeaders) {
+	if err != nil || !corsHeadersRegex.MatchString(config.CorsExposeHeaders) {
 		config.CorsExposeHeaders = ""
 	}
 

--- a/internal/ingress/annotations/cors/main_test.go
+++ b/internal/ingress/annotations/cors/main_test.go
@@ -77,7 +77,7 @@ func TestIngressCorsConfigValid(t *testing.T) {
 
 	// Valid
 	data[parser.GetAnnotationWithPrefix(corsEnableAnnotation)] = "true"
-	data[parser.GetAnnotationWithPrefix(corsAllowHeadersAnnotation)] = "DNT,X-CustomHeader, Keep-Alive,User-Agent"
+	data[parser.GetAnnotationWithPrefix(corsAllowHeadersAnnotation)] = "*, DNT,X-CustomHeader, Keep-Alive,User-Agent"
 	data[parser.GetAnnotationWithPrefix(corsAllowCredentialsAnnotation)] = "false"
 	data[parser.GetAnnotationWithPrefix(corsAllowMethodsAnnotation)] = "GET, PATCH"
 	data[parser.GetAnnotationWithPrefix(corsAllowOriginAnnotation)] = "https://origin123.test.com:4443"
@@ -103,7 +103,7 @@ func TestIngressCorsConfigValid(t *testing.T) {
 		t.Errorf("expected %v but returned %v", data[parser.GetAnnotationWithPrefix(corsAllowCredentialsAnnotation)], nginxCors.CorsAllowCredentials)
 	}
 
-	if nginxCors.CorsAllowHeaders != "DNT,X-CustomHeader, Keep-Alive,User-Agent" {
+	if nginxCors.CorsAllowHeaders != "*, DNT,X-CustomHeader, Keep-Alive,User-Agent" {
 		t.Errorf("expected %v but returned %v", data[parser.GetAnnotationWithPrefix(corsAllowHeadersAnnotation)], nginxCors.CorsAllowHeaders)
 	}
 


### PR DESCRIPTION
## What this PR does / why we need it:
The `nginx.ingress.kubernetes.io/cors-allow-headers` annotation does not allow a wildcard (`*`) value which is allowed both by nginx and the Fetch standard.

This PR allows the use of a wildcard in the same way `nginx.ingress.kubernetes.io/cors-expose-headers` already did.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
fixes #10501

## How Has This Been Tested?
Updated existing tests to include wildcard

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [x] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.
