### PR TITLE
Controller: Use Protocol Buffers for API access.

### DIFF
--- a/cmd/nginx/main.go
+++ b/cmd/nginx/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kuberuntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	discovery "k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/kubernetes"
@@ -201,6 +202,8 @@ func createApiserverClient(apiserverHost, rootCAFile, kubeConfig string) (*kuber
 
 		cfg.TLSClientConfig = tlsClientConfig
 	}
+
+	cfg.ContentType = kuberuntime.ContentTypeProtobuf
 
 	klog.InfoS("Creating API client", "host", cfg.Host)
 

--- a/cmd/plugin/request/request.go
+++ b/cmd/plugin/request/request.go
@@ -25,6 +25,7 @@ import (
 	discoveryv1 "k8s.io/api/discovery/v1"
 	networking "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	appsv1client "k8s.io/client-go/kubernetes/typed/apps/v1"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -97,6 +98,7 @@ func GetDeployments(flags *genericclioptions.ConfigFlags, namespace string) ([]a
 	if err != nil {
 		return make([]appsv1.Deployment, 0), err
 	}
+	rawConfig.ContentType = runtime.ContentTypeProtobuf
 
 	api, err := appsv1client.NewForConfig(rawConfig)
 	if err != nil {
@@ -117,6 +119,7 @@ func GetIngressDefinitions(flags *genericclioptions.ConfigFlags, namespace strin
 	if err != nil {
 		return make([]networking.Ingress, 0), err
 	}
+	rawConfig.ContentType = runtime.ContentTypeProtobuf
 
 	api, err := typednetworking.NewForConfig(rawConfig)
 	if err != nil {
@@ -193,6 +196,7 @@ func getEndpointSlices(flags *genericclioptions.ConfigFlags, namespace string) (
 	if err != nil {
 		return nil, err
 	}
+	rawConfig.ContentType = runtime.ContentTypeProtobuf
 
 	api, err := discoveryv1client.NewForConfig(rawConfig)
 	if err != nil {
@@ -259,6 +263,7 @@ func getPods(flags *genericclioptions.ConfigFlags) ([]apiv1.Pod, error) {
 	if err != nil {
 		return make([]apiv1.Pod, 0), err
 	}
+	rawConfig.ContentType = runtime.ContentTypeProtobuf
 
 	api, err := corev1.NewForConfig(rawConfig)
 	if err != nil {
@@ -280,6 +285,7 @@ func getLabeledPods(flags *genericclioptions.ConfigFlags, label string) ([]apiv1
 	if err != nil {
 		return make([]apiv1.Pod, 0), err
 	}
+	rawConfig.ContentType = runtime.ContentTypeProtobuf
 
 	api, err := corev1.NewForConfig(rawConfig)
 	if err != nil {
@@ -319,6 +325,7 @@ func getServices(flags *genericclioptions.ConfigFlags) ([]apiv1.Service, error) 
 	if err != nil {
 		return make([]apiv1.Service, 0), err
 	}
+	rawConfig.ContentType = runtime.ContentTypeProtobuf
 
 	api, err := corev1.NewForConfig(rawConfig)
 	if err != nil {

--- a/images/kube-webhook-certgen/rootfs/cmd/root.go
+++ b/images/kube-webhook-certgen/rootfs/cmd/root.go
@@ -6,7 +6,9 @@ import (
 	"github.com/onrik/logrus/filename"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
 )
@@ -88,8 +90,10 @@ func newKubernetesClients(kubeconfig string) (kubernetes.Interface, clientset.In
 	if err != nil {
 		log.WithError(err).Fatal("error building kubernetes config")
 	}
+	coreConfig := rest.CopyConfig(config)
+	coreConfig.ContentType = runtime.ContentTypeProtobuf
 
-	c, err := kubernetes.NewForConfig(config)
+	c, err := kubernetes.NewForConfig(coreConfig)
 	if err != nil {
 		log.WithError(err).Fatal("error creating kubernetes client")
 	}

--- a/internal/ingress/controller/store/store_test.go
+++ b/internal/ingress/controller/store/store_test.go
@@ -32,6 +32,7 @@ import (
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -98,6 +99,7 @@ func TestStore(t *testing.T) {
 
 	defer te.Stop() //nolint:errcheck // Ignore the error
 
+	cfg.ContentType = runtime.ContentTypeProtobuf
 	clientSet, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
 		t.Fatalf("error: %v", err)

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -35,6 +35,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -129,7 +130,9 @@ func (f *Framework) CreateEnvironment() {
 		// TODO: remove after k8s v1.22
 		f.KubeConfig.WarningHandler = rest.NoWarnings{}
 
-		f.KubeClientSet, err = kubernetes.NewForConfig(f.KubeConfig)
+		coreConfig := rest.CopyConfig(f.KubeConfig)
+		coreConfig.ContentType = runtime.ContentTypeProtobuf
+		f.KubeClientSet, err = kubernetes.NewForConfig(coreConfig)
 		assert.Nil(ginkgo.GinkgoT(), err, "creating a kubernetes client")
 	}
 


### PR DESCRIPTION
## What this PR does / why we need it:
If not specified explicitly, JSON encoding is used by default when talking to kube-apiserver.

For core K8s API objects like Pods, Nodes, etc., we can use protobuf encoding which reduces CPU consumption related to (de)serialization, reduces overall latency of the API call, reduces memory footprint, reduces the amount of work performed by the GC and results in quicker propagation of objects to event handlers of shared informers.

For CRDs, however, we still have to stick to JSON since they do not support protobuf encoding.

Standard system components of K8s default their serialization method to protobuf for some time already:
- `kube-scheduler`: [link](https://github.com/kubernetes/kubernetes/blob/d62b797c16fdffa55a8e2fc95f04bf72c019be70/pkg/scheduler/apis/config/v1/defaults.go#L143-L145)
- `kubelet`: [link](https://github.com/kubernetes/kubernetes/blob/d62b797c16fdffa55a8e2fc95f04bf72c019be70/pkg/kubelet/apis/config/v1beta1/defaults.go#L199-L201)
- `kube-proxy`: [link](https://github.com/kubernetes/kubernetes/blob/d62b797c16fdffa55a8e2fc95f04bf72c019be70/pkg/proxy/apis/config/v1alpha1/defaults.go#L126-L128)
- `kube-controller-manager`: [link](https://github.com/kubernetes/kubernetes/blob/d62b797c16fdffa55a8e2fc95f04bf72c019be70/staging/src/k8s.io/controller-manager/config/v1alpha1/defaults.go#L49) and [method's contents](https://github.com/kubernetes/kubernetes/blob/d62b797c16fdffa55a8e2fc95f04bf72c019be70/staging/src/k8s.io/component-base/config/v1alpha1/defaults.go#L66-L68)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
No issue is opened for that.

## How Has This Been Tested?
Unit tests.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.