### PR TITLE
Bump github.com/onsi/ginkgo/v2 from 2.23.3 to 2.23.4

### DIFF
--- a/build/run-in-docker.sh
+++ b/build/run-in-docker.sh
@@ -79,7 +79,7 @@ if [[ "$DOCKER_IN_DOCKER_ENABLED" == "true" ]]; then
   echo "..reached DIND check TRUE block, inside run-in-docker.sh"
   echo "FLAGS=$FLAGS"
   #go env
-  go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo@v2.23.3
+  go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo@v2.23.4
   find / -type f -name ginkgo 2>/dev/null
   which ginkgo
   /bin/bash -c "${FLAGS}"

--- a/images/test-runner/Makefile
+++ b/images/test-runner/Makefile
@@ -44,7 +44,7 @@ build: builder
 		--build-arg YAML_LINT_VERSION=1.33.0 \
 		--build-arg YAMALE_VERSION=4.0.4 \
 		--build-arg HELM_VERSION=3.14.4 \
-		--build-arg GINKGO_VERSION=2.23.3 \
+		--build-arg GINKGO_VERSION=2.23.4 \
 		--build-arg GOLINT_VERSION=latest \
 		rootfs \
 		--tag $(IMAGE):$(TAG) \

--- a/test/e2e/run-chart-test.sh
+++ b/test/e2e/run-chart-test.sh
@@ -78,7 +78,7 @@ fi
 
 if [ "${SKIP_IMAGE_CREATION:-false}" = "false" ]; then
   if ! command -v ginkgo &> /dev/null; then
-    go install github.com/onsi/ginkgo/v2/ginkgo@v2.23.3
+    go install github.com/onsi/ginkgo/v2/ginkgo@v2.23.4
   fi
   echo "[dev-env] building image"
   make -C ${DIR}/../../ clean-image build image

--- a/test/e2e/run-kind-e2e.sh
+++ b/test/e2e/run-kind-e2e.sh
@@ -95,7 +95,7 @@ fi
 
 if [ "${SKIP_E2E_IMAGE_CREATION}" = "false" ]; then
   if ! command -v ginkgo &> /dev/null; then
-    go install github.com/onsi/ginkgo/v2/ginkgo@v2.23.3
+    go install github.com/onsi/ginkgo/v2/ginkgo@v2.23.4
   fi
 
   echo "[dev-env] .. done building controller images"


### PR DESCRIPTION
/triage accepted
/kind cleanup
/priority backlog
/cc @strongjz 

This is a follow-up as we already automatically updated Ginkgo in the `go.mod` files via Dependabot.