### PR TITLE
Chart: Implement `controller.admissionWebhooks.service.servicePort`.

### DIFF
--- a/charts/ingress-nginx/templates/admission-webhooks/validating-webhook.yaml
+++ b/charts/ingress-nginx/templates/admission-webhooks/validating-webhook.yaml
@@ -40,6 +40,7 @@ webhooks:
       service:
         name: {{ include "ingress-nginx.controller.fullname" . }}-admission
         namespace: {{ include "ingress-nginx.namespace" . }}
+        port: {{ .Values.controller.admissionWebhooks.service.servicePort }}
         path: /networking/v1/ingresses
     {{- if .Values.controller.admissionWebhooks.timeoutSeconds }}
     timeoutSeconds: {{ .Values.controller.admissionWebhooks.timeoutSeconds }}

--- a/charts/ingress-nginx/templates/controller-service-webhook.yaml
+++ b/charts/ingress-nginx/templates/controller-service-webhook.yaml
@@ -29,7 +29,7 @@ spec:
 {{- end }}
   ports:
     - name: https-webhook
-      port: 443
+      port: {{ .Values.controller.admissionWebhooks.service.servicePort }}
       targetPort: webhook
     {{- if semverCompare ">=1.20.0-0" .Capabilities.KubeVersion.Version }}
       appProtocol: https

--- a/charts/ingress-nginx/tests/admission-webhooks/validating-webhook_test.yaml
+++ b/charts/ingress-nginx/tests/admission-webhooks/validating-webhook_test.yaml
@@ -1,0 +1,32 @@
+suite: Admission Webhooks > ValidatingWebhookConfiguration
+templates:
+  - admission-webhooks/validating-webhook.yaml
+
+tests:
+  - it: should not create a ValidatingWebhookConfiguration if `controller.admissionWebhooks.enabled` is false
+    set:
+      controller.admissionWebhooks.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create a ValidatingWebhookConfiguration if `controller.admissionWebhooks.enabled` is true
+    set:
+      controller.admissionWebhooks.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ValidatingWebhookConfiguration
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-admission
+
+  - it: should create a ValidatingWebhookConfiguration with a custom port if `controller.admissionWebhooks.service.servicePort` is set
+    set:
+      controller.admissionWebhooks.enabled: true
+      controller.admissionWebhooks.service.servicePort: 9443
+    asserts:
+      - equal:
+          path: webhooks[0].clientConfig.service.port
+          value: 9443

--- a/charts/ingress-nginx/tests/controller-service-webhook_test.yaml
+++ b/charts/ingress-nginx/tests/controller-service-webhook_test.yaml
@@ -1,0 +1,32 @@
+suite: Controller > Service > Webhook
+templates:
+  - controller-service-webhook.yaml
+
+tests:
+  - it: should not create a webhook Service if `controller.admissionWebhooks.enabled` is false
+    set:
+      controller.admissionWebhooks.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create a webhook Service if `controller.admissionWebhooks.enabled` is true
+    set:
+      controller.admissionWebhooks.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-ingress-nginx-controller-admission
+
+  - it: should create a webhook Service with a custom port if `controller.admissionWebhooks.service.servicePort` is set
+    set:
+      controller.admissionWebhooks.enabled: true
+      controller.admissionWebhooks.service.servicePort: 9443
+    asserts:
+      - equal:
+          path: spec.ports[0].port
+          value: 9443


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
<!--- Please make sure you title is descriptive, it is used in the Release notes to let others know what it does ---> 

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

While the chart values.yaml provides a controller.admissionWebhooks.service.servicePort option, its value was being ignored by the chart template.

This PR changes the template to use the value for the admission webhook service port in the Service definition and in the corresponding ValidatingWebhookConfiguration instead of ignoring it.

The PR also adds some Helm unit tests for this value.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Manually tested that the change works as expected (service uses the custom port, webhook configuration point to the right port).
- Launched `make kind-e2e-chart-tests` locally (mac M1): all tests passed
- Launched `helm unittest charts/ingress-nginx -d` locally (mac M1): all tests passed.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [x] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.
