### PR TITLE
Controller: Retain default backend service information.

### DIFF
--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -938,6 +938,7 @@ func (n *NGINXController) getBackendServers(ingresses []*ingress.Ingress) ([]*in
 					nb := upstream.DeepCopy()
 					nb.Name = name
 					nb.Endpoints = endps
+					nb.Service = location.DefaultBackend
 					aUpstreams = append(aUpstreams, nb)
 					location.DefaultBackendUpstreamName = name
 


### PR DESCRIPTION
## What this PR does / why we need it:

This is a copy of accidentally closed PR https://github.com/kubernetes/ingress-nginx/pull/12160

When the default backend is used as upstream, the information about its service is lost. As a consequence, if the default backend is an ExternalName service, it is used as a non-ExternalName service in the Lua part.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
fixes #12158
fixes #12173

## How Has This Been Tested?
The test case is described in #12158.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [X] All new and existing tests passed.
