### PR TITLE
Docs: Add CPU usage note for `--metrics-per-undefined-host`.

### DIFF
--- a/docs/user-guide/monitoring.md
+++ b/docs/user-guide/monitoring.md
@@ -168,7 +168,7 @@ According to the above example, this URL will be http://10.192.0.3:31086
 
   - By default request metrics are labeled with the hostname. When you have a wildcard domain ingress, then there will be no metrics for that ingress (to prevent the metrics from exploding in cardinality). To get metrics in this case you have two options:
     - Run the ingress controller with `--metrics-per-host=false`. You will lose labeling by hostname, but still have labeling by ingress.
-    - Run the ingress controller with `--metrics-per-undefined-host=true --metrics-per-host=true`. You will get labeling by hostname even if the hostname is not explicitly defined on an ingress. Be warned that cardinality could explode due to many hostnames.
+    - Run the ingress controller with `--metrics-per-undefined-host=true --metrics-per-host=true`. You will get labeling by hostname even if the hostname is not explicitly defined on an ingress. Be warned that cardinality could explode due to many hostnames and CPU usage could also increase.
 
 ### Grafana dashboard using ingress resource
   - If you want to expose the dashboard for grafana using an ingress resource, then you can :


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
<!--- Please make sure you title is descriptive, it is used in the Release notes to let others know what it does ---> 

## What this PR does / why we need it:

While using `--metrics-per-undefined-host=true` with high cardinality and high request
rate we have also noticed that CPU usage has increased a noticeable amount. This PR
updates the docs on the flag to mention CPU usage increase as a possible side effect.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation only

## Which issue/s this PR fixes
No issue - docs update.

## How Has This Been Tested?
CPU usage discovered by running the flag with high cardinality of hostnames and requests.

## Checklist:
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [X] All new and existing tests passed.

No tests since it's a doc change.