### PR TITLE
Annotations: Allow ciphers with underscores.

### DIFF
--- a/internal/ingress/annotations/sslcipher/main.go
+++ b/internal/ingress/annotations/sslcipher/main.go
@@ -33,7 +33,7 @@ const (
 
 // Should cover something like "ALL:!aNULL:!EXPORT56:RC4+RSA:+HIGH:+MEDIUM:+LOW:+SSLv2:+EXP"
 // (?:@STRENGTH) is included twice so it can appear before or after @SECLEVEL=n
-var regexValidSSLCipher = regexp.MustCompile(`^(?:(?:[A-Za-z0-9!:+\-])*(?:@STRENGTH)*(?:@SECLEVEL=[0-5])*(?:@STRENGTH)*)*$`)
+var regexValidSSLCipher = regexp.MustCompile(`^(?:(?:[A-Za-z0-9!:+\-_])*(?:@STRENGTH)*(?:@SECLEVEL=[0-5])*(?:@STRENGTH)*)*$`)
 
 var sslCipherAnnotations = parser.Annotation{
 	Group: "backend",

--- a/internal/ingress/annotations/sslcipher/main_test.go
+++ b/internal/ingress/annotations/sslcipher/main_test.go
@@ -57,6 +57,7 @@ func TestParse(t *testing.T) {
 		{map[string]string{annotationSSLCiphers: "ALL:!aNULL:!EXPORT56:RC4+RSA:+HIGH:+MEDIUM:+LOW:+SSLv2:+EXP", annotationSSLPreferServerCiphers: "true"}, Config{"ALL:!aNULL:!EXPORT56:RC4+RSA:+HIGH:+MEDIUM:+LOW:+SSLv2:+EXP", "on"}, false},
 		{map[string]string{annotationSSLCiphers: "ALL:SOMETHING:;locationXPTO"}, Config{"", ""}, true},
 		{map[string]string{}, Config{"", ""}, false},
+		{map[string]string{annotationSSLCiphers: "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256"}, Config{"TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256", ""}, false},
 		{nil, Config{"", ""}, false},
 	}
 


### PR DESCRIPTION
The ingress annotation `nginx.ingress.kubernetes.io/ssl-ciphers` is disallowing valid ciphers that have an underscore.

The nginx [documentation](https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_ciphers) - states about valid ciphers:
> The full list can be viewed using the “openssl ciphers” command.

From the latest official image: `registry.k8s.io/ingress-nginx/controller:v1.12.1@sha256:d2fbc4ec70d8aa2050dd91a91506e998765e86c96f32cffb56c503c9c34eed5b`

```
$ openssl ciphers
TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256:....
```

<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
<!--- Please make sure you title is descriptive, it is used in the Release notes to let others know what it does ---> 

## What this PR does / why we need it:
It allows for valid SSL ciphers with underscores.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes

## How Has This Been Tested?
Yes via the validation unit test

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [x] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.

If this is considered to be accepted I can go fill out the CLAs.