### PR TITLE
Config: Fix panic on invalid `lua-shared-dict`.

### DIFF
--- a/internal/ingress/controller/template/configmap.go
+++ b/internal/ingress/controller/template/configmap.go
@@ -125,8 +125,11 @@ func ReadConfig(src map[string]string) config.Configuration {
 		delete(conf, luaSharedDictsKey)
 		lsd := splitAndTrimSpace(val, ",")
 		for _, v := range lsd {
-			v = strings.ReplaceAll(v, " ", "")
-			results := strings.SplitN(v, ":", 2)
+			results := strings.SplitN(strings.ReplaceAll(v, " ", ""), ":", 2)
+			if len(results) != 2 {
+				klog.Errorf("Ignoring poorly formatted Lua dictionary %v", v)
+				continue
+			}
 			dictName := results[0]
 			size := dictStrToKb(results[1])
 			if size < 0 {

--- a/internal/ingress/controller/template/configmap_test.go
+++ b/internal/ingress/controller/template/configmap_test.go
@@ -391,6 +391,11 @@ func TestLuaSharedDictsParsing(t *testing.T) {
 			expect: map[string]int{"configuration_data": 10240, "my_random_dict": 15360, "another_example": 2048},
 		},
 		{
+			name:   "invalid format",
+			entry:  map[string]string{"lua-shared-dicts": "mydict: 10, invalid_dict 100"},
+			expect: map[string]int{"mydict": 10240},
+		},
+		{
 			name:   "invalid size value should be ignored",
 			entry:  map[string]string{"lua-shared-dicts": "mydict: 10, invalid_dict: 1a, bad_mb_dict:10mb"},
 			expect: map[string]int{"mydict": 10240},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
<!--- Please make sure you title is descriptive, it is used in the Release notes to let others know what it does ---> 

## What this PR does / why we need it:

https://github.com/kubernetes/ingress-nginx/blob/440575e151b24ecac5cfdeb4cc1dd1483948778b/internal/ingress/controller/template/configmap.go#L131 
The line above causes a panic if a colon is missing in the dict definition (e.g. `certificate_data 100` instead of `certificate_data: 100`) which leads to a `CrashLoopBackOff`. This is consistent with how other misconfigurations, such as invalid size and number of dicts, are handled.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [x] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
