### PR TITLE
Custom Error Pages: Do not write status code too soon.

### DIFF
--- a/images/custom-error-pages/rootfs/main.go
+++ b/images/custom-error-pages/rootfs/main.go
@@ -180,7 +180,7 @@ func errorHandler(path, defaultFormat string) func(http.ResponseWriter, *http.Re
 		w.WriteHeader(code)
 		io.Copy(w, f)
 
-		duration := time.Now().Sub(start).Seconds()
+		duration := time.Since(start).Seconds()
 
 		proto := strconv.Itoa(r.ProtoMajor)
 		proto = fmt.Sprintf("%s.%s", proto, strconv.Itoa(r.ProtoMinor))


### PR DESCRIPTION
Remove duplicate `WriteHeader` call if requested file not found.

<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
<!--- Please make sure you title is descriptive, it is used in the Release notes to let others know what it does ---> 

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The main purpose of this PR is to fix a dual call to `WriteHeader` if the requested file was not found and a `http.NotFound()` as this function will also call `WriteHeader` under the hood.

It could even `panic` if a wrong http code was sent via `curl -H "X-Code: 0" http://localhost:8080/`:
```
2025/11/11 13:52:58 format not specified. Using text/html
2025/11/11 13:52:58 http: panic serving 192.168.65.1:32712: invalid WriteHeader code 0
goroutine 10 [running]:
net/http.(*conn).serve.func1()
	/usr/local/go/src/net/http/server.go:1943 +0xd3
panic({0x7eb760?, 0xc0003cb2b0?})
	/usr/local/go/src/runtime/panic.go:783 +0x132
net/http.checkWriteHeaderCode(...)
	/usr/local/go/src/net/http/server.go:1162
net/http.(*response).WriteHeader(0xc0003aa3c0, 0x0)
	/usr/local/go/src/net/http/server.go:1196 +0x839
main.errorHandler.func1({0x929188, 0xc0003aa3c0}, 0xc0003e6000)
	/go/src/k8s.io/ingress-nginx/images/custom-error-pages/main.go:152 +0xfeb
net/http.HandlerFunc.ServeHTTP(0xc18520?, {0x929188?, 0xc0003aa3c0?}, 0x62ad36?)
	/usr/local/go/src/net/http/server.go:2322 +0x29
net/http.(*ServeMux).ServeHTTP(0x474df9?, {0x929188, 0xc0003aa3c0}, 0xc0003e6000)
	/usr/local/go/src/net/http/server.go:2861 +0x1c7
net/http.serverHandler.ServeHTTP({0xc000025b40?}, {0x929188?, 0xc0003aa3c0?}, 0x1?)
	/usr/local/go/src/net/http/server.go:3340 +0x8e
net/http.(*conn).serve(0xc0000e4240, {0x929978, 0xc0003cf620})
	/usr/local/go/src/net/http/server.go:2109 +0x665
created by net/http.(*Server).Serve in goroutine 1
	/usr/local/go/src/net/http/server.go:3493 +0x485
```

The fix is just to move the call near the `io.copy()` and be more robust.
Includes minor cosmetic changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?

By building the docker image manually and sending it a custom query:
- Build the image: `cd images/custom-error-pages/rootfs && docker build --build-arg GOLANG_VERSION=1.25.4 . -t custom-error-pages`
- Start the container: `docker run --rm -p 8080:8080 custom-error-pages`
- Send the query with a wrong code:
```bash
$ curl -H "X-Code: 0" http://localhost:8080/
404 page not found
```


Before:
```bash
$ docker run --rm -p 8080:8080 custom-error-pages
2025/11/11 13:52:58 format not specified. Using text/html
2025/11/11 13:52:58 http: panic serving 192.168.65.1:32712: invalid WriteHeader code 0
goroutine 10 [running]:
net/http.(*conn).serve.func1()
	/usr/local/go/src/net/http/server.go:1943 +0xd3
panic({0x7eb760?, 0xc0003cb2b0?})
	/usr/local/go/src/runtime/panic.go:783 +0x132
net/http.checkWriteHeaderCode(...)
	/usr/local/go/src/net/http/server.go:1162
net/http.(*response).WriteHeader(0xc0003aa3c0, 0x0)
	/usr/local/go/src/net/http/server.go:1196 +0x839
main.errorHandler.func1({0x929188, 0xc0003aa3c0}, 0xc0003e6000)
	/go/src/k8s.io/ingress-nginx/images/custom-error-pages/main.go:152 +0xfeb
net/http.HandlerFunc.ServeHTTP(0xc18520?, {0x929188?, 0xc0003aa3c0?}, 0x62ad36?)
	/usr/local/go/src/net/http/server.go:2322 +0x29
net/http.(*ServeMux).ServeHTTP(0x474df9?, {0x929188, 0xc0003aa3c0}, 0xc0003e6000)
	/usr/local/go/src/net/http/server.go:2861 +0x1c7
net/http.serverHandler.ServeHTTP({0xc000025b40?}, {0x929188?, 0xc0003aa3c0?}, 0x1?)
	/usr/local/go/src/net/http/server.go:3340 +0x8e
net/http.(*conn).serve(0xc0000e4240, {0x929978, 0xc0003cf620})
	/usr/local/go/src/net/http/server.go:2109 +0x665
created by net/http.(*Server).Serve in goroutine 1
	/usr/local/go/src/net/http/server.go:3493 +0x485
```

After the change:
```bash
$ docker run --rm -p 8080:8080 custom-error-pages
2025/11/11 13:48:20 format not specified. Using text/html
2025/11/11 13:48:20 unexpected error opening file: open /www/0.html: no such file or directory
2025/11/11 13:48:20 unexpected error opening file: open /www/0xx.html: no such file or directory
```

If sending another code with `curl -H "X-Code: 200" http://localhost:8080/`.
Before:
```
$ docker run --rm -p 8080:8080 custom-error-pages
2025/11/11 13:57:25 format not specified. Using text/html
2025/11/11 13:57:25 unexpected error opening file: open /www/200.html: no such file or directory
2025/11/11 13:57:25 unexpected error opening file: open /www/2xx.html: no such file or directory
2025/11/11 13:57:25 http: superfluous response.WriteHeader call from main.errorHandler.func1 (main.go:170)
```

After the change:
```
$ docker run --rm -p 8080:8080 custom-error-pages
2025/11/11 13:58:45 format not specified. Using text/html
2025/11/11 13:58:45 unexpected error opening file: open /www/200.html: no such file or directory
2025/11/11 13:58:45 unexpected error opening file: open /www/2xx.html: no such file or directory
```
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
