### PR TITLE
Chart: Add ServiceAccount tests.

### DIFF
--- a/charts/ingress-nginx/tests/controller-serviceaccount_test.yaml
+++ b/charts/ingress-nginx/tests/controller-serviceaccount_test.yaml
@@ -1,0 +1,47 @@
+suite: Controller > ServiceAccount
+templates:
+  - controller-serviceaccount.yaml
+
+tests:
+  - it: should not create a ServiceAccount if `serviceAccount.create` is false
+    set:
+      serviceAccount.create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create a ServiceAccount if `serviceAccount.create` is true
+    set:
+      serviceAccount.create: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-ingress-nginx
+
+  - it: should create a ServiceAccount with specified name if `serviceAccount.name` is set
+    set:
+      serviceAccount.name: ingress-nginx-admission-test-sa
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: ingress-nginx-admission-test-sa
+
+  - it: should create a ServiceAccount with token auto-mounting disabled if `serviceAccount.automountServiceAccountToken` is false
+    set:
+      serviceAccount.automountServiceAccountToken: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: automountServiceAccountToken
+          value: false

--- a/charts/ingress-nginx/tests/default-backend-serviceaccount_test.yaml
+++ b/charts/ingress-nginx/tests/default-backend-serviceaccount_test.yaml
@@ -1,0 +1,51 @@
+suite: Default Backend > ServiceAccount
+templates:
+  - default-backend-serviceaccount.yaml
+
+tests:
+  - it: should not create a ServiceAccount if `defaultBackend.serviceAccount.create` is false
+    set:
+      defaultBackend.enabled: true
+      defaultBackend.serviceAccount.create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create a ServiceAccount if `defaultBackend.serviceAccount.create` is true
+    set:
+      defaultBackend.enabled: true
+      defaultBackend.serviceAccount.create: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-ingress-nginx-backend
+
+  - it: should create a ServiceAccount with specified name if `defaultBackend.serviceAccount.name` is set
+    set:
+      defaultBackend.enabled: true
+      defaultBackend.serviceAccount.name: ingress-nginx-admission-test-sa
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: ingress-nginx-admission-test-sa
+
+  - it: should create a ServiceAccount with token auto-mounting disabled if `defaultBackend.serviceAccount.automountServiceAccountToken` is false
+    set:
+      defaultBackend.enabled: true
+      defaultBackend.serviceAccount.automountServiceAccountToken: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: automountServiceAccountToken
+          value: false


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
<!--- Please make sure you title is descriptive, it is used in the Release notes to let others know what it does ---> 

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Following up on the discussion under https://github.com/kubernetes/ingress-nginx/pull/12247, this PR adds helm unit-tests for controller+default-backend serviceAccount

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->
serviceAccounts for the controller and the default-backend were not being tested

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Running `helm unittest charts/ingress-nginx -f "tests/**/*_test.yaml"`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [x] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.
