### PR TITLE
Dynamic OCSP cache invalidation 

### DIFF
--- a/rootfs/etc/nginx/lua/certificate.lua
+++ b/rootfs/etc/nginx/lua/certificate.lua
@@ -148,8 +148,8 @@ local function fetch_and_cache_ocsp_response(uid, der_cert)
     return
   end
 
-  local ok
-  ok, err = ocsp.validate_ocsp_response(ocsp_response, der_cert)
+  local ok, error_or_next_update
+  ok, error_or_next_update = ocsp.validate_ocsp_response(ocsp_response, der_cert)
   if not ok then
     -- We are doing the same thing as vanilla Nginx here - if response status is not "good"
     -- we do not use it - no stapling.
@@ -173,14 +173,33 @@ local function fetch_and_cache_ocsp_response(uid, der_cert)
     -- the OCSP responder. Imagine OCSP responder is having an intermittent issue
     -- and we keep sending request. It might make things worse for the responder.
 
-    ngx.log(ngx.NOTICE, "OCSP response validation failed: ", err)
+    ngx.log(ngx.NOTICE, "OCSP response validation failed: ", error_or_next_update)
     return
   end
 
-  -- Normally this should be (nextUpdate - thisUpdate), but Lua API does not expose
-  -- those attributes.
-  local expiry = 3600 * 24 * 3
-  local success, forcible
+  local success, forcible, expiry
+
+  -- nextUpdate field is finally accessible via Lua API through validate_ocsp_response(), therefore we can calculate cache invalidation precisely
+  if ok then
+    local now = ngx.now()
+    local grace_period = 300
+    
+    -- handle nextUpdate field from OCSP
+    if  error_or_next_update ~= nil then
+      expiry = error_or_next_update - now - grace_period
+      ngx.log(ngx.NOTICE, "OCSP Response cache was provided by OCSP server and is valid for: ", expiry)
+
+      if expiry <= 0 then
+        ngx.log(ngx.WARN, "OCSP next_update is in the past, setting ocsp_response_cache to 0")
+        expiry = 0
+      end
+    else
+      -- fallback to original logic if OCSP server did not provide nextUpdate field
+      expiry = 3600 * 24 * 3 
+      ngx.log(ngx.NOTICE, "OCSP did not provide nextUpdate therefore it is set to fixed value of 3 days")
+    end
+  end
+
   success, err, forcible = ocsp_response_cache:set(uid, ocsp_response, expiry)
   if not success then
     ngx.log(ngx.ERR, "failed to cache OCSP response: ", err)


### PR DESCRIPTION
## What this PR does / why we need it:

OpenResty Lua library supports for about a year new field for OCSP (next_update) which provides exact value retrieved directly from OCSP server until when the response is valid.
Here is the updated function in their repo: (https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/ocsp.lua#L126)

This feature is able to be used since those versions of libraries:
export LUA_NGX_VERSION=v0.10.27
export LUA_STREAM_NGX_VERSION=v0.0.15
export LUA_RESTY_CORE=v0.1.29

Currently main branch contains higher versions than this so this feature is available to be used:
export LUA_NGX_VERSION=v0.10.28
export LUA_STREAM_NGX_VERSION=v0.0.16
export LUA_RESTY_CORE=v0.1.31

Current solution caches OCSP response for fixed 3 days, this PR is able to set cache properly based on the real value provided by OCSP response, if OCSP response does not contain next_update field (its optional), we fallback to the original logic of fixed 3 days

<!--- Why is this change required? What problem does it solve? -->
This helps with better OCSP cache invalidation. Fixed 3 days no longer needed as the only option.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I received request in my company to create proper cache invalidation for our nginx ingress controllers which are basically fork of your repo from which we are building the image of nginx controller. So tests were done in our own k8s clusters across 2 stages. Thanks to the log messages introduced in this PR, we were able to see what value has been used for cache invalidation directly in the nginx controller pods and it has matched with the OCSP response provided from OCSP server and hence we got much better cache invalidation.

<!--- Include details of your testing environment, and the tests you ran to -->
K8s cluster 1.31.9
Nginx controller image built from your repo + changes introduced in this PR


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.

Please, point out any issue you see with this PR. It is first time I am trying to merge code changes into your repo.
