### PR TITLE
Docs: Clarify `from-to-www` redirect direction.

### DIFF
--- a/docs/user-guide/nginx-configuration/annotations.md
+++ b/docs/user-guide/nginx-configuration/annotations.md
@@ -655,8 +655,9 @@ To preserve the trailing slash in the URI with `ssl-redirect`, set `nginx.ingres
 
 ### Redirect from/to www
 
-In some scenarios is required to redirect from `www.domain.com` to `domain.com` or vice versa,
-which way the redirect is performed depends on the configured `host` value in the Ingress object.
+In some scenarios, it is required to redirect from `www.domain.com` to `domain.com` or vice versa, which way the redirect is performed depends on the configured `host` value in the Ingress object.
+
+For example, if `.spec.rules.host` is configured with a value like `www.example.com`, then this annotation will redirect to `example.com`. If `.spec.rules.host` is configured with a value like `example.com`, so without a `www`, then this annotation will redirect to `www.example.com` instead.
 
 To enable this feature use the annotation `nginx.ingress.kubernetes.io/from-to-www-redirect: "true"`
 

--- a/docs/user-guide/nginx-configuration/annotations.md
+++ b/docs/user-guide/nginx-configuration/annotations.md
@@ -655,7 +655,9 @@ To preserve the trailing slash in the URI with `ssl-redirect`, set `nginx.ingres
 
 ### Redirect from/to www
 
-In some scenarios is required to redirect from `www.domain.com` to `domain.com` or vice versa.
+In some scenarios is required to redirect from `www.domain.com` to `domain.com` or vice versa,
+which way the redirect is performed depends on the configured `host` value in the Ingress object.
+
 To enable this feature use the annotation `nginx.ingress.kubernetes.io/from-to-www-redirect: "true"`
 
 !!! attention

--- a/internal/ingress/annotations/redirect/redirect.go
+++ b/internal/ingress/annotations/redirect/redirect.go
@@ -51,7 +51,7 @@ var redirectAnnotations = parser.Annotation{
 			Validator:     parser.ValidateBool,
 			Scope:         parser.AnnotationScopeLocation,
 			Risk:          parser.AnnotationRiskLow, // Low, as it allows just a set of options
-			Documentation: `In some scenarios is required to redirect from www.domain.com to domain.com or vice versa. To enable this feature use this annotation.`,
+			Documentation: `In some scenarios, it is required to redirect from www.domain.com to domain.com or vice versa, which way the redirect is performed depends on the configured host value in the Ingress object.`,
 		},
 		temporalRedirectAnnotation: {
 			Validator: parser.ValidateRegex(parser.URLIsValidRegex, false),


### PR DESCRIPTION
This was not clear to me when reading the docs whether the ingress will redirect from non-www to with-www or the reverse. It's also not very clear from just grepping around the codebase. I found the answer by reading from this reddit link:

https://www.reddit.com/r/kubernetes/comments/pbl033/k8s_ingress_redirecting_www_to_nonwww_domains/

So, to save time for other people doing the same, which I assumes is a lot of people since it's a common scenario, I believe this little revision in the docs is warranted.

## What this PR does / why we need it:
Update the docs to clarify, when setting `from-to-www-redirect`, which direction of redirection is going to be performed.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation only

## Which issue/s this PR fixes
-

## How Has This Been Tested?
Ran `mkdocs` and things seemed fine.

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
