### PR TITLE
Metrics: Remove `ingress_upstream_latency_seconds`.

### DIFF
--- a/docs/user-guide/monitoring.md
+++ b/docs/user-guide/monitoring.md
@@ -386,10 +386,6 @@ Prometheus metrics are exposed on port 10254.
   The number of bytes sent to a client. **Deprecated**, use `nginx_ingress_controller_response_size`\
   nginx var: `bytes_sent`
 
-* `nginx_ingress_controller_ingress_upstream_latency_seconds` Summary\
-  Upstream service latency per Ingress. **Deprecated**, use `nginx_ingress_controller_connect_duration_seconds`\
-  nginx var: `upstream_connect_time`
-
 ```
 # HELP nginx_ingress_controller_bytes_sent The number of bytes sent to a client. DEPRECATED! Use nginx_ingress_controller_response_size
 # TYPE nginx_ingress_controller_bytes_sent histogram
@@ -397,8 +393,6 @@ Prometheus metrics are exposed on port 10254.
 # TYPE nginx_ingress_controller_connect_duration_seconds nginx_ingress_controller_connect_duration_seconds
 * HELP nginx_ingress_controller_header_duration_seconds The time spent on receiving first header from the upstream server
 # TYPE nginx_ingress_controller_header_duration_seconds histogram
-# HELP nginx_ingress_controller_ingress_upstream_latency_seconds Upstream service latency per Ingress DEPRECATED! Use nginx_ingress_controller_connect_duration_seconds
-# TYPE nginx_ingress_controller_ingress_upstream_latency_seconds summary
 # HELP nginx_ingress_controller_request_duration_seconds The request processing time in milliseconds
 # TYPE nginx_ingress_controller_request_duration_seconds histogram
 # HELP nginx_ingress_controller_request_size The request length (including request line, header, and request body)

--- a/internal/ingress/metric/collectors/socket.go
+++ b/internal/ingress/metric/collectors/socket.go
@@ -64,11 +64,10 @@ type metricMapping map[string]prometheus.Collector
 type SocketCollector struct {
 	prometheus.Collector
 
-	upstreamLatency *prometheus.SummaryVec // TODO: DEPRECATED, remove
-	connectTime     *prometheus.HistogramVec
-	headerTime      *prometheus.HistogramVec
-	requestTime     *prometheus.HistogramVec
-	responseTime    *prometheus.HistogramVec
+	connectTime  *prometheus.HistogramVec
+	headerTime   *prometheus.HistogramVec
+	requestTime  *prometheus.HistogramVec
+	responseTime *prometheus.HistogramVec
 
 	requestLength  *prometheus.HistogramVec
 	responseLength *prometheus.HistogramVec
@@ -97,10 +96,6 @@ var requestTags = []string{
 	"service",
 	"canary",
 }
-
-// DefObjectives was removed in https://github.com/prometheus/client_golang/pull/262
-// updating the library to latest version changed the output of the metrics
-var defObjectives = map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001}
 
 // NewSocketCollector creates a new SocketCollector instance using
 // the ingress watch namespace and class used by the controller
@@ -248,19 +243,6 @@ func NewSocketCollector(pod, namespace, class string, metricsPerHost, reportStat
 			em,
 			mm,
 		),
-
-		upstreamLatency: summaryMetric(
-			&prometheus.SummaryOpts{
-				Name:        "ingress_upstream_latency_seconds",
-				Help:        "DEPRECATED Upstream service latency per Ingress",
-				Namespace:   PrometheusNamespace,
-				ConstLabels: constLabels,
-				Objectives:  defObjectives,
-			},
-			[]string{"ingress", "namespace", "service", "canary"},
-			em,
-			mm,
-		),
 	}
 
 	sc.metricMapping = mm
@@ -273,18 +255,6 @@ func containsMetric(excludeMetrics map[string]struct{}, name string) bool {
 		return true
 	}
 	return false
-}
-
-func summaryMetric(opts *prometheus.SummaryOpts, requestTags []string, excludeMetrics map[string]struct{}, metricMapping metricMapping) *prometheus.SummaryVec {
-	if containsMetric(excludeMetrics, opts.Name) {
-		return nil
-	}
-	m := prometheus.NewSummaryVec(
-		*opts,
-		requestTags,
-	)
-	metricMapping[prometheus.BuildFQName(PrometheusNamespace, "", opts.Name)] = m
-	return m
 }
 
 func counterMetric(opts *prometheus.CounterOpts, requestTags []string, excludeMetrics map[string]struct{}, metricMapping metricMapping) *prometheus.CounterVec {
@@ -358,13 +328,6 @@ func (sc *SocketCollector) handleMessage(msg []byte) {
 			collectorLabels["host"] = stats.Host
 		}
 
-		latencyLabels := prometheus.Labels{
-			"namespace": stats.Namespace,
-			"ingress":   stats.Ingress,
-			"service":   stats.Service,
-			"canary":    stats.Canary,
-		}
-
 		if sc.requests != nil {
 			requestsMetric, err := sc.requests.GetMetricWith(collectorLabels)
 			if err != nil {
@@ -381,15 +344,6 @@ func (sc *SocketCollector) handleMessage(msg []byte) {
 					klog.ErrorS(err, "Error fetching connect time metric")
 				} else {
 					connectTimeMetric.Observe(stats.Latency)
-				}
-			}
-
-			if sc.upstreamLatency != nil {
-				latencyMetric, err := sc.upstreamLatency.GetMetricWith(latencyLabels)
-				if err != nil {
-					klog.ErrorS(err, "Error fetching latency metric")
-				} else {
-					latencyMetric.Observe(stats.Latency)
 				}
 			}
 		}


### PR DESCRIPTION
## What this PR does / why we need it:
fix nginx controller oom due to `ingress_upstream_latency_seconds` metric

`ingress_upstream_latency_seconds` will cause nginx pod oom, and this metric has been deprecated, so we can delete this


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
#10141

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
