### PR TITLE
Config/Annotations: Fix `proxy-busy-buffers-size`.

### DIFF
--- a/internal/ingress/annotations/proxy/main.go
+++ b/internal/ingress/annotations/proxy/main.go
@@ -301,9 +301,11 @@ func (a proxy) Parse(ing *networking.Ingress) (interface{}, error) {
 		config.BufferSize = defBackend.ProxyBufferSize
 	}
 
+	// Only set BusyBuffersSize if annotation is present, blank is NGINX default
+	// https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_busy_buffers_size
 	config.BusyBuffersSize, err = parser.GetStringAnnotation(proxyBusyBuffersSizeAnnotation, ing, a.annotationConfig.Annotations)
 	if err != nil {
-		config.BusyBuffersSize = defBackend.ProxyBusyBuffersSize
+		config.BusyBuffersSize = ""
 	}
 
 	config.CookiePath, err = parser.GetStringAnnotation(proxyCookiePathAnnotation, ing, a.annotationConfig.Annotations)

--- a/internal/ingress/annotations/proxy/main_test.go
+++ b/internal/ingress/annotations/proxy/main_test.go
@@ -258,6 +258,9 @@ func TestProxyWithNoAnnotation(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected a Config type")
 	}
+	if p.BusyBuffersSize != "" {
+		t.Errorf("expected empty BusyBuffersSize but returned %v", p.BusyBuffersSize)
+	}
 	if p.ConnectTimeout != 10 {
 		t.Errorf("expected 10 as connect-timeout but returned %v", p.ConnectTimeout)
 	}
@@ -272,9 +275,6 @@ func TestProxyWithNoAnnotation(t *testing.T) {
 	}
 	if p.BufferSize != "10k" {
 		t.Errorf("expected 10k as buffer-size but returned %v", p.BufferSize)
-	}
-	if p.BusyBuffersSize != "15k" {
-		t.Errorf("expected 15k as buffer-size but returned %v", p.BusyBuffersSize)
 	}
 	if p.BodySize != "3k" {
 		t.Errorf("expected 3k as body-size but returned %v", p.BodySize)
@@ -296,5 +296,24 @@ func TestProxyWithNoAnnotation(t *testing.T) {
 	}
 	if p.ProxyMaxTempFileSize != "1024m" {
 		t.Errorf("expected 1024m as proxy-max-temp-file-size but returned %v", p.ProxyMaxTempFileSize)
+	}
+}
+
+// Add a test for when annotation is set
+func TestProxyWithBusyBuffersSizeAnnotation(t *testing.T) {
+	ing := buildIngress()
+	data := map[string]string{}
+	data[parser.GetAnnotationWithPrefix("proxy-busy-buffers-size")] = "4k"
+	ing.SetAnnotations(data)
+	i, err := NewParser(mockBackend{}).Parse(ing)
+	if err != nil {
+		t.Fatalf("unexpected error parsing a valid")
+	}
+	p, ok := i.(*Config)
+	if !ok {
+		t.Fatalf("expected a Config type")
+	}
+	if p.BusyBuffersSize != "4k" {
+		t.Errorf("expected 4k as BusyBuffersSize but returned %v", p.BusyBuffersSize)
 	}
 }

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -1076,7 +1076,9 @@ stream {
             {{ end }}
             proxy_buffer_size                       {{ $location.Proxy.BufferSize }};
             proxy_buffers                           {{ $location.Proxy.BuffersNumber }} {{ $location.Proxy.BufferSize }};
+            {{ if $location.Proxy.BusyBuffersSize }}
             proxy_busy_buffers_size                 {{ $location.Proxy.BusyBuffersSize }};
+            {{ end }}
             proxy_request_buffering                 {{ $location.Proxy.RequestBuffering }};
 
             proxy_ssl_server_name       on;
@@ -1334,7 +1336,9 @@ stream {
             proxy_buffering                         {{ $location.Proxy.ProxyBuffering }};
             proxy_buffer_size                       {{ $location.Proxy.BufferSize }};
             proxy_buffers                           {{ $location.Proxy.BuffersNumber }} {{ $location.Proxy.BufferSize }};
+            {{ if $location.Proxy.BusyBuffersSize }}
             proxy_busy_buffers_size                 {{ $location.Proxy.BusyBuffersSize }};
+            {{ end }}
             {{ if isValidByteSize $location.Proxy.ProxyMaxTempFileSize true }}
             proxy_max_temp_file_size                {{ $location.Proxy.ProxyMaxTempFileSize }};
             {{ end }}


### PR DESCRIPTION
- Fix backward compatibility for the `proxy-busy-buffers-size` annotation.
- Now, the `proxy_busy_buffers_size` directive is only rendered in the nginx template if the annotation is explicitly set.
- If the annotation is not defined, the directive is omitted from the generated config (restoring pre-d1dc3e8 behavior).
- Updated annotation parsing logic to avoid setting a default value when the annotation is missing.
- Added and updated unit tests to verify both presence and absence scenarios.

<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
<!--- Please make sure you title is descriptive, it is used in the Release notes to let others know what it does ---> 

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
#13598 
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #13598
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
