### PR TITLE
Chart: Template default backend extra volumes.

### DIFF
--- a/charts/ingress-nginx/templates/default-backend-deployment.yaml
+++ b/charts/ingress-nginx/templates/default-backend-deployment.yaml
@@ -118,6 +118,6 @@ spec:
     {{- end }}
       terminationGracePeriodSeconds: 60
     {{- if .Values.defaultBackend.extraVolumes }}
-      volumes: {{ toYaml .Values.defaultBackend.extraVolumes | nindent 8 }}
+      volumes: {{ tpl (toYaml .Values.defaultBackend.extraVolumes) $ | nindent 8 }}
     {{- end }}
 {{- end }}

--- a/charts/ingress-nginx/tests/default-backend-deployment_test.yaml
+++ b/charts/ingress-nginx/tests/default-backend-deployment_test.yaml
@@ -196,3 +196,26 @@ tests:
       - equal:
           path: spec.template.spec.automountServiceAccountToken
           value: false
+
+  - it: should create a Deployment with extra volumes if `defaultBackend.extraVolumes` is set
+    set:
+      defaultBackend.enabled: true
+      defaultBackend.extraVolumes:
+        - name: extra-volume
+          configMap:
+            name: '{{ .Release.Name }}'
+      defaultBackend.extraVolumeMounts:
+        - name: extra-volume
+          mountPath: /extra
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes
+          value:
+            - name: extra-volume
+              configMap:
+                name: RELEASE-NAME
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts
+          value:
+            - name: extra-volume
+              mountPath: /extra


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
<!--- Please make sure you title is descriptive, it is used in the Release notes to let others know what it does ---> 

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We wanted to add custom error pages for our load balancer, and since each load balancer dependens on their own ingress-nginx we need to be able to template the volume configmap.

```
    extraVolumes:
      - name: custom-error-pages
        configMap:
          name: "{{ .Release.Name }}-custom-error-pages"
```

Now gives us:
```
      volumes: 
        - configMap: name: '{{ .Release.Name }}-custom-error-pages'
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I've added a Helm chart test that covers my explicit change.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [x] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
