### PR TITLE
Lua: Remove plugins from `.luacheckrc` & E2E docs.

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,6 +1,6 @@
 std = 'ngx_lua'
 max_line_length = 100
-exclude_files = {'./rootfs/etc/nginx/lua/test/**/*.lua', './rootfs/etc/nginx/lua/plugins/**/test/**/*.lua'}
+exclude_files = {'./rootfs/etc/nginx/lua/test/**/*.lua'}
 files["rootfs/etc/nginx/lua/lua_ingress.lua"] = {
   ignore = { "122" },
   -- TODO(elvinefendi) figure out why this does not work

--- a/docs/e2e-tests.md
+++ b/docs/e2e-tests.md
@@ -495,8 +495,6 @@ Do not try to edit it manually.
 - [should include opentelemetry_trust_incoming_spans on directive when enabled](https://github.com/kubernetes/ingress-nginx/tree/main//test/e2e/settings/opentelemetry.go#L76)
 - [should not exists opentelemetry_operation_name directive when is empty](https://github.com/kubernetes/ingress-nginx/tree/main//test/e2e/settings/opentelemetry.go#L91)
 - [should exists opentelemetry_operation_name directive when is configured](https://github.com/kubernetes/ingress-nginx/tree/main//test/e2e/settings/opentelemetry.go#L106)
-### [plugins](https://github.com/kubernetes/ingress-nginx/tree/main//test/e2e/settings/plugins.go#L28)
-- [should exist a x-hello-world header](https://github.com/kubernetes/ingress-nginx/tree/main//test/e2e/settings/plugins.go#L35)
 ### [proxy-connect-timeout](https://github.com/kubernetes/ingress-nginx/tree/main//test/e2e/settings/proxy_connect_timeout.go#L29)
 - [should set valid proxy timeouts using configmap values](https://github.com/kubernetes/ingress-nginx/tree/main//test/e2e/settings/proxy_connect_timeout.go#L37)
 - [should not set invalid proxy timeouts using configmap values](https://github.com/kubernetes/ingress-nginx/tree/main//test/e2e/settings/proxy_connect_timeout.go#L53)


### PR DESCRIPTION
Follow-up on https://github.com/kubernetes/ingress-nginx/pull/11821.