### PR TITLE
Metrics: Fix `nginx_ingress_controller_config_last_reload_successful`.

### DIFF
--- a/internal/ingress/controller/nginx.go
+++ b/internal/ingress/controller/nginx.go
@@ -264,6 +264,8 @@ type NGINXController struct {
 	validationWebhookServer *http.Server
 
 	command NginxExecTester
+
+	lastConfigSuccess bool
 }
 
 // Start starts a new NGINX master process running in the foreground.


### PR DESCRIPTION
## What this PR does / why we need it:
This patch fixes an issue in the NGINX Ingress Controller where invalid Ingress resources caused metric `nginx_ingress_controller_config_last_reload_successful` to be set value to `0` and never restored after the resource was deleted. 

**With this change, metrics are now correctly updated even if an Ingress is removed, or its configuration is invalid.**  

This ensures that monitoring data remains consistent and accurate.

🪲 P.S. this PR also resolved [Issue#13818](https://github.com/kubernetes/ingress-nginx/issues/13818) 

Previously, when an Ingress contained misconfigurations (e.g. invalid annotations or unsupported snippet directives), the following problems occurred:

1. Metrics such as `nginx_ingress_controller_config_last_reload_successful` were set to `0`.  
2. After deleting the invalid Ingress, metrics stayed at `0` instead of being restored to `1`.  
3. Some parts of the `syncIngress` logic were skipped due to an early `Equal` check, preventing proper metric updates.  

As a result:
- Metrics did not reflect the real state of the controller.  
- Monitoring systems could generate false alerts.  
- Operators had no reliable signal that the system had recovered after removing a faulty Ingress.  

This patch resolves those issues by ensuring metrics are always properly updated, regardless of Ingress validity.
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
This PR fixed [Issue#13818](https://github.com/kubernetes/ingress-nginx/issues/13818)

## How Has This Been Tested?
1. Create an invalid Ingress resource;
```
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: my-app-ingress
  namespace: default
  annotations:
    nginx.ingress.kubernetes.io/configuration-snippet: |
      bla-bla-bla
spec:
  ingressClassName: nginx
  rules:
    - host: myapp.example.com
      http:
        paths:
          - path: /
            pathType: Prefix
            backend:
              service:
                name: myapp
                port:
                  number: 80
```
2. See in logs that NGINX complains about invalid configuration;
```
Error reloading NGINX:
-------------------------------------------------------------------------------
Error: exit status 1
nginx: [emerg] unknown directive "bla-bla-bla" in /tmp/nginx/nginx-cfg3530923120:6208
nginx: configuration file /tmp/nginx/nginx-cfg3530923120 test failed
-------------------------------------------------------------------------------
```
3. Check metrics inside the pod, value is `0`;
```
curl 127.0.0.1:10254/metrics -s | grep reload_successful{
nginx_ingress_controller_config_last_reload_successful{controller_class="ingress-nginx.deckhouse.io/nginx",controller_namespace="d8-ingress-nginx",controller_pod="controller-nginx-rwmf5"} 0
```
4. Delete the invalid Ingress resource;
5. Check metrics again, value is should be `1`.
```
curl 127.0.0.1:10254/metrics -s | grep reload_successful{
nginx_ingress_controller_config_last_reload_successful{controller_class="ingress-nginx.deckhouse.io/nginx",controller_namespace="d8-ingress-nginx",controller_pod="controller-nginx-rwmf5"} 1
```

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.
