### PR TITLE
Config: Remove notes about future defaults.

### DIFF
--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -97,12 +97,10 @@ type Configuration struct {
 	// AllowCrossNamespaceResources enables users to consume cross namespace resource on annotations
 	// Case disabled, attempts to use secrets or configmaps from a namespace different from Ingress will
 	// be denied
-	// This value will default to `false` on future releases
 	AllowCrossNamespaceResources bool `json:"allow-cross-namespace-resources"`
 
 	// AnnotationsRiskLevel represents the risk accepted on an annotation. If the risk is, for instance `Medium`, annotations
 	// with risk High and Critical will not be accepted.
-	// Default Risk is Critical by default, but this may be changed in future releases
 	AnnotationsRiskLevel string `json:"annotations-risk-level"`
 
 	// AnnotationValueWordBlocklist defines words that should not be part of an user annotation value

--- a/internal/ingress/defaults/main.go
+++ b/internal/ingress/defaults/main.go
@@ -195,7 +195,6 @@ type SecurityConfiguration struct {
 	// AllowCrossNamespaceResources enables users to consume cross namespace resource on annotations
 	// Case disabled, attempts to use secrets or configmaps from a namespace different from Ingress will
 	// be denied
-	// This valid will default to `false` on future releases
 	AllowCrossNamespaceResources bool `json:"allow-cross-namespace-resources"`
 
 	// AnnotationsRiskLevel represents the risk accepted on an annotation. If the risk is, for instance `Medium`, annotations


### PR DESCRIPTION
following #11819, some defaults became obsolete.
I think removing the comment altogether prevents us from forgetting to update it in the future. the source code should suffice for anyone willing to check the default


## What this PR does / why we need it:
following #11819, some comments in the code became erroneous. this PR removes those obsolete comments.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation only

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.
