### PR TITLE
fix: upstreamName(ns, backend) outputs same name for different backends

### DIFF
--- a/internal/ingress/controller/util.go
+++ b/internal/ingress/controller/util.go
@@ -50,13 +50,13 @@ func newUpstream(name string) *ingress.Backend {
 func upstreamName(namespace string, service *networking.IngressServiceBackend) string {
 	if service != nil {
 		if service.Port.Number > 0 {
-			return fmt.Sprintf("%s-%s-%d", namespace, service.Name, service.Port.Number)
+			return fmt.Sprintf("%s_%s_%d", namespace, service.Name, service.Port.Number)
 		}
 		if service.Port.Name != "" {
-			return fmt.Sprintf("%s-%s-%s", namespace, service.Name, service.Port.Name)
+			return fmt.Sprintf("%s_%s_%s", namespace, service.Name, service.Port.Name)
 		}
 	}
-	return fmt.Sprintf("%s-INVALID", namespace)
+	return fmt.Sprintf("%s_INVALID", namespace)
 }
 
 // upstreamServiceNameAndPort verifies if service is not nil, and then return the


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
<!--- Please make sure you title is descriptive, it is used in the Release notes to let others know what it does ---> 

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The original upstreamName function can outputs the same name for different ingress backends.
```
// fmt.Sprintf("%s-%s-%d", namespace, service.Name, service.Port.Number)
fmt.Sprintf("%s-%s-%d", "a", "b", "c-d") == fmt.Sprintf("%s-%s-%d", "a", "b-c", "d") == fmt.Sprintf("%s-%s-%d", "a-b", "c", "d")
```

While the names in k8s must follow [RFC1123](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names), which means they cannot have underscore character(`_`)

So my fix use underscore to join the names to avoid conflicts.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

fixes #11938 #11937 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This function does not have unit test before, I'm still thinking how to make one.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
