### PR TITLE
docs:clarify allowed values for proxy-request-buffering annotation values

### DIFF
--- a/docs/user-guide/nginx-configuration/annotations.md
+++ b/docs/user-guide/nginx-configuration/annotations.md
@@ -674,7 +674,7 @@ In some scenarios is required to have different values. To allow this we provide
 - `nginx.ingress.kubernetes.io/proxy-next-upstream`
 - `nginx.ingress.kubernetes.io/proxy-next-upstream-timeout`
 - `nginx.ingress.kubernetes.io/proxy-next-upstream-tries`
-- `nginx.ingress.kubernetes.io/proxy-request-buffering`
+- `nginx.ingress.kubernetes.io/proxy-request-buffering`: Valid values are `on` or `off`.
 
 If you indicate [Backend Protocol](#backend-protocol) as `GRPC` or `GRPCS`, the following grpc values will be set and inherited from proxy timeouts:
 


### PR DESCRIPTION
This fixes the documentation for nginx.ingress.kubernetes.io/proxy-request-buffering
to clarify that only "on" and "off" are valid values.

Fixes #10916