### PR TITLE
Images: Use latest Alpine 3.20 everywhere.

### DIFF
--- a/docs/examples/customization/sysctl/patch.json
+++ b/docs/examples/customization/sysctl/patch.json
@@ -4,7 +4,7 @@
 			"spec": {
 				"initContainers": [{
 					"name": "sysctl",
-					"image": "alpine:3.18",
+					"image": "alpine:3.20",
 					"securityContext": {
 						"privileged": true
 					},

--- a/images/cfssl/rootfs/Dockerfile
+++ b/images/cfssl/rootfs/Dockerfile
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.20.0
+FROM alpine:3.20
 
-RUN echo "@testing http://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
+RUN echo "@testing https://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
 RUN apk update \
     && apk upgrade &&  \
     apk add --no-cache \

--- a/images/nginx-1.25/rootfs/Dockerfile
+++ b/images/nginx-1.25/rootfs/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM alpine:3.20.0 as builder
+FROM alpine:3.20 as builder
 
 COPY . /
 
@@ -21,7 +21,7 @@ RUN apk update \
   && /build.sh
 
 # Use a multi-stage build
-FROM alpine:3.20.0
+FROM alpine:3.20
 
 ENV PATH=$PATH:/usr/local/luajit/bin:/usr/local/nginx/sbin:/usr/local/nginx/bin
 

--- a/images/nginx/rootfs/Dockerfile
+++ b/images/nginx/rootfs/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM alpine:3.20.0 as builder
+FROM alpine:3.20 as builder
 
 COPY . /
 
@@ -21,7 +21,7 @@ RUN apk update \
   && /build.sh
 
 # Use a multi-stage build
-FROM alpine:3.20.0
+FROM alpine:3.20
 
 ENV PATH=$PATH:/usr/local/luajit/bin:/usr/local/nginx/sbin:/usr/local/nginx/bin
 

--- a/images/opentelemetry/rootfs/Dockerfile
+++ b/images/opentelemetry/rootfs/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-FROM alpine:3.20.0 AS base
+FROM alpine:3.20 AS base
 
 RUN mkdir -p /opt/third_party/install
 COPY . /opt/third_party/

--- a/images/test-runner/rootfs/Dockerfile
+++ b/images/test-runner/rootfs/Dockerfile
@@ -48,7 +48,7 @@ RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
 
 COPY --from=etcd /usr/local/bin/etcd /usr/local/bin/etcd
 
-RUN echo "@testing https://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
+RUN echo "@testing https://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
 
 RUN apk update && apk upgrade && apk add --no-cache \
   bash \

--- a/rootfs/Dockerfile-chroot
+++ b/rootfs/Dockerfile-chroot
@@ -23,7 +23,7 @@ RUN apk update \
   && apk upgrade \
   && /chroot.sh
 
-FROM alpine:3.20.0
+FROM alpine:3.20
 
 ARG TARGETARCH
 ARG VERSION

--- a/test/e2e-image/Dockerfile
+++ b/test/e2e-image/Dockerfile
@@ -1,7 +1,7 @@
 ARG E2E_BASE_IMAGE
 FROM ${E2E_BASE_IMAGE} AS BASE
 
-FROM alpine:3.20.0
+FROM alpine:3.20
 
 RUN apk update \
 	&& apk upgrade && apk add -U --no-cache \


### PR DESCRIPTION
This PR ensures we're using Alpine 3.20 independent of the particular patch level everywhere, so it automatically always uses the latest patch level and obsoletes bumping Alpine on every patch release.

/triage accepted
/kind cleanup
/priority backlog
/cc @strongjz @rikatz @tao12345666333 @cpanato