### PR TITLE
fix: only set progressDeadlineSeconds if it's a valid value and set

### DIFF
--- a/charts/ingress-nginx/templates/controller-deployment.yaml
+++ b/charts/ingress-nginx/templates/controller-deployment.yaml
@@ -22,7 +22,7 @@ spec:
   replicas: {{ .Values.controller.replicaCount }}
   {{- end }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
-  {{- if .Values.controller.progressDeadlineSeconds }}
+  {{- if and .Values.controller.progressDeadlineSeconds (ne .Values.controller.progressDeadlineSeconds 0) }}
   progressDeadlineSeconds: {{ .Values.controller.progressDeadlineSeconds }}
   {{- end }}
   {{- if .Values.controller.updateStrategy }}


### PR DESCRIPTION
## What this PR does / why we need it:
Since upgrading to helm package 4.12.2, and attempting to reinstall it with tile I get repeated failures due to 

> ERROR: Build Failed: Deployment.apps "ingress-nginx-controller" is invalid: spec.progressDeadlineSeconds: Invalid value: 0: must be greater than minReadySeconds

This is because the default value in the helm package is 0, which kubernetes does not consider valid in my k8s 1.32 cluster

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes


## How Has This Been Tested?


## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
