### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -33,7 +33,7 @@ jobs:
           version: v4.1.0
 
       - name: Set up Helm Chart Testing
-        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f
+        uses: helm/chart-testing-action@0d28d3144d3a25ea2cc349d6e59901c4ff469b3b  # v2.8.0
 
       - name: Set up Artifact Hub
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -228,7 +228,7 @@ jobs:
           version: v4.1.0
 
       - name: Set up Helm Chart Testing
-        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f
+        uses: helm/chart-testing-action@0d28d3144d3a25ea2cc349d6e59901c4ff469b3b  # v2.8.0
 
       - name: Set up Artifact Hub
         run: |

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -183,7 +183,7 @@ jobs:
           version: latest
           platforms: ${{ env.PLATFORMS }}
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3.7.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/junit-reports.yaml
+++ b/.github/workflows/junit-reports.yaml
@@ -13,7 +13,7 @@ jobs:
   report:
     runs-on: ubuntu-latest
     steps:
-      - uses: dorny/test-reporter@b082adf0eced0765477756c2a610396589b8c637 # v2.5.0
+      - uses: dorny/test-reporter@2c14ff72a244f739866b0d898151a9a1a9fd1c58  # v2.5.0
         with:
           artifact: /e2e-test-reports-(.*)/
           name: JEST Tests $1               # Name of the check run which will be created

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -59,6 +59,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@19b2f06db2b6f5108140aeb04014ef02b648f789 # v4.31.11
+        uses: github/codeql-action/upload-sarif@ab28d5ce09b08e4700b2296d39d684a7ac71d1e7  # v4
         with:
           sarif_file: results.sarif

--- a/.github/workflows/vulnerability-scans.yaml
+++ b/.github/workflows/vulnerability-scans.yaml
@@ -75,7 +75,7 @@ jobs:
 
       # This step checks out a copy of your repository.
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@19b2f06db2b6f5108140aeb04014ef02b648f789 # v4.31.11
+        uses: github/codeql-action/upload-sarif@ab28d5ce09b08e4700b2296d39d684a7ac71d1e7  # v4
         with:
           token: ${{ github.token }}
           # Path to SARIF file relative to the root of the repository

--- a/.github/workflows/zz-tmpl-images.yaml
+++ b/.github/workflows/zz-tmpl-images.yaml
@@ -70,7 +70,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3.7.0
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions for improved features, bug fixes, and security updates.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `docker/login-action` | [`5e57cd1`](https://github.com/docker/login-action/commit/5e57cd118135c172c3672efd75eb46360885c0ef) | [`c94ce9f`](https://github.com/docker/login-action/commit/c94ce9fb468520275223c153574b00df6fe4bcc9) | [Release](https://github.com/docker/login-action/releases/tag/v3) | images.yaml, zz-tmpl-images.yaml |
| `dorny/test-reporter` | [`b082adf`](https://github.com/dorny/test-reporter/commit/b082adf0eced0765477756c2a610396589b8c637) | [`2c14ff7`](https://github.com/dorny/test-reporter/commit/2c14ff72a244f739866b0d898151a9a1a9fd1c58) | [Release](https://github.com/dorny/test-reporter/releases/tag/release/v1.9.1) | junit-reports.yaml |
| `github/codeql-action/upload-sarif` | [`19b2f06`](https://github.com/github/codeql-action/upload-sarif/commit/19b2f06db2b6f5108140aeb04014ef02b648f789) | [`ab28d5c`](https://github.com/github/codeql-action/upload-sarif/commit/ab28d5ce09b08e4700b2296d39d684a7ac71d1e7) | [Release](https://github.com/github/codeql-action/upload-sarif/releases/tag/v4) | scorecards.yml, vulnerability-scans.yaml |
| `helm/chart-testing-action` | [`6ec842c`](https://github.com/helm/chart-testing-action/commit/6ec842c01de15ebb84c8627d2744a0c2f2755c9f) | [`0d28d31`](https://github.com/helm/chart-testing-action/commit/0d28d3144d3a25ea2cc349d6e59901c4ff469b3b) | [Release](https://github.com/helm/chart-testing-action/releases/tag/v2) | chart.yaml, ci.yaml |

## Why upgrade?

Keeping GitHub Actions up to date ensures:
- **Security**: Latest security patches and fixes
- **Features**: Access to new functionality and improvements
- **Compatibility**: Better support for current GitHub features
- **Performance**: Optimizations and efficiency improvements

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
