### PR TITLE
Added additional logs for downloading geoip databases

### DIFF
--- a/internal/nginx/maxmind.go
+++ b/internal/nginx/maxmind.go
@@ -88,6 +88,9 @@ func DownloadGeoLite2DB(attempts int, period time.Duration) error {
 		attempts = minimumRetriesCount
 	}
 
+	klog.Infof("Starting GeoLite2 DB download (editions: %s, attempts: %d, interval: %s)",
+		MaxmindEditionIDs, attempts, period)
+
 	defaultRetry := wait.Backoff{
 		Steps:    attempts,
 		Duration: period,
@@ -103,7 +106,14 @@ func DownloadGeoLite2DB(attempts int, period time.Duration) error {
 
 	lastErr = wait.ExponentialBackoff(defaultRetry, func() (bool, error) {
 		var dlError error
+
 		for _, dbName := range strings.Split(MaxmindEditionIDs, ",") {
+			dbName = strings.TrimSpace(dbName)
+			if dbName == "" {
+				continue
+			}
+
+			klog.V(2).Infof("Attempting to download GeoIP DB: %s", dbName)
 			dlError = downloadDatabase(dbName)
 			if dlError != nil {
 				break
@@ -112,6 +122,7 @@ func DownloadGeoLite2DB(attempts int, period time.Duration) error {
 
 		lastErr = dlError
 		if dlError == nil {
+			klog.Infof("GeoLite2 DBs downloaded successfully")
 			return true, nil
 		}
 
@@ -120,14 +131,21 @@ func DownloadGeoLite2DB(attempts int, period time.Duration) error {
 				if e, ok := e.Err.(*os.SyscallError); ok {
 					if e.Err == syscall.ECONNREFUSED {
 						retries++
-						klog.InfoS("download failed on attempt " + fmt.Sprint(retries))
+						klog.V(1).Infof("Download attempt %d failed: connection refused", retries)
 						return false, nil
 					}
 				}
 			}
 		}
+
+		klog.Errorf("GeoLite2 DB download failed: %v", dlError)
 		return true, nil
 	})
+
+	if lastErr != nil {
+		klog.Errorf("All attempts to download GeoLite2 DBs failed: %v", lastErr)
+	}
+
 	return lastErr
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
<!--- Please make sure you title is descriptive, it is used in the Release notes to let others know what it does ---> 

## What this PR does / why we need it:

This PR improves the logging of MaxMind GeoIP2 database downloads. Previously, only a single message downloading maxmind GeoIP2 databases was emitted before the actual download process. This made it difficult to understand what happened in case of partial failures or silent skips.

We now log:

Which database editions are being downloaded.

Per-edition success or failure.

Final status of the operation (success or failure).

This helps with diagnosing download issues and provides visibility into controller startup.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x]  Logging improvement (non-breaking, internal visibility only)


## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?

Tested in a Kubernetes cluster with GeoIP2 download enabled, both in success and failure scenarios (e.g. invalid license, missing archive contents). Verified that logs now reflect per-edition status and final result.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
