### PR TITLE
Plugin: Change `rewriteTargetWithoutCaptureGroup` lint to include any numbered capture group.

### DIFF
--- a/cmd/plugin/lints/ingress.go
+++ b/cmd/plugin/lints/ingress.go
@@ -18,6 +18,7 @@ package lints
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	networking "k8s.io/api/networking/v1"
@@ -126,7 +127,7 @@ func annotationPrefixIsNginxOrg(ing *networking.Ingress) bool {
 
 func rewriteTargetWithoutCaptureGroup(ing *networking.Ingress) bool {
 	for name, val := range ing.Annotations {
-		if strings.HasSuffix(name, "/rewrite-target") && !strings.Contains(val, "$1") {
+		if strings.HasSuffix(name, "/rewrite-target") && !regexp.MustCompile(`\$\d+`).MatchString(val) {
 			return true
 		}
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
<!--- Please make sure you title is descriptive, it is used in the Release notes to let others know what it does ---> 

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR fixes https://github.com/kubernetes/ingress-nginx/issues/4282. Previously the lint would validate if only the first capture group is mentioned, now it can accept any numbered capture group.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
fixes #4282

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally with a new build of the `kubectl` plugin.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
