### PR TITLE
Enable validation of nginx.conf back in chroot mode

### DIFF
--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -421,14 +421,15 @@ func (n *NGINXController) CheckIngress(ing *networking.Ingress) error {
 		return err
 	}
 
-	/* Deactivated to mitigate CVE-2025-1974
+	// Deactivated to mitigate CVE-2025-1974
 	// TODO: Implement sandboxing so this test can be done safely
-	err = n.testTemplate(content)
-	if err != nil {
-		n.metricCollector.IncCheckErrorCount(ing.ObjectMeta.Namespace, ing.Name)
-		return err
+	if n.cfg.IsChroot {
+		err = n.testTemplate(content)
+		if err != nil {
+			n.metricCollector.IncCheckErrorCount(ing.ObjectMeta.Namespace, ing.Name)
+			return err
+		}
 	}
-	*/
 
 	n.metricCollector.IncCheckCount(ing.ObjectMeta.Namespace, ing.Name)
 	endCheck := time.Now().UnixNano() / 1000000

--- a/internal/ingress/controller/controller_test.go
+++ b/internal/ingress/controller/controller_test.go
@@ -250,7 +250,6 @@ func TestCheckIngress(t *testing.T) {
 			}
 		})
 
-		/* Deactivated to mitigate CVE-2025-1974
 		// TODO: Implement sandboxing so this test can be done safely
 		t.Run("When nginx test returns an error", func(t *testing.T) {
 			nginx.command = testNginxTestCommand{
@@ -259,11 +258,11 @@ func TestCheckIngress(t *testing.T) {
 				out:      []byte("this is the test command output"),
 				expected: "_,test.example.com",
 			}
+			nginx.cfg.IsChroot = true
 			if nginx.CheckIngress(ing) == nil {
 				t.Errorf("with a new ingress with an error, an error should be returned")
 			}
 		})
-		*/
 
 		t.Run("When the default annotation prefix is used despite an override", func(t *testing.T) {
 			defer func() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
<!--- Please make sure you title is descriptive, it is used in the Release notes to let others know what it does ---> 

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Due to CVE-2025-1974 validation of nginx.conf was disabled here: 
https://github.com/kubernetes/ingress-nginx/pull/13070/
Here is a more technical CVE description I was able to find:
- Use NGINX Client Body Buffering to upload a shared library to the target pod
- Send an AdmissionReview request to the NGINX admission controller with the `ssl_engine load_module` directive, causing NGINX to load the previously uploaded shared library
- Get the shared library being executed using the file descriptor reference from the `/proc` filesystem (in particular, by searching for it in `/proc/*/fd/*`)

So to exploit it, attacker need no connect simultaneously to nginx and ingress-controller sharing the same FS. It works for `non-chroot` mode, as `nginx` can then access service-account token in Pod at `/var/run/secrets`.

But that does not valid for `chroot` image, where nginx is running scoped to `/chroot` folder in Pod, so cannot access `/var/run/secrets` above. At time of Admission Webhook controller would call `nginx -t`:
https://github.com/kubernetes/ingress-nginx/blob/dcfa4507aeecb332b3866d0d8d1855f70c5c1065/internal/ingress/controller/util.go#L145
but in chroot image `nginx` executable is actually a wrapper:
https://github.com/kubernetes/ingress-nginx/blob/4038211261e464a36296dee9d31c1868198236f5/rootfs/Dockerfile-chroot#L69
Which in turn would run `nginx -t` scoped to the same `/chroot`.

Validation of nginx.conf is very important in muti-team, multi-tenant clusters, where users learning k8s and often try to submit Ingress objects with errors. Currently that requires manual work to find out broken Ingress, fix it and communicate the problem.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->
https://github.com/kubernetes/kubernetes/issues/131009

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests are re-enabled back.
Also manual tests of resulting image in KIND by submitting invalid Ingress object.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [x] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.
