### PR TITLE
Images: Update `kubectl` to v1.32.2.

### DIFF
--- a/images/test-runner/Makefile
+++ b/images/test-runner/Makefile
@@ -50,7 +50,7 @@ image:
 		--build-arg BASE_IMAGE=${NGINX_BASE_IMAGE} \
 		--build-arg GOLANG_VERSION=${GO_VERSION} \
 		--build-arg ETCD_VERSION=3.5.13-0 \
-		--build-arg K8S_RELEASE=v1.31.5 \
+		--build-arg K8S_RELEASE=v1.32.2 \
 		--build-arg RESTY_CLI_VERSION=0.27 \
 		--build-arg RESTY_CLI_SHA=e5f4f3128af49ba5c4d039d0554e5ae91bbe05866f60eccfa96d3653274bff90 \
 		--build-arg LUAROCKS_VERSION=3.8.0 \
@@ -71,7 +71,7 @@ build: ensure-buildx
 		--build-arg BASE_IMAGE=${NGINX_BASE_IMAGE} \
 		--build-arg GOLANG_VERSION=${GO_VERSION} \
 		--build-arg ETCD_VERSION=3.5.13-0 \
-		--build-arg K8S_RELEASE=v1.31.5 \
+		--build-arg K8S_RELEASE=v1.32.2 \
 		--build-arg RESTY_CLI_VERSION=0.27 \
 		--build-arg RESTY_CLI_SHA=e5f4f3128af49ba5c4d039d0554e5ae91bbe05866f60eccfa96d3653274bff90 \
 		--build-arg LUAROCKS_VERSION=3.8.0 \


### PR DESCRIPTION
/triage accepted
/kind cleanup
/priority backlog
/cc @strongjz
/hold