### PR TITLE
Plugin: Improve error handling.

### DIFF
--- a/cmd/plugin/kubectl/kubectl.go
+++ b/cmd/plugin/kubectl/kubectl.go
@@ -73,6 +73,8 @@ func execToWriter(args []string, writer io.Writer) error {
 	//nolint:gosec // Ignore G204 error
 	cmd := exec.Command(args[0], args[1:]...)
 
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
 	op, err := cmd.StdoutPipe()
 	if err != nil {
 		return err
@@ -83,6 +85,9 @@ func execToWriter(args []string, writer io.Writer) error {
 	}()
 	err = cmd.Run()
 	if err != nil {
+		if _, ok := err.(*exec.ExitError); ok {
+			println(stderr.String())
+		}
 		return err
 	}
 

--- a/cmd/plugin/kubectl/kubectl.go
+++ b/cmd/plugin/kubectl/kubectl.go
@@ -32,7 +32,7 @@ import (
 // PodExecString takes a pod and a command, uses kubectl exec to run the command in the pod
 // and returns stdout as a string
 func PodExecString(flags *genericclioptions.ConfigFlags, pod *apiv1.Pod, container string, args []string) (string, error) {
-	args = append([]string{"exec", "-n", pod.Namespace, "-c", container, pod.Name}, args...)
+	args = append([]string{"exec", "-n", pod.Namespace, "-c", container, pod.Name, "--"}, args...)
 	return ExecToString(flags, args)
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
<!--- Please make sure you title is descriptive, it is used in the Release notes to let others know what it does ---> 

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
kubectl exec [POD] [COMMAND] had been deprecated for 5 years, and they've just removed it now. After some gdb'ing i found the problem being stderr not going anywhere, and then i found https://github.com/kubernetes/kubernetes/pull/125437

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Before
```bash
~> go build && ./plugin  conf -n ingress-nginx -lapp.kubernetes.io/name=ingress-nginx
exit status 1
```
After stderr change
```bash
~> go build && ./plugin  conf -n ingress-nginx -lapp.kubernetes.io/name=ingress-nginx
error: exec [POD] [COMMAND] is not supported anymore. Use exec [POD] -- [COMMAND] instead
See 'kubectl exec -h' for help and examples

exit status 1
```
After
```bash
~> go build && ./plugin  conf -n ingress-nginx -lapp.kubernetes.io/name=ingress-nginx
... nginx.conf ...
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
