### PR TITLE
fix http host override

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -820,7 +820,7 @@ stream {
             proxy_set_header       X-Service-Port     $service_port;
             proxy_set_header       X-Request-ID       $req_id;
             proxy_set_header       X-Forwarded-For    $remote_addr;
-            proxy_set_header       Host               $best_http_host;
+            proxy_set_header       Host               $host;
 
             set $proxy_upstream_name {{ $upstreamName | quote }};
 
@@ -1241,7 +1241,7 @@ stream {
             {{ if not (empty $location.UpstreamVhost) }}
             {{ $proxySetHeader }} Host                   {{ $location.UpstreamVhost | quote }};
             {{ else }}
-            {{ $proxySetHeader }} Host                   $best_http_host;
+            {{ $proxySetHeader }} Host                   $host;
             {{ end }}
 
             # Pass the extracted client certificate to the backend


### PR DESCRIPTION
## What this PR does / why we need it:
This PR addresses a long-standing security issue (over 7 years old, see [#2030](https://github.com/kubernetes/ingress-nginx/pull/2030)) in the ingress-nginx controller. Currently, if a client sends an X-Forwarded-Host header, ingress-nginx uses it to rewrite the Host header. This behavior means an attacker could set `X-Forwarded-Host: localhost` (or any arbitrary value), causing the backend web server to see a Host header of `localhost` without any trace of the original request.

* Security Implications
Host Header Injection:
Allowing the X-Forwarded-Host header to override the Host header opens the door to host header injection attacks. Malicious users can manipulate the host used by the backend, potentially leading to misrouting or unauthorized access.

* Routing and Virtual Host Mismatch:
The Host header is critical for proper virtual host selection and routing, as mandated by RFC 7230. Overriding it with an unverified value can cause the server to treat the request as if it were intended for a different domain, leading to unexpected behavior or security bypasses.

* Loss of Original Request Information:
Since the backend server only sees the overridden Host header, it loses the ability to verify the original host requested by the client. This lack of transparency can hinder logging, auditing, and application-level security checks.

* Documentation and Standards
RFC 7230 (HTTP/1.1 Message Syntax and Routing):
RFC 7230, Section 5.4, requires that every HTTP/1.1 request include a valid Host header to correctly identify the target server. Altering this header based on client-provided X-Forwarded-Host contradicts the specification, leading to potential misrouting and security issues.

* Nginx Best Practices:
The official Nginx documentation for proxying recommends preserving the original Host header by setting it explicitly (e.g., using proxy_set_header Host $host). There is no documentation that endorses replacing the Host header with X-Forwarded-Host, reinforcing that doing so is not in line with best practices.

Conclusion
This PR fixes a critical bug where ingress-nginx allows client-supplied X-Forwarded-Host to override the Host header. This behavior is both non-compliant with RFC 7230 and a potential security risk, as it permits host header injection and misrouting attacks. By preserving the original Host header, we ensure proper routing and adherence to established HTTP standards and security best practices.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
https://github.com/kubernetes/ingress-nginx/issues/5701
https://github.com/kubernetes/ingress-nginx/issues/10582

## How Has This Been Tested?


## Checklist:
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [X] All new and existing tests passed.
