### PR TITLE
docs: update proxy-next-upstream timeout and tries annotation value types

### DIFF
--- a/docs/user-guide/nginx-configuration/annotations.md
+++ b/docs/user-guide/nginx-configuration/annotations.md
@@ -76,8 +76,8 @@ You can add these Kubernetes annotations to specific Ingress objects to customiz
 |[nginx.ingress.kubernetes.io/proxy-send-timeout](#custom-timeouts)|number|
 |[nginx.ingress.kubernetes.io/proxy-read-timeout](#custom-timeouts)|number|
 |[nginx.ingress.kubernetes.io/proxy-next-upstream](#custom-timeouts)|string|
-|[nginx.ingress.kubernetes.io/proxy-next-upstream-timeout](#custom-timeouts)|number|
-|[nginx.ingress.kubernetes.io/proxy-next-upstream-tries](#custom-timeouts)|number|
+|[nginx.ingress.kubernetes.io/proxy-next-upstream-timeout](#custom-timeouts)|string|
+|[nginx.ingress.kubernetes.io/proxy-next-upstream-tries](#custom-timeouts)|string|
 |[nginx.ingress.kubernetes.io/proxy-request-buffering](#custom-timeouts)|string|
 |[nginx.ingress.kubernetes.io/proxy-redirect-from](#proxy-redirect)|string|
 |[nginx.ingress.kubernetes.io/proxy-redirect-to](#proxy-redirect)|string|


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
<!--- Please make sure you title is descriptive, it is used in the Release notes to let others know what it does ---> 

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

`proxy-next-upstream-tries` and `proxy-next-upstream-timeout` incorrectly state that their values are of type number. This change updates their types to string to align with actual behavior.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I deployed my applications using ArgoCD and set the following annotations:

```
ingress:
  annotations:
    nginx.ingress.kubernetes.io/proxy-next-upstream-tries: 10
    nginx.ingress.kubernetes.io/proxy-next-upstream-timeout: 10
```

After syncing the application, I encountered this error:

`unable to decode "/dev/shm/1696302033": json: cannot unmarshal number into Go struct field ObjectMeta.metadata.annotations of type string`

This error occurs regardless of whether only one or both annotations are used.

After modifying the annotations to use string values:

```
ingress:
  annotations:
    nginx.ingress.kubernetes.io/proxy-next-upstream-tries: "10"
    nginx.ingress.kubernetes.io/proxy-next-upstream-timeout: "10"
```

The error no longer appears, and the ingress resource is healthy.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
