### PR TITLE
NGINX: add X-Original-Forwarded-Host header

### DIFF
--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -567,6 +567,10 @@ type Configuration struct {
 	// Default is X-Forwarded-For
 	ForwardedForHeader string `json:"forwarded-for-header,omitempty"`
 
+	// Sets the header field for identifying the originating host of a client
+	// Default is X-Forwarded-Host
+	ForwardedHostHeader string `json:"forwarded-host-header,omitempty"`
+
 	// Append the remote address to the X-Forwarded-For header instead of replacing it
 	// Default: false
 	ComputeFullForwardedFor bool `json:"compute-full-forwarded-for,omitempty"`
@@ -778,6 +782,7 @@ func NewDefault() Configuration {
 		UseForwardedHeaders:              false,
 		EnableRealIP:                     false,
 		ForwardedForHeader:               "X-Forwarded-For",
+		ForwardedHostHeader:              "X-Forwarded-Host",
 		ComputeFullForwardedFor:          false,
 		ProxyAddOriginalURIHeader:        false,
 		GenerateRequestID:                true,

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -1279,7 +1279,8 @@ stream {
             {{ $proxySetHeader }} X-Scheme               $pass_access_scheme;
 
             # Pass the original X-Forwarded-For
-            {{ $proxySetHeader }} X-Original-Forwarded-For {{ buildForwardedFor $all.Cfg.ForwardedForHeader }};
+            {{ $proxySetHeader }} X-Original-Forwarded-For  {{ buildForwardedFor $all.Cfg.ForwardedForHeader }};
+            {{ $proxySetHeader }} X-Original-Forwarded-Host {{ buildForwardedFor $all.Cfg.ForwardedHostHeader }};
 
             # mitigate HTTPoxy Vulnerability
             # https://www.nginx.com/blog/mitigating-the-httpoxy-vulnerability-with-nginx/

--- a/test/e2e/settings/forwarded_headers.go
+++ b/test/e2e/settings/forwarded_headers.go
@@ -121,6 +121,7 @@ var _ = framework.DescribeSetting("use-forwarded-headers", func() {
 		assert.Contains(ginkgo.GinkgoT(), body, "x-forwarded-proto=http")
 		assert.Contains(ginkgo.GinkgoT(), body, "x-forwarded-scheme=http")
 		assert.Contains(ginkgo.GinkgoT(), body, "x-original-forwarded-for=1.2.3.4")
+		assert.Contains(ginkgo.GinkgoT(), body, "x-original-forwarded-host=myhost")
 		assert.NotContains(ginkgo.GinkgoT(), body, "host=myhost")
 		assert.NotContains(ginkgo.GinkgoT(), body, "x-forwarded-host=myhost")
 		assert.NotContains(ginkgo.GinkgoT(), body, "x-forwarded-proto=myproto")


### PR DESCRIPTION
adds the equivalent of the existing X-Original-Forwarded-For header but for the X-Forwarded-Host instead.
typically helps in the context of configuration snippet deprecation, as there is currently no safe way to add this header when it was already set upstream


## What this PR does / why we need it:

with nginx controller version 1.12.0, configuration snippets are considered Critical per default and not allowed anymore. as a result, some users who relied on config snippets to set an `X-Original-Forwarded-Host` header are left without a solution.

this PR adds the `X-Original-Forwarded-Host` per default, akin to the existing `X-Original-Forwarded-For` header. Those headers are used to pass the original `X-Forwarded-{For,Host}` further to the upstream.


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## How Has This Been Tested?

I tested the implementation locally and added an e2e test to cover this new header.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [x] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.
