### PR TITLE
Util: Fix panic for empty `cpu.max` file.

### DIFF
--- a/pkg/util/runtime/cpu_linux.go
+++ b/pkg/util/runtime/cpu_linux.go
@@ -96,6 +96,10 @@ func readCgroup2StringToInt64Tuple(cgroupString string) (quota, period int64) {
 
 	values := strings.Fields(cgroupString)
 
+	if len(values) == 0 {
+		return -1, -1
+	}
+
 	if values[0] == "max" {
 		return -1, -1
 	}

--- a/pkg/util/runtime/cpu_linux_test.go
+++ b/pkg/util/runtime/cpu_linux_test.go
@@ -1,0 +1,94 @@
+//go:build linux
+// +build linux
+
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtime
+
+import (
+	"testing"
+)
+
+func TestReadCgroup2StringToInt64Tuple(t *testing.T) {
+	tests := []struct {
+		name           string
+		input          string
+		expectedQuota  int64
+		expectedPeriod int64
+	}{
+		{
+			name:           "empty string",
+			input:          "",
+			expectedQuota:  -1,
+			expectedPeriod: -1,
+		},
+		{
+			name:           "whitespace only",
+			input:          "   ",
+			expectedQuota:  -1,
+			expectedPeriod: -1,
+		},
+		{
+			name:           "max value",
+			input:          "max 100000",
+			expectedQuota:  -1,
+			expectedPeriod: -1,
+		},
+		{
+			name:           "quota only",
+			input:          "50000",
+			expectedQuota:  50000,
+			expectedPeriod: 100000,
+		},
+		{
+			name:           "quota and period",
+			input:          "50000 100000",
+			expectedQuota:  50000,
+			expectedPeriod: 100000,
+		},
+		{
+			name:           "quota and custom period",
+			input:          "100000 200000",
+			expectedQuota:  100000,
+			expectedPeriod: 200000,
+		},
+		{
+			name:           "invalid quota",
+			input:          "invalid 100000",
+			expectedQuota:  -1,
+			expectedPeriod: -1,
+		},
+		{
+			name:           "invalid period",
+			input:          "50000 invalid",
+			expectedQuota:  -1,
+			expectedPeriod: -1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			quota, period := readCgroup2StringToInt64Tuple(tc.input)
+			if quota != tc.expectedQuota {
+				t.Errorf("expected quota %d, got %d", tc.expectedQuota, quota)
+			}
+			if period != tc.expectedPeriod {
+				t.Errorf("expected period %d, got %d", tc.expectedPeriod, period)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What this PR does / why we need it

This PR fixes a potential panic in `readCgroup2StringToInt64Tuple` when the cgroup2 `cpu.max` file is empty or contains only whitespace.

## Bug Description

The function `readCgroup2StringToInt64Tuple` in `pkg/util/runtime/cpu_linux.go` accesses `values[0]` without first checking if the slice has any elements:

```go
values := strings.Fields(cgroupString)

if values[0] == "max" {  // PANIC: index out of range if values is empty
    return -1, -1
}
```

When `cgroupString` is empty or contains only whitespace, `strings.Fields()` returns an empty slice, and accessing `values[0]` causes a panic with "index out of range".

This could happen in edge cases like:
- A corrupted or truncated cgroup2 `cpu.max` file
- Race conditions where the file is being written while being read
- Malformed container runtime configurations

## Fix

Add a length check before accessing the slice:

```go
values := strings.Fields(cgroupString)

if len(values) == 0 {
    return -1, -1
}

if values[0] == "max" {
    return -1, -1
}
```

This is consistent with how similar code in `internal/net/dns/dns.go` handles the same pattern safely.

## Testing

Added unit tests for `readCgroup2StringToInt64Tuple` covering:
- Empty string input
- Whitespace-only input
- Valid quota/period values
- Invalid inputs

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Added new unit tests in `pkg/util/runtime/cpu_linux_test.go`