### PR TITLE
Tests: Bump `e2e-test-runner` to v20241224-68ed4e7b.

### DIFF
--- a/build/run-in-docker.sh
+++ b/build/run-in-docker.sh
@@ -44,7 +44,7 @@ function cleanup {
 }
 trap cleanup EXIT
 
-E2E_IMAGE=${E2E_IMAGE:-registry.k8s.io/ingress-nginx/e2e-test-runner:v20241104-02a3933e@sha256:baf30e414c5657cc71f5bd1db502f0e0ee4ab721b6560340eff214935e96bef0}
+E2E_IMAGE=${E2E_IMAGE:-registry.k8s.io/ingress-nginx/e2e-test-runner:v20241224-68ed4e7b@sha256:871642296ebc0dd386f9a43b0cf2606028d757d6c4a2737d41180f02f8172823}
 
 if [[ "$RUNTIME" == podman ]]; then
   # Podman does not support both tag and digest

--- a/test/e2e-image/Makefile
+++ b/test/e2e-image/Makefile
@@ -1,6 +1,6 @@
 
 DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
-E2E_BASE_IMAGE ?= "registry.k8s.io/ingress-nginx/e2e-test-runner:v20241104-02a3933e@sha256:baf30e414c5657cc71f5bd1db502f0e0ee4ab721b6560340eff214935e96bef0"
+E2E_BASE_IMAGE ?= "registry.k8s.io/ingress-nginx/e2e-test-runner:v20241224-68ed4e7b@sha256:871642296ebc0dd386f9a43b0cf2606028d757d6c4a2737d41180f02f8172823"
 
 image:
 	echo "..entered Makefile in /test/e2e-image"

--- a/test/e2e/run-chart-test.sh
+++ b/test/e2e/run-chart-test.sh
@@ -114,5 +114,5 @@ docker run \
   --workdir /workdir \
   --entrypoint ct \
   --rm \
-  registry.k8s.io/ingress-nginx/e2e-test-runner:v20241104-02a3933e@sha256:baf30e414c5657cc71f5bd1db502f0e0ee4ab721b6560340eff214935e96bef0 \
+  registry.k8s.io/ingress-nginx/e2e-test-runner:v20241224-68ed4e7b@sha256:871642296ebc0dd386f9a43b0cf2606028d757d6c4a2737d41180f02f8172823 \
     install --charts charts/ingress-nginx


### PR DESCRIPTION
/triage accepted
/kind cleanup
/priority backlog
/cc @strongjz @tao12345666333 @cpanato