### PR TITLE
NGINX: Migrate auth cache key to NJS

### DIFF
--- a/images/nginx/rootfs/build.sh
+++ b/images/nginx/rootfs/build.sh
@@ -106,6 +106,9 @@ export OPENTELEMETRY_CPP_VERSION="v1.11.0"
 # Check on https://github.com/open-telemetry/opentelemetry-proto
 export OPENTELEMETRY_PROTO_VERSION="v1.1.0"
 
+# http://hg.nginx.org/njs
+export NGINX_NJS_VERSION="0.8.4"
+
 export BUILD_PATH=/tmp/build
 
 ARCH=$(uname -m)
@@ -275,6 +278,9 @@ get_src efb767487ea3f6031577b9b224467ddbda2ad51a41c5867a47582d4ad85d609e \
 
 get_src d74f86ada2329016068bc5a243268f1f555edd620b6a7d6ce89295e7d6cf18da \
         "https://github.com/microsoft/mimalloc/archive/${MIMALOC_VERSION}.tar.gz" "mimalloc"
+
+get_src 8191bff8491af9169a92e30e383ef8614717b0c6d40913d83b95051031e92321 \
+        "http://hg.nginx.org/njs/archive/${NGINX_NJS_VERSION}.tar.gz" "njs"
 
 # improve compilation times
 CORES=$(($(grep -c ^processor /proc/cpuinfo) - 1))
@@ -481,7 +487,8 @@ WITH_MODULES=" \
   --add-dynamic-module=$BUILD_PATH/nginx-http-auth-digest \
   --add-dynamic-module=$BUILD_PATH/ModSecurity-nginx \
   --add-dynamic-module=$BUILD_PATH/ngx_http_geoip2_module \
-  --add-dynamic-module=$BUILD_PATH/ngx_brotli"
+  --add-dynamic-module=$BUILD_PATH/ngx_brotli \
+  --add-dynamic-module=$BUILD_PATH/njs/nginx"
 
 ./configure \
   --prefix=/usr/local/nginx \

--- a/rootfs/etc/nginx/js/nginx/ngx_conf_rewrite_auth.js
+++ b/rootfs/etc/nginx/js/nginx/ngx_conf_rewrite_auth.js
@@ -1,0 +1,7 @@
+const crypto = require('crypto');
+
+function cache_key(req) {
+    return crypto.createHash('sha1').update(req.variables.tmp_cache_key).digest('base64');
+}
+
+export default { cache_key };

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -74,6 +74,10 @@ http {
 
     init_worker_by_lua_file /etc/nginx/lua/ngx_conf_init_worker.lua;
 
+    js_import /etc/nginx/js/nginx/ngx_conf_rewrite_auth.js;
+
+    js_set $njs_cache_key ngx_conf_rewrite_auth.cache_key;
+
     {{/* Enable the real_ip module only if we use either X-Forwarded headers or Proxy Protocol. */}}
     {{/* we use the value of the real IP for the geo_ip module */}}
     {{ if or (or $cfg.UseForwardedHeaders $cfg.UseProxyProtocol) $cfg.EnableRealIP }}
@@ -988,9 +992,6 @@ stream {
 
             {{ if $externalAuth.AuthCacheKey }}
             set $tmp_cache_key '{{ $server.Hostname }}{{ $authPath }}{{ $externalAuth.AuthCacheKey }}';
-            set $cache_key '';
-
-            rewrite_by_lua_file /etc/nginx/lua/nginx/ngx_conf_rewrite_auth.lua;
 
             proxy_cache auth_cache;
 
@@ -998,7 +999,7 @@ stream {
             proxy_cache_valid {{ $dur }};
             {{- end }}
 
-            proxy_cache_key "$cache_key";
+            proxy_cache_key "$njs_cache_key";
             {{ end }}
 
             # ngx_auth_request module overrides variables in the parent request,

--- a/test/e2e/annotations/auth.go
+++ b/test/e2e/annotations/auth.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"regexp"
 	"strings"
 
 	"golang.org/x/crypto/bcrypt"
@@ -341,11 +340,9 @@ var _ = framework.DescribeAnnotation("auth-*", func() {
 		ing := framework.NewSingleIngress(host, "/", host, f.Namespace, framework.EchoService, 80, annotations)
 		f.EnsureIngress(ing)
 
-		cacheRegex := regexp.MustCompile(`\$cache_key.*foo`)
-
 		f.WaitForNginxServer(host,
 			func(server string) bool {
-				return cacheRegex.MatchString(server) &&
+				return strings.Contains(server, "proxy_cache_key \"$njs_cache_key\";") &&
 					strings.Contains(server, `proxy_cache_valid 200 202 401 30m;`)
 			})
 	})

--- a/test/e2e/settings/global_external_auth.go
+++ b/test/e2e/settings/global_external_auth.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"regexp"
 	"strings"
 
 	"github.com/onsi/ginkgo/v2"
@@ -169,11 +168,9 @@ var _ = framework.DescribeSetting("[Security] global-auth-url", func() {
 				globalExternalAuthURLSetting:           globalExternalAuthURL,
 			})
 
-			cacheRegex := regexp.MustCompile(`\$cache_key.*foo`)
-
 			f.WaitForNginxServer(host,
 				func(server string) bool {
-					return cacheRegex.MatchString(server) &&
+					return strings.Contains(server, "proxy_cache_key \"$njs_cache_key\";") &&
 						strings.Contains(server, `proxy_cache_valid 200 201 401 30m;`)
 				})
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
<!--- Please make sure you title is descriptive, it is used in the Release notes to let others know what it does ---> 

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Migrate the Lua scripting code for calculating the auth cache key to NJS, maintaining the same behavior.

Depends on #12345 (change starts from that branch)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->
Part of #12383

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The new implementation has been tested manually to verify that the result it produces matches the one in Lua, as well as passing the e2e test suite

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.
