### PR TITLE
Add possibility to configure ttlSecondsAfterFinished for admission webhooks

### DIFF
--- a/charts/ingress-nginx/README.md
+++ b/charts/ingress-nginx/README.md
@@ -261,6 +261,7 @@ metadata:
 | controller.admissionWebhooks.certManager.rootCert.revisionHistoryLimit | int | `0` | Revision history limit of the root certificate. Ref.: https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.CertificateSpec |
 | controller.admissionWebhooks.certificate | string | `"/usr/local/certificates/cert"` |  |
 | controller.admissionWebhooks.createSecretJob.name | string | `"create"` |  |
+| controller.admissionWebhooks.createSecretJob.ttlSecondsAfterFinished  | int | `0` | defines the time-to-live duration in seconds after the job has finished |
 | controller.admissionWebhooks.createSecretJob.resources | object | `{}` |  |
 | controller.admissionWebhooks.createSecretJob.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":65532,"runAsNonRoot":true,"runAsUser":65532,"seccompProfile":{"type":"RuntimeDefault"}}` | Security context for secret creation containers |
 | controller.admissionWebhooks.enabled | bool | `true` |  |
@@ -291,6 +292,7 @@ metadata:
 | controller.admissionWebhooks.patch.serviceAccount.name | string | `""` | Custom service account name |
 | controller.admissionWebhooks.patch.tolerations | list | `[]` |  |
 | controller.admissionWebhooks.patchWebhookJob.name | string | `"patch"` |  |
+| controller.admissionWebhooks.patchWebhookJob.ttlSecondsAfterFinished  | int | `0` | defines the time-to-live duration in seconds after the job has finished |
 | controller.admissionWebhooks.patchWebhookJob.resources | object | `{}` |  |
 | controller.admissionWebhooks.patchWebhookJob.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":65532,"runAsNonRoot":true,"runAsUser":65532,"seccompProfile":{"type":"RuntimeDefault"}}` | Security context for webhook patch containers |
 | controller.admissionWebhooks.port | int | `8443` |  |

--- a/charts/ingress-nginx/templates/admission-webhooks/job-patch/job-createSecret.yaml
+++ b/charts/ingress-nginx/templates/admission-webhooks/job-patch/job-createSecret.yaml
@@ -17,7 +17,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  ttlSecondsAfterFinished: 0
+  ttlSecondsAfterFinished: {{ .Values.controller.admissionWebhooks.createSecretJob.ttlSecondsAfterFinished }}
   template:
     metadata:
       name: {{ include "ingress-nginx.admissionWebhooks.createSecretJob.fullname" . }}

--- a/charts/ingress-nginx/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
+++ b/charts/ingress-nginx/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
@@ -17,7 +17,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  ttlSecondsAfterFinished: 0
+  ttlSecondsAfterFinished: {{ .Values.controller.admissionWebhooks.patchWebhookJob.ttlSecondsAfterFinished }}
   template:
     metadata:
       name: {{ include "ingress-nginx.admissionWebhooks.patchWebhookJob.fullname" . }}

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -776,6 +776,7 @@ controller:
       type: ClusterIP
     createSecretJob:
       name: create
+      ttlSecondsAfterFinished: 0
       # -- Security context for secret creation containers
       securityContext:
         runAsNonRoot: true
@@ -797,6 +798,7 @@ controller:
       #   memory: 20Mi
     patchWebhookJob:
       name: patch
+      ttlSecondsAfterFinished: 0
       # -- Security context for webhook patch containers
       securityContext:
         runAsNonRoot: true


### PR DESCRIPTION
## What this PR does / why we need it:
This PR let you set the ttlSecondsAfterFinished field for the admission webhooks Jobs created by the ingress-nginx Helm chart.

The reason for this change is to improve compatibility with Argo CD and similar GitOps tools, which often require some time to detect the final status of a Job. Without setting ttlSecondsAfterFinished, the Job may be cleaned up by the cluster before Argo CD can register its successful completion, leading to synchronization or health check issues.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
This change has been tested using helm template to render the ingress-nginx chart under the following conditions:

Default behavior – Rendered the chart without specifying the ttlSecondsAfterFinished value to confirm that the field is 0 from the resulting Job manifests.
Custom TTL configured – Rendered the chart with the ttlSecondsAfterFinished value explicitly set, and verified that the field appears correctly in the output Job spec.

This ensures that the chart behaves correctly both when the value is provided and when it is left unset.

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
