### PR TITLE
Use PCRE on proxy redirect property

### DIFF
--- a/internal/ingress/annotations/parser/validators.go
+++ b/internal/ingress/annotations/parser/validators.go
@@ -79,6 +79,8 @@ var (
 	// URLWithNginxVariableRegex defines a url that can contain nginx variables.
 	// It is a risky operation
 	URLWithNginxVariableRegex = regexp.MustCompile("^[" + extendedAlphaNumeric + urlEnabledChars + "$]*$")
+	// Used for NGINX properties that accepts URLs with PCRE regex
+	URLWithPCRERegex = regexp.MustCompile("^[" + regexEnabledChars + alphaNumericChars + urlEnabledChars + "]*$")
 	// MaliciousRegex defines chars that are known to inject RCE
 	MaliciousRegex = regexp.MustCompile(`\r|\n`)
 )

--- a/internal/ingress/annotations/proxy/main.go
+++ b/internal/ingress/annotations/proxy/main.go
@@ -134,13 +134,13 @@ var proxyAnnotations = parser.Annotation{
 			Documentation: `This annotation enables or disables buffering of a client request body.`,
 		},
 		proxyRedirectFromAnnotation: {
-			Validator:     parser.ValidateRegex(parser.URLIsValidRegex, true),
+			Validator:     parser.ValidateRegex(parser.URLWithPCRERegex, true),
 			Scope:         parser.AnnotationScopeLocation,
 			Risk:          parser.AnnotationRiskMedium,
 			Documentation: `The annotations proxy-redirect-from and proxy-redirect-to will set the first and second parameters of NGINX's proxy_redirect directive respectively`,
 		},
 		proxyRedirectToAnnotation: {
-			Validator:     parser.ValidateRegex(parser.URLIsValidRegex, true),
+			Validator:     parser.ValidateRegex(parser.URLWithPCRERegex, true),
 			Scope:         parser.AnnotationScopeLocation,
 			Risk:          parser.AnnotationRiskMedium,
 			Documentation: `The annotations proxy-redirect-from and proxy-redirect-to will set the first and second parameters of NGINX's proxy_redirect directive respectively`,

--- a/test/e2e/annotations/proxy.go
+++ b/test/e2e/annotations/proxy.go
@@ -84,6 +84,23 @@ var _ = framework.DescribeAnnotation("proxy-*", func() {
 			})
 	})
 
+	ginkgo.It("should set proxy_redirect with PCRE", func() {
+		proxyRedirectFrom := "~^(http|https)://hello.com/v1/(.*)$"
+		proxyRedirectTo := "$1://$host/$2"
+
+		annotations := make(map[string]string)
+		annotations["nginx.ingress.kubernetes.io/proxy-redirect-from"] = proxyRedirectFrom
+		annotations["nginx.ingress.kubernetes.io/proxy-redirect-to"] = proxyRedirectTo
+
+		ing := framework.NewSingleIngress(host, "/", host, f.Namespace, framework.EchoService, 80, annotations)
+		f.EnsureIngress(ing)
+
+		f.WaitForNginxServer(host,
+			func(server string) bool {
+				return strings.Contains(server, fmt.Sprintf("proxy_redirect %s %s;", proxyRedirectFrom, proxyRedirectTo))
+			})
+	})
+
 	ginkgo.It("should set proxy client-max-body-size to 8m", func() {
 		proxyBodySize := "8m"
 


### PR DESCRIPTION
NGINX accepts PCRE patterns on the `proxy_redirect` property.
This PR introduces URLWithNginxVariableRegex, a validation to make sure that both `proxy-redirect-from` and `proxy-redirect-to` annotations accept this pattern.
Added e2e tests to cover it.

## What this PR does / why we need it:
This PR covers at least these two open issues:
[12917](https://github.com/kubernetes/ingress-nginx/issues/12917)
[10698](https://github.com/kubernetes/ingress-nginx/issues/10698)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
Fixes [12917](https://github.com/kubernetes/ingress-nginx/issues/12917) and [10698](https://github.com/kubernetes/ingress-nginx/issues/10698)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Created e2e tests, after that: `make kind-e2e-test`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [x] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.
