### PR TITLE
Annotations: Reload on custom header changes.

### DIFF
--- a/internal/ingress/annotations/customheaders/main.go
+++ b/internal/ingress/annotations/customheaders/main.go
@@ -18,6 +18,7 @@ package customheaders
 
 import (
 	"fmt"
+	"reflect"
 	"regexp"
 
 	"k8s.io/klog/v2"
@@ -33,6 +34,18 @@ import (
 // Config returns the custom response headers for an Ingress rule
 type Config struct {
 	Headers map[string]string `json:"headers,omitempty"`
+}
+
+// Equal tests for equality between two Config types
+func (c1 *Config) Equal(c2 *Config) bool {
+	if c1 == c2 {
+		return true
+	}
+	if c1 == nil || c2 == nil {
+		return false
+	}
+
+	return reflect.DeepEqual(c1.Headers, c2.Headers)
 }
 
 var (

--- a/pkg/apis/ingress/types_equals.go
+++ b/pkg/apis/ingress/types_equals.go
@@ -467,6 +467,10 @@ func (l1 *Location) Equal(l2 *Location) bool {
 		return false
 	}
 
+	if !l1.CustomHeaders.Equal(&l2.CustomHeaders) {
+		return false
+	}
+
 	return true
 }
 

--- a/test/manifests/configuration-a.json
+++ b/test/manifests/configuration-a.json
@@ -302,7 +302,12 @@
 				"validationDepth": 0
 			},
 			"use-port-in-redirects": false,
-			"configuration-snippet": ""
+			"configuration-snippet": "",
+			"customHeaders": {
+				"headers": {
+					"Server": "HAL9000"
+				}
+			}
 		}]
 	}, {
 		"hostname": "dev.mycompany.com",

--- a/test/manifests/configuration-b.json
+++ b/test/manifests/configuration-b.json
@@ -302,7 +302,12 @@
 				"validationDepth": 0
 			},
 			"use-port-in-redirects": false,
-			"configuration-snippet": ""
+			"configuration-snippet": "",
+			"customHeaders": {
+				"headers": {
+					"Server": "HAL9000"
+				}
+			}
 		}]
 	}, {
 		"hostname": "dev.mycompany.com",


### PR DESCRIPTION

## What this PR does / why we need it:
It fixes an open issue #11680.
The problem extends to the response headers not reflecting updates made to the ConfigMap's contents. This limitation stems from the fact that the Ingress object remains unmodified, making it impossible to address through code changes alone. However, a straightforward solution exists: adding a checksum annotation on the Ingress that includes a hash of the ConfigMap's content. This approach would effectively trigger the necessary updates.

```yaml
kind: Ingress
metadata:
  name: podinfo-ingress
  annotations:
    nginx.ingress.kubernetes.io/custom-headers: custom-security-headers
    checksum/config: cfe9d9d1a364866309f498c8fd07a6208ac5c68aaefa15212e50585fca9cbebe
spec:
...
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
Fixes #11680

## How Has This Been Tested?
Add extra config to test manifests used by `types_equals_test.go`.
Manual testing.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [x] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.
