### PR TITLE
Lua: Fix `ExternalName` services without endpoints.

### DIFF
--- a/rootfs/etc/nginx/lua/balancer.lua
+++ b/rootfs/etc/nginx/lua/balancer.lua
@@ -73,6 +73,10 @@ local function get_implementation(backend)
 end
 
 local function resolve_external_names(original_backend)
+  if not original_backend.endpoints or
+     #original_backend.endpoints == 0 then
+    return original_backend
+  end
   local backend = util.deepcopy(original_backend)
   local endpoints = {}
   for _, endpoint in ipairs(backend.endpoints) do


### PR DESCRIPTION
Due to https://github.com/kubernetes/kubernetes/pull/114814 kubernetes no longer creates endpoints for services of type `ExternalService`. This in turn causes an exception when using an ingress that is backed by such service.

Due to https://github.com/kubernetes/ingress-nginx/pull/12952 , which I authored, this causes an exception reported in several recent issues that were opened after the new functionality was released.

I'm still puzzled why the e2e tests in https://github.com/kubernetes/ingress-nginx/blob/main/test/e2e/servicebackend/service_externalname.go did not catch those problems on effected versions of Kubernetes.

This is also related to:
- kubernetes/ingress-nginx#13081 specifically see [this comment](https://github.com/kubernetes/ingress-nginx/issues/13081#issuecomment-2766269334)
- kubernetes/ingress-nginx#13076


## What this PR does / why we need it:
We need this to stabilize the behavior of Ingress backend by a service with type ExternalName across different kubernetes versions and going forward.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
fixes kubernetes/ingress-nginx#13081

## How Has This Been Tested?
Adding tests to the Lua part of the code that was effected covering previously untested behavior and the specific exception from issue kubernetes/ingress-nginx#13081

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [x] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.
