### PR TITLE
Chart: Use generic values for `ConfigMap` test.

### DIFF
--- a/charts/ingress-nginx/tests/controller-configmap_test.yaml
+++ b/charts/ingress-nginx/tests/controller-configmap_test.yaml
@@ -16,16 +16,16 @@ tests:
   - it: should create a ConfigMap with templated values if `controller.config` contains templates
     set:
       controller.config:
-        global-rate-limit-memcached-host: "memcached.{{ .Release.Namespace }}.svc.kubernetes.local"
-        global-rate-limit-memcached-port: 11211
-        use-gzip: true
+        template: "test.{{ .Release.Namespace }}.svc.kubernetes.local"
+        integer: 12345
+        boolean: true
     asserts:
       - equal:
-          path: data.global-rate-limit-memcached-host
-          value: memcached.NAMESPACE.svc.kubernetes.local
+          path: data.template
+          value: test.NAMESPACE.svc.kubernetes.local
       - equal:
-          path: data.global-rate-limit-memcached-port
-          value: "11211"
+          path: data.integer
+          value: "12345"
       - equal:
-          path: data.use-gzip
+          path: data.boolean
           value: "true"


### PR DESCRIPTION
Manual cherry-pick of https://github.com/kubernetes/ingress-nginx/pull/11877.

/triage accepted
/kind cleanup
/priority backlog
/cc @strongjz @rikatz @tao12345666333