### PR TITLE
Chart: Allow control of jobs TTL durations using values

### DIFF
--- a/charts/ingress-nginx/README.md
+++ b/charts/ingress-nginx/README.md
@@ -264,6 +264,7 @@ metadata:
 | controller.admissionWebhooks.createSecretJob.name | string | `"create"` |  |
 | controller.admissionWebhooks.createSecretJob.resources | object | `{}` |  |
 | controller.admissionWebhooks.createSecretJob.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":65532,"runAsNonRoot":true,"runAsUser":65532,"seccompProfile":{"type":"RuntimeDefault"}}` | Security context for secret creation containers |
+| controller.admissionWebhooks.createSecretJob.ttlSecondsAfterFinished | int | `0` | Duration in seconds before job removal. Must be greater to 0 to ensure argocd has time to detect job completion. |
 | controller.admissionWebhooks.createSecretJob.volumeMounts | list | `[]` | Volume mounts for secret creation containers |
 | controller.admissionWebhooks.createSecretJob.volumes | list | `[]` | Volumes for secret creation pod |
 | controller.admissionWebhooks.enabled | bool | `true` |  |
@@ -297,6 +298,7 @@ metadata:
 | controller.admissionWebhooks.patchWebhookJob.name | string | `"patch"` |  |
 | controller.admissionWebhooks.patchWebhookJob.resources | object | `{}` |  |
 | controller.admissionWebhooks.patchWebhookJob.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":65532,"runAsNonRoot":true,"runAsUser":65532,"seccompProfile":{"type":"RuntimeDefault"}}` | Security context for webhook patch containers |
+| controller.admissionWebhooks.patchWebhookJob.ttlSecondsAfterFinished | int | `0` | Duration in seconds before job removal. Must be greater to 0 to ensure argocd has time to detect job completion. |
 | controller.admissionWebhooks.patchWebhookJob.volumeMounts | list | `[]` | Volume mounts for webhook patch containers |
 | controller.admissionWebhooks.patchWebhookJob.volumes | list | `[]` | Volumes for webhook patch pod |
 | controller.admissionWebhooks.port | int | `8443` |  |

--- a/charts/ingress-nginx/templates/admission-webhooks/job-patch/job-createSecret.yaml
+++ b/charts/ingress-nginx/templates/admission-webhooks/job-patch/job-createSecret.yaml
@@ -17,7 +17,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  ttlSecondsAfterFinished: 0
+  ttlSecondsAfterFinished: {{ .Values.controller.admissionWebhooks.createSecretJob.ttlSecondsAfterFinished }}
 {{- if gt (int .Values.controller.admissionWebhooks.createSecretJob.activeDeadlineSeconds) 0 }}
   activeDeadlineSeconds: {{ .Values.controller.admissionWebhooks.createSecretJob.activeDeadlineSeconds }}
 {{- end }}

--- a/charts/ingress-nginx/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
+++ b/charts/ingress-nginx/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
@@ -17,7 +17,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  ttlSecondsAfterFinished: 0
+  ttlSecondsAfterFinished: {{ .Values.controller.admissionWebhooks.patchWebhookJob.ttlSecondsAfterFinished }}
 {{- if gt (int .Values.controller.admissionWebhooks.patchWebhookJob.activeDeadlineSeconds) 0 }}
   activeDeadlineSeconds: {{ .Values.controller.admissionWebhooks.patchWebhookJob.activeDeadlineSeconds }}
 {{- end }}

--- a/charts/ingress-nginx/tests/admission-webhooks/job-patch/job-createSecret_test.yaml
+++ b/charts/ingress-nginx/tests/admission-webhooks/job-patch/job-createSecret_test.yaml
@@ -76,3 +76,11 @@ tests:
                           fieldRef:
                             apiVersion: v1
                             fieldPath: metadata.namespace
+
+  - it: should create a Job with `ttlSecondsAfterFinished` set to value from `controller.admissionWebhooks.createSecretJob.ttlSecondsAfterFinished`
+    set:
+      controller.admissionWebhooks.createSecretJob.ttlSecondsAfterFinished: 60
+    asserts:
+      - equal:
+          path: spec.ttlSecondsAfterFinished
+          value: 60

--- a/charts/ingress-nginx/tests/admission-webhooks/job-patch/job-patchWebhook_test.yaml
+++ b/charts/ingress-nginx/tests/admission-webhooks/job-patch/job-patchWebhook_test.yaml
@@ -76,3 +76,11 @@ tests:
                           fieldRef:
                             apiVersion: v1
                             fieldPath: metadata.namespace
+
+  - it: should create a Job with `ttlSecondsAfterFinished` set to value from `controller.admissionWebhooks.patchWebhookJob.ttlSecondsAfterFinished`
+    set:
+      controller.admissionWebhooks.patchWebhookJob.ttlSecondsAfterFinished: 30
+    asserts:
+      - equal:
+          path: spec.ttlSecondsAfterFinished
+          value: 30

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -774,6 +774,8 @@ controller:
       type: ClusterIP
     createSecretJob:
       name: create
+      # -- Duration in seconds before job removal. Must be greater to 0 to ensure argocd has time to detect job completion.
+      ttlSecondsAfterFinished: 0
       # -- Deadline in seconds for the job to complete. Must be greater than 0 to enforce. If unset or 0, no deadline is enforced.
       activeDeadlineSeconds: 0
       # -- Security context for secret creation containers
@@ -807,6 +809,8 @@ controller:
       #     secretName: my-webhook-secret
     patchWebhookJob:
       name: patch
+      # -- Duration in seconds before job removal. Must be greater to 0 to ensure argocd has time to detect job completion.
+      ttlSecondsAfterFinished: 0
       # -- Deadline in seconds for the job to complete. Must be greater than 0 to enforce. If unset or 0, no deadline is enforced.
       activeDeadlineSeconds: 0
       # -- Security context for webhook patch containers


### PR DESCRIPTION
## What this PR does / why we need it:
When using ArgoCD to update an existing `ingress-nginx` chart deployment without using `certmanager`, it stays in the `Syncing` state forever.
This issue has been documented and analyzed in https://github.com/argoproj/argo-cd/issues/6880 .

The core problem is that the helm hooks `Job`s (`createSecretJob` and `patchWebhookJob`) are created with `.spec.ttlSecondsAfterFinished` hardcoded to 0 (zero).

As a result, the `Job` can execute very fast (when the image is already available in the k8s cluster and it has nothing to do) and the corresponding `Job` is removed right away.
In this case, because of its internal model to process helm hooks, argocd has no way to check that the job has completed -  argocd considers the Job was not even created in the first place and awaits for its creation - fovever.

This change allows to control the value of the `.spec.ttlSecondsAfterFinished` field of both jobs (independantly, default value stays to zero to ensure backward compatibility) as chart values.

Users hit by this problem can then set them to 30 or 60 seconds, which is more than enough for argocd to successfully pick the job completion outcome and proceed with the rest of the deployment upgrade.

Documentation for these two additional values have been added to `README.md` and related unit tests added.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes

## How Has This Been Tested?

Versions:
* `helm` v3.18.2
* `unittest` helm plugin: 0.3.1

```make helm-test```
```
### Chart [ ingress-nginx ] charts/ingress-nginx

 PASS  Controller > ConfigMap > Add Headers	charts/ingress-nginx/tests/controller-configmap-addheaders_test.yaml
 PASS  Controller > ConfigMap > Proxy Headers	charts/ingress-nginx/tests/controller-configmap-proxyheaders_test.yaml
 PASS  Controller > ConfigMap	charts/ingress-nginx/tests/controller-configmap_test.yaml
 PASS  Controller > DaemonSet	charts/ingress-nginx/tests/controller-daemonset_test.yaml
 PASS  Controller > Deployment	charts/ingress-nginx/tests/controller-deployment_test.yaml
 PASS  Controller > HPA	charts/ingress-nginx/tests/controller-hpa_test.yaml
 PASS  Controller > IngressClass > Aliases	charts/ingress-nginx/tests/controller-ingressclass-aliases_test.yaml
 PASS  Controller > IngressClass	charts/ingress-nginx/tests/controller-ingressclass_test.yaml
 PASS  Controller > KEDA	charts/ingress-nginx/tests/controller-keda_test.yaml
 PASS  Controller > NetworkPolicy	charts/ingress-nginx/tests/controller-networkpolicy_test.yaml
 PASS  Controller > PodDisruptionBudget	charts/ingress-nginx/tests/controller-poddisruptionbudget_test.yaml
 PASS  Controller > PrometheusRule	charts/ingress-nginx/tests/controller-prometheusrule_test.yaml
 PASS  Controller > Service > Internal	charts/ingress-nginx/tests/controller-service-internal_test.yaml
 PASS  Controller > Service > Metrics	charts/ingress-nginx/tests/controller-service-metrics_test.yaml
 PASS  Controller > Service > Webhook	charts/ingress-nginx/tests/controller-service-webhook_test.yaml
 PASS  Controller > Service	charts/ingress-nginx/tests/controller-service_test.yaml
 PASS  Controller > ServiceAccount	charts/ingress-nginx/tests/controller-serviceaccount_test.yaml
 PASS  Controller > ServiceMonitor	charts/ingress-nginx/tests/controller-servicemonitor_test.yaml
 PASS  Default Backend > Deployment	charts/ingress-nginx/tests/default-backend-deployment_test.yaml
 PASS  Default Backend > Extra ConfigMaps	charts/ingress-nginx/tests/default-backend-extra-configmaps_test.yaml
 PASS  Default Backend > PodDisruptionBudget	charts/ingress-nginx/tests/default-backend-poddisruptionbudget_test.yaml
 PASS  Default Backend > Service	charts/ingress-nginx/tests/default-backend-service_test.yaml
 PASS  Default Backend > ServiceAccount	charts/ingress-nginx/tests/default-backend-serviceaccount_test.yaml
 PASS  Admission Webhooks > CertManager	charts/ingress-nginx/tests/admission-webhooks/cert-manager_test.yaml
 PASS  Admission Webhooks > ValidatingWebhookConfiguration	charts/ingress-nginx/tests/admission-webhooks/validating-webhook_test.yaml
 PASS  Admission Webhooks > Patch Job > ClusterRole	charts/ingress-nginx/tests/admission-webhooks/job-patch/clusterrole_test.yaml
 PASS  Admission Webhooks > Patch Job > ClusterRoleBinding	charts/ingress-nginx/tests/admission-webhooks/job-patch/clusterrolebinding_test.yaml
 PASS  Admission Webhooks > Patch Job > Create Secret Job	charts/ingress-nginx/tests/admission-webhooks/job-patch/job-createSecret_test.yaml
 PASS  Admission Webhooks > Patch Job > Patch Webhook Job	charts/ingress-nginx/tests/admission-webhooks/job-patch/job-patchWebhook_test.yaml
 PASS  Admission Webhooks > Patch Job > Role	charts/ingress-nginx/tests/admission-webhooks/job-patch/role_test.yaml
 PASS  Admission Webhooks > Patch Job > RoleBinding	charts/ingress-nginx/tests/admission-webhooks/job-patch/rolebinding_test.yaml
 PASS  Admission Webhooks > Patch Job > ServiceAccount	charts/ingress-nginx/tests/admission-webhooks/job-patch/serviceaccount_test.yaml

Charts:      1 passed, 1 total
Test Suites: 32 passed, 32 total
Tests:       156 passed, 156 total
Snapshot:    0 passed, 0 total
Time:        1.735940294s
```

Also verified that a real-life deployment (which was stuck in the `Syncing` state after chart upgrade) was successfully upgraded with this chart including the changes.

## Checklist:
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [X] I have added unit and/or e2e tests to cover my changes.
- [X] All new and existing tests passed.
