### PR TITLE
Redirects: Set HSTS header.

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -632,6 +632,11 @@ http {
         }
         {{ end }}
 
+        header_filter_by_lua_block {
+            lua_ingress.header()
+            plugins.run()
+        }
+
         set_by_lua_block $redirect_to {
             local request_uri = ngx.var.request_uri
             if string.sub(request_uri, -1) == "/" then


### PR DESCRIPTION
## What this PR does / why we need it:
fix #11591

https://github.com/kubernetes/ingress-nginx/blob/b93ccdf7b600be4c40a874819c21f4e3f842cbea/rootfs/etc/nginx/lua/lua_ingress.lua#L170-L181

`_M.header` will set `hsts` header, but this is not work with redirect (from/to www), we should also make header_filter_by_lua_block for redirect

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
fixes #11591

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
