### PR TITLE
Template: Use `RawURLEncoding` instead of `URLEncoding` with padding removal.

### DIFF
--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -564,9 +564,7 @@ func buildAuthLocation(input interface{}, globalExternalAuthURL string) string {
 		return ""
 	}
 
-	str := base64.URLEncoding.EncodeToString([]byte(location.Path))
-	// removes "=" after encoding
-	str = strings.ReplaceAll(str, "=", "")
+	str := base64.RawURLEncoding.EncodeToString([]byte(location.Path))
 
 	pathType := "default"
 	if location.PathType != nil {


### PR DESCRIPTION
Problem

buildAuthLocation currently uses base64.URLEncoding and then manually strips = padding.
This results in non-standard handling and reduces readability.

Change

Switch to base64.RawURLEncoding, which is explicitly designed for unpadded base64 and removes the need for manual trimming.

Result

The generated auth location remains URL-safe and becomes easier to understand and trace.
This change does not alter the generated auth location values; it only simplifies the implementation by using the standard unpadded base64 encoder.