### PR TITLE
Allow CORS `Access-Control-Allow-Origin: null`

### DIFF
--- a/internal/ingress/annotations/cors/main.go
+++ b/internal/ingress/annotations/cors/main.go
@@ -40,12 +40,12 @@ var (
 	// that could cause the Response to contain some internal value/variable (like returning $pid, $upstream_addr, etc)
 	// Origin must contain a http/s Origin (including or not the port) or the value '*'
 	// This Regex is composed of the following:
-	// * Sets a group that can be (https?://)?*?.something.com:port?
+	// * Sets a group that can be (https?://)?*?.something.com:port? OR null
 	// * Allows this to be repeated as much as possible, and separated by comma
 	// Otherwise it should be '*'
-	corsOriginRegexValidator = regexp.MustCompile(`^(((([a-z]+://)?(\*\.)?[A-Za-z0-9\-.]*(:\d+)?,?)+)|\*)?$`)
+	corsOriginRegexValidator = regexp.MustCompile(`^((((([a-z]+://)?(\*\.)?[A-Za-z0-9\-.]*(:\d+)?,?)|null)+)|\*)?$`)
 	// corsOriginRegex defines the regex for validation inside Parse
-	corsOriginRegex = regexp.MustCompile(`^([a-z]+://(\*\.)?[A-Za-z0-9\-.]*(:\d+)?|\*)?$`)
+	corsOriginRegex = regexp.MustCompile(`^([a-z]+://(\*\.)?[A-Za-z0-9\-.]*(:\d+)?|\*|null)?$`)
 	// Method must contain valid methods list (PUT, GET, POST, BLA)
 	// May contain or not spaces between each verb
 	corsMethodsRegex = regexp.MustCompile(`^([A-Za-z]+,?\s?)+$`)
@@ -78,7 +78,7 @@ var corsAnnotation = parser.Annotation{
 			Scope:     parser.AnnotationScopeIngress,
 			Risk:      parser.AnnotationRiskMedium,
 			Documentation: `This annotation controls what's the accepted Origin for CORS.
-			This is a multi-valued field, separated by ','. It must follow this format: protocol://origin-site.com or protocol://origin-site.com:port
+			This is a multi-valued field, separated by ','. It must follow this format: protocol://origin-site.com, protocol://origin-site.com:port, null, or *.
 			It also supports single level wildcard subdomains and follows this format: https://*.foo.bar, http://*.bar.foo:8080 or myprotocol://*.abc.bar.foo:9000
 			Protocol can be any lowercase string, like http, https, or mycustomprotocol.`,
 		},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
<!--- Please make sure you title is descriptive, it is used in the Release notes to let others know what it does ---> 

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Right now, we are allowing to set the CORS header `Access-Control-Allow-Origin` through the annotation `nginx.ingress.kubernetes.io/cors-allow-origin` either to a valid set of origins, or to `*` (wildcard). However, the Fetch API standard that defines the CORS protocol [specifies](https://fetch.spec.whatwg.org/#http-access-control-allow-origin) that a value `null` should be accepted as well. This PR adds this new lacking functionality along with its corresponding tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->
Fixes #8983 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Apart from adding its corresponding unit test, this has been tested with the following use-cases:
- Standalone `null` value in the `cors-allow-origin` annotation (happy path)
- Along with a different domain name origin (both origins work as expected)
- Between two different domain name origins in the annotation (all origins work as expected)
- Both a standalone domain name origin and a `*` wildcard (ensuring no breaking changes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [x] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.
