### PR TITLE
Docs: Bump mkdocs to v9.6.16, fix links

### DIFF
--- a/.github/actions/mkdocs/Dockerfile
+++ b/.github/actions/mkdocs/Dockerfile
@@ -1,4 +1,4 @@
-FROM squidfunk/mkdocs-material:9.4.5
+FROM squidfunk/mkdocs-material:9.6.16
 
 COPY action.sh /action.sh
 

--- a/docs/deploy/baremetal.md
+++ b/docs/deploy/baremetal.md
@@ -261,7 +261,7 @@ for generating redirect URLs that take into account the URL used by external cli
     Location: https://myapp.example.com/  #-> missing NodePort in HTTPS redirect
     ```
 
-[install-baremetal]: ./index.md#bare-metal
+[install-baremetal]: ./index.md#bare-metal-clusters
 [install-quickstart]: ./index.md#quick-start
 [nodeport-def]: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
 [nodeport-nat]: https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-type-nodeport

--- a/docs/deploy/index.md
+++ b/docs/deploy/index.md
@@ -100,7 +100,7 @@ kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/cont
     resources as if you had used Helm to install the controller.
 
 !!! attention
-    If you are running an old version of Kubernetes (1.18 or earlier), please read [this paragraph](#running-on-Kubernetes-versions-older-than-1.19) for specific instructions.
+    If you are running an old version of Kubernetes (1.18 or earlier), please read [this paragraph](#running-on-kubernetes-versions-older-than-119) for specific instructions.
     Because of api deprecations, the default manifest may not work on your cluster.
     Specific manifests for supported Kubernetes versions are available within a sub-folder of each provider.
 

--- a/docs/examples/customization/custom-errors/README.md
+++ b/docs/examples/customization/custom-errors/README.md
@@ -49,7 +49,7 @@ If you do not already have an instance of the Ingress-Nginx Controller running, 
     The `ingress-nginx` Service is of type `ClusterIP` in this example. This may vary depending on your environment.
     Make sure you can use the Service to reach NGINX before proceeding with the rest of this example.
 
-[deploy]: ../../../deploy/
+[deploy]: ../../../deploy/index.md
 
 ## Testing error pages
 

--- a/docs/examples/customization/jwt/README.md
+++ b/docs/examples/customization/jwt/README.md
@@ -45,4 +45,4 @@ data:
 ```
 
 References:
- * [Custom Configuration](../custom-configuration/)
+ * [Custom Configuration](../custom-configuration/README.md)

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -5,7 +5,7 @@ Please review the [prerequisites](PREREQUISITES.md) before trying them.
 
 The examples on these pages include the `spec.ingressClassName` field which replaces the deprecated `kubernetes.io/ingress.class: nginx` annotation. Users of ingress-nginx < 1.0.0 (Helm chart < 4.0.0) should use the [legacy documentation](https://github.com/kubernetes/ingress-nginx/tree/legacy/docs/examples).
 
-For more information, check out the [Migration to apiVersion networking.k8s.io/v1](../#faq-migration-to-apiversion-networkingk8siov1) guide.
+For more information, check out the [Migration to apiVersion networking.k8s.io/v1](../user-guide/k8s-122-migration.md) guide.
 
 Category | Name | Description | Complexity Level
 ---------| ---- | ----------- | ----------------

--- a/docs/examples/rewrite/README.md
+++ b/docs/examples/rewrite/README.md
@@ -6,7 +6,7 @@ This example demonstrates how to use `Rewrite` annotations.
 
 You will need to make sure your Ingress targets exactly one Ingress
 controller by specifying the [ingress.class annotation](../../user-guide/multiple-ingress.md),
-and that you have an ingress controller [running](../../deploy/) in your cluster.
+and that you have an ingress controller [running](../../deploy/index.md) in your cluster.
 
 ## Deployment
 

--- a/docs/examples/static-ip/README.md
+++ b/docs/examples/static-ip/README.md
@@ -7,7 +7,7 @@ This example demonstrates how to assign a static-ip to an Ingress on through the
 You need a [TLS cert](../PREREQUISITES.md#tls-certificates) and a [test HTTP service](../PREREQUISITES.md#test-http-service) for this example.
 You will also need to make sure your Ingress targets exactly one Ingress
 controller by specifying the [ingress.class annotation](../../user-guide/multiple-ingress.md),
-and that you have an ingress controller [running](../../deploy/) in your cluster.
+and that you have an ingress controller [running](../../deploy/index.md) in your cluster.
 
 ## Acquiring an IP
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,5 +8,5 @@ You can learn more about using [Ingress](https://kubernetes.io/docs/concepts/ser
 
 # Getting Started
 
-See [Deployment](./deploy/) for a whirlwind tour that will get you started.
+See [Deployment](./deploy/index.md) for a whirlwind tour that will get you started.
 

--- a/docs/lua_tests.md
+++ b/docs/lua_tests.md
@@ -13,7 +13,7 @@ installations besides docker
 
 ## Where are the Lua Tests?
 
-Lua Tests can be found in the [rootfs/etc/nginx/lua/test](../rootfs/etc/nginx/lua/test) directory
+Lua Tests can be found in the [rootfs/etc/nginx/lua/test](https://github.com/kubernetes/ingress-nginx/tree/main/rootfs/etc/nginx/lua/test) directory
 
 
 [1]: https://openresty.org/en/installation.html

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs-material==9.4.5
-mkdocs-awesome-pages-plugin==2.9.2
-mkdocs-minify-plugin==0.7.1
-mkdocs-redirects==1.2.1
+mkdocs-material==9.6.16
+mkdocs-awesome-pages-plugin==2.10.1
+mkdocs-minify-plugin==0.8.0
+mkdocs-redirects==1.2.2

--- a/docs/user-guide/custom-errors.md
+++ b/docs/user-guide/custom-errors.md
@@ -28,4 +28,4 @@ See also the [Custom errors][example-custom-errors] example.
 
 [cm-custom-http-errors]: ./nginx-configuration/configmap.md#custom-http-errors
 [img-custom-error-pages]: https://github.com/kubernetes/ingress-nginx/tree/main/images/custom-error-pages
-[example-custom-errors]: ../../examples/customization/custom-errors
+[example-custom-errors]: ../examples/customization/custom-errors/README.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,7 +24,7 @@ markdown_extensions:
   - pymdownx.critic
   - pymdownx.details
   - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
       emoji_generator: !!python/name:materialx.emoji.to_svg
   - pymdownx.highlight
   - pymdownx.inlinehilite


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
<!--- Please make sure you title is descriptive, it is used in the Release notes to let others know what it does ---> 

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR upgrades mkdocs version and fixes broken links.
```
 % make live-docs
...
INFO    -  DeprecationWarning: 'materialx.emoji.twemoji' is deprecated.
           Material emoji logic has been officially moved into mkdocs-material
           version 9.4. Please use Material's 'material.extensions.emoji.twemoji'
           instead of 'materialx.emoji.twemoji' in your 'mkdocs.yml' file.

           ```
           markdown_extensions:
             - pymdownx.emoji:
                 emoji_index: !!python/name:material.extensions.emoji.twemoji
                 emoji_generator: !!python/name:material.extensions.emoji.to_svg
           ```

           'mkdocs_material_extensions' is deprecated and will no longer be
           supported moving forward. This is the last release.

             File "/usr/local/lib/python3.11/site-packages/materialx/emoji.py", line 118, in twemoji
               return _patch_index(options)
             File "/usr/local/lib/python3.11/site-packages/materialx/emoji.py", line 68, in _deprecated_func
               warnings.warn(
WARNING -  Material emoji logic has been officially moved into mkdocs-material
           version 9.4. Please use Material's 'material.extensions.emoji.twemoji'
           instead of 'materialx.emoji.twemoji' in your 'mkdocs.yml' file.

           ```
           markdown_extensions:
             - pymdownx.emoji:
                 emoji_index: !!python/name:material.extensions.emoji.twemoji
                 emoji_generator: !!python/name:material.extensions.emoji.to_svg
           ```

           'mkdocs_material_extensions' is deprecated and will no longer be
           supported moving forward. This is the last release.
...
INFO    -  Doc file 'index.md' contains an unrecognized relative link './deploy/', it was left as is. Did you mean 'deploy/index.md'?
INFO    -  Doc file 'lua_tests.md' contains an unrecognized relative link '../rootfs/etc/nginx/lua/test', it was left as is.
INFO    -  Doc file 'examples/index.md' contains an unrecognized relative link '../#faq-migration-to-apiversion-networkingk8siov1', it was left as is. Did you mean
           '../index.md#faq-migration-to-apiversion-networkingk8siov1'?
INFO    -  Doc file 'examples/customization/custom-errors/README.md' contains an unrecognized relative link '../../../deploy/', it was left as is. Did you mean '../../../deploy/index.md'?
INFO    -  Doc file 'examples/customization/jwt/README.md' contains an unrecognized relative link '../custom-configuration/', it was left as is. Did you mean '../custom-configuration/README.md'?
INFO    -  Doc file 'examples/rewrite/README.md' contains an unrecognized relative link '../../deploy/', it was left as is. Did you mean '../../deploy/index.md'?
INFO    -  Doc file 'examples/static-ip/README.md' contains an unrecognized relative link '../../deploy/', it was left as is. Did you mean '../../deploy/index.md'?
INFO    -  Doc file 'user-guide/custom-errors.md' contains an unrecognized relative link '../../examples/customization/custom-errors', it was left as is. Did you mean
           '../examples/customization/custom-errors/README.md'?
INFO    -  Doc file 'deploy/index.md' contains a link '#running-on-Kubernetes-versions-older-than-1.19', but there is no such anchor on this page.
INFO    -  Doc file 'deploy/baremetal.md' contains a link './index.md#bare-metal', but the doc 'deploy/index.md' does not contain an anchor '#bare-metal'.
...
```


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`make live-docs` command and manual tests

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
