### PR TITLE
Add loadBalancerIP option - so users can identify where to place the public ip address 

### DIFF
--- a/deploy/static/provider/oracle/deploy.yaml
+++ b/deploy/static/provider/oracle/deploy.yaml
@@ -369,6 +369,7 @@ spec:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
   type: LoadBalancer
+  #loadBalancerIP: <reserved public ip address if applicable>
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
This comment will help users to identiy where to place the public ip address on the ingress nginx for Oracle Cloud cluster (OKE).

## What this PR does / why we need it:
It only show the user with a comment where to place the public ip address, just a helper.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation only

## How Has This Been Tested?
In Oracle Cloud after creating a cluster, reserving a public ip address, uncommenting this line and placing the ip address as of:
```yaml
loadBalancerIP: 1.1.1.1
```

## Checklist:
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
