### PR TITLE
Support for Annotations Risk Level in controller configmap

### DIFF
--- a/charts/ingress-nginx/templates/controller-configmap.yaml
+++ b/charts/ingress-nginx/templates/controller-configmap.yaml
@@ -16,6 +16,9 @@ data:
 {{- if .Values.controller.allowSnippetAnnotations }}
   allow-snippet-annotations: "true"
 {{- end }}
+{{- if .Values.controller.annotationsRiskLevel }}
+  annotations-risk-level: {{ .Values.controller.annotationsRiskLevel }}
+{{- end }}
 {{- if .Values.controller.addHeaders }}
   add-headers: {{ include "ingress-nginx.namespace" . }}/{{ include "ingress-nginx.fullname" . }}-custom-add-headers
 {{- end }}


### PR DESCRIPTION
## What this PR does / why we need it:
This PR adds the ability to change the `annotations-risk-level` in the controller configmap

For example, if  we use configuration snippets for things like external auth, the risk level needs to be set to Critical. Recent versions of the chart changes that to High. This value lets the developer configure said level.

Issue #10672 talks about this in detail

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [*] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only


## How Has This Been Tested?
Yes, I've tested by directly patching the configmap with the effective change, works. Validation webhook now lets ingress resources with configuration snippets in as long as the level is set to Critical

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [*] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
