### PR TITLE
CI: Fix chart testing.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -256,7 +256,7 @@ jobs:
           git diff --exit-code charts/ingress-nginx/README.md
 
       - name: Run tests
-        run: helm unittest charts/ingress-nginx -f "tests/**/*_test.yaml"
+        run: helm unittest charts/ingress-nginx --file "tests/**/*_test.yaml"
 
   chart-test:
     name: Chart / Test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -256,7 +256,7 @@ jobs:
           git diff --exit-code charts/ingress-nginx/README.md
 
       - name: Run tests
-        run: helm unittest charts/ingress-nginx
+        run: helm unittest charts/ingress-nginx -f "tests/**/*_test.yaml"
 
   chart-test:
     name: Chart / Test

--- a/charts/ingress-nginx/tests/admission-webhooks/job-patch/serviceaccount_test.yaml
+++ b/charts/ingress-nginx/tests/admission-webhooks/job-patch/serviceaccount_test.yaml
@@ -20,7 +20,7 @@ tests:
           of: ServiceAccount
       - equal:
           path: metadata.name
-          value: ingress-nginx-admission
+          value: RELEASE-NAME-ingress-nginx-admission
 
   - it: should create a ServiceAccount with specified name if `controller.admissionWebhooks.patch.serviceAccount.name` is set
     set:

--- a/charts/ingress-nginx/tests/admission-webhooks/validating-webhook_test.yaml
+++ b/charts/ingress-nginx/tests/admission-webhooks/validating-webhook_test.yaml
@@ -20,7 +20,7 @@ tests:
           of: ValidatingWebhookConfiguration
       - equal:
           path: metadata.name
-          value: RELEASE-NAME-admission
+          value: RELEASE-NAME-ingress-nginx-admission
 
   - it: should create a ValidatingWebhookConfiguration with a custom port if `controller.admissionWebhooks.service.servicePort` is set
     set:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
<!--- Please make sure you title is descriptive, it is used in the Release notes to let others know what it does ---> 

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

As discussed in https://github.com/kubernetes/ingress-nginx/pull/12247, currently the CI runs `helm unittest charts/ingress-nginx`, where the default tests path for "helm unittest" command is "tests/*_test.yaml", which won't catch subdirectories.

This PR fixes the command to include any tests under subdirectories, and fixes 2 existing tests that have been broken but missed due to being in a sub-directory.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local run of `helm unittest charts/ingress-nginx -f "tests/**/*_test.yaml"`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.
