### PR TITLE
Docs: Clarify external & service port in TCP/UDP services explanation.

### DIFF
--- a/docs/user-guide/exposing-tcp-udp-services.md
+++ b/docs/user-guide/exposing-tcp-udp-services.md
@@ -3,7 +3,7 @@
 While the Kubernetes Ingress resource only officially supports routing external HTTP(s) traffic to services, ingress-nginx can be configured to receive external TCP/UDP traffic from non-HTTP protocols and route them to internal services using TCP/UDP port mappings that are specified within a ConfigMap.
 
 To support this, the `--tcp-services-configmap` and `--udp-services-configmap` flags can be used to point to an existing config map where the key is the external port to use and the value indicates the service to expose using the format:
-`<service port>:<namespace/service name>:[PROXY]:[PROXY]`
+`<external port>:<namespace/service name>:[service port/name]:[PROXY]:[PROXY]`
 
 It is also possible to use a number or the name of the port. The two last fields are optional.
 Adding `PROXY` in either or both of the two last fields we can use [Proxy Protocol](https://www.nginx.com/resources/admin-guide/proxy-protocol) decoding (listen) and/or encoding (proxy_pass) in a TCP service. 

--- a/docs/user-guide/exposing-tcp-udp-services.md
+++ b/docs/user-guide/exposing-tcp-udp-services.md
@@ -3,7 +3,7 @@
 While the Kubernetes Ingress resource only officially supports routing external HTTP(s) traffic to services, ingress-nginx can be configured to receive external TCP/UDP traffic from non-HTTP protocols and route them to internal services using TCP/UDP port mappings that are specified within a ConfigMap.
 
 To support this, the `--tcp-services-configmap` and `--udp-services-configmap` flags can be used to point to an existing config map where the key is the external port to use and the value indicates the service to expose using the format:
-`<external port>:<namespace/service name>:[service port/name]:[PROXY]:[PROXY]`
+`<external port>:<namespace/service name>:<service port/name>:[PROXY]:[PROXY]`
 
 It is also possible to use a number or the name of the port. The two last fields are optional.
 Adding `PROXY` in either or both of the two last fields we can use [Proxy Protocol](https://www.nginx.com/resources/admin-guide/proxy-protocol) decoding (listen) and/or encoding (proxy_pass) in a TCP service. 


### PR DESCRIPTION
Following the changes on the previous PR https://github.com/kubernetes/ingress-nginx/pull/10220  I found the missing service port in the format confusing with the examples, as it seemed that the service name/port was to be used in the field of the PROXY keyword. 

In my experience I've always needed to specify the service port and I thought this was required, but as it's currently stated in the documentation is an optional field, so I've kept it that way in the format syntax. Please correct me if I'm wrong.

<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
<!--- Please make sure you title is descriptive, it is used in the Release notes to let others know what it does ---> 

## What this PR does / why we need it:
Clarification of the documentation to the example provided.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
