### PR TITLE
Lua: Fix `limit_except` returning 503.

### DIFF
--- a/rootfs/etc/nginx/lua/balancer.lua
+++ b/rootfs/etc/nginx/lua/balancer.lua
@@ -277,6 +277,11 @@ local function get_balancer()
 
   local backend_name = ngx.var.proxy_upstream_name
 
+  if backend_name == '-' then
+    ngx.status = ngx.HTTP_FORBIDDEN
+    return ngx.exit(ngx.status)                                                     
+  end
+
   local balancer = balancers[backend_name]
   if not balancer then
     return nil

--- a/test/e2e/annotations/limitexcept.go
+++ b/test/e2e/annotations/limitexcept.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package annotations
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/onsi/ginkgo/v2"
+
+	"k8s.io/ingress-nginx/test/e2e/framework"
+)
+
+var _ = framework.DescribeAnnotation("limit-except", func() {
+	f := framework.NewDefaultFramework("limitexcept")
+
+	ginkgo.BeforeEach(func() {
+		f.NewEchoDeployment()
+	})
+
+	ginkgo.It("should return 403 when the request is not allowed", func() {
+		host := "foo.com"
+
+        annotations := map[string]string{
+            "nginx.ingress.kubernetes.io/server-snippet": `
+                location = / {
+                    return 403;
+                }`,
+            "nginx.ingress.kubernetes.io/configuration-snippet": `
+                limit_except GET {
+                    deny all;
+                }`,
+        }
+    
+        ing := framework.NewSingleIngress(host, "/foo", host, f.Namespace, framework.EchoService, 80, annotations)
+		f.EnsureIngress(ing)
+
+        f.WaitForNginxServer(host,
+			func(server string) bool {
+				return strings.Contains(server, `location = / { return 403; }`) &&
+					strings.Contains(server, `limit_except GET { deny all; }`)
+			})
+
+		ginkgo.By("sending request to foo.com")
+		f.HTTPTestClient().
+		    POST("/").
+			WithHeader("Host", host).
+			Expect().
+			Status(http.StatusForbidden)
+
+        f.HTTPTestClient().
+			GET("/").
+			WithHeader("Host", host).
+			Expect().
+			Status(http.StatusForbidden)
+
+        f.HTTPTestClient().
+		    POST("/foo").
+			WithHeader("Host", host).
+			Expect().
+			Status(http.StatusForbidden)
+
+        f.HTTPTestClient().
+			GET("/foo").
+			WithHeader("Host", host).
+			Expect().
+			Status(http.StatusOK)
+	})
+})


### PR DESCRIPTION
## What this PR does / why we need it:
Using limit_except GET { deny all; } together with location = / { return 403; } ,  When the request is POST ，results in 503, instead of 403.
This issue involves the ngx_http_core_module.c module of Nginx. When the limit_except directive is used, variables set within a location block cannot be accessed. Currently, the balancer.rewrite() in nginx.conf relies on the proxy_upstream_name variable, which leads to a failure in obtaining the balancer and results in a 503 error. However, it should actually return a 403 error.
If you need more details please let me know

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
fixes #11742 

## How Has This Been Tested?

```apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: foo-ingress
  namespace: default
  annotations:
    nginx.ingress.kubernetes.io/configuration-snippet: limit_except GET { deny all; }
    nginx.ingress.kubernetes.io/server-snippet: |
      location  =/ {
        return 403;
      }
spec:
  ingressClassName: nginx
  rules:
  - host:
    http:
      paths:
      - path: /foo
        pathType: Prefix
        backend:
          service:
            name: foo-service
            port:
              number: 8080
```
```
curl -X POST http://1xx.xxx.xxx.xx:32080/foo

<html>
<head><title>503 Service Temporarily Unavailable</title></head>
<body>
<center><h1>503 Service Temporarily Unavailable</h1></center>
<hr><center>nginx</center>
</body>
</html>
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
