### PR TITLE
Custom Error Pages: Accept first of many MIME types.

### DIFF
--- a/images/custom-error-pages/rootfs/main.go
+++ b/images/custom-error-pages/rootfs/main.go
@@ -126,6 +126,12 @@ func errorHandler(path, defaultFormat string) func(http.ResponseWriter, *http.Re
 			log.Printf("format not specified. Using %v", format)
 		}
 
+		// if multiple formats are provided, use the first one
+		index := strings.Index(format, ",")
+		if index != -1 {
+			format = format[:index]
+		}
+
 		cext, err := mime.ExtensionsByType(format)
 		if err != nil {
 			log.Printf("unexpected error reading media type extension: %v. Using %v", err, ext)


### PR DESCRIPTION
## What this PR does / why we need it:
If an application sends an [Accept header with multiple mime types](https://strawberry.rocks/docs/operations/deployment#graphiql), the app will error:

```
unexpected error reading media type extension: mime: unexpected content after media subtype. Using .htm
```

Example header: `Accept: application/json, multipart/mixed`

This PR resolves that error by taking the first requested type in the header. We could also loop through the mime types, checking each, or also consider the [q-factor weighting](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Accept#q), but I think it's reasonable to take the first one. Most apps put what they most want first.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only


## How Has This Been Tested?
Manually tested in my application. We have a [Strawberry GraphiQL](https://strawberry.rocks/docs/operations/deployment#graphiql) interface that sends: `Accept: application/json, multipart/mixed`. That now works, as do the other pages that worked before.

This is a small change, and I don't see other test for this part of the application.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.
