### PR TITLE
Delete datadog* configs from documentation

### DIFF
--- a/docs/user-guide/nginx-configuration/configmap.md
+++ b/docs/user-guide/nginx-configuration/configmap.md
@@ -148,13 +148,6 @@ The following table shows a configuration option's name, type, and the default v
 | [jaeger-debug-header](#jaeger-debug-header)                                     | string       | uber-debug-id                                                                                                                                                                                                                                                                                                                                                |                                                                                     |
 | [jaeger-baggage-header](#jaeger-baggage-header)                                 | string       | jaeger-baggage                                                                                                                                                                                                                                                                                                                                               |                                                                                     |
 | [jaeger-trace-baggage-header-prefix](#jaeger-trace-baggage-header-prefix)       | string       | uberctx-                                                                                                                                                                                                                                                                                                                                                     |                                                                                     |
-| [datadog-collector-host](#datadog-collector-host)                               | string       | ""                                                                                                                                                                                                                                                                                                                                                           |                                                                                     |
-| [datadog-collector-port](#datadog-collector-port)                               | int          | 8126                                                                                                                                                                                                                                                                                                                                                         |                                                                                     |
-| [datadog-service-name](#datadog-service-name)                                   | string       | "nginx"                                                                                                                                                                                                                                                                                                                                                      |                                                                                     |
-| [datadog-environment](#datadog-environment)                                     | string       | "prod"                                                                                                                                                                                                                                                                                                                                                       |                                                                                     |
-| [datadog-operation-name-override](#datadog-operation-name-override)             | string       | "nginx.handle"                                                                                                                                                                                                                                                                                                                                               |                                                                                     |
-| [datadog-priority-sampling](#datadog-priority-sampling)                         | bool         | "true"                                                                                                                                                                                                                                                                                                                                                       |                                                                                     |
-| [datadog-sample-rate](#datadog-sample-rate)                                     | float        | 1.0                                                                                                                                                                                                                                                                                                                                                          |                                                                                     |
 | [enable-opentelemetry](#enable-opentelemetry)                                   | bool         | "false"                                                                                                                                                                                                                                                                                                                                                      |                                                                                     |
 | [opentelemetry-trust-incoming-span](#opentelemetry-trust-incoming-span)         | bool         | "true"                                                                                                                                                                                                                                                                                                                                                       |                                                                                     |
 | [opentelemetry-operation-name](#opentelemetry-operation-name)                   | string       | ""                                                                                                                                                                                                                                                                                                                                                           |                                                                                     |
@@ -983,36 +976,6 @@ Specifies the header name used to submit baggage if there is no root span. _**de
 ## jaeger-tracer-baggage-header-prefix
 
 Specifies the header prefix used to propagate baggage. _**default:**_ uberctx-
-
-## datadog-collector-host
-
-Specifies the datadog agent host to use when uploading traces. It must be a valid URL.
-
-## datadog-collector-port
-
-Specifies the port to use when uploading traces. _**default:**_ 8126
-
-## datadog-service-name
-
-Specifies the service name to use for any traces created. _**default:**_ nginx
-
-## datadog-environment
-
-Specifies the environment this trace belongs to. _**default:**_ prod
-
-## datadog-operation-name-override
-
-Overrides the operation name to use for any traces crated. _**default:**_ nginx.handle
-
-## datadog-priority-sampling
-
-Specifies to use client-side sampling.
-If true disables client-side sampling (thus ignoring `sample_rate`) and enables distributed priority sampling, where traces are sampled based on a combination of user-assigned priorities and configuration from the agent. _**default:**_ true
-
-## datadog-sample-rate
-
-Specifies sample rate for any traces created.
-This is effective only when `datadog-priority-sampling` is `false` _**default:**_ 1.0
 
 ## enable-opentelemetry
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
<!--- Please make sure you title is descriptive, it is used in the Release notes to let others know what it does ---> 

## What this PR does / why we need it:

The native integration with datadog has long been deleted and these config keys no longer exist, so let's just delete them from the documentation.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation only

## How Has This Been Tested?

I searched the code and couldn't find any of these keywords.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
