### PR TITLE
CI: Disable verification for Helm Unit Test.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -240,7 +240,7 @@ jobs:
         uses: gabe565/setup-helm-docs-action@d5c35bdc9133cfbea3b671acadf50a29029e87c2 # v1.0.4
 
       - name: Set up Helm Unit Test
-        run: helm plugin install https://github.com/helm-unittest/helm-unittest
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest --verify=false
 
       - name: Checkout code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1


### PR DESCRIPTION
It does not support the verification introduced in Helm v4.0.0, yet.

/triage accepted
/kind cleanup
/priority backlog
/cc @cpanato @strongjz @tao12345666333