### PR TITLE
Docs: Fix character format.

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -165,8 +165,8 @@ default on the next breaking change release, set for 2.0.0.
 
 - When "`ingress.spec.rules.http.pathType=Exact`" or "`pathType=Prefix`", this
 validation will limit the characters accepted on the field "`ingress.spec.rules.http.paths.path`",
-to "`alphanumeric characters`", and  `"/," "_," "-."` Also, in this case,
-the path should start with `"/."`
+to "`alphanumeric characters`", and  "`/`", "`_`", "`-`". Also, in this case,
+the path should start with "`/`".
 
 - When the ingress resource path contains other characters (like on rewrite
 configurations), the pathType value should be "`ImplementationSpecific`".
@@ -175,7 +175,7 @@ configurations), the pathType value should be "`ImplementationSpecific`".
 
 - When this option is enabled, the validation will happen on the Admission
 Webhook. So if any new ingress object contains characters other than
-alphanumeric characters, and, `"/,","_","-"`, in the `path` field, but
+alphanumeric characters, and, "`/`", "`_`", "`-`", in the `path` field, but
 is not using `pathType` value as `ImplementationSpecific`, then the ingress
 object will be denied admission.
 


### PR DESCRIPTION
Characters enumerated in the "Validation Of path" section were incorrectly formatted (with the "," separator inside the quotes and with the "`" outside the quotes).

<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
<!--- Please make sure you title is descriptive, it is used in the Release notes to let others know what it does ---> 

## What this PR does / why we need it:
It cleans the format of characters that can be used so it's easier to understand what characters are allowed to be used.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation only

## How Has This Been Tested?
Checked format in the GitHub Preview.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
