### PR TITLE
Docs: Fix link in installation instructions.

### DIFF
--- a/docs/deploy/index.md
+++ b/docs/deploy/index.md
@@ -434,9 +434,7 @@ By default, the controller watches Ingress objects from all namespaces. If you w
 use the flag `--watch-namespace` or check the Helm chart value `controller.scope` to limit the controller to a single
 namespace. Although the use of this flag is not popular, one important fact to note is that the secret containing the default-ssl-certificate needs to also be present in the watched namespace(s).
 
-See also
-[“How to easily install multiple instances of the Ingress NGINX controller in the same cluster”](https://kubernetes.github.io/ingress-nginx/#how-to-easily-install-multiple-instances-of-the-ingress-nginx-controller-in-the-same-cluster)
-for more details.
+See also [“How to install multiple Ingress controllers in the same cluster”](https://kubernetes.github.io/ingress-nginx/user-guide/multiple-ingress/) for more details.
 
 ### Webhook network access
 


### PR DESCRIPTION
This PR updates the broken link https://kubernetes.github.io/ingress-nginx/#how-to-easily-install-multiple-instances-of-the-ingress-nginx-controller-in-the-same-cluster to the page describing how to install multiple Ingress controllers in the same cluster: https://kubernetes.github.io/ingress-nginx/user-guide/multiple-ingress/

## What this PR does / why we need it:
The link to install multiple controllers is broken, you have to dig in the documentation to find the corresponding article.

The only reference I found online with the initial title is https://www.linkedin.com/pulse/how-easily-install-multiple-instances-ingress-nginx-controller-kumar-1f, which is more or less the same content as in https://kubernetes.github.io/ingress-nginx/user-guide/multiple-ingress/.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
