### PR TITLE
Switch default OTel sampler to TraceIdRatioBased and fix various doc inconsistencies

### DIFF
--- a/docs/user-guide/nginx-configuration/configmap.md
+++ b/docs/user-guide/nginx-configuration/configmap.md
@@ -160,12 +160,12 @@ The following table shows a configuration option's name, type, and the default v
 | [opentelemetry-config](#/etc/nginx/opentelemetry.toml)                          | string       | "/etc/nginx/opentelemetry.toml"                                                                                                                                                                                                                                                                                                                              |                                                                                     |
 | [otlp-collector-host](#otlp-collector-host)                                     | string       | ""                                                                                                                                                                                                                                                                                                                                                           |                                                                                     |
 | [otlp-collector-port](#otlp-collector-port)                                     | int          | 4317                                                                                                                                                                                                                                                                                                                                                         |                                                                                     |
-| [otel-max-queuesize](#otel-max-queuesize)                                       | int          |                                                                                                                                                                                                                                                                                                                                                              |                                                                                     |
-| [otel-schedule-delay-millis](#otel-schedule-delay-millis)                       | int          |                                                                                                                                                                                                                                                                                                                                                              |                                                                                     |
-| [otel-max-export-batch-size](#otel-max-export-batch-size)                       | int          |                                                                                                                                                                                                                                                                                                                                                              |                                                                                     |
+| [otel-max-queuesize](#otel-max-queuesize)                                       | int          | 2048                                                                                                                                                                                                                                                                                                                                                         |                                                                                     |
+| [otel-schedule-delay-millis](#otel-schedule-delay-millis)                       | int          | 5000                                                                                                                                                                                                                                                                                                                                                         |                                                                                     |
+| [otel-max-export-batch-size](#otel-max-export-batch-size)                       | int          | 512                                                                                                                                                                                                                                                                                                                                                          |                                                                                     |
 | [otel-service-name](#otel-service-name)                                         | string       | "nginx"                                                                                                                                                                                                                                                                                                                                                      |                                                                                     |
-| [otel-sampler](#otel-sampler)                                                   | string       | "AlwaysOff"                                                                                                                                                                                                                                                                                                                                                  |                                                                                     |
-| [otel-sampler-parent-based](#otel-sampler-parent-based)                         | bool         | "false"                                                                                                                                                                                                                                                                                                                                                      |                                                                                     |
+| [otel-sampler](#otel-sampler)                                                   | string       | "TraceIdRatioBased"                                                                                                                                                                                                                                                                                                                                          |                                                                                     |
+| [otel-sampler-parent-based](#otel-sampler-parent-based)                         | bool         | "true"                                                                                                                                                                                                                                                                                                                                                       |                                                                                     |
 | [otel-sampler-ratio](#otel-sampler-ratio)                                       | float        | 0.01                                                                                                                                                                                                                                                                                                                                                         |                                                                                     |
 | [main-snippet](#main-snippet)                                                   | string       | ""                                                                                                                                                                                                                                                                                                                                                           |                                                                                     |
 | [http-snippet](#http-snippet)                                                   | string       | ""                                                                                                                                                                                                                                                                                                                                                           |                                                                                     |
@@ -1034,12 +1034,25 @@ Specifies the port to use when uploading traces. _**default:**_ 4317
 
 Specifies the service name to use for any traces created. _**default:**_ nginx
 
-##  opentelemetry-trust-incoming-span: "true"
+## opentelemetry-trust-incoming-span
+
 Enables or disables using spans from incoming requests as parent for created ones. _**default:**_ true
 
-##  otel-sampler-parent-based
+## otel-max-queuesize
 
-Uses sampler implementation which by default will take a sample if parent Activity is sampled. _**default:**_ false
+The maximum queue size. After the size is reached data are dropped. _**default:**_ 2048
+
+## otel-schedule-delay-millis
+
+The delay interval in milliseconds between two consecutive exports. _**default:**_ 5000
+
+## otel-max-export-batch-size
+
+The maximum batch size of every export. It must be smaller or equal to [otel-max-queuesize](#otel-max-queuesize). _**default:**_ 512
+
+## otel-sampler-parent-based
+
+Uses sampler implementation which by default will take a sample if parent Activity is sampled. _**default:**_ true
 
 ## otel-sampler-ratio
 
@@ -1047,7 +1060,7 @@ Specifies sample rate for any traces created. _**default:**_ 0.01
 
 ## otel-sampler
 
-Specifies the sampler to be used when sampling traces. The available samplers are: AlwaysOff, AlwaysOn, TraceIdRatioBased, remote. _**default:**_ AlwaysOff
+Specifies the sampler to be used when sampling traces. The available samplers are: AlwaysOff, AlwaysOn, TraceIdRatioBased. _**default:**_ TraceIdRatioBased
 
 ## main-snippet
 

--- a/docs/user-guide/third-party-addons/opentelemetry.md
+++ b/docs/user-guide/third-party-addons/opentelemetry.md
@@ -60,26 +60,23 @@ otlp-collector-port
 # specifies the service name to use for any traces created, Default: nginx
 otel-service-name
 
-# The maximum queue size. After the size is reached data are dropped.
+# The maximum queue size. After the size is reached data are dropped, Default: 2048
 otel-max-queuesize
 
-# The delay interval in milliseconds between two consecutive exports.
+# The delay interval in milliseconds between two consecutive exports, Default: 5000
 otel-schedule-delay-millis
 
-# How long the export can run before it is cancelled.
-otel-schedule-delay-millis
-
-# The maximum batch size of every export. It must be smaller or equal to maxQueueSize.
+# The maximum batch size of every export. It must be smaller or equal to otel-max-queuesize, Default: 512
 otel-max-export-batch-size
 
 # specifies sample rate for any traces created, Default: 0.01
 otel-sampler-ratio
 
 # specifies the sampler to be used when sampling traces.
-# The available samplers are: AlwaysOn,  AlwaysOff, TraceIdRatioBased, Default: AlwaysOff
+# The available samplers are: AlwaysOn, AlwaysOff, TraceIdRatioBased, Default: TraceIdRatioBased
 otel-sampler
 
-# Uses sampler implementation which by default will take a sample if parent Activity is sampled, Default: false
+# Uses sampler implementation which by default will take a sample if parent Activity is sampled, Default: true
 otel-sampler-parent-based
 ```
 
@@ -164,9 +161,9 @@ To install the example and collectors run:
         otel-schedule-delay-millis: "5000"
         otel-max-export-batch-size: "512"
         otel-service-name: "nginx-proxy" # Opentelemetry resource name
-        otel-sampler: "AlwaysOn" # Also: AlwaysOff, TraceIdRatioBased
-        otel-sampler-ratio: "1.0"
-        otel-sampler-parent-based: "false"
+        otel-sampler: "TraceIdRatioBased" # Also: AlwaysOn, AlwaysOff
+        otel-sampler-ratio: "0.01"
+        otel-sampler-parent-based: "true"
       metadata:
         name: ingress-nginx-controller
         namespace: ingress-nginx

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -609,7 +609,7 @@ type Configuration struct {
 	OtelServiceName string `json:"otel-service-name"`
 
 	// OtelSampler specifies the sampler to use for any traces created
-	// Default: AlwaysOn
+	// Default: TraceIdRatioBased
 	OtelSampler string `json:"otel-sampler"`
 
 	// OtelSamplerRatio specifies the sampler ratio to use for any traces created
@@ -620,15 +620,15 @@ type Configuration struct {
 	// Default: true
 	OtelSamplerParentBased bool `json:"otel-sampler-parent-based"`
 
-	// MaxQueueSize specifies the max queue size for uploading traces
+	// OtelMaxQueueSize specifies the max queue size for uploading traces
 	// Default: 2048
 	OtelMaxQueueSize int32 `json:"otel-max-queuesize"`
 
-	// ScheduleDelayMillis specifies the max delay between uploading traces
+	// OtelScheduleDelayMillis specifies the max delay between uploading traces
 	// Default: 5000
 	OtelScheduleDelayMillis int32 `json:"otel-schedule-delay-millis"`
 
-	// MaxExportBatchSize specifies the max export batch size to used when uploading traces
+	// OtelMaxExportBatchSize specifies the max export batch size to used when uploading traces
 	// Default: 512
 	OtelMaxExportBatchSize int32 `json:"otel-max-export-batch-size"`
 
@@ -886,7 +886,7 @@ func NewDefault() Configuration {
 		OpentelemetryConfig:            "/etc/ingress-controller/telemetry/opentelemetry.toml",
 		OtlpCollectorPort:              "4317",
 		OtelServiceName:                "nginx",
-		OtelSampler:                    "AlwaysOn",
+		OtelSampler:                    "TraceIdRatioBased",
 		OtelSamplerRatio:               0.01,
 		OtelSamplerParentBased:         true,
 		OtelScheduleDelayMillis:        5000,

--- a/internal/ingress/controller/nginx.go
+++ b/internal/ingress/controller/nginx.go
@@ -1063,7 +1063,7 @@ max_export_batch_size = {{ .OtelMaxExportBatchSize }}
 name = "{{ .OtelServiceName }}" # Opentelemetry resource name
 
 [sampler]
-name = "{{ .OtelSampler }}" # Also: AlwaysOff, TraceIdRatioBased
+name = "{{ .OtelSampler }}"
 ratio = {{ .OtelSamplerRatio }}
 parent_based = {{ .OtelSamplerParentBased }}
 `


### PR DESCRIPTION
## What this PR does / why we need it:
* switches the default OTel sampler from `AlwaysOn` to `TraceIdRatioBased`, which is a more sane default in regards to load
  * solves #12443
* fixes various documentation inconsitencies
  * solves #12443 and #12432

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation

## Which issue/s this PR fixes
fixes #12443
fixes #12432

## How Has This Been Tested?
Checked that the default generated config files contains the expected configuration.

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.
