### PR TITLE
fix: Support standard Forwarded header

### DIFF
--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -581,6 +581,16 @@ type Configuration struct {
 	// Default: false
 	ComputeFullForwardedFor bool `json:"compute-full-forwarded-for,omitempty"`
 
+	// EnableForwardedHeader enables the generation of the RFC 7239 Forwarded header
+	// https://tools.ietf.org/html/rfc7239
+	// Default: false
+	EnableForwardedHeader bool `json:"enable-forwarded-header,omitempty"`
+
+	// ForwardedHeaderIncludeBy includes the "by" parameter in the Forwarded header.
+	// The value will be the server's IP address (or obfuscated identifier if specified).
+	// Default: false
+	ForwardedHeaderIncludeBy bool `json:"forwarded-header-include-by,omitempty"`
+
 	// If the request does not have a request-id, should we generate a random value?
 	// Default: true
 	GenerateRequestID bool `json:"generate-request-id,omitempty"`

--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -315,6 +315,7 @@ var funcMap = text_template.FuncMap{
 	"isValidByteSize":                    isValidByteSize,
 	"buildForwardedFor":                  buildForwardedFor,
 	"buildForwardedHost":                 buildForwardedHost,
+	"buildForwardedHeaderValue":          buildForwardedHeaderValue,
 	"buildAuthSignURL":                   buildAuthSignURL,
 	"buildAuthSignURLLocation":           buildAuthSignURLLocation,
 	"buildOpentelemetry":                 buildOpentelemetry,
@@ -1165,6 +1166,20 @@ func buildForwardedHost(input interface{}) string {
 	fhh := strings.ReplaceAll(s, "-", "_")
 	fhh = strings.ToLower(fhh)
 	return fmt.Sprintf("$http_%v", fhh)
+}
+
+// buildForwardedHeaderValue builds the value for the RFC 7239 Forwarded header.
+// Format: for=<client>;proto=<scheme>;host=<host>[;by=<proxy>]
+// IPv6 addresses must be quoted and enclosed in brackets per RFC 7239.
+func buildForwardedHeaderValue(includeBy bool) string {
+	// Build the Forwarded header value using nginx variables
+	// We use $forwarded_for_value which handles IPv6 formatting
+	// The nginx template will set this variable appropriately
+	value := "for=$forwarded_for_value;proto=$pass_access_scheme;host=$best_http_host"
+	if includeBy {
+		value += ";by=$server_addr"
+	}
+	return value
 }
 
 func buildAuthSignURL(authSignURL, authRedirectParam string) string {

--- a/internal/ingress/controller/template/template_test.go
+++ b/internal/ingress/controller/template/template_test.go
@@ -888,6 +888,24 @@ func TestBuildForwardedHost(t *testing.T) {
 	}
 }
 
+func TestBuildForwardedHeaderValue(t *testing.T) {
+	// Test without "by" parameter
+	expected := "for=$forwarded_for_value;proto=$pass_access_scheme;host=$best_http_host"
+	actual := buildForwardedHeaderValue(false)
+
+	if expected != actual {
+		t.Errorf("Expected '%v' but returned '%v'", expected, actual)
+	}
+
+	// Test with "by" parameter
+	expected = "for=$forwarded_for_value;proto=$pass_access_scheme;host=$best_http_host;by=$server_addr"
+	actual = buildForwardedHeaderValue(true)
+
+	if expected != actual {
+		t.Errorf("Expected '%v' but returned '%v'", expected, actual)
+	}
+}
+
 func TestBuildResolvers(t *testing.T) {
 	ipOne := net.ParseIP("192.0.0.1")
 	ipTwo := net.ParseIP("2001:db8:1234:0000:0000:0000:0000:0000")

--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -450,6 +450,19 @@ http {
         default "$";
     }
 
+    {{ if $cfg.EnableForwardedHeader }}
+    # RFC 7239 Forwarded header support
+    # Format the client IP for the "for" parameter according to RFC 7239
+    # IPv6 addresses must be quoted and enclosed in brackets: for="[::1]"
+    # IPv4 addresses are used as-is: for=192.0.2.1
+    map $remote_addr $forwarded_for_value {
+        ~^[0-9.]+$          $remote_addr;
+        ~^::               "\"[$remote_addr]\"";
+        ~:                 "\"[$remote_addr]\"";
+        default             $remote_addr;
+    }
+    {{ end }}
+
     server_name_in_redirect off;
     port_in_redirect        off;
 
@@ -1310,6 +1323,10 @@ stream {
             {{ $proxySetHeader }} X-Forwarded-Port       $pass_port;
             {{ $proxySetHeader }} X-Forwarded-Proto      $pass_access_scheme;
             {{ $proxySetHeader }} X-Forwarded-Scheme     $pass_access_scheme;
+            {{ if $all.Cfg.EnableForwardedHeader }}
+            # RFC 7239 Forwarded header
+            {{ $proxySetHeader }} Forwarded              "{{ buildForwardedHeaderValue $all.Cfg.ForwardedHeaderIncludeBy }}";
+            {{ end }}
             {{ if $all.Cfg.ProxyAddOriginalURIHeader }}
             {{ $proxySetHeader }} X-Original-URI         $request_uri;
             {{ end }}


### PR DESCRIPTION
## Summary
This PR fixes #10263

## Changes
- `internal/ingress/controller/config/config.go`
- `internal/ingress/controller/template/template.go`
- `internal/ingress/controller/template/template_test.go`
- `rootfs/etc/nginx/template/nginx.tmpl`
