### PR TITLE
[#11087] Determine if a given controller is the last pod using electionId label

### DIFF
--- a/charts/ingress-nginx/Chart.yaml
+++ b/charts/ingress-nginx/Chart.yaml
@@ -1,6 +1,6 @@
 annotations:
   artifacthub.io/changes: |
-    - Update Ingress-Nginx version controller-v1.12.2
+    - Add electionID label to controller pods when leader election is enabled
   artifacthub.io/prerelease: "false"
 apiVersion: v2
 appVersion: 1.12.2
@@ -20,4 +20,4 @@ maintainers:
 name: ingress-nginx
 sources:
 - https://github.com/kubernetes/ingress-nginx
-version: 4.12.2
+version: 4.12.3

--- a/charts/ingress-nginx/changelog/helm-chart-4.12.3.md
+++ b/charts/ingress-nginx/changelog/helm-chart-4.12.3.md
@@ -1,0 +1,9 @@
+# Changelog
+
+This file documents all notable changes to [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
+
+### 4.12.3
+
+* Add electionID label to controller pods when leader election is enabled
+
+**Full Changelog**: https://github.com/kubernetes/ingress-nginx/compare/helm-chart-4.12.2...helm-chart-4.12.3

--- a/charts/ingress-nginx/templates/controller-daemonset.yaml
+++ b/charts/ingress-nginx/templates/controller-daemonset.yaml
@@ -34,6 +34,9 @@ spec:
       labels:
         {{- include "ingress-nginx.labels" . | nindent 8 }}
         app.kubernetes.io/component: controller
+        {{- if not .Values.controller.disableLeaderElection }}
+        nginx.ingress.kubernetes.io/electionID: {{ include "ingress-nginx.controller.electionID" . }}
+        {{- end }}
         {{- with .Values.controller.labels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/ingress-nginx/templates/controller-deployment.yaml
+++ b/charts/ingress-nginx/templates/controller-deployment.yaml
@@ -40,6 +40,9 @@ spec:
       labels:
         {{- include "ingress-nginx.labels" . | nindent 8 }}
         app.kubernetes.io/component: controller
+        {{- if not .Values.controller.disableLeaderElection }}
+        nginx.ingress.kubernetes.io/electionID: {{ include "ingress-nginx.controller.electionID" . }}
+        {{- end }}
         {{- with .Values.controller.labels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/ingress-nginx/tests/controller-daemonset_test.yaml
+++ b/charts/ingress-nginx/tests/controller-daemonset_test.yaml
@@ -208,3 +208,30 @@ tests:
       - equal:
           path: spec.template.spec.runtimeClassName
           value: myClass
+
+  - it: should create a DaemonSet with the electionID label on the pod template when leader election is enabled
+    set:
+      controller.kind: DaemonSet
+      controller.disableLeaderElection: false
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels.[nginx.ingress.kubernetes.io/electionID]
+          value: RELEASE-NAME-ingress-nginx-leader
+
+  - it: should create a DaemonSet with the custom electionID label on the pod template when controller.electionID is set and leader election is enabled
+    set:
+      controller.kind: DaemonSet
+      controller.disableLeaderElection: false
+      controller.electionID: custom-election-id
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels.[nginx.ingress.kubernetes.io/electionID]
+          value: custom-election-id
+
+  - it: should create a DaemonSet without the electionID label on the pod template when leader election is disabled
+    set:
+      controller.kind: DaemonSet
+      controller.disableLeaderElection: true
+    asserts:
+      - notExists:
+          path: spec.template.metadata.labels.[nginx.ingress.kubernetes.io/electionID]

--- a/charts/ingress-nginx/tests/controller-deployment_test.yaml
+++ b/charts/ingress-nginx/tests/controller-deployment_test.yaml
@@ -231,3 +231,27 @@ tests:
       - equal:
           path: spec.template.spec.runtimeClassName
           value: myClass
+
+  - it: should create a Deployment with the electionID label on the pod template when leader election is enabled
+    set:
+      controller.disableLeaderElection: false
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels.[nginx.ingress.kubernetes.io/electionID]
+          value: RELEASE-NAME-ingress-nginx-leader
+
+  - it: should create a Deployment with the custom electionID label on the pod template when controller.electionID is set and leader election is enabled
+    set:
+      controller.disableLeaderElection: false
+      controller.electionID: custom-election-id
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels.[nginx.ingress.kubernetes.io/electionID]
+          value: custom-election-id
+
+  - it: should create a Deployment without the electionID label on the pod template when leader election is disabled
+    set:
+      controller.disableLeaderElection: true
+    asserts:
+      - notExists:
+          path: spec.template.metadata.labels.[nginx.ingress.kubernetes.io/electionID]

--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -143,6 +143,8 @@ type Configuration struct {
 
 	DisableSyncEvents bool
 
+	UseElectionIDSelectorOnShutdown bool
+
 	EnableTopologyAwareRouting bool
 }
 

--- a/internal/ingress/controller/nginx.go
+++ b/internal/ingress/controller/nginx.go
@@ -152,6 +152,8 @@ func NewNGINXController(config *Configuration, mc metric.Collector) *NGINXContro
 			IngressLister:          n.store,
 			UpdateStatusOnShutdown: config.UpdateStatusOnShutdown,
 			UseNodeInternalIP:      config.UseNodeInternalIP,
+			UseElectionIDSelectorOnShutdown: config.UseElectionIDSelectorOnShutdown,
+			ElectionID:             config.ElectionID,
 		})
 	} else {
 		klog.Warning("Update of Ingress status is disabled (flag --update-status)")

--- a/internal/ingress/status/status.go
+++ b/internal/ingress/status/status.go
@@ -40,6 +40,11 @@ import (
 	"k8s.io/ingress-nginx/pkg/apis/ingress"
 )
 
+const (
+	// ElectionIDLabelKey is the label key used to identify controller pods by election ID
+	ElectionIDLabelKey = "nginx.ingress.kubernetes.io/electionID"
+)
+
 // UpdateInterval defines the time interval, in seconds, in
 // which the status should check if an update is required.
 var UpdateInterval = 60
@@ -67,6 +72,10 @@ type Config struct {
 	UpdateStatusOnShutdown bool
 
 	UseNodeInternalIP bool
+
+	UseElectionIDSelectorOnShutdown bool
+
+	ElectionID string
 
 	IngressLister ingressLister
 }
@@ -175,6 +184,36 @@ func nameOrIPToLoadBalancerIngress(nameOrIP string) v1.IngressLoadBalancerIngres
 
 // runningAddresses returns a list of IP addresses and/or FQDN where the
 // ingress controller is currently running
+// listControllerPods returns a list of running pods with controller labels
+func (s *statusSync) listControllerPods(useElectionID bool) (*apiv1.PodList, error) {
+	podLabel := make(map[string]string)
+	
+	if useElectionID {
+		// When using electionID, only look for pods with the electionID label
+		// This is more specific and will correctly identify pods belonging to the same controller group
+		// Note: This requires the electionID label to be set on the pods (done by helm chart)
+		podLabel[ElectionIDLabelKey] = s.Config.ElectionID
+	} else {
+		// As a standard, app.kubernetes.io are "reserved well-known" labels.
+		// In our case, we add those labels as identifiers of the Ingress
+		// deployment in this namespace, so we can select it as a set of Ingress instances.
+		// As those labels are also generated as part of a HELM deployment, we can be "safe" they
+		// cover 95% of the cases
+		for k, v := range k8s.IngressPodDetails.Labels {
+			// Skip labels that are frequently modified by deployment controllers
+			if k != "pod-template-hash" && k != "controller-revision-hash" && k != "pod-template-generation" {
+				podLabel[k] = v
+			}
+		}
+	}
+	
+	return s.Client.CoreV1().Pods(k8s.IngressPodDetails.Namespace).List(
+		context.TODO(), 
+		metav1.ListOptions{
+			LabelSelector: labels.SelectorFromSet(podLabel).String(),
+		})
+}
+
 func (s *statusSync) runningAddresses() ([]v1.IngressLoadBalancerIngress, error) {
 	if s.PublishStatusAddress != "" {
 		re := regexp.MustCompile(`,\s*`)
@@ -191,9 +230,7 @@ func (s *statusSync) runningAddresses() ([]v1.IngressLoadBalancerIngress, error)
 	}
 
 	// get information about all the pods running the ingress controller
-	pods, err := s.Client.CoreV1().Pods(k8s.IngressPodDetails.Namespace).List(context.TODO(), metav1.ListOptions{
-		LabelSelector: labels.SelectorFromSet(k8s.IngressPodDetails.Labels).String(),
-	})
+	pods, err := s.listControllerPods(false)
 	if err != nil {
 		return nil, err
 	}
@@ -230,21 +267,7 @@ func (s *statusSync) runningAddresses() ([]v1.IngressLoadBalancerIngress, error)
 }
 
 func (s *statusSync) isRunningMultiplePods() bool {
-	// As a standard, app.kubernetes.io are "reserved well-known" labels.
-	// In our case, we add those labels as identifiers of the Ingress
-	// deployment in this namespace, so we can select it as a set of Ingress instances.
-	// As those labels are also generated as part of a HELM deployment, we can be "safe" they
-	// cover 95% of the cases
-	podLabel := make(map[string]string)
-	for k, v := range k8s.IngressPodDetails.Labels {
-		if k != "pod-template-hash" && k != "controller-revision-hash" && k != "pod-template-generation" {
-			podLabel[k] = v
-		}
-	}
-
-	pods, err := s.Client.CoreV1().Pods(k8s.IngressPodDetails.Namespace).List(context.TODO(), metav1.ListOptions{
-		LabelSelector: labels.SelectorFromSet(podLabel).String(),
-	})
+	pods, err := s.listControllerPods(s.UseElectionIDSelectorOnShutdown) // Use election ID-compatible labels if configured
 	if err != nil {
 		return false
 	}

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -232,6 +232,8 @@ Takes the form "<host>:port". If not provided, no admission controller is starte
 
 		disableSyncEvents = flags.Bool("disable-sync-events", false, "Disables the creation of 'Sync' event resources")
 
+		useElectionIDSelectorOnShutdown = flags.Bool("use-election-id-selector-on-shutdown", true, "Determine if other pods are running based on the electionID label, rather than all pod labels.")
+
 		enableTopologyAwareRouting = flags.Bool("enable-topology-aware-routing", false, "Enable topology aware routing feature, needs service object annotation service.kubernetes.io/topology-mode sets to auto or trafficDistribution.")
 	)
 
@@ -377,6 +379,7 @@ https://blog.maxmind.com/2019/12/significant-changes-to-accessing-and-using-geol
 		HealthCheckHost:             *healthzHost,
 		DynamicConfigurationRetries: *dynamicConfigurationRetries,
 		EnableTopologyAwareRouting:  *enableTopologyAwareRouting,
+		UseElectionIDSelectorOnShutdown: *useElectionIDSelectorOnShutdown,
 		ListenPorts: &ngx_config.ListenPorts{
 			Default:  *defServerPort,
 			Health:   *healthzPort,


### PR DESCRIPTION
## What this PR does / why we need it:
- #11087 is a serious footgun: if a user upgrades the helm chart version in-place, or adds pod labels (either via the helm chart or some other mechanism), ingress-nginx may shutdown an ingress even though there are other ingress-nginx pods running and serving traffic.
- The root cause of #11087 is that ingress-nginx re-uses the set of pod labels on the terminating pod to find other pods belonging to the same controller group. This is a bug, since there are cases where we expect the set of labels on the terminating pod to differ from the labels on other pods belonging to the same controller group (for example, during an in-place helm upgrade, the chart version label will be different on old vs. new pods).
- ingress-nginx already has an appropriate primitive to track the pods belonging to the same controller group: `electionID`. We expect a pod to tear down an ingress iff all pods with the same electionID have gone away (i.e. meaning there will be no future successful master election).

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

This is a breaking change in two respects:
1. I would argue _all_ helm chart upgrades are currently breaking changes because of #11087. This is dangerous for users until resolved.
2. The PR enables this new behavior by default. I don't believe this is a breaking change for users, but would like other eyes to validate my assumption.

## Which issue/s this PR fixes
- fixes #1877[^1]
- fixes #4774[^1]
- fixes #7047[^1]
- fixes #11087

## How Has This Been Tested?
- I have added unit tests to the `helm chart` to validate the new label is defined.
- I have added unit tests to the `status.go` component to validate the pod finding behavior.

## Checklist:
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [X] I have added unit and/or e2e tests to cover my changes.
- [X] All new and existing tests passed.

[^1]: 