### PR TITLE
Docs: Fix typos.

### DIFF
--- a/cmd/plugin/util/util.go
+++ b/cmd/plugin/util/util.go
@@ -34,7 +34,7 @@ const (
 	DefaultIngressContainerName  = "controller"
 )
 
-// IssuePrefix is the github url that we can append an issue number to to link to it
+// IssuePrefix is the github url that we can append an issue number to link to it
 const IssuePrefix = "https://github.com/kubernetes/ingress-nginx/issues/"
 
 var versionRegex = regexp.MustCompile(`(\d)+\.(\d)+\.(\d)+.*`)

--- a/internal/ingress/controller/nginx.go
+++ b/internal/ingress/controller/nginx.go
@@ -276,7 +276,7 @@ func (n *NGINXController) Start() {
 
 	// we need to use the defined ingress class to allow multiple leaders
 	// in order to update information about ingress status
-	// TODO: For now, as the the IngressClass logics has changed, is up to the
+	// TODO: For now, as the IngressClass logics has changed, is up to the
 	// cluster admin to create different Leader Election IDs.
 	// Should revisit this in a future
 


### PR DESCRIPTION
Fix typos: `to to` → `to`, `the the` → `the`