### PR TITLE
Canary Weighted Consistent Hashing

### DIFF
--- a/docs/user-guide/nginx-configuration/annotations.md
+++ b/docs/user-guide/nginx-configuration/annotations.md
@@ -41,6 +41,7 @@ You can add these Kubernetes annotations to specific Ingress objects to customiz
 |[nginx.ingress.kubernetes.io/canary-by-header-pattern](#canary)|string|
 |[nginx.ingress.kubernetes.io/canary-by-cookie](#canary)|string|
 |[nginx.ingress.kubernetes.io/canary-weight](#canary)|number|
+|[nginx.ingress.kubernetes.io/canary-weight-total](#canary)|number|
 |[nginx.ingress.kubernetes.io/client-body-buffer-size](#client-body-buffer-size)|string|
 |[nginx.ingress.kubernetes.io/configuration-snippet](#configuration-snippet)|string|
 |[nginx.ingress.kubernetes.io/custom-http-errors](#custom-http-errors)|[]int|
@@ -138,7 +139,9 @@ In some cases, you may want to "canary" a new set of changes by sending a small 
 
 * `nginx.ingress.kubernetes.io/canary-by-cookie`: The cookie to use for notifying the Ingress to route the request to the service specified in the Canary Ingress. When the cookie value is set to `always`, it will be routed to the canary. When the cookie is set to `never`, it will never be routed to the canary. For any other value, the cookie will be ignored and the request compared against the other canary rules by precedence.
 
-* `nginx.ingress.kubernetes.io/canary-weight`: The integer based (0 - 100) percent of random requests that should be routed to the service specified in the canary Ingress. A weight of 0 implies that no requests will be sent to the service in the Canary ingress by this canary rule. A weight of 100 means implies all requests will be sent to the alternative service specified in the Ingress.
+* `nginx.ingress.kubernetes.io/canary-weight`: The integer based (0 - <weight-total>) percent of random requests that should be routed to the service specified in the canary Ingress. A weight of 0 implies that no requests will be sent to the service in the Canary ingress by this canary rule. A weight of <weight-total> means implies all requests will be sent to the alternative service specified in the Ingress. `<weight-total>` defaults to 100, and can be increased via `nginx.ingress.kubernetes.io/canary-weight-total`.
+
+* `nginx.ingress.kubernetes.io/canary-weight-total`: The total weight of traffic. If unspecified, it defaults to 100.
 
 Canary rules are evaluated in order of precedence. Precedence is as follows:
 `canary-by-header -> canary-by-cookie -> canary-weight`

--- a/internal/ingress/annotations/canary/main.go
+++ b/internal/ingress/annotations/canary/main.go
@@ -32,6 +32,7 @@ type canary struct {
 type Config struct {
 	Enabled       bool
 	Weight        int
+	WeightTotal   int
 	Header        string
 	HeaderValue   string
 	HeaderPattern string
@@ -57,6 +58,11 @@ func (c canary) Parse(ing *networking.Ingress) (interface{}, error) {
 	config.Weight, err = parser.GetIntAnnotation("canary-weight", ing)
 	if err != nil {
 		config.Weight = 0
+	}
+
+	config.WeightTotal, err = parser.GetIntAnnotation("canary-weight-total", ing)
+	if err != nil {
+		config.WeightTotal = 100
 	}
 
 	config.Header, err = parser.GetStringAnnotation("canary-by-header", ing)

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -891,6 +891,7 @@ func (n *NGINXController) createUpstreams(data []*ingress.Ingress, du *ingress.B
 				upstreams[defBackend].NoServer = true
 				upstreams[defBackend].TrafficShapingPolicy = ingress.TrafficShapingPolicy{
 					Weight:        anns.Canary.Weight,
+					WeightTotal:   anns.Canary.WeightTotal,
 					Header:        anns.Canary.Header,
 					HeaderValue:   anns.Canary.HeaderValue,
 					HeaderPattern: anns.Canary.HeaderPattern,

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -890,12 +890,14 @@ func (n *NGINXController) createUpstreams(data []*ingress.Ingress, du *ingress.B
 			if anns.Canary.Enabled {
 				upstreams[defBackend].NoServer = true
 				upstreams[defBackend].TrafficShapingPolicy = ingress.TrafficShapingPolicy{
-					Weight:        anns.Canary.Weight,
-					WeightTotal:   anns.Canary.WeightTotal,
-					Header:        anns.Canary.Header,
-					HeaderValue:   anns.Canary.HeaderValue,
-					HeaderPattern: anns.Canary.HeaderPattern,
-					Cookie:        anns.Canary.Cookie,
+					Weight:            anns.Canary.Weight,
+					WeightTotal:       anns.Canary.WeightTotal,
+					Header:            anns.Canary.Header,
+					HeaderValue:       anns.Canary.HeaderValue,
+					HeaderPattern:     anns.Canary.HeaderPattern,
+					Cookie:            anns.Canary.Cookie,
+					CanaryConsistency: anns.Canary.CanaryConsistency,
+					HashSeed:          anns.Canary.HashSeed,
 				}
 			}
 
@@ -962,11 +964,13 @@ func (n *NGINXController) createUpstreams(data []*ingress.Ingress, du *ingress.B
 				if anns.Canary.Enabled {
 					upstreams[name].NoServer = true
 					upstreams[name].TrafficShapingPolicy = ingress.TrafficShapingPolicy{
-						Weight:        anns.Canary.Weight,
-						Header:        anns.Canary.Header,
-						HeaderValue:   anns.Canary.HeaderValue,
-						HeaderPattern: anns.Canary.HeaderPattern,
-						Cookie:        anns.Canary.Cookie,
+						Weight:            anns.Canary.Weight,
+						Header:            anns.Canary.Header,
+						HeaderValue:       anns.Canary.HeaderValue,
+						HeaderPattern:     anns.Canary.HeaderPattern,
+						Cookie:            anns.Canary.Cookie,
+						CanaryConsistency: anns.Canary.CanaryConsistency,
+						HashSeed:          anns.Canary.HashSeed,
 					}
 				}
 

--- a/internal/ingress/types.go
+++ b/internal/ingress/types.go
@@ -128,6 +128,10 @@ type TrafficShapingPolicy struct {
 	HeaderPattern string `json:"headerPattern"`
 	// Cookie on which to redirect requests to this backend
 	Cookie string `json:"cookie"`
+	// the value can be "header" or "cookie", which one will be keeping consistency
+	CanaryConsistency string `json:"canaryConsistency"`
+	//it's optional, the different seeds can result different hashcode
+	HashSeed string `json:"hashSeed"`
 }
 
 // HashInclude defines if a field should be used or not to calculate the hash

--- a/internal/ingress/types.go
+++ b/internal/ingress/types.go
@@ -111,10 +111,15 @@ type Backend struct {
 // alternative backend
 // +k8s:deepcopy-gen=true
 type TrafficShapingPolicy struct {
-	// Weight (0-100) of traffic to redirect to the backend.
-	// e.g. Weight 20 means 20% of traffic will be redirected to the backend and 80% will remain
-	// with the other backend. 0 weight will not send any traffic to this backend
+	// Weight (0-<WeightTotal>) of traffic to redirect to the backend.
+	// e.g. <WeightTotal> defaults to 100, weight 20 means 20% of traffic will be
+	// redirected to the backend and 80% will remain with the other backend. If
+	// <WeightTotal> is set to 1000, weight 2 means 0.2% of traffic will be
+	// redirected to the backend and 99.8% will remain with the other backend.
+	// 0 weight will not send any traffic to this backend
 	Weight int `json:"weight"`
+	// The total weight of traffic (>= 100). If unspecified, it defaults to 100.
+	WeightTotal int `json:"weightTotal"`
 	// Header on which to redirect requests to this backend
 	Header string `json:"header"`
 	// HeaderValue on which to redirect requests to this backend

--- a/internal/ingress/types_equals.go
+++ b/internal/ingress/types_equals.go
@@ -260,6 +260,12 @@ func (tsp1 TrafficShapingPolicy) Equal(tsp2 TrafficShapingPolicy) bool {
 	if tsp1.Cookie != tsp2.Cookie {
 		return false
 	}
+	if tsp1.CanaryConsistency != tsp2.CanaryConsistency {
+		return false
+	}
+	if tsp1.HashSeed != tsp2.HashSeed {
+		return false
+	}
 
 	return true
 }

--- a/rootfs/etc/nginx/lua/balancer.lua
+++ b/rootfs/etc/nginx/lua/balancer.lua
@@ -259,7 +259,11 @@ local function route_to_alternative_balancer(balancer)
     end
   end
 
-  if math.random(100) <= traffic_shaping_policy.weight then
+  local weightTotal = 100
+  if traffic_shaping_policy.weightTotal ~= nil and traffic_shaping_policy.weightTotal > 100 then
+    weightTotal = traffic_shaping_policy.weightTotal
+  end
+  if math.random(weightTotal) <= traffic_shaping_policy.weight then
     return true
   end
 

--- a/rootfs/etc/nginx/lua/balancer/hashcode.lua
+++ b/rootfs/etc/nginx/lua/balancer/hashcode.lua
@@ -1,0 +1,17 @@
+local string = string
+local _M = {}
+
+function _M.str_hash_to_int(str)
+    local h = 0
+    local l = #str
+    if l > 0 then
+        local i = 0
+        while i < l do
+            h = 31 * h + string.byte(str, i + 1)
+            i = i + 1
+        end
+    end
+    return h
+end
+
+return _M

--- a/rootfs/etc/nginx/lua/test/balancer_test.lua
+++ b/rootfs/etc/nginx/lua/test/balancer_test.lua
@@ -203,6 +203,20 @@ describe("Balancer", function()
           balancer.sync_backend(backend)
           assert.equal(false, balancer.route_to_alternative_balancer(_primaryBalancer))
         end)
+
+        it("returns true when weight is 1000 and weight total is 1000", function()
+          backend.trafficShapingPolicy.weight = 1000
+          backend.trafficShapingPolicy.weightTotal = 1000
+          balancer.sync_backend(backend)
+          assert.equal(true, balancer.route_to_alternative_balancer(_primaryBalancer))
+        end)
+
+        it("returns false when weight is 0 and weight total is 1000", function()
+          backend.trafficShapingPolicy.weight = 1000
+          backend.trafficShapingPolicy.weightTotal = 1000
+          balancer.sync_backend(backend)
+          assert.equal(true, balancer.route_to_alternative_balancer(_primaryBalancer))
+        end)
       end)
 
       describe("canary by cookie", function()


### PR DESCRIPTION
**Weighted Consistent Hashing**

consider that
1.route 30% requests to canary backends just like what canary-weight did
2.the requests of a single user/device route to primary backends or canary backends randomly, it cause unconsistency
3.we want a single user routes to primary backends or canary backends all the time during the lifecycle

**Add two new canary annotations**
canary-consistency
it has two option, "header" or "cookie", means

header="userId" value="1" this userId routes to primary backends all the time
header="userId" value="2" this userId routes to canary backends all the time
or
cookie="userId" value="1" this userId routes to primary backends all the time
cookie="userId" value="2" this userId routes to canary backends all the time

canary-hash-seed
it's optional, it makes sure two experiments requests are different, the different seeds can result different hashcode

**three old canary annotations are reused**
canary-weight
canary-by-header
cookie

**Compatibility**
won't harm other canary strategies
but if canary-consistency is configured, other strategies won't work