### PR TITLE
Chart: Add `controller.metrics.service.enabled`.

### DIFF
--- a/charts/ingress-nginx/README.md
+++ b/charts/ingress-nginx/README.md
@@ -372,6 +372,7 @@ As of version `1.26.0` of this chart, by simply not providing any clusterIP valu
 | controller.metrics.prometheusRule.enabled | bool | `false` |  |
 | controller.metrics.prometheusRule.rules | list | `[]` |  |
 | controller.metrics.service.annotations | object | `{}` |  |
+| controller.metrics.service.enabled | bool | `true` | Enable the metrics service or not. |
 | controller.metrics.service.externalIPs | list | `[]` | List of IP addresses at which the stats-exporter service is available # Ref: https://kubernetes.io/docs/concepts/services-networking/service/#external-ips # |
 | controller.metrics.service.labels | object | `{}` | Labels to be added to the metrics service resource |
 | controller.metrics.service.loadBalancerSourceRanges | list | `[]` |  |

--- a/charts/ingress-nginx/templates/controller-service-metrics.yaml
+++ b/charts/ingress-nginx/templates/controller-service-metrics.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.controller.metrics.enabled -}}
+{{- if and .Values.controller.metrics.enabled .Values.controller.metrics.service.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/ingress-nginx/tests/controller-service-metrics_test.yaml
+++ b/charts/ingress-nginx/tests/controller-service-metrics_test.yaml
@@ -3,16 +3,34 @@ templates:
   - controller-service-metrics.yaml
 
 tests:
-  - it: should not create a metrics Service if `controller.metrics.enabled` is false
+  - it: should not create a metrics Service if `controller.metrics.enabled` is false and `controller.metrics.service.enabled` is false
     set:
       controller.metrics.enabled: false
+      controller.metrics.service.enabled: false
     asserts:
       - hasDocuments:
           count: 0
 
-  - it: should create a metrics Service if `controller.metrics.enabled` is true
+  - it: should not create a metrics Service if `controller.metrics.enabled` is false and `controller.metrics.service.enabled` is true
+    set:
+      controller.metrics.enabled: false
+      controller.metrics.service.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not create a metrics Service if `controller.metrics.enabled` is true and `controller.metrics.service.enabled` is false
     set:
       controller.metrics.enabled: true
+      controller.metrics.service.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create a metrics Service if `controller.metrics.enabled` is true and `controller.metrics.service.enabled` is true
+    set:
+      controller.metrics.enabled: true
+      controller.metrics.service.enabled: true
     asserts:
       - hasDocuments:
           count: 1

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -844,6 +844,8 @@ controller:
     # if this port is changed, change healthz-port: in extraArgs: accordingly
     enabled: false
     service:
+      # -- Enable the metrics service or not.
+      enabled: true
       annotations: {}
       # prometheus.io/scrape: "true"
       # prometheus.io/port: "10254"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
<!--- Please make sure you title is descriptive, it is used in the Release notes to let others know what it does ---> 

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Add support to disable the controller metrics service, because sometimes we don't need to have the service exposed cluster-wide, like you have a local agent on the node (like datadog agent)
So a new values in created: `controller.metrics.service.enabled`.
Allow to have the same behaviour as before chart v4.10.0 and #10959 
So you can have metrics enabled on nginx but no service created.
Default is to have the service created if the controller metrics part is enabled, so there is no regression.
Updated the test to reflect the changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->
No Issue created.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Modified the chart on my non-production environement and confirm we got the same behaviour as before chart 4.10.0.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [x] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.
