### PR TITLE
Add include-endpoint-target-refs option

### DIFF
--- a/docs/user-guide/nginx-configuration/configmap.md
+++ b/docs/user-guide/nginx-configuration/configmap.md
@@ -195,6 +195,8 @@ The following table shows a configuration option's name, type, and the default v
 |[limit-rate](#limit-rate)| int          | 0                                                                                                                                                                                                                                                                                                                                                            ||
 |[limit-rate-after](#limit-rate-after)| int          | 0                                                                                                                                                                                                                                                                                                                                                            ||
 |[lua-shared-dicts](#lua-shared-dicts)| string       | ""                                                                                                                                                                                                                                                                                                                                                           ||
+|[include-endpoint-target-refs](#include-endpoint-target-refs)| bool | "false" ||
+
 |[http-redirect-code](#http-redirect-code)| int          | 308                                                                                                                                                                                                                                                                                                                                                          ||
 |[proxy-buffering](#proxy-buffering)| string       | "off"                                                                                                                                                                                                                                                                                                                                                        ||
 |[limit-req-status-code](#limit-req-status-code)| int          | 503                                                                                                                                                                                                                                                                                                                                                          ||
@@ -1211,6 +1213,10 @@ lua-shared-dicts: "certificate_data: 100, my_custom_plugin: 512k"
 
 _References:_
 [https://nginx.org/en/docs/http/ngx_http_core_module.html#limit_rate_after](https://nginx.org/en/docs/http/ngx_http_core_module.html#limit_rate_after)
+
+## include-endpoint-target-refs
+
+Enables including an endpoint's target reference when updating the dynamic configuration of backends. Useful for exposing things like pod name.
 
 ## http-redirect-code
 

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -709,6 +709,9 @@ type Configuration struct {
 	// Lua shared dict configuration data / certificate data
 	LuaSharedDicts map[string]int `json:"lua-shared-dicts"`
 
+	// Include endpoint target references (e.g., pod name) when updating dynamic configuration
+	IncludeEndpointTargetRefs bool `json:"include-endpoint-target-refs"`
+
 	// DefaultSSLCertificate holds the default SSL certificate to use in the configuration
 	// It can be the fake certificate or the one behind the flag --default-ssl-certificate
 	DefaultSSLCertificate *ingress.SSLCert `json:"-"`
@@ -828,6 +831,7 @@ func NewDefault() Configuration {
 		LogFormatEscapeJSON:              false,
 		LogFormatStream:                  logFormatStream,
 		LogFormatUpstream:                logFormatUpstream,
+		IncludeEndpointTargetRefs:        false,
 		EnableMultiAccept:                true,
 		MaxWorkerConnections:             16384,
 		MaxWorkerOpenFiles:               0,


### PR DESCRIPTION
## What this PR does / why we need it:

When updating the dynamic configuration, we would like to have access to the TargetRef object of an endpoint (pod name in particular) in order to build custom logic around this. In the past, this was accessible, but was later removed in https://github.com/kubernetes/ingress-nginx/pull/2365.

This PR here introduces an option (defaulting to false to preserve the current behaviour) where users can opt-in to the old behaviour.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## How Has This Been Tested?
Not properly tested yet. Want to get some feedback first whether this has a chance of being accepted.

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
