### PR TITLE
Tests: Bump Test Runner to v1.4.2.

### DIFF
--- a/build/run-in-docker.sh
+++ b/build/run-in-docker.sh
@@ -41,7 +41,7 @@ function cleanup {
 }
 trap cleanup EXIT
 
-E2E_IMAGE=${E2E_IMAGE:-registry.k8s.io/ingress-nginx/e2e-test-runner:v1.4.1@sha256:a550c4fc42804e80b43d75511b888e9c287e2bfce9f186a2d7b9b2d686042e61}
+E2E_IMAGE=${E2E_IMAGE:-registry.k8s.io/ingress-nginx/e2e-test-runner:v1.4.2@sha256:9a4f68e566b9ca69285e6d5d4e65a91eb563d8d52b652b631199b9f754fd7502}
 
 if [[ "$RUNTIME" == podman ]]; then
   # Podman does not support both tag and digest

--- a/test/e2e-image/Makefile
+++ b/test/e2e-image/Makefile
@@ -1,6 +1,6 @@
 
 DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
-E2E_BASE_IMAGE ?= "registry.k8s.io/ingress-nginx/e2e-test-runner:v1.4.1@sha256:a550c4fc42804e80b43d75511b888e9c287e2bfce9f186a2d7b9b2d686042e61"
+E2E_BASE_IMAGE ?= "registry.k8s.io/ingress-nginx/e2e-test-runner:v1.4.2@sha256:9a4f68e566b9ca69285e6d5d4e65a91eb563d8d52b652b631199b9f754fd7502"
 
 image:
 	echo "..entered Makefile in /test/e2e-image"

--- a/test/e2e/run-chart-test.sh
+++ b/test/e2e/run-chart-test.sh
@@ -114,5 +114,5 @@ docker run \
   --workdir /workdir \
   --entrypoint ct \
   --rm \
-  registry.k8s.io/ingress-nginx/e2e-test-runner:v1.4.1@sha256:a550c4fc42804e80b43d75511b888e9c287e2bfce9f186a2d7b9b2d686042e61 \
+  registry.k8s.io/ingress-nginx/e2e-test-runner:v1.4.2@sha256:9a4f68e566b9ca69285e6d5d4e65a91eb563d8d52b652b631199b9f754fd7502 \
     install --charts charts/ingress-nginx


### PR DESCRIPTION
/triage accepted
/kind cleanup
/priority backlog
/hold

Tests are intended to fail as this image has not been published, yet. I am still waiting for approval [here](https://github.com/kubernetes/k8s.io/pull/8445).