### PR TITLE
Docs: Add retirement notice to website.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,17 @@
+# Retirement
+
+[What You Need to Know about Ingress NGINX Retirement](https://www.kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/):
+
+* Best-effort maintenance will continue until March 2026.
+* Afterward, there will be no further releases, no bugfixes, and no updates to resolve any security vulnerabilities that may be discovered.
+* Existing deployments of Ingress NGINX will not be broken.
+  * Existing project artifacts such as Helm charts and container images will remain available.
+
+You can still find the documentation for the Ingress NGINX Controller on this page.
+
 # Overview
 
-This is the documentation for the Ingress NGINX Controller.
-
-It is built around the [Kubernetes Ingress resource](https://kubernetes.io/docs/concepts/services-networking/ingress/), using a [ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/) to store the controller configuration.
+The Ingress NGINX Controller is built around the [Kubernetes Ingress resource](https://kubernetes.io/docs/concepts/services-networking/ingress/), using a [ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/) to store the controller configuration.
 
 You can learn more about using [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) in the official [Kubernetes documentation](https://docs.k8s.io).
 


### PR DESCRIPTION
## What this PR does / why we need it:

The retirement notice is in the repository README, but users won't see this if they land on the project from its website https://kubernetes.github.io/ingress-nginx/, which is how I first found the project.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] CVE Report (Scanner found CVE and adding report)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation only