### PR TITLE
Docs: Clarify valid values for `proxy-request-buffering`.

### DIFF
--- a/docs/user-guide/nginx-configuration/configmap.md
+++ b/docs/user-guide/nginx-configuration/configmap.md
@@ -1117,6 +1117,7 @@ _References:_
 ## proxy-request-buffering
 
 Enables or disables [buffering of a client request body](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_request_buffering).
+Valid values are `on` and `off`.
 
 ## ssl-redirect
 


### PR DESCRIPTION
## What this PR does / why we need it

Clarifies the valid values for the proxy-request-buffering ConfigMap option.

Fixes #10916