### PR TITLE
Improve error message to avoid exposing ingress resource details

### DIFF
--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -1834,11 +1834,11 @@ func checkOverlap(ing *networking.Ingress, servers []*ingress.Server) error {
 				isExistingCanaryEnabled, existingAnnotationErr := parser.GetBoolAnnotation("canary", existing, canary.CanaryAnnotations.Annotations)
 
 				if isCanaryEnabled && isExistingCanaryEnabled {
-					return fmt.Errorf(`host "%s" and path "%s" is already defined in ingress %s/%s`, rule.Host, path.Path, existing.Namespace, existing.Name)
+					return fmt.Errorf(`host "%s" and path "%s" is already defined`, rule.Host, path.Path)
 				}
 
 				if annotationErr == errors.ErrMissingAnnotations && existingAnnotationErr == errors.ErrMissingAnnotations {
-					return fmt.Errorf(`host "%s" and path "%s" is already defined in ingress %s/%s`, rule.Host, path.Path, existing.Namespace, existing.Name)
+					return fmt.Errorf(`host "%s" and path "%s" is already defined`, rule.Host, path.Path)
 				}
 			}
 


### PR DESCRIPTION
Avoid exposing ingress namespace and name in error messages

## What this PR does / why we need it:
This PR improves security by removing the ingress resource's namespace and name from error messages related to conflicting host and path definitions. The new message ends with "is already defined" to prevent leaking potentially sensitive resource information.

## Checklist:
- [ X ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
