### PR TITLE
Change oauth redirect to 307

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -1104,7 +1104,7 @@ stream {
             modsecurity off;
             {{ end }}
 
-            return 302 {{ buildAuthSignURL $externalAuth.SigninURL $externalAuth.SigninURLRedirectParam }};
+            return 307 {{ buildAuthSignURL $externalAuth.SigninURL $externalAuth.SigninURLRedirectParam }};
         }
         {{ end }}
         {{ end }}

--- a/test/e2e/annotations/auth.go
+++ b/test/e2e/annotations/auth.go
@@ -494,7 +494,7 @@ http {
 				WithQuery("a", "b").
 				WithQuery("c", "d").
 				Expect().
-				Status(http.StatusFound).
+				Status(http.StatusTemporaryRedirect).
 				Header("Location").Equal(fmt.Sprintf("http://%s/auth/start?rd=http://%s%s", host, host, url.QueryEscape("/?a=b&c=d")))
 		})
 
@@ -714,7 +714,7 @@ http {
 				WithQuery("a", "b").
 				WithQuery("c", "d").
 				Expect().
-				Status(http.StatusFound).
+				Status(http.StatusTemporaryRedirect).
 				Header("Location").Equal(fmt.Sprintf("http://%s/auth/start?orig=http://%s%s", host, host, url.QueryEscape("/?a=b&c=d")))
 		})
 
@@ -861,7 +861,7 @@ http {
 				WithQuery("a", "b").
 				WithQuery("c", "d").
 				Expect().
-				Status(http.StatusFound).
+				Status(http.StatusTemporaryRedirect).
 				Header("Location").Equal(fmt.Sprintf("http://%s/auth/start?rd=http://%s%s", thisHost, thisHost, url.QueryEscape("/?a=b&c=d")))
 		})
 	})

--- a/test/e2e/annotations/satisfy.go
+++ b/test/e2e/annotations/satisfy.go
@@ -121,7 +121,7 @@ var _ = framework.DescribeAnnotation("satisfy", func() {
 			WithQuery("a", "b").
 			WithQuery("c", "d").
 			Expect().
-			Status(http.StatusFound).
+			Status(http.StatusTemporaryRedirect).
 			Header("Location").Equal(fmt.Sprintf("http://%s/auth/start?rd=http://%s%s", host, host, url.QueryEscape("/?a=b&c=d")))
 	})
 })


### PR DESCRIPTION
## What this PR does / why we need it:

OAuth2 is broken for non GET requests due to the way browser handle those. The 302 redirection code lead browsers to loose the original method and replacing it with GET.
This PR will allow to fix the first step to make oauth2 work even for non GET requests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes

Fixes #12636 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This change has been tested though the officials tests which have been updated.
This change doesn't impact other part of the code, but might be a breaking change for other applications which have hard coded the 302 redirection code. However, change this change will allow to enhance oauth2 protocol to work even for non GET request.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [x] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.
