### PR TITLE
Fix make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,8 +121,8 @@ build:  ## Build ingress controller, debug tool and pre-stop hook.
 
 
 .PHONY: clean
-clean: ## Remove .gocache directory.
-	rm -rf bin/ .gocache/ .cache/
+clean: ## Remove cache and bin directories.
+	rm -rf bin/ .modcache/ .cache/ rootfs/bin
 
 .PHONY: verify-docs
 verify-docs: ## Verify doc generation

--- a/build/build.sh
+++ b/build/build.sh
@@ -41,7 +41,7 @@ echo "Building targets for ${ARCH}, generated targets in ${TARGETS_DIR} director
 echo "Building ${PKG}/cmd/nginx"
 
 ${GO_BUILD_CMD} \
-  -trimpath -ldflags="-buildid= -w -s \
+  -modcacherw -trimpath -ldflags="-buildid= -w -s \
   -X ${PKG}/version.RELEASE=${TAG} \
   -X ${PKG}/version.COMMIT=${COMMIT_SHA} \
   -X ${PKG}/version.REPO=${REPO_INFO}" \
@@ -51,7 +51,7 @@ ${GO_BUILD_CMD} \
 echo "Building ${PKG}/cmd/dbg"
 
 ${GO_BUILD_CMD} \
-  -trimpath -ldflags="-buildid= -w -s \
+  -modcacherw -trimpath -ldflags="-buildid= -w -s \
   -X ${PKG}/version.RELEASE=${TAG} \
   -X ${PKG}/version.COMMIT=${COMMIT_SHA} \
   -X ${PKG}/version.REPO=${REPO_INFO}" \
@@ -61,7 +61,7 @@ ${GO_BUILD_CMD} \
 echo "Building ${PKG}/cmd/waitshutdown"
 
 ${GO_BUILD_CMD} \
-  -trimpath -ldflags="-buildid= -w -s \
+  -modcacherw -trimpath -ldflags="-buildid= -w -s \
   -X ${PKG}/version.RELEASE=${TAG} \
   -X ${PKG}/version.COMMIT=${COMMIT_SHA} \
   -X ${PKG}/version.REPO=${REPO_INFO}" \

--- a/build/run-in-docker.sh
+++ b/build/run-in-docker.sh
@@ -89,7 +89,7 @@ if [[ "$DOCKER_IN_DOCKER_ENABLED" == "true" ]]; then
 else
   echo "Reached DIND check ELSE block, inside run-in-docker.sh"
 
-  args="${PLATFORM_FLAG} ${PLATFORM} --tty --rm ${DOCKER_OPTS} -e DEBUG=${DEBUG} -e GOCACHE="/go/src/${PKG}/.cache" -e GOMODCACHE="/go/src/${PKG}/.modcache" -e DOCKER_IN_DOCKER_ENABLED="true" -v "${HOME}/.kube:${HOME}/.kube" -v "${KUBE_ROOT}:/go/src/${PKG}" -v "${KUBE_ROOT}/bin/${ARCH}:/go/bin/linux_${ARCH}" -v "${INGRESS_VOLUME}:/etc/ingress-controller/" -w "/go/src/${PKG}""
+  args="${PLATFORM_FLAG} ${PLATFORM} --tty --rm ${DOCKER_OPTS} -e DEBUG=${DEBUG} -e GOCACHE="/go/src/${PKG}/.cache" -e GOMODCACHE="/go/src/${PKG}/.modcache" -e DOCKER_IN_DOCKER_ENABLED="true" -v "${HOME}/.kube:${HOME}/.kube" -v "${KUBE_ROOT}:/go/src/${PKG}" -v "${KUBE_ROOT}/bin/${ARCH}:/go/bin/linux_${ARCH}" -v "${INGRESS_VOLUME}:/etc/ingress-controller/" -w "/go/src/${PKG}" -u "$(id -u ${USER}):$(id -g ${USER})""
 
   if [[ "$RUNTIME" == "docker" ]]; then
     args="$args -v /var/run/docker.sock:/var/run/docker.sock"


### PR DESCRIPTION
Avoid elevating permissions to clean cache directories by using host user in docker and `-modcacherw` in go build command.

Permissions were used previously but were modified in #8400 to be used for [mac users only](https://github.com/kubernetes/ingress-nginx/pull/8400/files#diff-405d7c73a263cffe9023dda72791751fcc59ecee3cf632c05f6de28f93abd541R108) and subsequently removed in #9124.

The issue let me think that no one runs `make clean`, so another option is just to remove it.

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes

fixes #12227


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
