### PR TITLE
Bump golangci-lint on actions and disable deprecated linters

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -30,4 +30,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # v6.1.1
         with:
-          version: v1.56
+          version: v1.62
+          only-new-issues: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,7 +22,6 @@ linters:
     - errcheck
     - errchkjson
     - errname
-    - execinquery
     - ginkgolinter
     - gocheckcompilerdirectives
     - goconst


### PR DESCRIPTION

## What this PR does / why we need it:
Bumps Golangci-lint and disable deprecated linters

