### PR TITLE
Docs: Enable metrics in manifest-based deployments.

### DIFF
--- a/docs/user-guide/monitoring.md
+++ b/docs/user-guide/monitoring.md
@@ -72,6 +72,9 @@ This tutorial will show you how to install [Prometheus](https://prometheus.io/) 
              spec:
                containers:
                  - name: controller
+                   args:
+                     ..
+                     - '--enable-metrics=true'  
                    ports:
                      - name: prometheus
                        containerPort: 10254


### PR DESCRIPTION
## What this PR does / why we need it:
This pull request improves the `monitoring.md` documentation by explicitly showing how to enable Prometheus metrics when deploying ingress-nginx using raw manifests. 

Currently, the documentation only shows how to expose the Prometheus metrics port (`10254`) via the `prometheus` named port in the Deployment manifest. However, it omits the required argument `--enable-metrics=true` that actually enables nginx-specific metrics.

Without this argument, Prometheus can successfully scrape the `/metrics` endpoint, but it will only retrieve default Go and process-level metrics — not the nginx-related metrics such as HTTP requests, connections, or response codes. Adding `--enable-metrics=true` ensures that these nginx-specific metrics are computed and made available.

This clarification is particularly important for users not deploying via Helm.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] CVE Report (Scanner found CVE and adding report)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change)  
- [x] Documentation only  

## Which issue/s this PR fixes
No specific issue opened, but it addresses a documentation gap related to Prometheus monitoring setup.

## How Has This Been Tested?
The changes were validated by deploying ingress-nginx using the official manifests and confirming that Prometheus was able to scrape and display nginx-specific metrics from the exposed port 10254 after setting `--enable-metrics=true`.

## Checklist:
- [x] My change requires a change to the documentation.  
- [x] I have updated the documentation accordingly.  
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide  
- [ ] I have added unit and/or e2e tests to cover my changes.  
- [ ] All new and existing tests passed.  
