### PR TITLE
Chart: Align default backend `PodDisruptionBudget`.

### DIFF
--- a/charts/ingress-nginx/README.md
+++ b/charts/ingress-nginx/README.md
@@ -516,7 +516,7 @@ As of version `1.26.0` of this chart, by simply not providing any clusterIP valu
 | defaultBackend.livenessProbe.periodSeconds | int | `10` |  |
 | defaultBackend.livenessProbe.successThreshold | int | `1` |  |
 | defaultBackend.livenessProbe.timeoutSeconds | int | `5` |  |
-| defaultBackend.minAvailable | int | `1` |  |
+| defaultBackend.minAvailable | int | `1` | Minimum available pods set in PodDisruptionBudget. |
 | defaultBackend.minReadySeconds | int | `0` | `minReadySeconds` to avoid killing pods before we are ready # |
 | defaultBackend.name | string | `"defaultbackend"` |  |
 | defaultBackend.networkPolicy.enabled | bool | `false` | Enable 'networkPolicy' or not |

--- a/charts/ingress-nginx/templates/default-backend-poddisruptionbudget.yaml
+++ b/charts/ingress-nginx/templates/default-backend-poddisruptionbudget.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.defaultBackend.enabled -}}
-{{- if or (gt (.Values.defaultBackend.replicaCount | int) 1) (gt (.Values.defaultBackend.autoscaling.minReplicas | int) 1) }}
+{{- $replicas := .Values.defaultBackend.replicaCount }}
+{{- if .Values.defaultBackend.autoscaling.enabled }}
+{{- $replicas = .Values.defaultBackend.autoscaling.minReplicas }}
+{{- end }}
+{{- if gt ($replicas | int) 1 }}
 apiVersion: {{ ternary "policy/v1" "policy/v1beta1" (semverCompare ">=1.21.0-0" .Capabilities.KubeVersion.Version) }}
 kind: PodDisruptionBudget
 metadata:

--- a/charts/ingress-nginx/tests/default-backend-poddisruptionbudget_test.yaml
+++ b/charts/ingress-nginx/tests/default-backend-poddisruptionbudget_test.yaml
@@ -1,0 +1,48 @@
+suite: Default Backend > PodDisruptionBudget
+templates:
+  - default-backend-poddisruptionbudget.yaml
+
+tests:
+  - it: should create a PodDisruptionBudget if `defaultBackend.replicaCount` is greater than 1
+    set:
+      defaultBackend.enabled: true
+      defaultBackend.replicaCount: 2
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-ingress-nginx-defaultbackend
+
+  - it: should not create a PodDisruptionBudget if `defaultBackend.replicaCount` is less than or equal 1
+    set:
+      defaultBackend.enabled: true
+      defaultBackend.replicaCount: 1
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create a PodDisruptionBudget if `defaultBackend.autoscaling.enabled` is true and `defaultBackend.autoscaling.minReplicas` is greater than 1
+    set:
+      defaultBackend.enabled: true
+      defaultBackend.autoscaling.enabled: true
+      defaultBackend.autoscaling.minReplicas: 2
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-ingress-nginx-defaultbackend
+
+  - it: should not create a PodDisruptionBudget if `defaultBackend.autoscaling.enabled` is true and `defaultBackend.autoscaling.minReplicas` is less than or equal 1
+    set:
+      defaultBackend.enabled: true
+      defaultBackend.autoscaling.enabled: true
+      defaultBackend.autoscaling.minReplicas: 1
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -1096,6 +1096,7 @@ defaultBackend:
   ##
   podAnnotations: {}
   replicaCount: 1
+  # -- Minimum available pods set in PodDisruptionBudget.
   minAvailable: 1
   resources: {}
   # limits:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
<!--- Please make sure you title is descriptive, it is used in the Release notes to let others know what it does ---> 

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR aligns the default backend `PodDisruptionBudget` to the controller's one. It adds some documentation on the values, unit tests and improves the entry condition of the PDB resource.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

Towards https://github.com/kubernetes/ingress-nginx/issues/11983.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Helm Unit Tests and CI.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [x] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.
