### PR TITLE
Allow specifying only the configmap name for 'auth-proxy-set-headers' annotation without requiring namespace

### DIFF
--- a/internal/ingress/annotations/authreq/main.go
+++ b/internal/ingress/annotations/authreq/main.go
@@ -430,7 +430,7 @@ func (a authReq) Parse(ing *networking.Ingress) (interface{}, error) {
 		klog.V(3).InfoS("auth-set-proxy-headers annotation is undefined and will not be set", "err", err)
 	}
 
-	cns, _, err := cache.SplitMetaNamespaceKey(proxySetHeaderMap)
+	cns, cn, err := cache.SplitMetaNamespaceKey(proxySetHeaderMap)
 	if err != nil {
 		return nil, ing_errors.LocationDeniedError{
 			Reason: fmt.Errorf("error reading configmap name %s from annotation: %w", proxySetHeaderMap, err),
@@ -452,7 +452,7 @@ func (a authReq) Parse(ing *networking.Ingress) (interface{}, error) {
 	var proxySetHeaders map[string]string
 
 	if proxySetHeaderMap != "" {
-		proxySetHeadersMapContents, err := a.r.GetConfigMap(proxySetHeaderMap)
+		proxySetHeadersMapContents, err := a.r.GetConfigMap(cns + "/" + cn)
 		if err != nil {
 			return nil, ing_errors.NewLocationDenied(fmt.Sprintf("unable to find configMap %q", proxySetHeaderMap))
 		}


### PR DESCRIPTION


## What this PR does / why we need it:
Fixes #12996

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## How Has This Been Tested?
It hasn't been tested. But there aren't any tests for the current reading of configmaps either.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
