### PR TITLE
Controller: Fix sync for when host clock jumps to future.

### DIFF
--- a/internal/task/queue.go
+++ b/internal/task/queue.go
@@ -122,7 +122,7 @@ func (t *Queue) worker() {
 		if item.Timestamp != 0 && t.lastSync > item.Timestamp {
 			// fix issue https://github.com/kubernetes/ingress-nginx/issues/14374
 			if t.lastSync > ts {
-				klog.Warningf("The lastSync time %v is later than the current time %v, set lastSync to %v", t.lastSync, ts, item.Timestamp)
+				klog.Warningf("The lastSync time %d is later than the current time %d; setting lastSync to %d", t.lastSync, ts, item.Timestamp)
 				t.lastSync = item.Timestamp
 			} else {
 				klog.V(3).InfoS("skipping sync", "key", item.Key, "last", t.lastSync, "now", item.Timestamp)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->
<!--- Please make sure you title is descriptive, it is used in the Release notes to let others know what it does ---> 

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix the problem of ingress-nginx stops applying updates after host clock jump to future and back
https://github.com/kubernetes/ingress-nginx/issues/14374

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->
fixes #14374

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
On the node running ingress-nginx, change the system time forward to a far future date (e.g. year 2040).
Make some ingress resource changes.
Restore the system time to the correct value.
Make some ingress resource changes.
Observe that ingress-nginx applies subsequent ingress changes.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added unit and/or e2e tests to cover my changes.
- [ ] All new and existing tests passed.
