### PR TITLE
feat(chart): Add resizePolicy support for ingress-nginx pods

### DIFF
--- a/charts/ingress-nginx/README.md
+++ b/charts/ingress-nginx/README.md
@@ -262,6 +262,7 @@ metadata:
 | controller.admissionWebhooks.certificate | string | `"/usr/local/certificates/cert"` |  |
 | controller.admissionWebhooks.createSecretJob.activeDeadlineSeconds | int | `0` | Deadline in seconds for the job to complete. Must be greater than 0 to enforce. If unset or 0, no deadline is enforced. |
 | controller.admissionWebhooks.createSecretJob.name | string | `"create"` |  |
+| controller.admissionWebhooks.createSecretJob.resizePolicy | list | `[]` | Container resizePolicy for createSecret job |
 | controller.admissionWebhooks.createSecretJob.resources | object | `{}` |  |
 | controller.admissionWebhooks.createSecretJob.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":65532,"runAsNonRoot":true,"runAsUser":65532,"seccompProfile":{"type":"RuntimeDefault"}}` | Security context for secret creation containers |
 | controller.admissionWebhooks.createSecretJob.volumeMounts | list | `[]` | Volume mounts for secret creation containers |
@@ -295,6 +296,7 @@ metadata:
 | controller.admissionWebhooks.patch.tolerations | list | `[]` |  |
 | controller.admissionWebhooks.patchWebhookJob.activeDeadlineSeconds | int | `0` | Deadline in seconds for the job to complete. Must be greater than 0 to enforce. If unset or 0, no deadline is enforced. |
 | controller.admissionWebhooks.patchWebhookJob.name | string | `"patch"` |  |
+| controller.admissionWebhooks.patchWebhookJob.resizePolicy | list | `[]` | Container resizePolicy for patchWebhook job |
 | controller.admissionWebhooks.patchWebhookJob.resources | object | `{}` |  |
 | controller.admissionWebhooks.patchWebhookJob.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":65532,"runAsNonRoot":true,"runAsUser":65532,"seccompProfile":{"type":"RuntimeDefault"}}` | Security context for webhook patch containers |
 | controller.admissionWebhooks.patchWebhookJob.volumeMounts | list | `[]` | Volume mounts for webhook patch containers |
@@ -443,6 +445,7 @@ metadata:
 | controller.readinessProbe.timeoutSeconds | int | `1` |  |
 | controller.replicaCount | int | `1` |  |
 | controller.reportNodeInternalIp | bool | `false` | Bare-metal considerations via the host network https://kubernetes.github.io/ingress-nginx/deploy/baremetal/#via-the-host-network Ingress status was blank because there is no Service exposing the Ingress-Nginx Controller in a configuration using the host network, the default --publish-service flag used in standard cloud setups does not apply |
+| controller.resizePolicy | list | `[]` | Container resizePolicy for CPU and memory ref: https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/ |
 | controller.resources.requests.cpu | string | `"100m"` |  |
 | controller.resources.requests.memory | string | `"90Mi"` |  |
 | controller.runtimeClassName | string | `""` | Instruct the kubelet to use the named RuntimeClass to run the pod |

--- a/charts/ingress-nginx/templates/admission-webhooks/job-patch/job-createSecret.yaml
+++ b/charts/ingress-nginx/templates/admission-webhooks/job-patch/job-createSecret.yaml
@@ -68,6 +68,9 @@ spec:
           {{- if .Values.controller.admissionWebhooks.createSecretJob.resources }}
           resources: {{ toYaml .Values.controller.admissionWebhooks.createSecretJob.resources | nindent 12 }}
           {{- end }}
+          {{- if .Values.controller.admissionWebhooks.createSecretJob.resizePolicy }}
+          resizePolicy: {{ toYaml .Values.controller.admissionWebhooks.createSecretJob.resizePolicy | nindent 12 }}
+          {{- end }}
           {{- if .Values.controller.admissionWebhooks.createSecretJob.volumeMounts }}
           volumeMounts: {{- toYaml .Values.controller.admissionWebhooks.createSecretJob.volumeMounts | nindent 12 }}
           {{- end }}

--- a/charts/ingress-nginx/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
+++ b/charts/ingress-nginx/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
@@ -70,6 +70,9 @@ spec:
           {{- if .Values.controller.admissionWebhooks.patchWebhookJob.resources }}
           resources: {{ toYaml .Values.controller.admissionWebhooks.patchWebhookJob.resources | nindent 12 }}
           {{- end }}
+          {{- if .Values.controller.admissionWebhooks.patchWebhookJob.resizePolicy }}
+          resizePolicy: {{ toYaml .Values.controller.admissionWebhooks.patchWebhookJob.resizePolicy | nindent 12 }}
+          {{- end }}
           {{- if .Values.controller.admissionWebhooks.patchWebhookJob.volumeMounts }}
           volumeMounts: {{- toYaml .Values.controller.admissionWebhooks.patchWebhookJob.volumeMounts | nindent 12 }}
           {{- end }}

--- a/charts/ingress-nginx/templates/controller-daemonset.yaml
+++ b/charts/ingress-nginx/templates/controller-daemonset.yaml
@@ -174,6 +174,9 @@ spec:
         {{- if .Values.controller.resources }}
           resources: {{ toYaml .Values.controller.resources | nindent 12 }}
         {{- end }}
+        {{- if .Values.controller.resizePolicy }}
+          resizePolicy: {{ toYaml .Values.controller.resizePolicy | nindent 12 }}
+        {{- end }}
       {{- if .Values.controller.extraContainers }}
         {{- toYaml .Values.controller.extraContainers | nindent 8 }}
       {{- end }}

--- a/charts/ingress-nginx/templates/controller-deployment.yaml
+++ b/charts/ingress-nginx/templates/controller-deployment.yaml
@@ -180,6 +180,9 @@ spec:
         {{- if .Values.controller.resources }}
           resources: {{ toYaml .Values.controller.resources | nindent 12 }}
         {{- end }}
+        {{- if .Values.controller.resizePolicy }}
+          resizePolicy: {{ toYaml .Values.controller.resizePolicy | nindent 12 }}
+        {{- end }}
       {{- if .Values.controller.extraContainers }}
         {{- toYaml .Values.controller.extraContainers | nindent 8 }}
       {{- end }}

--- a/charts/ingress-nginx/tests/admission-webhooks/job-patch/job-createSecret_test.yaml
+++ b/charts/ingress-nginx/tests/admission-webhooks/job-patch/job-createSecret_test.yaml
@@ -76,3 +76,31 @@ tests:
                           fieldRef:
                             apiVersion: v1
                             fieldPath: metadata.namespace
+
+  - it: should create a Job with resizePolicy if `controller.admissionWebhooks.createSecretJob.resizePolicy` is set
+    set:
+      controller.admissionWebhooks.createSecretJob.resizePolicy:
+        - resourceName: cpu
+          restartPolicy: NotRequired
+        - resourceName: memory
+          restartPolicy: RestartContainer
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resizePolicy[0].resourceName
+          value: cpu
+      - equal:
+          path: spec.template.spec.containers[0].resizePolicy[0].restartPolicy
+          value: NotRequired
+      - equal:
+          path: spec.template.spec.containers[0].resizePolicy[1].resourceName
+          value: memory
+      - equal:
+          path: spec.template.spec.containers[0].resizePolicy[1].restartPolicy
+          value: RestartContainer
+
+  - it: should not include resizePolicy if `controller.admissionWebhooks.createSecretJob.resizePolicy` is empty
+    set:
+      controller.admissionWebhooks.createSecretJob.resizePolicy: []
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].resizePolicy

--- a/charts/ingress-nginx/tests/admission-webhooks/job-patch/job-patchWebhook_test.yaml
+++ b/charts/ingress-nginx/tests/admission-webhooks/job-patch/job-patchWebhook_test.yaml
@@ -76,3 +76,31 @@ tests:
                           fieldRef:
                             apiVersion: v1
                             fieldPath: metadata.namespace
+
+  - it: should create a Job with resizePolicy if `controller.admissionWebhooks.patchWebhookJob.resizePolicy` is set
+    set:
+      controller.admissionWebhooks.patchWebhookJob.resizePolicy:
+        - resourceName: cpu
+          restartPolicy: NotRequired
+        - resourceName: memory
+          restartPolicy: RestartContainer
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resizePolicy[0].resourceName
+          value: cpu
+      - equal:
+          path: spec.template.spec.containers[0].resizePolicy[0].restartPolicy
+          value: NotRequired
+      - equal:
+          path: spec.template.spec.containers[0].resizePolicy[1].resourceName
+          value: memory
+      - equal:
+          path: spec.template.spec.containers[0].resizePolicy[1].restartPolicy
+          value: RestartContainer
+
+  - it: should not include resizePolicy if `controller.admissionWebhooks.patchWebhookJob.resizePolicy` is empty
+    set:
+      controller.admissionWebhooks.patchWebhookJob.resizePolicy: []
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].resizePolicy

--- a/charts/ingress-nginx/tests/controller-daemonset_test.yaml
+++ b/charts/ingress-nginx/tests/controller-daemonset_test.yaml
@@ -208,3 +208,33 @@ tests:
       - equal:
           path: spec.template.spec.runtimeClassName
           value: myClass
+
+  - it: should create a DaemonSet with resizePolicy if `controller.resizePolicy` is set
+    set:
+      controller.kind: DaemonSet
+      controller.resizePolicy:
+        - resourceName: cpu
+          restartPolicy: NotRequired
+        - resourceName: memory
+          restartPolicy: RestartContainer
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resizePolicy[0].resourceName
+          value: cpu
+      - equal:
+          path: spec.template.spec.containers[0].resizePolicy[0].restartPolicy
+          value: NotRequired
+      - equal:
+          path: spec.template.spec.containers[0].resizePolicy[1].resourceName
+          value: memory
+      - equal:
+          path: spec.template.spec.containers[0].resizePolicy[1].restartPolicy
+          value: RestartContainer
+
+  - it: should not include resizePolicy if `controller.resizePolicy` is empty
+    set:
+      controller.kind: DaemonSet
+      controller.resizePolicy: []
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].resizePolicy

--- a/charts/ingress-nginx/tests/controller-deployment_test.yaml
+++ b/charts/ingress-nginx/tests/controller-deployment_test.yaml
@@ -231,3 +231,31 @@ tests:
       - equal:
           path: spec.template.spec.runtimeClassName
           value: myClass
+
+  - it: should create a Deployment with resizePolicy if `controller.resizePolicy` is set
+    set:
+      controller.resizePolicy:
+        - resourceName: cpu
+          restartPolicy: NotRequired
+        - resourceName: memory
+          restartPolicy: RestartContainer
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resizePolicy[0].resourceName
+          value: cpu
+      - equal:
+          path: spec.template.spec.containers[0].resizePolicy[0].restartPolicy
+          value: NotRequired
+      - equal:
+          path: spec.template.spec.containers[0].resizePolicy[1].resourceName
+          value: memory
+      - equal:
+          path: spec.template.spec.containers[0].resizePolicy[1].restartPolicy
+          value: RestartContainer
+
+  - it: should not include resizePolicy if `controller.resizePolicy` is empty
+    set:
+      controller.resizePolicy: []
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].resizePolicy

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -401,6 +401,13 @@ controller:
     requests:
       cpu: 100m
       memory: 90Mi
+  # -- Container resizePolicy for CPU and memory
+  # ref: https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/
+  resizePolicy: []
+    # - resourceName: cpu
+    #   restartPolicy: NotRequired
+    # - resourceName: memory
+    #   restartPolicy: RestartContainer
   # Mutually exclusive with keda autoscaling
   autoscaling:
     enabled: false
@@ -795,6 +802,12 @@ controller:
       # requests:
       #   cpu: 10m
       #   memory: 20Mi
+      # -- Container resizePolicy for createSecret job
+      resizePolicy: []
+        # - resourceName: cpu
+        #   restartPolicy: NotRequired
+        # - resourceName: memory
+        #   restartPolicy: RestartContainer
       # -- Volume mounts for secret creation containers
       volumeMounts: []
       # - name: certs
@@ -822,6 +835,12 @@ controller:
             - ALL
         readOnlyRootFilesystem: true
       resources: {}
+      # -- Container resizePolicy for patchWebhook job
+      resizePolicy: []
+        # - resourceName: cpu
+        #   restartPolicy: NotRequired
+        # - resourceName: memory
+        #   restartPolicy: RestartContainer
       # -- Volume mounts for webhook patch containers
       volumeMounts: []
       # - name: certs


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
<!--- Please make sure you title is descriptive, it is used in the Release notes to let others know what it does ---> 

## What this PR does / why we need it:

This PR adds support for Kubernetes resizePolicy configuration to the ingress-nginx Helm chart. The resizePolicy feature allows containers to be resized without pod restarts, enabling dynamic resource adjustments for better resource utilization and cost efficiency.

The implementation adds resizePolicy support for:
- Controller pods (Deployment and DaemonSet)
- Admission webhook jobs (createSecret and patchWebhook)

Related Kubernetes Documentation

- https://kubernetes.io/docs/concepts/workloads/pods/resize-pod-resources/
- https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#Container

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?

  - Added comprehensive unit tests for all resizePolicy configurations
  - All tests pass successfully:

```bash
$ helm unittest .
### Chart [ ingress-nginx ] .

 PASS  Controller > ConfigMap > Add Headers     tests/controller-configmap-addheaders_test.yaml
 PASS  Controller > ConfigMap > Proxy Headers   tests/controller-configmap-proxyheaders_test.yaml
 PASS  Controller > ConfigMap   tests/controller-configmap_test.yaml
 PASS  Controller > DaemonSet   tests/controller-daemonset_test.yaml
 PASS  Controller > Deployment  tests/controller-deployment_test.yaml
 PASS  Controller > HPA tests/controller-hpa_test.yaml
 PASS  Controller > IngressClass > Aliases      tests/controller-ingressclass-aliases_test.yaml
 PASS  Controller > IngressClass        tests/controller-ingressclass_test.yaml
 PASS  Controller > KEDA        tests/controller-keda_test.yaml
 PASS  Controller > NetworkPolicy       tests/controller-networkpolicy_test.yaml
 PASS  Controller > PodDisruptionBudget tests/controller-poddisruptionbudget_test.yaml
 PASS  Controller > PrometheusRule      tests/controller-prometheusrule_test.yaml
 PASS  Controller > Service > Internal  tests/controller-service-internal_test.yaml
 PASS  Controller > Service > Metrics   tests/controller-service-metrics_test.yaml
 PASS  Controller > Service > Webhook   tests/controller-service-webhook_test.yaml
 PASS  Controller > Service     tests/controller-service_test.yaml
 PASS  Controller > ServiceAccount      tests/controller-serviceaccount_test.yaml
 PASS  Controller > ServiceMonitor      tests/controller-servicemonitor_test.yaml
 PASS  Default Backend > Deployment     tests/default-backend-deployment_test.yaml
 PASS  Default Backend > Extra ConfigMaps       tests/default-backend-extra-configmaps_test.yaml
 PASS  Default Backend > PodDisruptionBudget    tests/default-backend-poddisruptionbudget_test.yaml
 PASS  Default Backend > Service        tests/default-backend-service_test.yaml
 PASS  Default Backend > ServiceAccount tests/default-backend-serviceaccount_test.yaml

Charts:      1 passed, 1 total
Test Suites: 23 passed, 23 total
Tests:       138 passed, 138 total
Snapshot:    0 passed, 0 total
Time:        1.075678208s
```
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [x] I have added unit and/or e2e tests to cover my changes.
- [x] All new and existing tests passed.
