### PR TITLE
fix `ipallowlist` parser not handling `validation` type errors

### DIFF
--- a/internal/ingress/annotations/ipallowlist/main.go
+++ b/internal/ingress/annotations/ipallowlist/main.go
@@ -95,6 +95,9 @@ func (a ipallowlist) Parse(ing *networking.Ingress) (interface{}, error) {
 		if err == ing_errors.ErrMissingAnnotations {
 			return &SourceRange{CIDR: defaultAllowlistSourceRange}, nil
 		}
+		if ing_errors.IsValidationError(err) {
+			return &SourceRange{CIDR: defaultAllowlistSourceRange}, err
+		}
 
 		return &SourceRange{CIDR: defaultAllowlistSourceRange}, ing_errors.LocationDeniedError{
 			Reason: err,


### PR DESCRIPTION
## What this PR does / why we need it:
fix `ipallowlist` parser not handling `validation` type errors

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
fixes #11967 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
