### PR TITLE
[discuss] fail annotation parsing fast and report errors as events

### DIFF
--- a/internal/ingress/annotations/annotations.go
+++ b/internal/ingress/annotations/annotations.go
@@ -209,7 +209,8 @@ func (e Extractor) Extract(ing *networking.Ingress) (*Ingress, error) {
 				val = nil
 			}
 
-			_, alreadyDenied := data[DeniedKeyName]
+			return nil, err
+			/* _, alreadyDenied := data[DeniedKeyName]
 			if !alreadyDenied {
 				errString := err.Error()
 				data[DeniedKeyName] = &errString
@@ -217,7 +218,7 @@ func (e Extractor) Extract(ing *networking.Ingress) (*Ingress, error) {
 				continue
 			}
 
-			klog.V(5).ErrorS(err, "error reading Ingress annotation", "name", name, "ingress", klog.KObj(ing))
+			klog.V(5).ErrorS(err, "error reading Ingress annotation", "name", name, "ingress", klog.KObj(ing)) */
 		}
 
 		if val != nil {

--- a/internal/ingress/annotations/annotations.go
+++ b/internal/ingress/annotations/annotations.go
@@ -209,8 +209,7 @@ func (e Extractor) Extract(ing *networking.Ingress) (*Ingress, error) {
 				val = nil
 			}
 
-			return nil, err
-			/* _, alreadyDenied := data[DeniedKeyName]
+			_, alreadyDenied := data[DeniedKeyName]
 			if !alreadyDenied {
 				errString := err.Error()
 				data[DeniedKeyName] = &errString
@@ -218,7 +217,7 @@ func (e Extractor) Extract(ing *networking.Ingress) (*Ingress, error) {
 				continue
 			}
 
-			klog.V(5).ErrorS(err, "error reading Ingress annotation", "name", name, "ingress", klog.KObj(ing)) */
+			klog.V(5).ErrorS(err, "error reading Ingress annotation", "name", name, "ingress", klog.KObj(ing))
 		}
 
 		if val != nil {

--- a/internal/ingress/controller/store/store.go
+++ b/internal/ingress/controller/store/store.go
@@ -938,9 +938,11 @@ func (s *k8sStore) syncIngress(ing *networkingv1.Ingress) {
 
 	parsed, err := s.annotations.Extract(ing)
 	if err != nil {
-		s.recorder.Eventf(ing, corev1.EventTypeWarning, "AnnotationParsingFailed", fmt.Sprintf("Error parsing annotations: %v", err))
 		klog.Error(err)
 		return
+	}
+	if parsed.Denied != nil {
+		s.recorder.Eventf(ing, corev1.EventTypeWarning, "AnnotationParsingFailed", fmt.Sprintf("Error parsing annotations: %v", *parsed.Denied))
 	}
 	err = s.listers.IngressWithAnnotation.Update(&ingress.Ingress{
 		Ingress:           *copyIng,


### PR DESCRIPTION
To address problems like #5282 it would be good if processing errors that prevent an ingress from progressing to be logged as a proper events.

The difficulty here is how to deal with annotation-related errors. Right now many of those are logged and ignored but might lead to downstream problems.

For this POC, the annotation processing is failed early as soon as a broken annotation is found and the error will be reported as an event.

I cannot foresee the full consequences of an approach like this. How could it be improved?

**Update: I simplified the suggestion by creating an event whenever the annotations report an error in the "Denied" field. So, the actual behavior is not changed only the reporting.**