### PR TITLE
Docs: fix limit-rate-after references

### DIFF
--- a/docs/user-guide/nginx-configuration/configmap.md
+++ b/docs/user-guide/nginx-configuration/configmap.md
@@ -1173,6 +1173,9 @@ _References:_
 
 Sets the initial amount after which the further transmission of a response to a client will be rate limited.
 
+_References:_
+[https://nginx.org/en/docs/http/ngx_http_core_module.html#limit_rate_after](https://nginx.org/en/docs/http/ngx_http_core_module.html#limit_rate_after)
+
 ## lua-shared-dicts
 
 Customize default Lua shared dictionaries or define more. You can use the following syntax to do so:
@@ -1193,9 +1196,6 @@ You can optionally set a size unit to allow for kilobyte-granularity. Allowed un
 ```
 lua-shared-dicts: "certificate_data: 100, my_custom_plugin: 512k"
 ```
-
-_References:_
-[https://nginx.org/en/docs/http/ngx_http_core_module.html#limit_rate_after](https://nginx.org/en/docs/http/ngx_http_core_module.html#limit_rate_after)
 
 ## http-redirect-code
 


### PR DESCRIPTION
The reference is currently under wrong option.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation only

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
