### PR TITLE
Move ttlSecondsAfterFinished value to parameter for admissionWebhooks createSecretJob and patchWebhookJob jobs

### DIFF
--- a/charts/ingress-nginx/README.md
+++ b/charts/ingress-nginx/README.md
@@ -260,6 +260,7 @@ metadata:
 | controller.admissionWebhooks.certManager.rootCert.duration | string | `""` |  |
 | controller.admissionWebhooks.certManager.rootCert.revisionHistoryLimit | int | `0` | Revision history limit of the root certificate. Ref.: https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.CertificateSpec |
 | controller.admissionWebhooks.certificate | string | `"/usr/local/certificates/cert"` |  |
+| controller.admissionWebhooks.createSecretJob.ttlSecondsAfterFinished | int | `0` | Time to live in seconds for the job after it has finished. Must be greater than or equal to 0 or null. If null, job deletion will be managed by helm or e.q. argocd lifecycle management. |
 | controller.admissionWebhooks.createSecretJob.activeDeadlineSeconds | int | `0` | Deadline in seconds for the job to complete. Must be greater than 0 to enforce. If unset or 0, no deadline is enforced. |
 | controller.admissionWebhooks.createSecretJob.name | string | `"create"` |  |
 | controller.admissionWebhooks.createSecretJob.resources | object | `{}` |  |
@@ -291,6 +292,7 @@ metadata:
 | controller.admissionWebhooks.patch.serviceAccount.create | bool | `true` | Create a service account or not |
 | controller.admissionWebhooks.patch.serviceAccount.name | string | `""` | Custom service account name |
 | controller.admissionWebhooks.patch.tolerations | list | `[]` |  |
+| controller.admissionWebhooks.patchWebhookJob.ttlSecondsAfterFinished | int | `0` | Time to live in seconds for the job after it has finished. Must be greater than or equal to 0 or null. If null, job deletion will be managed by helm or e.q. argocd lifecycle management. |
 | controller.admissionWebhooks.patchWebhookJob.activeDeadlineSeconds | int | `0` | Deadline in seconds for the job to complete. Must be greater than 0 to enforce. If unset or 0, no deadline is enforced. |
 | controller.admissionWebhooks.patchWebhookJob.name | string | `"patch"` |  |
 | controller.admissionWebhooks.patchWebhookJob.resources | object | `{}` |  |

--- a/charts/ingress-nginx/templates/admission-webhooks/job-patch/job-createSecret.yaml
+++ b/charts/ingress-nginx/templates/admission-webhooks/job-patch/job-createSecret.yaml
@@ -17,7 +17,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  ttlSecondsAfterFinished: 0
+{{- if ge (int .Values.controller.admissionWebhooks.createSecretJob.ttlSecondsAfterFinished) 0 }}
+  ttlSecondsAfterFinished: {{ .Values.controller.admissionWebhooks.createSecretJob.ttlSecondsAfterFinished }}
+{{- end }}
 {{- if gt (int .Values.controller.admissionWebhooks.createSecretJob.activeDeadlineSeconds) 0 }}
   activeDeadlineSeconds: {{ .Values.controller.admissionWebhooks.createSecretJob.activeDeadlineSeconds }}
 {{- end }}

--- a/charts/ingress-nginx/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
+++ b/charts/ingress-nginx/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
@@ -17,7 +17,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  ttlSecondsAfterFinished: 0
+{{- if ge (int .Values.controller.admissionWebhooks.patchWebhookJob.ttlSecondsAfterFinished) 0 }}
+  ttlSecondsAfterFinished: {{ .Values.controller.admissionWebhooks.patchWebhookJob.ttlSecondsAfterFinished }}
+{{- end }}
 {{- if gt (int .Values.controller.admissionWebhooks.patchWebhookJob.activeDeadlineSeconds) 0 }}
   activeDeadlineSeconds: {{ .Values.controller.admissionWebhooks.patchWebhookJob.activeDeadlineSeconds }}
 {{- end }}

--- a/charts/ingress-nginx/tests/admission-webhooks/job-patch/job-createSecret_test.yaml
+++ b/charts/ingress-nginx/tests/admission-webhooks/job-patch/job-createSecret_test.yaml
@@ -18,3 +18,18 @@ tests:
       - equal:
           path: spec.activeDeadlineSeconds
           value: 1
+  
+  - it: should create a Job with `ttlSecondsAfterFinished` if `controller.admissionWebhooks.createSecretJob.ttlSecondsAfterFinished ` is set
+    set:
+      controller.admissionWebhooks.createSecretJob.ttlSecondsAfterFinished: 1
+    asserts:
+      - equal:
+          path: spec.ttlSecondsAfterFinished
+          value: 1
+
+  - it: should create a Job without `ttlSecondsAfterFinished` if `controller.admissionWebhooks.createSecretJob.ttlSecondsAfterFinished ` is null
+    set:
+      controller.admissionWebhooks.createSecretJob.ttlSecondsAfterFinished: null
+    asserts:
+      - isNullOrEmpty:
+          path: spec.ttlSecondsAfterFinished

--- a/charts/ingress-nginx/tests/admission-webhooks/job-patch/job-patchWebhook_test.yaml
+++ b/charts/ingress-nginx/tests/admission-webhooks/job-patch/job-patchWebhook_test.yaml
@@ -18,3 +18,18 @@ tests:
       - equal:
           path: spec.activeDeadlineSeconds
           value: 1
+
+  - it: should create a Job with `ttlSecondsAfterFinished` if `controller.admissionWebhooks.patchWebhookJob.ttlSecondsAfterFinished ` is set
+    set:
+      controller.admissionWebhooks.patchWebhookJob.ttlSecondsAfterFinished: 1
+    asserts:
+      - equal:
+          path: spec.ttlSecondsAfterFinished
+          value: 1
+  
+  - it: should create a Job without `ttlSecondsAfterFinished` if `controller.admissionWebhooks.patchWebhookJob.ttlSecondsAfterFinished ` is null
+    set:
+      controller.admissionWebhooks.patchWebhookJob.ttlSecondsAfterFinished: null
+    asserts:
+      - isNullOrEmpty:
+          path: spec.ttlSecondsAfterFinished

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -774,6 +774,8 @@ controller:
       type: ClusterIP
     createSecretJob:
       name: create
+      # -- Time to live in seconds for the job after it has finished. Must be greater than or equal to 0 or null. If null, job deletion will be managed by helm or e.q. argocd lifecycle management.
+      ttlSecondsAfterFinished: 0
       # -- Deadline in seconds for the job to complete. Must be greater than 0 to enforce. If unset or 0, no deadline is enforced.
       activeDeadlineSeconds: 0
       # -- Security context for secret creation containers
@@ -797,6 +799,8 @@ controller:
       #   memory: 20Mi
     patchWebhookJob:
       name: patch
+      # -- Time to live in seconds for the job after it has finished. Must be greater than or equal to 0 or null. If null, job deletion will be managed by helm or e.q. argocd lifecycle management.
+      ttlSecondsAfterFinished: 0
       # -- Deadline in seconds for the job to complete. Must be greater than 0 to enforce. If unset or 0, no deadline is enforced.
       activeDeadlineSeconds: 0
       # -- Security context for webhook patch containers


### PR DESCRIPTION
Setting the ‘ttlSecondsAfterFinished’ parameter to 0 permanently prevents ingress-nginx from being updated using ArgoCD because it freezes when attempting to delete a job (https://argo-cd.readthedocs.io/en/stable/user-guide/resource_hooks/# sync-status-with-jobsworkflows-with-time-to-live-ttl)
Moving ttlSecondsAfterFinished to a parameter allows you to set it to null or a larger value so that argocd can manage the hook's lifecycle
This change broke argo cd upgrade: https://github.com/kubernetes/ingress-nginx/compare/helm-chart-4.11.6...helm-chart-4.11.7#diff-cbb80da09794f8efe70b4a0d0208f1f3b68af66af0eaceecbb64a60a7ac9515c 

## What this PR does / why we need it:
This PR add option to override default ttlSecondsAfterFinished parameter for admissionWebhooks createSecretJob and patchWebhookJob jobs

## Types of changes
- Bug fix

## How Has This Been Tested?
I have tested it using ArgoCD.