### PR TITLE
Deploy: Use LoadBalancer for KIND.

### DIFF
--- a/hack/manifest-templates/provider/kind/values.yaml
+++ b/hack/manifest-templates/provider/kind/values.yaml
@@ -8,11 +8,9 @@ controller:
     enabled: true
   terminationGracePeriodSeconds: 0
   service:
-    type: NodePort
+    type: LoadBalancer
   watchIngressWithoutClass: true
 
-  nodeSelector:
-    ingress-ready: "true"
   tolerations:
     - key: "node-role.kubernetes.io/master"
       operator: "Equal"


### PR DESCRIPTION
KIND supports LoadBalancers services with Cloud Provider KIND, that avoids to have to use portmaps and node selectors, providing a much better user experience


## What this PR does / why we need it:

It provides the same user experience in KIND as in a cloud provider

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation only

## Which issue/s this PR fixes


fixes #12231


## How Has This Been Tested?

manually

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
