### PR TITLE
Chart: Add volumes for webhook patch job.

### DIFF
--- a/charts/ingress-nginx/README.md
+++ b/charts/ingress-nginx/README.md
@@ -264,6 +264,8 @@ metadata:
 | controller.admissionWebhooks.createSecretJob.name | string | `"create"` |  |
 | controller.admissionWebhooks.createSecretJob.resources | object | `{}` |  |
 | controller.admissionWebhooks.createSecretJob.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":65532,"runAsNonRoot":true,"runAsUser":65532,"seccompProfile":{"type":"RuntimeDefault"}}` | Security context for secret creation containers |
+| controller.admissionWebhooks.createSecretJob.volumeMounts | list | `[]` | Volume mounts for secret creation containers |
+| controller.admissionWebhooks.createSecretJob.volumes | list | `[]` | Volumes for secret creation pod |
 | controller.admissionWebhooks.enabled | bool | `true` |  |
 | controller.admissionWebhooks.extraEnvs | list | `[]` | Additional environment variables to set |
 | controller.admissionWebhooks.failurePolicy | string | `"Fail"` | Admission Webhook failure policy to use |
@@ -295,6 +297,8 @@ metadata:
 | controller.admissionWebhooks.patchWebhookJob.name | string | `"patch"` |  |
 | controller.admissionWebhooks.patchWebhookJob.resources | object | `{}` |  |
 | controller.admissionWebhooks.patchWebhookJob.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":65532,"runAsNonRoot":true,"runAsUser":65532,"seccompProfile":{"type":"RuntimeDefault"}}` | Security context for webhook patch containers |
+| controller.admissionWebhooks.patchWebhookJob.volumeMounts | list | `[]` | Volume mounts for webhook patch containers |
+| controller.admissionWebhooks.patchWebhookJob.volumes | list | `[]` | Volumes for webhook patch pod |
 | controller.admissionWebhooks.port | int | `8443` |  |
 | controller.admissionWebhooks.service.annotations | object | `{}` |  |
 | controller.admissionWebhooks.service.externalIPs | list | `[]` |  |

--- a/charts/ingress-nginx/templates/admission-webhooks/job-patch/job-createSecret.yaml
+++ b/charts/ingress-nginx/templates/admission-webhooks/job-patch/job-createSecret.yaml
@@ -68,6 +68,9 @@ spec:
           {{- if .Values.controller.admissionWebhooks.createSecretJob.resources }}
           resources: {{ toYaml .Values.controller.admissionWebhooks.createSecretJob.resources | nindent 12 }}
           {{- end }}
+          {{- if .Values.controller.admissionWebhooks.createSecretJob.volumeMounts }}
+          volumeMounts: {{- toYaml .Values.controller.admissionWebhooks.createSecretJob.volumeMounts | nindent 12 }}
+          {{- end }}
       restartPolicy: OnFailure
       serviceAccountName: {{ include "ingress-nginx.admissionWebhooks.patch.serviceAccountName" . }}
       automountServiceAccountToken: {{ .Values.controller.admissionWebhooks.patch.serviceAccount.automountServiceAccountToken }}
@@ -79,5 +82,8 @@ spec:
     {{- end }}
     {{- if .Values.controller.admissionWebhooks.patch.securityContext }}
       securityContext: {{ toYaml .Values.controller.admissionWebhooks.patch.securityContext | nindent 8 }}
+    {{- end }}
+    {{- if .Values.controller.admissionWebhooks.createSecretJob.volumes }}
+      volumes: {{- toYaml .Values.controller.admissionWebhooks.createSecretJob.volumes | nindent 8 }}
     {{- end }}
 {{- end }}

--- a/charts/ingress-nginx/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
+++ b/charts/ingress-nginx/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
@@ -70,6 +70,9 @@ spec:
           {{- if .Values.controller.admissionWebhooks.patchWebhookJob.resources }}
           resources: {{ toYaml .Values.controller.admissionWebhooks.patchWebhookJob.resources | nindent 12 }}
           {{- end }}
+          {{- if .Values.controller.admissionWebhooks.patchWebhookJob.volumeMounts }}
+          volumeMounts: {{- toYaml .Values.controller.admissionWebhooks.patchWebhookJob.volumeMounts | nindent 12 }}
+          {{- end }}
       restartPolicy: OnFailure
       serviceAccountName: {{ include "ingress-nginx.admissionWebhooks.patch.serviceAccountName" . }}
       automountServiceAccountToken: {{ .Values.controller.admissionWebhooks.patch.serviceAccount.automountServiceAccountToken }}
@@ -81,5 +84,8 @@ spec:
     {{- end }}
     {{- if .Values.controller.admissionWebhooks.patch.securityContext }}
       securityContext: {{ toYaml .Values.controller.admissionWebhooks.patch.securityContext | nindent 8 }}
+    {{- end }}
+    {{- if .Values.controller.admissionWebhooks.patchWebhookJob.volumes }}
+      volumes: {{- toYaml .Values.controller.admissionWebhooks.patchWebhookJob.volumes | nindent 8 }}
     {{- end }}
 {{- end }}

--- a/charts/ingress-nginx/tests/admission-webhooks/job-patch/job-createSecret_test.yaml
+++ b/charts/ingress-nginx/tests/admission-webhooks/job-patch/job-createSecret_test.yaml
@@ -18,3 +18,61 @@ tests:
       - equal:
           path: spec.activeDeadlineSeconds
           value: 1
+
+  - it: should create a Job with custom volumes and volume mounts if `controller.admissionWebhooks.createSecretJob.volumes` and `controller.admissionWebhooks.createSecretJob.volumeMounts` are set
+    set:
+      controller.admissionWebhooks.patch.serviceAccount.automountServiceAccountToken: false
+      controller.admissionWebhooks.createSecretJob.volumeMounts:
+        - name: kube-api-access
+          mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          readOnly: true
+      controller.admissionWebhooks.createSecretJob.volumes:
+        - name: kube-api-access
+          projected:
+            defaultMode: 0444
+            sources:
+              - serviceAccountToken:
+                  path: token
+                  expirationSeconds: 3600
+              - configMap:
+                  name: kube-root-ca.crt
+                  items:
+                    - key: ca.crt
+                      path: ca.crt
+              - downwardAPI:
+                  items:
+                    - path: namespace
+                      fieldRef:
+                        apiVersion: v1
+                        fieldPath: metadata.namespace
+    asserts:
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: false
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts
+          value:
+            - name: kube-api-access
+              mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              readOnly: true
+      - equal:
+          path: spec.template.spec.volumes
+          value:
+            - name: kube-api-access
+              projected:
+                defaultMode: 0444
+                sources:
+                  - serviceAccountToken:
+                      path: token
+                      expirationSeconds: 3600
+                  - configMap:
+                      name: kube-root-ca.crt
+                      items:
+                        - key: ca.crt
+                          path: ca.crt
+                  - downwardAPI:
+                      items:
+                        - path: namespace
+                          fieldRef:
+                            apiVersion: v1
+                            fieldPath: metadata.namespace

--- a/charts/ingress-nginx/tests/admission-webhooks/job-patch/job-patchWebhook_test.yaml
+++ b/charts/ingress-nginx/tests/admission-webhooks/job-patch/job-patchWebhook_test.yaml
@@ -18,3 +18,61 @@ tests:
       - equal:
           path: spec.activeDeadlineSeconds
           value: 1
+
+  - it: should create a Job with custom volumes and volume mounts if `controller.admissionWebhooks.patchWebhookJob.volumes` and `controller.admissionWebhooks.patchWebhookJob.volumeMounts` are set
+    set:
+      controller.admissionWebhooks.patch.serviceAccount.automountServiceAccountToken: false
+      controller.admissionWebhooks.patchWebhookJob.volumeMounts:
+        - name: kube-api-access
+          mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          readOnly: true
+      controller.admissionWebhooks.patchWebhookJob.volumes:
+        - name: kube-api-access
+          projected:
+            defaultMode: 0444
+            sources:
+              - serviceAccountToken:
+                  path: token
+                  expirationSeconds: 3600
+              - configMap:
+                  name: kube-root-ca.crt
+                  items:
+                    - key: ca.crt
+                      path: ca.crt
+              - downwardAPI:
+                  items:
+                    - path: namespace
+                      fieldRef:
+                        apiVersion: v1
+                        fieldPath: metadata.namespace
+    asserts:
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: false
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts
+          value:
+            - name: kube-api-access
+              mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              readOnly: true
+      - equal:
+          path: spec.template.spec.volumes
+          value:
+            - name: kube-api-access
+              projected:
+                defaultMode: 0444
+                sources:
+                  - serviceAccountToken:
+                      path: token
+                      expirationSeconds: 3600
+                  - configMap:
+                      name: kube-root-ca.crt
+                      items:
+                        - key: ca.crt
+                          path: ca.crt
+                  - downwardAPI:
+                      items:
+                        - path: namespace
+                          fieldRef:
+                            apiVersion: v1
+                            fieldPath: metadata.namespace

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -795,6 +795,16 @@ controller:
       # requests:
       #   cpu: 10m
       #   memory: 20Mi
+      # -- Volume mounts for secret creation containers
+      volumeMounts: []
+      # - name: certs
+      #   mountPath: /etc/webhook/certs
+      #   readOnly: true
+      # -- Volumes for secret creation pod
+      volumes: []
+      # - name: certs
+      #   secret:
+      #     secretName: my-webhook-secret
     patchWebhookJob:
       name: patch
       # -- Deadline in seconds for the job to complete. Must be greater than 0 to enforce. If unset or 0, no deadline is enforced.
@@ -812,6 +822,16 @@ controller:
             - ALL
         readOnlyRootFilesystem: true
       resources: {}
+      # -- Volume mounts for webhook patch containers
+      volumeMounts: []
+      # - name: certs
+      #   mountPath: /etc/webhook/certs
+      #   readOnly: true
+      # -- Volumes for webhook patch pod
+      volumes: []
+      # - name: certs
+      #   secret:
+      #     secretName: my-webhook-secret
     patch:
       enabled: true
       image:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
<!--- Please make sure you title is descriptive, it is used in the Release notes to let others know what it does ---> 

## What this PR does / why we need it:
This PR adds support for specifying custom volumes and volumeMounts in the AdmissionWebhook createSecretJob and patchWebhookJob.  The template provides the attribute `automountServiceAccountToken`. However, if `automountServiceAccountToken` is set to false, the jobs fail. Therefore, to fix that issue, `volumeMount` and `volume` needs to be set.

This provides flexibility for users who need to mount additional data (e.g., certificates, configuration files, or shared volumes) into the admission webhook jobs.
Previously, these jobs did not support custom volumes or mounts, which limited use cases where external data is required during webhook secret creation or patching.


## Types of changes
- [X] New feature (non-breaking change which adds functionality)

## Which issue/s this PR fixes
fixes #13810 

## How Has This Been Tested?
- Deployed Helm chart with custom volumes and volumeMounts defined in values.yaml.
- Verified that both createSecretJob and patchWebhookJob rendered correctly with the custom mounts in the Job manifests.
- Confirmed Jobs executed successfully with the mounted volumes present in the containers.
- Verified that no changes occur when values are left as defaults ([]).
- Tested the scenario in a dev cluster manually


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [x] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
