### PR TITLE
Lua: Fix type mismatch.

### DIFF
--- a/rootfs/etc/nginx/lua/nginx/ngx_conf_external_auth.lua
+++ b/rootfs/etc/nginx/lua/nginx/ngx_conf_external_auth.lua
@@ -1,5 +1,5 @@
 local auth_path = ngx.var.auth_path
-local auth_keepalive_share_vars = ngx.var.auth_keepalive_share_vars
+local auth_keepalive_share_vars = ngx.var.auth_keepalive_share_vars == "true" and true or false
 local auth_response_headers = ngx.var.auth_response_headers
 local ngx_re_split = require("ngx.re").split
 local ipairs = ipairs


### PR DESCRIPTION
During conversion from inline to file, this broke. Before the variable has been assigned inside a Lua block, so `true` and `false` were understood as booleans. After it is being set in NGINX configuration, where it's being understood as string.

/triage accepted
/kind bug
/priority backlog
/cc @cpanato @strongjz @tao12345666333

Also CC @rikatz, because you initially converted this from inline to file in this PR: https://github.com/kubernetes/ingress-nginx/pull/12250.

/cc @rikatz

I think what breaks it is the change from [this line](https://github.com/kubernetes/ingress-nginx/pull/12250/changes#diff-cbf382cc05c9f274b5db56a581b335dba8ecb80fd96a8f1a6a068b2594c9b1caL1189) (interpreted as boolean) to [this line](https://github.com/kubernetes/ingress-nginx/pull/12250/changes#diff-cbf382cc05c9f274b5db56a581b335dba8ecb80fd96a8f1a6a068b2594c9b1caR1189) (interpreted as string).