### PR TITLE
Chart: Implement ServiceMonitor limits.

### DIFF
--- a/charts/ingress-nginx/README.md
+++ b/charts/ingress-nginx/README.md
@@ -399,12 +399,17 @@ metadata:
 | controller.metrics.serviceMonitor.additionalLabels | object | `{}` |  |
 | controller.metrics.serviceMonitor.annotations | object | `{}` | Annotations to be added to the ServiceMonitor. |
 | controller.metrics.serviceMonitor.enabled | bool | `false` |  |
+| controller.metrics.serviceMonitor.labelLimit | int | `0` | Per-scrape limit on number of labels that will be accepted for a sample. |
+| controller.metrics.serviceMonitor.labelNameLengthLimit | int | `0` | Per-scrape limit on length of labels name that will be accepted for a sample. |
+| controller.metrics.serviceMonitor.labelValueLengthLimit | int | `0` | Per-scrape limit on length of labels value that will be accepted for a sample. |
 | controller.metrics.serviceMonitor.metricRelabelings | list | `[]` |  |
 | controller.metrics.serviceMonitor.namespace | string | `""` |  |
 | controller.metrics.serviceMonitor.namespaceSelector | object | `{}` |  |
 | controller.metrics.serviceMonitor.relabelings | list | `[]` |  |
+| controller.metrics.serviceMonitor.sampleLimit | int | `0` | Defines a per-scrape limit on the number of scraped samples that will be accepted. |
 | controller.metrics.serviceMonitor.scrapeInterval | string | `"30s"` |  |
 | controller.metrics.serviceMonitor.targetLabels | list | `[]` |  |
+| controller.metrics.serviceMonitor.targetLimit | int | `0` | Defines a limit on the number of scraped targets that will be accepted. |
 | controller.minAvailable | int | `1` | Minimum available pods set in PodDisruptionBudget. Define either 'minAvailable' or 'maxUnavailable', never both. |
 | controller.minReadySeconds | int | `0` | `minReadySeconds` to avoid killing pods before we are ready # |
 | controller.name | string | `"controller"` |  |

--- a/charts/ingress-nginx/templates/controller-servicemonitor.yaml
+++ b/charts/ingress-nginx/templates/controller-servicemonitor.yaml
@@ -47,4 +47,19 @@ spec:
   {{- if .Values.controller.metrics.serviceMonitor.targetLabels }}
   targetLabels: {{ toYaml .Values.controller.metrics.serviceMonitor.targetLabels | nindent 2 }}
   {{- end }}
+  {{- if .Values.controller.metrics.serviceMonitor.labelLimit }}
+  labelLimit: {{ .Values.controller.metrics.serviceMonitor.labelLimit }}
+  {{- end }}
+  {{- if .Values.controller.metrics.serviceMonitor.labelNameLengthLimit }}
+  labelNameLengthLimit: {{ .Values.controller.metrics.serviceMonitor.labelNameLengthLimit }}
+  {{- end }}
+  {{- if .Values.controller.metrics.serviceMonitor.labelValueLengthLimit }}
+  labelValueLengthLimit: {{ .Values.controller.metrics.serviceMonitor.labelValueLengthLimit }}
+  {{- end }}
+  {{- if .Values.controller.metrics.serviceMonitor.sampleLimit }}
+  sampleLimit: {{ .Values.controller.metrics.serviceMonitor.sampleLimit }}
+  {{- end }}
+  {{- if .Values.controller.metrics.serviceMonitor.targetLimit }}
+  targetLimit: {{ .Values.controller.metrics.serviceMonitor.targetLimit }}
+  {{- end }}
 {{- end }}

--- a/charts/ingress-nginx/tests/controller-servicemonitor_test.yaml
+++ b/charts/ingress-nginx/tests/controller-servicemonitor_test.yaml
@@ -27,3 +27,53 @@ tests:
           path: metadata.annotations
           value:
             my-little-annotation: test-value
+
+  - it: should create a ServiceMonitor with `labelLimit` if `controller.metrics.serviceMonitor.labelLimit` is set
+    set:
+      controller.metrics.enabled: true
+      controller.metrics.serviceMonitor.enabled: true
+      controller.metrics.serviceMonitor.labelLimit: 20
+    asserts:
+      - equal:
+          path: spec.labelLimit
+          value: 20
+
+  - it: should create a ServiceMonitor with `labelNameLengthLimit` if `controller.metrics.serviceMonitor.labelNameLengthLimit` is set
+    set:
+      controller.metrics.enabled: true
+      controller.metrics.serviceMonitor.enabled: true
+      controller.metrics.serviceMonitor.labelNameLengthLimit: 50
+    asserts:
+      - equal:
+          path: spec.labelNameLengthLimit
+          value: 50
+
+  - it: should create a ServiceMonitor with `labelValueLengthLimit` if `controller.metrics.serviceMonitor.labelValueLengthLimit` is set
+    set:
+      controller.metrics.enabled: true
+      controller.metrics.serviceMonitor.enabled: true
+      controller.metrics.serviceMonitor.labelValueLengthLimit: 50
+    asserts:
+      - equal:
+          path: spec.labelValueLengthLimit
+          value: 50
+
+  - it: should create a ServiceMonitor with `sampleLimit` if `controller.metrics.serviceMonitor.sampleLimit` is set
+    set:
+      controller.metrics.enabled: true
+      controller.metrics.serviceMonitor.enabled: true
+      controller.metrics.serviceMonitor.sampleLimit: 5000
+    asserts:
+      - equal:
+          path: spec.sampleLimit
+          value: 5000
+
+  - it: should create a ServiceMonitor with `targetLimit` if `controller.metrics.serviceMonitor.targetLimit` is set
+    set:
+      controller.metrics.enabled: true
+      controller.metrics.serviceMonitor.enabled: true
+      controller.metrics.serviceMonitor.targetLimit: 100
+    asserts:
+      - equal:
+          path: spec.targetLimit
+          value: 100

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -882,6 +882,16 @@ controller:
       targetLabels: []
       relabelings: []
       metricRelabelings: []
+      # -- Per-scrape limit on number of labels that will be accepted for a sample.
+      labelLimit: 0
+      # -- Per-scrape limit on length of labels name that will be accepted for a sample.
+      labelNameLengthLimit: 0
+      # -- Per-scrape limit on length of labels value that will be accepted for a sample.
+      labelValueLengthLimit: 0
+      # -- Defines a per-scrape limit on the number of scraped samples that will be accepted.
+      sampleLimit: 0
+      # -- Defines a limit on the number of scraped targets that will be accepted.
+      targetLimit: 0
     prometheusRule:
       enabled: false
       additionalLabels: {}


### PR DESCRIPTION
- Introduced proper serviceMonitor configuration in helm chart: added new parameters labelLimit, labelNameLengthLimit, labelValueLengthLimit, sampleLimit, and targetLimit.

<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
<!--- Please make sure you title is descriptive, it is used in the Release notes to let others know what it does ---> 

## What this PR does / why we need it:
These parameters allow users to tailor monitoring configurations to fit specific needs and compliance requirements.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
fixes #12248 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
